### PR TITLE
Implement initial support for Vince USB-DMX512 interface

### DIFF
--- a/plugins/dmxusb/src/dmxusb.cpp
+++ b/plugins/dmxusb/src/dmxusb.cpp
@@ -133,7 +133,8 @@ QString DMXUSB::pluginInfo()
     str += QString("<H3>%1</H3>").arg(name());
     str += tr("This plugin provides DMX output support for");
     str += QString(" DMXKing ultraDMX range, Enttec DMX USB Pro, "
-                   "Enttec Open DMX USB, FTDI USB COM485 Plus1 ");
+                   "Enttec Open DMX USB, FTDI USB COM485 Plus1, "
+                   "Vince USB-DMX512 ");
     str += tr("and compatible devices.");
     str += QString("</P>");
 

--- a/plugins/dmxusb/src/dmxusbconfig.cpp
+++ b/plugins/dmxusb/src/dmxusbconfig.cpp
@@ -131,6 +131,7 @@ QComboBox* DMXUSBConfig::createTypeCombo(DMXUSBWidget *widget)
     combo->addItem(QString("Pro Mk2"), DMXUSBWidget::ProMk2);
     combo->addItem(QString("Ultra Pro Tx"), DMXUSBWidget::UltraProTx);
     combo->addItem(QString("DMX4ALL"), DMXUSBWidget::DMX4ALL);
+    combo->addItem(QString("Vince TX"), DMXUSBWidget::VinceTX);
     int index = combo->findData(widget->type());
     combo->setCurrentIndex(index);
 

--- a/plugins/dmxusb/src/dmxusbwidget.h
+++ b/plugins/dmxusb/src/dmxusbwidget.h
@@ -46,7 +46,8 @@ public:
         ProRX,     //! Enttec Pro widget using the RX side of the dongle
         ProMk2,    //! Enttec Pro Mk2 widget using 2 TX outputs
         UltraProTx, //! DMXKing Ultra Pro widget using 2 TX ports
-        DMX4ALL
+        DMX4ALL,
+        VinceTX    //! Vince USB-DMX512 widget using the TX side of the dongle
     };
 
     /** Get the type of the widget */

--- a/plugins/dmxusb/src/qlcftdi-ftd2xx.cpp
+++ b/plugins/dmxusb/src/qlcftdi-ftd2xx.cpp
@@ -28,6 +28,7 @@
 #include "enttecdmxusbopen.h"
 #include "ultradmxusbprotx.h"
 #include "dmx4all.h"
+#include "vinceusbdmx512tx.h"
 #include "qlcftdi.h"
 
 /**
@@ -226,6 +227,9 @@ QList <DMXUSBWidget*> QLCFTDI::widgets()
                     widgetList << prorx;
                     break;
                 }
+                case DMXUSBWidget::VinceTX:
+                    widgetList << new VinceUSBDMX512TX(serial, name, vendor, NULL, i);
+                    break;
                 default:
                 case DMXUSBWidget::ProTX:
                     widgetList << new EnttecDMXUSBProTX(serial, name, vendor, i);
@@ -283,6 +287,10 @@ QList <DMXUSBWidget*> QLCFTDI::widgets()
             else if (vendor.toUpper().contains("DMX4ALL") == true)
             {
                 widgetList << new DMX4ALL(serial, name, vendor, NULL, i);
+            }
+            else if (name.toUpper().contains("USB-DMX512 CONVERTER") == true)
+            {
+                widgetList << new VinceUSBDMX512TX(serial, name, vendor, NULL, i);
             }
             else
             {

--- a/plugins/dmxusb/src/qlcftdi-libftdi.cpp
+++ b/plugins/dmxusb/src/qlcftdi-libftdi.cpp
@@ -29,6 +29,7 @@
 #include "enttecdmxusbopen.h"
 #include "ultradmxusbprotx.h"
 #include "dmx4all.h"
+#include "vinceusbdmx512tx.h"
 #include "qlcftdi.h"
 
 QLCFTDI::QLCFTDI(const QString& serial, const QString& name, const QString& vendor, quint32 id)
@@ -165,6 +166,9 @@ QList <DMXUSBWidget*> QLCFTDI::widgets()
                 widgetList << prorx;
                 break;
             }
+            case DMXUSBWidget::VinceTX:
+                widgetList << new VinceUSBDMX512TX(serial, name, vendor);
+                break;
             default:
             case DMXUSBWidget::ProTX:
                 widgetList << new EnttecDMXUSBProTX(serial, name, vendor);
@@ -218,6 +222,10 @@ QList <DMXUSBWidget*> QLCFTDI::widgets()
                 EnttecDMXUSBProRX* prorx = new EnttecDMXUSBProRX(serial, name, vendor, input_id++, protx->ftdi());
                 widgetList << prorx;
             }
+        }
+        else if (nme.toUpper().contains("USB-DMX512 CONVERTER") == true)
+        {
+            widgetList << new VinceUSBDMX512TX(serial, name, vendor);
         }
         else
         {

--- a/plugins/dmxusb/src/qlcftdi-qtserial.cpp
+++ b/plugins/dmxusb/src/qlcftdi-qtserial.cpp
@@ -216,6 +216,10 @@ QList <DMXUSBWidget*> QLCFTDI::widgets()
         {
             widgetList << new DMX4ALL(serial, name, vendor, NULL, id++);
         }
+        else if (name.toUpper().contains("USB-DMX512 CONVERTER") == true)
+        {
+            qDebug() << Q_FUNC_INFO << name << "not supported with QtSerialPort yet";
+        }
         else
         {
             /* This is probably an Open DMX USB widget */

--- a/plugins/dmxusb/src/src.pro
+++ b/plugins/dmxusb/src/src.pro
@@ -64,6 +64,8 @@ HEADERS += dmxusb.h \
            enttecdmxusbopen.h \
            ultradmxusbprotx.h \
            dmx4all.h \
+           vinceusbdmx512.h \
+           vinceusbdmx512tx.h \
            qlcftdi.h
 
 SOURCES += dmxusb.cpp \
@@ -74,7 +76,9 @@ SOURCES += dmxusb.cpp \
            enttecdmxusbprotx.cpp \
            enttecdmxusbopen.cpp \
            dmx4all.cpp \
-           ultradmxusbprotx.cpp
+           ultradmxusbprotx.cpp \
+           vinceusbdmx512.cpp \
+           vinceusbdmx512tx.cpp
 
 serialport {
     SOURCES += qlcftdi-qtserial.cpp

--- a/plugins/dmxusb/src/vinceusbdmx512.cpp
+++ b/plugins/dmxusb/src/vinceusbdmx512.cpp
@@ -1,0 +1,151 @@
+/*
+  Q Light Controller
+  vinceusbdmx512.cpp
+
+  Copyright (C) Heikki Junnila
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QDebug>
+#include "vinceusbdmx512.h"
+
+VinceUSBDMX512::VinceUSBDMX512(const QString &serial, const QString &name, const QString &vendor, QLCFTDI *ftdi, quint32 id)
+    : DMXUSBWidget(serial, name, vendor, ftdi, id)
+{
+    // TODO: Check if DMX IN is available
+}
+
+VinceUSBDMX512::~VinceUSBDMX512()
+{
+}
+
+/****************************************************************************
+ * Open & Close
+ ****************************************************************************/
+
+bool VinceUSBDMX512::open()
+{
+    if (DMXUSBWidget::open() == false)
+        return false;
+
+    if (ftdi()->clearRts() == false)
+        return false;
+
+    // Write two null bytes
+    if (ftdi()->write(QByteArray(2, 0x00)) == false)
+        return false;
+
+    // Request start DMX command
+    return this->writeData(VinceUSBDMX512::StartDMX);
+}
+
+bool VinceUSBDMX512::close()
+{
+    if (isOpen() == false)
+        return true;
+
+    // Reqest stop DMX command
+    if (this->writeData(VinceUSBDMX512::StopDMX) == true)
+        return DMXUSBWidget::close();
+
+    return false;
+}
+
+/****************************************************************************
+ * Name & Serial
+ ****************************************************************************/
+
+QString VinceUSBDMX512::uniqueName() const
+{
+    return QString("%1 (S/N: %2)").arg(name()).arg(serial());
+}
+
+/****************************************************************************
+ * Write & Read
+ ****************************************************************************/
+
+bool VinceUSBDMX512::writeData(Command command, const QByteArray &data)
+{
+    QByteArray message(1, command);                     // Command
+    message.prepend(QByteArray(2, VINCE_START_OF_MSG)); // Start condition
+    if (data.size() == 0)
+        message.append(QByteArray(2, 0x00));            // Data length
+    else
+    {
+        message.append(int((data.size() + 2) / 256));   // Data length
+        message.append(int((data.size() + 2) % 256));
+        message.append(QByteArray(2, 0x00));            // Gap with data
+        message.append(data);                           // Data
+    }
+    message.append(VINCE_END_OF_MSG);                   // Stop condition
+
+    return ftdi()->write(message);
+}
+
+QByteArray VinceUSBDMX512::readData(bool* ok)
+{
+    uchar byte = 0;
+    ushort dataLength = 0;
+    QByteArray data = QByteArray();
+
+    // Read headers
+    for (int i = 0; i < 6; i++)
+    {
+        *ok = false;
+        // Attempt to read byte
+        byte = ftdi()->readByte(ok);
+        if (*ok == false)
+            return data;
+
+        // Retrieve response (4th byte)
+        if (i == 3 && byte != VINCE_RESP_OK)
+        {
+            qWarning() << Q_FUNC_INFO << "Error" << byte << "in readed message";
+            *ok = false;
+        }
+        // Retrieve length (5th & 6th bytes)
+        else if (i == 4)
+            dataLength = ushort(byte) * 256;
+        else if (i == 5)
+            dataLength += ushort(byte);
+    }
+
+    // Read data
+    if (dataLength > 0)
+    {
+        qDebug() << Q_FUNC_INFO << "Attempt to read" << dataLength << "bytes";
+
+        ushort i;
+        for (i = 0; i < dataLength; i++)
+        {
+            byte = ftdi()->readByte(ok);
+            if (*ok == false)
+            {
+                qWarning() << Q_FUNC_INFO << "No available byte to read (" << (dataLength - i) << "missing bytes)";
+                return data;
+            }
+            data.append(byte);
+        }
+    }
+
+    // Read end of message
+    byte = ftdi()->readByte();
+    if (byte != VINCE_END_OF_MSG)
+    {
+        qWarning() << Q_FUNC_INFO << "Incorrect end of message received:" << byte;
+        *ok = false;
+    }
+
+    return data;
+}

--- a/plugins/dmxusb/src/vinceusbdmx512.h
+++ b/plugins/dmxusb/src/vinceusbdmx512.h
@@ -1,0 +1,104 @@
+/*
+  Q Light Controller
+  vinceusbdmx512.h
+
+  Copyright (C) Heikki Junnila
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef VINCEUSBDMX512_H
+#define VINCEUSBDMX512_H
+
+#include <QByteArray>
+#include <QObject>
+
+#include "dmxusbwidget.h"
+
+#define VINCE_CMD_START_DMX   char(0x01) //! CMD_START_DMX
+#define VINCE_CMD_STOP_DMX    char(0x02) //! CMD_STOP_DMX
+#define VINCE_CMD_RESET_DMX   char(0x10) //! CMD_RAZ_DMX
+#define VINCE_CMD_UPDATE_DMX  char(0x11) //! CMD_MAJ_DMX
+#define VINCE_START_OF_MSG    char(0x0f) //! STX
+#define VINCE_END_OF_MSG      char(0x04) //! ETX
+
+#define VINCE_RESP_OK         char(0x00) //! CMD_OK
+#define VINCE_RESP_KO         char(0x01) //! CMD_KO
+#define VINCE_RESP_WARNING    char(0x02) //! CMD_WARNING
+#define VINCE_RESP_UNKNOWN    char(0x02) //! CMD_UNKNOWN
+#define VINCE_RESP_IO_ERR     char(0x10) //! CMD_IO_ERR
+#define VINCE_RESP_PARAM_ERR  char(0x11) //! CMD_PARAM_ERR
+
+/**
+ * This is the base interface class for Vince USB-DMX512 widgets.
+ */
+class VinceUSBDMX512 : public DMXUSBWidget
+{
+    /************************************************************************
+     * Initialization
+     ************************************************************************/
+public:
+    VinceUSBDMX512(const QString& serial, const QString& name, const QString& vendor,
+                   QLCFTDI *ftdi = NULL, quint32 id = 0);
+    virtual ~VinceUSBDMX512();
+
+protected:
+    /** Requests commands */
+    enum Command
+    {
+        StartDMX  = VINCE_CMD_START_DMX,
+        StopDMX   = VINCE_CMD_STOP_DMX,
+        ResetDMX  = VINCE_CMD_RESET_DMX,
+        UpdateDMX = VINCE_CMD_UPDATE_DMX
+    };
+
+    /****************************************************************************
+     * Open & Close
+     ****************************************************************************/
+public:
+    /** @reimp */
+    virtual bool open();
+
+    /** @reimp */
+    virtual bool close();
+
+    /************************************************************************
+     * Name & Serial
+     ************************************************************************/
+public:
+    /** @reimp */
+    virtual QString uniqueName() const;
+
+    /************************************************************************
+     * Write & Read
+     ************************************************************************/
+protected:
+    /**
+     * Format and write data to the opened interface.
+     *
+     * @param command The request type
+     * @param data The data to write
+     * @return true if the values were sent successfully, otherwise false
+     */
+    bool writeData(enum Command command, const QByteArray& data = QByteArray());
+
+    /**
+     * Read and extract data from the opened interface.
+     *
+     * @param ok A pointer which tells if data was read or not
+     * @return The available data
+     */
+    QByteArray readData(bool* ok = NULL);
+};
+
+#endif

--- a/plugins/dmxusb/src/vinceusbdmx512tx.cpp
+++ b/plugins/dmxusb/src/vinceusbdmx512tx.cpp
@@ -1,0 +1,94 @@
+/*
+  Q Light Controller
+  vinceusbdmx512tx.cpp
+
+  Copyright (C) Heikki Junnila
+  Copyright (C) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QByteArray>
+#include <QDebug>
+
+#include "vinceusbdmx512tx.h"
+
+VinceUSBDMX512TX::VinceUSBDMX512TX(const QString& serial, const QString& name, const QString &vendor,
+                                   QLCFTDI *ftdi, quint32 id)
+    : VinceUSBDMX512(serial, name, vendor, ftdi, id)
+{
+}
+
+VinceUSBDMX512TX::~VinceUSBDMX512TX()
+{
+}
+
+DMXUSBWidget::Type VinceUSBDMX512TX::type() const
+{
+    return DMXUSBWidget::VinceTX;
+}
+
+/****************************************************************************
+ * Name & Serial
+ ****************************************************************************/
+
+QString VinceUSBDMX512TX::additionalInfo() const
+{
+    QString info;
+
+    info += QString("<P>");
+    info += QString("<B>%1:</B> %2 (%3)").arg(QObject::tr("Protocol"))
+                                         .arg("Vince USB-DMX512")
+                                         .arg(QObject::tr("Output"));
+    info += QString("<BR>");
+    info += QString("<B>%1:</B> %2").arg(QObject::tr("Serial number"))
+                                    .arg(serial());
+    info += QString("</P>");
+
+    return info;
+}
+
+/****************************************************************************
+ * Write universe
+ ****************************************************************************/
+
+bool VinceUSBDMX512TX::writeUniverse(const QByteArray& universe)
+{
+    if (isOpen() == false)
+        return false;
+
+    // Write only if universe has changed
+    if (universe == m_universe)
+        return true;
+
+    if (this->writeData(VinceUSBDMX512::UpdateDMX, universe) == false)
+    {
+        qWarning() << Q_FUNC_INFO << name() << "will not accept DMX data";
+        return false;
+    }
+    else
+    {
+        bool ok = false;
+        QByteArray resp = this->readData(&ok);
+
+        // Check the interface reponse
+        if (ok == false || resp.size() > 0)
+        {
+            qWarning() << Q_FUNC_INFO << name() << "doesn't respond properly";
+            return false;
+        }
+
+        m_universe = universe;
+        return true;
+    }
+}

--- a/plugins/dmxusb/src/vinceusbdmx512tx.h
+++ b/plugins/dmxusb/src/vinceusbdmx512tx.h
@@ -1,0 +1,57 @@
+/*
+  Q Light Controller
+  vinceusbdmx512tx.h
+
+  Copyright (C) Heikki Junnila
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef VINCEUSBDMX512TX_H
+#define VINCEUSBDMX512TX_H
+
+#include "vinceusbdmx512.h"
+
+class QByteArray;
+class VinceUSBDMX512TX : public VinceUSBDMX512
+{
+    /************************************************************************
+     * Initialization
+     ************************************************************************/
+public:
+    VinceUSBDMX512TX(const QString& serial, const QString& name, const QString& vendor,
+                     QLCFTDI *ftdi = NULL, quint32 id = 0);
+    ~VinceUSBDMX512TX();
+
+    /** @reimp */
+    Type type() const;
+
+    /****************************************************************************
+     * Name & Serial
+     ****************************************************************************/
+public:
+    /** @reimp */
+    QString additionalInfo() const;
+
+    /************************************************************************
+     * Write universe
+     ************************************************************************/
+public:
+    /** @reimp */
+    bool writeUniverse(const QByteArray& universe);
+
+private:
+    QByteArray m_universe;
+};
+
+#endif


### PR DESCRIPTION
Implement support for Tx side of Vince USB-DMX512 interface

The USB-DMX512 interface (http://www.dmx512-online.net/en-article58.html) provides one input and one output of 512 channels and it's based on a FTDI chipset. Thanks to the explanations of the constructor, Vince, I've been able to implement the support for the output at the moment.
