### PR TITLE
EFX Improvements

### DIFF
--- a/engine/src/efx.cpp
+++ b/engine/src/efx.cpp
@@ -374,13 +374,13 @@ void EFX::updateRotationCache()
 
 void EFX::setStartOffset(int startOffset)
 {
-    m_startOffset = static_cast<int> (CLAMP(startOffset, 0, 359));
+    m_startOffset = CLAMP(startOffset, 0, 359);
     emit changed(this->id());
 }
 
 int EFX::startOffset() const
 {
-    return static_cast<int> (m_startOffset);
+    return m_startOffset;
 }
 
 qreal EFX::convertOffset(int offset) const

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -166,7 +166,7 @@ bool EFXFixture::loadXML(const QDomElement& root)
         else if (tag.tagName() == KXMLQLCEFXFixtureStartOffset)
         {
             /* Start offset */
-            setStartOffset(int(tag.text().toInt()));
+            setStartOffset(tag.text().toInt());
         }
         else if (tag.tagName() == KXMLQLCEFXFixtureIntensity)
         {

--- a/engine/test/efxfixture/efxfixture_test.cpp
+++ b/engine/test/efxfixture/efxfixture_test.cpp
@@ -362,6 +362,20 @@ void EFXFixture_Test::reset()
     QVERIFY(ef4->m_elapsed == 0);
 }
 
+void EFXFixture_Test::startOffset()
+{
+    EFX e(m_doc);
+    EFXFixture ef(&e);
+    ef.setFixture(0);
+
+    QCOMPARE(0, ef.startOffset());
+    for(int i = 0; i < 360; i += 90)
+    {
+        ef.setStartOffset(i);
+        QCOMPARE(i, ef.startOffset());
+    }
+}
+
 void EFXFixture_Test::setPoint8bit()
 {
     const QLCFixtureDef* def = m_doc->fixtureDefCache()->fixtureDef("Futurelight", "DJScan250");

--- a/engine/test/efxfixture/efxfixture_test.h
+++ b/engine/test/efxfixture/efxfixture_test.h
@@ -51,6 +51,7 @@ private slots:
 
     void setPoint8bit();
     void setPoint16bit();
+    void startOffset();
     void nextStepLoop();
     void nextStepLoopZeroDuration();
     void nextStepSingleShot();

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -454,6 +454,7 @@ void EFXEditor::updateStartOffsetColumn(QTreeWidgetItem* item, EFXFixture* ef)
         spin->setAutoFillBackground(true);
         spin->setRange(0, 359);
         spin->setValue(ef->startOffset());
+        spin->setSuffix(QChar(0x00b0)); // degree
         m_tree->setItemWidget(item, KColumnStartOffset, spin);
         spin->setProperty(PROPERTY_FIXTURE, (qulonglong) ef);
         connect(spin, SIGNAL(valueChanged(int)),
@@ -538,7 +539,7 @@ void EFXEditor::slotFixtureStartOffsetChanged(int startOffset)
     Q_ASSERT(spin != NULL);
     EFXFixture* ef = (EFXFixture*) spin->property(PROPERTY_FIXTURE).toULongLong();
     Q_ASSERT(ef != NULL);
-    ef->setStartOffset(uchar(startOffset));
+    ef->setStartOffset(startOffset);
 
     // Restart the test after the latest intensity change, delayed
     m_testTimer.start();

--- a/ui/src/efxeditor.ui
+++ b/ui/src/efxeditor.ui
@@ -380,6 +380,9 @@
             <property name="toolTip">
              <string>Rotation of the pattern's starting point</string>
             </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
             <property name="maximum">
              <number>359</number>
             </property>
@@ -504,6 +507,9 @@
           </item>
           <item row="5" column="1">
            <widget class="QSpinBox" name="m_startOffsetSpin">
+            <property name="suffix">
+             <string>°</string>
+            </property>
             <property name="maximum">
              <number>359</number>
             </property>


### PR DESCRIPTION
- fix issue #144 - efx fixture offset is limited to 8 bits
- add degree symbol to offsets
- remove excessive typecasts
- add test for EFXFixture::startOffset
