### PR TITLE
Adjust column count for click'n'go to fit all values in the screen

### DIFF
--- a/ui/src/clickandgowidget.h
+++ b/ui/src/clickandgowidget.h
@@ -134,6 +134,8 @@ protected:
     /** Geometry parameters of the widget */
     int m_width;
     int m_height;
+    int m_cols;
+    int m_rows;
     int m_hoverCellIdx;
     int m_cellBarXpos;
     int m_cellBarYpos;


### PR DESCRIPTION
Basically it wraps the preset list to screen size (see GLP volkslicht, channel 12 -  129 presets).

Unit tests are missing, I won't be able to add them this week.

NB: vcframeproperties_test crashes (unrelated, just observation)
