### PR TITLE
Fix issue 141: MIDI feedback - moving a fader caused moving all non-zero faders.

### DIFF
--- a/plugins/midi/alsa/alsamidioutputdevice.cpp
+++ b/plugins/midi/alsa/alsamidioutputdevice.cpp
@@ -98,9 +98,19 @@ bool AlsaMidiOutputDevice::isOpen() const
 
 void AlsaMidiOutputDevice::writeChannel(ushort channel, uchar value)
 {
-    if (channel < ushort(m_universe.size()) && uchar(m_universe[channel]) != value)
+    // m_universe contains scaled values (0-127), so we have to compare scaled value as well
+    // however, since writeUniverse scales the value again, we have to store unscaled value.
+    char scaled = DMX2MIDI(value);
+    if (channel < ushort(m_universe.size()) && m_universe[channel] != scaled)
     {
         QByteArray tmp(m_universe);
+        
+        for (uchar ch = 0; ch < MAX_MIDI_DMX_CHANNELS && ch < tmp.size(); ++ch)
+        {
+           char midi = tmp[ch];
+           tmp[ch] = (char)MIDI2DMX(midi);
+        }
+
         tmp[channel] = value;
         writeUniverse(tmp);
     }

--- a/plugins/midi/macx/coremidioutputdevice.cpp
+++ b/plugins/midi/macx/coremidioutputdevice.cpp
@@ -92,9 +92,19 @@ bool CoreMidiOutputDevice::isOpen() const
 
 void CoreMidiOutputDevice::writeChannel(ushort channel, uchar value)
 {
-    if (channel < ushort(m_universe.size()) && uchar(m_universe[channel]) != value)
+    // m_universe contains scaled values (0-127), so we have to compare scaled value as well
+    // however, since writeUniverse scales the value again, we have to store unscaled value.
+    char scaled = DMX2MIDI(value);
+    if (channel < ushort(m_universe.size()) && m_universe[channel] != scaled)
     {
         QByteArray tmp(m_universe);
+
+        for (uchar ch = 0; ch < MAX_MIDI_DMX_CHANNELS && ch < tmp.size(); ++ch)
+        {
+           char midi = tmp[ch];
+           tmp[ch] = (char)MIDI2DMX(midi);
+        }
+
         tmp[channel] = value;
         writeUniverse(tmp);
     }

--- a/plugins/midi/win32/win32midioutputdevice.cpp
+++ b/plugins/midi/win32/win32midioutputdevice.cpp
@@ -79,11 +79,21 @@ bool Win32MidiOutputDevice::isOpen() const
 
 void Win32MidiOutputDevice::writeChannel(ushort channel, uchar value)
 {
-    if (channel < m_universe.size())
+    // m_universe contains scaled values (0-127), so we have to compare scaled value as well
+    // however, since writeUniverse scales the value again, we have to store unscaled value.
+    char scaled = DMX2MIDI(value);
+    if (channel < ushort(m_universe.size()) && m_universe[channel] != scaled)
     {
-        QByteArray ua(m_universe);
-        ua[channel] = value;
-        writeUniverse(ua);
+        QByteArray tmp(m_universe);
+
+        for (uchar ch = 0; ch < MAX_MIDI_DMX_CHANNELS && ch < tmp.size(); ++ch)
+        {
+           char midi = tmp[ch];
+           tmp[ch] = (char)MIDI2DMX(midi);
+        }
+
+        tmp[channel] = value;
+        writeUniverse(tmp);
     }
 }
 


### PR DESCRIPTION
Problem was that the code mixed MIDI and DMX data.
Tested only unix code; win and mac are copy&paste.
