### PR TITLE
Fix and rename osx builds

### DIFF
--- a/create-dmg.sh
+++ b/create-dmg.sh
@@ -14,7 +14,7 @@ if [ ! $? -eq 0 ]; then
     exit $?
 fi
 
-# Install to ~/QLC.app/
+# Install to ~/QLC+.app/
 make install
 if [ ! $? -eq 0 ]; then
     echo Installation error. Aborting package creation.
@@ -23,10 +23,10 @@ fi
 
 # Create Apple Disk iMaGe from ~/QLC.app/
 cd dmg
-./create-dmg --volname "Q Light Controller $VERSION" \
+./create-dmg --volname "Q Light Controller Plus $VERSION" \
 	     --background background.png \
 	     --window-size 300 225 \
 	     --icon-size 128 --icon "qlc" 150 16 \
-	     QLC-$VERSION.dmg \
-	     ~/QLC.app
+	     QLC+-$VERSION.dmg \
+	     ~/QLC+.app
 cd ..

--- a/variables.pri
+++ b/variables.pri
@@ -44,7 +44,7 @@ win32:QMAKE_LFLAGS += -enable-auto-import
 
 # Install root
 win32:INSTALLROOT       = $$(SystemDrive)/QLC
-macx:INSTALLROOT        = ~/QLC.app/Contents
+macx:INSTALLROOT        = ~/QLC+.app/Contents
 unix:!macx:INSTALLROOT += /usr
 
 # Binaries


### PR DESCRIPTION
This branch will remove the test for obsolete Apple tool in the ./create-dmg. sh script, as well as renaming all instance of QLC to QLC+.
