### PR TITLE
Add relative mode to EFX - the movement is relative to head's current po...

### DIFF
--- a/engine/src/efx.cpp
+++ b/engine/src/efx.cpp
@@ -53,6 +53,7 @@ EFX::EFX(Doc* doc) : Function(doc, Function::EFX)
     m_yOffset = 127;
     m_rotation = 0;
     m_startOffset = 0;
+    m_isRelative = false;
 
     updateRotationCache();
 
@@ -135,6 +136,7 @@ bool EFX::copyFrom(const Function* function)
     m_yOffset = efx->m_yOffset;
     m_rotation = efx->m_rotation;
     m_startOffset = efx->m_startOffset;
+    m_isRelative = efx->m_isRelative;
 
     updateRotationCache();
 
@@ -391,6 +393,21 @@ int EFX::startOffset() const
 qreal EFX::convertOffset(int offset) const
 {
     return M_PI/180 * (offset % 360);
+}
+
+/*****************************************************************************
+ * Is Relative
+ *****************************************************************************/
+
+void EFX::setIsRelative(bool isRelative)
+{
+    m_isRelative = isRelative;
+    emit changed(this->id());
+}
+
+bool EFX::isRelative() const
+{
+    return m_isRelative;
 }
 
 /*****************************************************************************
@@ -700,6 +717,13 @@ bool EFX::saveXML(QDomDocument* doc, QDomElement* wksp_root)
     text = doc->createTextNode(str);
     tag.appendChild(text);
 
+    /* IsRelative */
+    tag = doc->createElement(KXMLQLCEFXIsRelative);
+    root.appendChild(tag);
+    str.setNum(isRelative() ? 1 : 0);
+    text = doc->createTextNode(str);
+    tag.appendChild(text);
+
     /********************************************
      * X-Axis
      ********************************************/
@@ -839,6 +863,11 @@ bool EFX::loadXML(const QDomElement& root)
         {
             /* StartOffset */
             setStartOffset(tag.text().toInt());
+        }
+        else if (tag.tagName() == KXMLQLCEFXIsRelative)
+        {
+            /* IsRelative */
+            setIsRelative(tag.text().toInt() != 0);
         }
         else if (tag.tagName() == KXMLQLCEFXAxis)
         {

--- a/engine/src/efx.h
+++ b/engine/src/efx.h
@@ -44,6 +44,7 @@ class Fixture;
 #define KXMLQLCEFXHeight "Height"
 #define KXMLQLCEFXRotation "Rotation"
 #define KXMLQLCEFXStartOffset "StartOffset"
+#define KXMLQLCEFXIsRelative "IsRelative"
 #define KXMLQLCEFXAxis "Axis"
 #define KXMLQLCEFXOffset "Offset"
 #define KXMLQLCEFXFrequency "Frequency"
@@ -311,6 +312,30 @@ private:
      * Pattern start offset, see setStartOffset()
      */
     int m_startOffset;
+
+    /*********************************************************************
+     * IsRelative
+     *********************************************************************/
+public:
+    /**
+     * Set whether the efx is relative
+     *
+     * @param isRelative if true, the position is relative to current position
+     */
+    void setIsRelative(bool isRelative);
+
+    /**
+     * Is pattern relative?
+     *
+     * @return true if pattern is relative
+     */
+    bool isRelative() const;
+
+private:
+    /**
+     * Whether the pattern is relative, see setIsRelative()
+     */
+    int m_isRelative;
 
     /*********************************************************************
      * Offset

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -344,24 +344,24 @@ void EFXFixture::setPoint(UniverseArray* universes, qreal pan, qreal tilt)
     /* Write coarse point data to universes */
     if (fxi->panMsbChannel() != QLCChannel::invalid())
         universes->write(fxi->universeAddress() + fxi->panMsbChannel(),
-                         static_cast<char>(pan), QLCChannel::Pan);
+                         static_cast<char>(pan), QLCChannel::Pan, m_parent->isRelative());
     if (fxi->tiltMsbChannel() != QLCChannel::invalid())
         universes->write(fxi->universeAddress() + fxi->tiltMsbChannel(),
-                         static_cast<char> (tilt), QLCChannel::Tilt);
+                         static_cast<char> (tilt), QLCChannel::Tilt, m_parent->isRelative());
 
     /* Write fine point data to universes if applicable */
     if (fxi->panLsbChannel() != QLCChannel::invalid())
     {
         /* Leave only the fraction */
         char value = static_cast<char> ((pan - floor(pan)) * double(UCHAR_MAX));
-        universes->write(fxi->universeAddress() + fxi->panLsbChannel(), value, QLCChannel::Pan);
+        universes->write(fxi->universeAddress() + fxi->panLsbChannel(), value, QLCChannel::Pan, m_parent->isRelative());
     }
 
     if (fxi->tiltLsbChannel() != QLCChannel::invalid())
     {
         /* Leave only the fraction */
         char value = static_cast<char> ((tilt - floor(tilt)) * double(UCHAR_MAX));
-        universes->write(fxi->universeAddress() + fxi->tiltLsbChannel(), value, QLCChannel::Tilt);
+        universes->write(fxi->universeAddress() + fxi->tiltLsbChannel(), value, QLCChannel::Tilt, m_parent->isRelative());
     }
 }
 

--- a/engine/src/mastertimer.cpp
+++ b/engine/src/mastertimer.cpp
@@ -95,6 +95,7 @@ void MasterTimer::timerTick()
 
     UniverseArray* universes = doc->outputMap()->claimUniverses();
     universes->zeroIntensityChannels();
+    universes->zeroRelativeValues();
 
     timerTickFunctions(universes);
     timerTickDMXSources(universes);

--- a/engine/src/universearray.h
+++ b/engine/src/universearray.h
@@ -171,6 +171,8 @@ public:
      */
     const QByteArray preGMValues() const;
 
+    void zeroRelativeValues();
+
 protected:
     /**
      * Apply Grand Master to the value.
@@ -191,6 +193,8 @@ protected:
     QSet <int> m_gMNonIntensityChannels;
     QByteArray* m_preGMValues;
     QByteArray* m_postGMValues;
+    QVector<short> m_relativeValues;
+    bool m_doRelative;
 
     /************************************************************************
      * Writing
@@ -206,7 +210,7 @@ public:
      * @return true if successful, otherwise false
      */
     bool write(int channel, uchar value,
-               QLCChannel::Group group = QLCChannel::NoGroup);
+               QLCChannel::Group group = QLCChannel::NoGroup, bool isRelative = false);
 };
 
 #endif

--- a/engine/test/efx/efx_test.cpp
+++ b/engine/test/efx/efx_test.cpp
@@ -2333,6 +2333,7 @@ void EFX_Test::save()
     e1.setHeight(42);
     e1.setRotation(78);
     e1.setStartOffset(91);
+    e1.setIsRelative(false);
     e1.setXOffset(34);
     e1.setYOffset(27);
     e1.setXFrequency(5);
@@ -2364,7 +2365,7 @@ void EFX_Test::save()
     QVERIFY(root.firstChild().toElement().attribute("Name") == "First");
 
     bool dir = false, off = false, run = false, algo = false, w = false,
-         h = false, rot = false, xoff = false, yoff = false,
+         h = false, rot = false, isRelative = false, xoff = false, yoff = false,
          xfreq = false, yfreq = false, xpha = false, ypha = false,
          prop = false, intensity = false, speed = false;
     int fixtureid = 0, fixturedirection = 0, fixtureStartOffset = 0;
@@ -2419,6 +2420,11 @@ void EFX_Test::save()
         {
             QVERIFY(tag.text() == "78");
             rot = true;
+        }
+        else if (tag.tagName() == "IsRelative")
+        {
+            QVERIFY(tag.text() == "0");
+            isRelative = true;
         }
         else if (tag.tagName() == "PropagationMode")
         {
@@ -2568,6 +2574,7 @@ void EFX_Test::save()
     QVERIFY(w == true);
     QVERIFY(h == true);
     QVERIFY(rot == true);
+    QVERIFY(isRelative == true);
     QVERIFY(xoff == true);
     QVERIFY(yoff == true);
     QVERIFY(xfreq == true);

--- a/engine/test/universearray/test.sh
+++ b/engine/test/universearray/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export LD_LIBRARY_PATH=../../src
 export DYLD_FALLBACK_LIBRARY_PATH=../../src
-./universearray_test
+./universearray_test -iterations 5000

--- a/engine/test/universearray/universearray_test.cpp
+++ b/engine/test/universearray/universearray_test.cpp
@@ -212,6 +212,70 @@ void UniverseArray_Test::write()
     QCOMPARE(ua.postGMValues()->at(0), char(127));
 }
 
+void UniverseArray_Test::writeRelative()
+{
+    UniverseArray ua(10);
+
+    // past the end of the array
+    QVERIFY(ua.write(10, 255, QLCChannel::Pan, true) == false);
+    QCOMPARE(ua. m_relativeValues[9], short(0));
+    QCOMPARE(ua.m_relativeValues[4], short(0));
+    QCOMPARE(ua.m_relativeValues[0], short(0));
+    QCOMPARE(ua.postGMValues()->at(9), char(0));
+    QCOMPARE(ua.postGMValues()->at(4), char(0));
+    QCOMPARE(ua.postGMValues()->at(0), char(0));
+
+    // 127 == 0
+    QVERIFY(ua.write(9, 127, QLCChannel::Pan, true) == true);
+    QCOMPARE(ua.m_relativeValues[9], short(0));
+    QCOMPARE(ua.m_relativeValues[4], short(0));
+    QCOMPARE(ua.m_relativeValues[0], short(0));
+    QCOMPARE(int(ua.postGMValues()->at(9)), 0);
+    QCOMPARE(int(ua.postGMValues()->at(4)), 0);
+    QCOMPARE(int(ua.postGMValues()->at(0)), 0);
+
+    // 255 == -128
+    QVERIFY(ua.write(9, 255, QLCChannel::Pan, true) == true);
+    QCOMPARE(ua.m_relativeValues[9], short(128));
+    QCOMPARE(ua.m_relativeValues[4], short(0));
+    QCOMPARE(ua.m_relativeValues[0], short(0));
+    QCOMPARE(ua.postGMValues()->at(9), char(128));
+    QCOMPARE(ua.postGMValues()->at(4), char(0));
+    QCOMPARE(ua.postGMValues()->at(0), char(0));
+
+    // 0 == -127
+    QVERIFY(ua.write(9, 0, QLCChannel::Pan, true) == true);
+    QCOMPARE(ua.m_relativeValues[9], short(1));
+    QCOMPARE(ua.m_relativeValues[4], short(0));
+    QCOMPARE(ua.m_relativeValues[0], short(0));
+    QCOMPARE(ua.postGMValues()->at(9), char(1));
+    QCOMPARE(ua.postGMValues()->at(4), char(0));
+    QCOMPARE(ua.postGMValues()->at(0), char(0));
+
+    ua.reset();
+
+    QVERIFY(ua.write(9, 85, QLCChannel::Pan, false) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(85));
+    QVERIFY(ua.write(9, 117, QLCChannel::Pan, true) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(75));
+    QVERIFY(ua.write(9, 75, QLCChannel::Pan, false) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(65));
+
+    ua.reset();
+
+    QVERIFY(ua.write(9, 255, QLCChannel::Pan, false) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(255));
+    QVERIFY(ua.write(9, 255, QLCChannel::Pan, true) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(255));
+
+    ua.reset();
+
+    QVERIFY(ua.write(9, 0, QLCChannel::Pan, false) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(0));
+    QVERIFY(ua.write(9, 0, QLCChannel::Pan, true) == true);
+    QCOMPARE(ua.postGMValues()->at(9), char(0));
+}
+
 void UniverseArray_Test::reset()
 {
     UniverseArray ua(128);

--- a/engine/test/universearray/universearray_test.h
+++ b/engine/test/universearray/universearray_test.h
@@ -36,6 +36,7 @@ private slots:
     void applyGM();
     void setGMValue();
     void write();
+    void writeRelative();
     void reset();
     void setGMValueEfficiency();
     void writeEfficiency();

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -206,6 +206,8 @@ void EFXEditor::initMovementPage()
             this, SLOT(slotRotationSpinChanged(int)));
     connect(m_startOffsetSpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotStartOffsetSpinChanged(int)));
+    connect(m_isRelativeCheckbox, SIGNAL(stateChanged(int)),
+            this, SLOT(slotIsRelativeCheckboxChanged(int)));
 
     connect(m_xFrequencySpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotXFrequencySpinChanged(int)));
@@ -237,6 +239,7 @@ void EFXEditor::initMovementPage()
     m_yOffsetSpin->setValue(m_efx->yOffset());
     m_rotationSpin->setValue(m_efx->rotation());
     m_startOffsetSpin->setValue(m_efx->startOffset());
+    m_isRelativeCheckbox->setChecked(m_efx->isRelative());
 
     m_xFrequencySpin->setValue(m_efx->xFrequency());
     m_yFrequencySpin->setValue(m_efx->yFrequency());
@@ -855,6 +858,12 @@ void EFXEditor::slotStartOffsetSpinChanged(int value)
     Q_ASSERT(m_efx != NULL);
     m_efx->setStartOffset(value);
     redrawPreview();
+}
+
+void EFXEditor::slotIsRelativeCheckboxChanged(int value)
+{
+    Q_ASSERT(m_efx != NULL);
+    m_efx->setIsRelative(value == Qt::Checked);
 }
 
 void EFXEditor::slotXOffsetSpinChanged(int value)

--- a/ui/src/efxeditor.h
+++ b/ui/src/efxeditor.h
@@ -127,6 +127,7 @@ private slots:
     void slotYOffsetSpinChanged(int value);
     void slotRotationSpinChanged(int value);
     void slotStartOffsetSpinChanged(int value);
+    void slotIsRelativeCheckboxChanged(int value);
 
     void slotXFrequencySpinChanged(int value);
     void slotYFrequencySpinChanged(int value);

--- a/ui/src/efxeditor.ui
+++ b/ui/src/efxeditor.ui
@@ -20,7 +20,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="General">
       <attribute name="title">
@@ -281,7 +281,23 @@
           <string>Parameters</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="6" column="0" colspan="2">
+          <item row="12" column="1">
+           <widget class="QSpinBox" name="m_yPhaseSpin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Lissajous pattern's Y phase</string>
+            </property>
+            <property name="maximum">
+             <number>360</number>
+            </property>
+            <property name="value">
+             <number>90</number>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" colspan="2">
            <widget class="Line" name="line_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -388,7 +404,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
+          <item row="9" column="0">
            <widget class="QLabel" name="m_xFrequencyLabel">
             <property name="enabled">
              <bool>false</bool>
@@ -398,7 +414,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
+          <item row="9" column="1">
            <widget class="QSpinBox" name="m_xFrequencySpin">
             <property name="enabled">
              <bool>false</bool>
@@ -414,7 +430,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="m_yFrequencyLabel">
             <property name="enabled">
              <bool>false</bool>
@@ -424,7 +440,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="1">
+          <item row="10" column="1">
            <widget class="QSpinBox" name="m_yFrequencySpin">
             <property name="enabled">
              <bool>false</bool>
@@ -440,7 +456,7 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="0">
+          <item row="11" column="0">
            <widget class="QLabel" name="m_xPhaseLabel">
             <property name="enabled">
              <bool>false</bool>
@@ -450,7 +466,20 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
+          <item row="13" column="0" colspan="2">
+           <spacer name="verticalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="11" column="1">
            <widget class="QSpinBox" name="m_xPhaseSpin">
             <property name="enabled">
              <bool>false</bool>
@@ -466,42 +495,13 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="0">
+          <item row="12" column="0">
            <widget class="QLabel" name="m_yPhaseLabel">
             <property name="enabled">
              <bool>false</bool>
             </property>
             <property name="text">
              <string>Y phase</string>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="0" colspan="2">
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="11" column="1">
-           <widget class="QSpinBox" name="m_yPhaseSpin">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="toolTip">
-             <string>Lissajous pattern's Y phase</string>
-            </property>
-            <property name="maximum">
-             <number>360</number>
-            </property>
-            <property name="value">
-             <number>90</number>
             </property>
            </widget>
           </item>
@@ -522,6 +522,13 @@
             </property>
             <property name="textFormat">
              <enum>Qt::AutoText</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="m_isRelativeCheckbox">
+            <property name="text">
+             <string>Relative</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
...sition

I have made this pre GM - I decided that GM should affect also relative EFX if needed/requested.
It also simplified the code a bit (compared to previous version)

This change allows few things:
- run more effects in parallel on the same movers (e.g. pan saw and tilt saw)
- prepare the efx's in advance without regard of the actual movers' position; then adjust
  the position using scene made at the venue (make some efx at home - with relative flag;
  at the venue, create scenes where all your head point down/up/left/right/center; now start
  e.g. center scene and an efx - the efx will point at the centre; start right scene -
  the efx will move to the right, etc.)
- control efx center in runtime by assigning xyarea/sliders to pan/tilt channels and adding relative efx

NOTE: prepare efx with center at 127;127 to be neutral
