### PR TITLE
Fixed fixture-definitions for Stairville LED Par56 MKII RGBA/W

### DIFF
--- a/fixtures/Stairville-LED-PAR56-MKII-RGBA.qxf
+++ b/fixtures/Stairville-LED-PAR56-MKII-RGBA.qxf
@@ -30,40 +30,69 @@
  <Channel Name="Mode">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="63">RGBA</Capability>
-  <Capability Min="64" Max="127">7-color chase</Capability>
-  <Capability Min="128" Max="191">12-color chase</Capability>
-  <Capability Min="192" Max="255">4-color chase</Capability>
+  <Capability Min="64" Max="127">Chase 7 colors</Capability>
+  <Capability Min="128" Max="191">Chase 12 colors</Capability>
+  <Capability Min="192" Max="255">Chase 4 colors</Capability>
  </Channel>
- <Channel Name="Chase Speed">
+ <Channel Name="Chase">
   <Group Byte="0">Speed</Group>
   <Capability Min="0" Max="10">None</Capability>
-  <Capability Min="11" Max="100">Descending</Capability>
+  <Capability Min="11" Max="100">Fast to slow</Capability>
   <Capability Min="101" Max="150">None</Capability>
   <Capability Min="151" Max="255">Random</Capability>
  </Channel>
  <Channel Name="Macros">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="15">None</Capability>
-  <Capability Min="16" Max="255">31 Macros (TBC)</Capability>
+  <Capability Min="16" Max="23">Macro 1</Capability>
+  <Capability Min="24" Max="31">Macro 2</Capability>
+  <Capability Min="32" Max="39">Macro 3</Capability>
+  <Capability Min="40" Max="47">Macro 4</Capability>
+  <Capability Min="48" Max="55">Macro 5</Capability>
+  <Capability Min="56" Max="63">Macro 6</Capability>
+  <Capability Min="64" Max="71">Macro 7</Capability>
+  <Capability Min="72" Max="79">Macro 8</Capability>
+  <Capability Min="80" Max="87">Macro 9</Capability>
+  <Capability Min="88" Max="95">Macro 10</Capability>
+  <Capability Min="96" Max="103">Macro 11</Capability>
+  <Capability Min="104" Max="111">Macro 12</Capability>
+  <Capability Min="112" Max="119">Macro 13</Capability>
+  <Capability Min="120" Max="127">Macro 14</Capability>
+  <Capability Min="128" Max="135">Macro 15</Capability>
+  <Capability Min="136" Max="143">Macro 16</Capability>
+  <Capability Min="144" Max="151">Macro 17</Capability>
+  <Capability Min="152" Max="159">Macro 18</Capability>
+  <Capability Min="160" Max="167">Macro 19</Capability>
+  <Capability Min="168" Max="175">Macro 20</Capability>
+  <Capability Min="176" Max="183">Macro 21</Capability>
+  <Capability Min="184" Max="191">Macro 22</Capability>
+  <Capability Min="192" Max="199">Macro 23</Capability>
+  <Capability Min="200" Max="207">Macro 24</Capability>
+  <Capability Min="208" Max="215">Macro 25</Capability>
+  <Capability Min="216" Max="223">Macro 26</Capability>
+  <Capability Min="224" Max="231">Macro 27</Capability>
+  <Capability Min="232" Max="239">Macro 28</Capability>
+  <Capability Min="240" Max="247">Macro 29</Capability>
+  <Capability Min="248" Max="255">Macro 30</Capability>
  </Channel>
- <Channel Name="Speed">
-  <Group Byte="0">Speed</Group>
+ <Channel Name="Strobe / Fade speed">
+  <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="15">None</Capability>
-  <Capability Min="16" Max="255">Increasing</Capability>
+  <Capability Min="16" Max="255">Slow to fast</Capability>
  </Channel>
  <Channel Name="Mode">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="31">RGBA</Capability>
-  <Capability Min="32" Max="63">Fade Out</Capability>
-  <Capability Min="64" Max="95">Fade In</Capability>
-  <Capability Min="96" Max="127">Fade In-Out</Capability>
-  <Capability Min="128" Max="159">Auto-Mix</Capability>
-  <Capability Min="160" Max="191">4-color Chase</Capability>
-  <Capability Min="192" Max="223">12-color Chase</Capability>
+  <Capability Min="32" Max="63">Fade out</Capability>
+  <Capability Min="64" Max="95">Fade in</Capability>
+  <Capability Min="96" Max="127">Fade in-out</Capability>
+  <Capability Min="128" Max="159">Auto-mix</Capability>
+  <Capability Min="160" Max="191">Chase 4 colors</Capability>
+  <Capability Min="192" Max="223">Chase 12 colors</Capability>
   <Capability Min="224" Max="255">Music</Capability>
  </Channel>
  <Channel Name="Master">
-  <Group Byte="0">Beam</Group>
+  <Group Byte="0">Intensity</Group>
   <Capability Min="0" Max="255">Dimmer</Capability>
  </Channel>
  <Mode Name="RGBA">
@@ -92,7 +121,7 @@
   <Channel Number="2">Green</Channel>
   <Channel Number="3">Blue</Channel>
   <Channel Number="4">Amber</Channel>
-  <Channel Number="5">Chase Speed</Channel>
+  <Channel Number="5">Chase</Channel>
  </Mode>
  <Mode Name="Full">
   <Physical>
@@ -107,7 +136,7 @@
   <Channel Number="2">Blue</Channel>
   <Channel Number="3">Amber</Channel>
   <Channel Number="4">Macros</Channel>
-  <Channel Number="5">Speed</Channel>
+  <Channel Number="5">Strobe / Fade speed</Channel>
   <Channel Number="6">Mode</Channel>
   <Channel Number="7">Master</Channel>
  </Mode>

--- a/fixtures/Stairville-LED-PAR56-MKII-RGBW.qxf
+++ b/fixtures/Stairville-LED-PAR56-MKII-RGBW.qxf
@@ -25,48 +25,77 @@
  </Channel>
  <Channel Name="White">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Amber</Capability>
+  <Capability Min="0" Max="255">White</Capability>
  </Channel>
  <Channel Name="Mode">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="63">RGBA</Capability>
-  <Capability Min="64" Max="127">7-color chase</Capability>
-  <Capability Min="128" Max="191">12-color chase</Capability>
-  <Capability Min="192" Max="255">4-color chase</Capability>
+  <Capability Min="64" Max="127">Chase 7 colors</Capability>
+  <Capability Min="128" Max="191">Chase 12 Colors</Capability>
+  <Capability Min="192" Max="255">Chase 4 colors</Capability>
  </Channel>
- <Channel Name="Chase Speed">
+ <Channel Name="Chase">
   <Group Byte="0">Speed</Group>
   <Capability Min="0" Max="10">None</Capability>
-  <Capability Min="11" Max="100">Descending</Capability>
+  <Capability Min="11" Max="100">Fast to slow</Capability>
   <Capability Min="101" Max="150">None</Capability>
   <Capability Min="151" Max="255">Random</Capability>
  </Channel>
  <Channel Name="Macros">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="15">None</Capability>
-  <Capability Min="16" Max="255">31 Macros (TBC)</Capability>
+  <Capability Min="16" Max="23">Macro 1</Capability>
+  <Capability Min="24" Max="31">Macro 2</Capability>
+  <Capability Min="32" Max="39">Macro 3</Capability>
+  <Capability Min="40" Max="47">Macro 4</Capability>
+  <Capability Min="48" Max="55">Macro 5</Capability>
+  <Capability Min="56" Max="63">Macro 6</Capability>
+  <Capability Min="64" Max="71">Macro 7</Capability>
+  <Capability Min="72" Max="79">Macro 8</Capability>
+  <Capability Min="80" Max="87">Macro 9</Capability>
+  <Capability Min="88" Max="95">Macro 10</Capability>
+  <Capability Min="96" Max="103">Macro 11</Capability>
+  <Capability Min="104" Max="111">Macro 12</Capability>
+  <Capability Min="112" Max="119">Macro 13</Capability>
+  <Capability Min="120" Max="127">Macro 14</Capability>
+  <Capability Min="128" Max="135">Macro 15</Capability>
+  <Capability Min="136" Max="143">Macro 16</Capability>
+  <Capability Min="144" Max="151">Macro 17</Capability>
+  <Capability Min="152" Max="159">Macro 18</Capability>
+  <Capability Min="160" Max="167">Macro 19</Capability>
+  <Capability Min="168" Max="175">Macro 20</Capability>
+  <Capability Min="176" Max="183">Macro 21</Capability>
+  <Capability Min="184" Max="191">Macro 22</Capability>
+  <Capability Min="192" Max="199">Macro 23</Capability>
+  <Capability Min="200" Max="207">Macro 24</Capability>
+  <Capability Min="208" Max="215">Macro 25</Capability>
+  <Capability Min="216" Max="223">Macro 26</Capability>
+  <Capability Min="224" Max="231">Macro 27</Capability>
+  <Capability Min="232" Max="239">Macro 28</Capability>
+  <Capability Min="240" Max="247">Macro 29</Capability>
+  <Capability Min="248" Max="255">Macro 30</Capability>
  </Channel>
- <Channel Name="Speed">
+ <Channel Name="Strobe / Fade speed">
   <Group Byte="0">Speed</Group>
   <Capability Min="0" Max="15">None</Capability>
-  <Capability Min="16" Max="255">Increasing</Capability>
+  <Capability Min="16" Max="255">Slow to fast</Capability>
  </Channel>
  <Channel Name="Mode">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="31">RGBA</Capability>
-  <Capability Min="32" Max="63">Fade Out</Capability>
-  <Capability Min="64" Max="95">Fade In</Capability>
-  <Capability Min="96" Max="127">Fade In-Out</Capability>
-  <Capability Min="128" Max="159">Auto-Mix</Capability>
-  <Capability Min="160" Max="191">4-color Chase</Capability>
-  <Capability Min="192" Max="223">12-color Chase</Capability>
+  <Capability Min="32" Max="63">Fade out</Capability>
+  <Capability Min="64" Max="95">Fade in</Capability>
+  <Capability Min="96" Max="127">Fade in-out</Capability>
+  <Capability Min="128" Max="159">Auto-mix</Capability>
+  <Capability Min="160" Max="191">Chase 4-color</Capability>
+  <Capability Min="192" Max="223">Chase 12-color</Capability>
   <Capability Min="224" Max="255">Music</Capability>
  </Channel>
  <Channel Name="Master">
-  <Group Byte="0">Beam</Group>
+  <Group Byte="0">Intensity</Group>
   <Capability Min="0" Max="255">Dimmer</Capability>
  </Channel>
- <Mode Name="RGBA">
+ <Mode Name="RGBW">
   <Physical>
    <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
    <Dimensions Width="220" Height="205" Weight="0" Depth="210"/>
@@ -77,8 +106,9 @@
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
  </Mode>
- <Mode Name="RGBA/Chase">
+ <Mode Name="RGBW/Chase">
   <Physical>
    <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
    <Dimensions Width="220" Height="205" Weight="0" Depth="210"/>
@@ -90,7 +120,8 @@
   <Channel Number="1">Red</Channel>
   <Channel Number="2">Green</Channel>
   <Channel Number="3">Blue</Channel>
-  <Channel Number="4">Chase Speed</Channel>
+  <Channel Number="4">White</Channel>
+  <Channel Number="5">Chase</Channel>
  </Mode>
  <Mode Name="Full">
   <Physical>
@@ -103,9 +134,10 @@
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
-  <Channel Number="3">Macros</Channel>
-  <Channel Number="4">Speed</Channel>
-  <Channel Number="5">Mode</Channel>
-  <Channel Number="6">Master</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Macros</Channel>
+  <Channel Number="5">Strobe / Fade speed</Channel>
+  <Channel Number="6">Mode</Channel>
+  <Channel Number="7">Master</Channel>
  </Mode>
 </FixtureDefinition>


### PR DESCRIPTION
- Added "white"-channel to modes in RGBW
- Changed descriptions
