### PR TITLE
Bugfix: crash upon adding pages to Button or Slider matrixes

### DIFF
--- a/ui/src/vcframe.cpp
+++ b/ui/src/vcframe.cpp
@@ -57,7 +57,7 @@ const QSize VCFrame::defaultSize(QSize(200, 200));
 const quint8 VCFrame::nextPageInputSourceId = 0;
 const quint8 VCFrame::previousPageInputSourceId = 1;
 
-VCFrame::VCFrame(QWidget* parent, Doc* doc, bool canCollapse) : VCWidget(parent, doc)
+VCFrame::VCFrame(QWidget* parent, Doc* doc, bool isMainConsole) : VCWidget(parent, doc)
     , m_hbox(NULL)
     , m_button(NULL)
     , m_label(NULL)
@@ -76,7 +76,7 @@ VCFrame::VCFrame(QWidget* parent, Doc* doc, bool canCollapse) : VCWidget(parent,
     setAllowChildren(true);
     setType(VCWidget::FrameWidget);
 
-    if (canCollapse == true)
+    if (isMainConsole == false)
     {
         QVBoxLayout *vbox = new QVBoxLayout(this);
         /* Main HBox */

--- a/ui/src/vcsoloframe.cpp
+++ b/ui/src/vcsoloframe.cpp
@@ -40,7 +40,7 @@
 #include "qlcfile.h"
 #include "doc.h"
 
-VCSoloFrame::VCSoloFrame(QWidget* parent, Doc* doc, bool canCollapse) : VCFrame(parent, doc, canCollapse)
+VCSoloFrame::VCSoloFrame(QWidget* parent, Doc* doc, bool isMainConsole) : VCFrame(parent, doc, isMainConsole)
 {
     /* Set the class name "VCSoloFrame" as the object name as well */
     setObjectName(VCSoloFrame::staticMetaObject.className());
@@ -48,7 +48,7 @@ VCSoloFrame::VCSoloFrame(QWidget* parent, Doc* doc, bool canCollapse) : VCFrame(
 
     m_frameStyle = KVCFrameStyleSunken;
 
-    if(canCollapse == true)
+    if(isMainConsole == false)
     {
         QString txtColor = "white";
         if (m_hasCustomForegroundColor)

--- a/ui/src/vcsoloframe.h
+++ b/ui/src/vcsoloframe.h
@@ -43,7 +43,7 @@ class VCSoloFrame : public VCFrame
      * Initialization
      *************************************************************************/
 public:
-    VCSoloFrame(QWidget* parent, Doc* doc, bool canCollapse = false);
+    VCSoloFrame(QWidget* parent, Doc* doc, bool isMainConsole = false );
     virtual ~VCSoloFrame();
 
     /*************************************************************************

--- a/ui/src/virtualconsole.cpp
+++ b/ui/src/virtualconsole.cpp
@@ -927,7 +927,7 @@ void VirtualConsole::slotAddFrame()
     if (parent == NULL)
         return;
 
-    VCFrame* frame = new VCFrame(parent, m_doc, true);
+    VCFrame* frame = new VCFrame(parent, m_doc);
     Q_ASSERT(frame != NULL);
     frame->setID(newWidgetId());
     checkWidgetPage(frame, parent);
@@ -944,7 +944,7 @@ void VirtualConsole::slotAddSoloFrame()
     if (parent == NULL)
         return;
 
-    VCSoloFrame* soloframe = new VCSoloFrame(parent, m_doc, true);
+    VCSoloFrame* soloframe = new VCSoloFrame(parent, m_doc);
     Q_ASSERT(soloframe != NULL);
     soloframe->setID(newWidgetId());
     checkWidgetPage(soloframe, parent);
@@ -1523,7 +1523,8 @@ void VirtualConsole::resetContents()
         delete m_contents;
 
     Q_ASSERT(m_scrollArea != NULL);
-    m_contents = new VCFrame(m_scrollArea, m_doc);
+    // This is the only one frame with true in the last argument
+    m_contents = new VCFrame(m_scrollArea, m_doc, true); 
     m_contents->setFrameStyle(0);
 
     // Get virtual console size from properties


### PR DESCRIPTION
- make also button/slider matrices collapsible
- the only non-collapsible frame is the main VC content

Fixes #184

Note that copying frames and loading from XML makes them collapsible. This was inconsistent, so it's easier/better
to make all frames the same.

TODO: adjust  (=move) content when header is shown/hidden
