### PR TITLE
Use std::string rather than string in the OLA plugin.

### DIFF
--- a/plugins/ola/qlclogdestination.cpp
+++ b/plugins/ola/qlclogdestination.cpp
@@ -25,6 +25,8 @@
 
 namespace ola {
 
+using std::string;
+
 const string QLCLogDestination::PREFIX = "OLA: ";
 
 void QLCLogDestination::Write(log_level level, const string &log_line) {

--- a/plugins/ola/qlclogdestination.h
+++ b/plugins/ola/qlclogdestination.h
@@ -30,9 +30,9 @@ namespace ola {
 class QLCLogDestination : public LogDestination
 {
 public:
-    void Write(log_level level, const string &log_line);
+    void Write(log_level level, const std::string &log_line);
 private:
-    static const string PREFIX;
+    static const std::string PREFIX;
 };
 
 } // ola


### PR DESCRIPTION
The QLCLogDestination code was relying on the "using std::string" in the OLA
header files. That was removed since using statements in header files pollute
the namespace and so this code started failing.
