### PR TITLE
Bugfix: crash in rgbmatrixeditor

### DIFF
--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -295,12 +295,10 @@ void RGBMatrixEditor::createPreviewItems()
 
     if (m_previewDirection == Function::Forward)
     {
-        m_previewStep = 0;
         m_matrix->setStepColor(m_matrix->startColor());
     }
     else
     {
-        m_previewStep = m_previewMaps.size() - 1;
         if (m_matrix->endColor().isValid())
             m_matrix->setStepColor(m_matrix->endColor());
         else
@@ -309,6 +307,15 @@ void RGBMatrixEditor::createPreviewItems()
 
     m_matrix->calculateColorDelta();
     m_previewMaps = m_matrix->previewMaps();
+
+    if ((m_previewDirection == Function::Forward) || m_previewMaps.isEmpty())
+    {
+        m_previewStep = 0;
+    }
+    else
+    {
+        m_previewStep = m_previewMaps.size() - 1;
+    }
 
     RGBMap map;
     if (m_previewStep < m_previewMaps.size())


### PR DESCRIPTION
- create group of fixtures, e.g 4 dimmers
- create rgb matrix e.g. full columns
- set backward direction
- save workspace
- load workspace
- edit the rgb matrix
- boom!

(on the first run through, m_previewStep is set to -1, because the m_previewMap is still empty)
