### PR TITLE
Add support for FX5 / Digital Enlightenment USB DMX interfaces

### DIFF
--- a/docs/createpdf.sh
+++ b/docs/createpdf.sh
@@ -59,6 +59,7 @@ wkhtmltopdf-i386 --footer-center "Page [page]" --image-quality 100 \
   peperonioutput.html \
   udmxoutput.html \
   vellemanoutput.html \
+  fx5output.html \
   fixturedefinitioneditor.html \
   capabilityeditor.html \
   capabilitywizard.html \

--- a/docs/docs.pro
+++ b/docs/docs.pro
@@ -30,6 +30,7 @@ docs.files = \
              fixturesremap.html \
              functionmanager.html \
              functionwizard.html \
+             fx5output.html \
              guicustomstyles.html \
              headeditor.html \
              howto-add-fixtures.html \

--- a/docs/fx5output.html
+++ b/docs/fx5output.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML>
+<HEAD>
+<TITLE>Q Light Controller Plus - FX5 Output Plugin</TITLE>
+<SCRIPT SRC="utility.js" TYPE="text/javascript"></SCRIPT>
+<link href="style.css" rel="stylesheet" type="text/css" />
+</HEAD>
+<BODY onLoad="replaceqrc()">
+
+<H1>FX5 output plugin</H1>
+
+<H1>1 Introduction</H1>
+<P>
+The FX5 Output plugin supports the <A HREF="http://www.digital-enlightenment.de/">Digital Enlightenment</A> and <A HREF="http://www.fx5.de/">FX5</A> USB-DMX interface on Linux.<BR/>
+The device also supports loopback and output, but that has not yet been implemented.
+</P>
+
+<H1>2 Requirements</H1>
+
+<H2>2.1 Linux</H2>
+<P>
+Everything is already included. You may need to reconnect your FX5 / Digital Enlightenment device or restart your computer for the udev rule to take effect.
+</P>
+
+<H2>2.2 Mac OS X</H2>
+<P>
+This device is not yet supported on Mac OS X.
+</P>
+
+<H2>2.3 Windows</H2>
+<P>
+This device is not yet supported on Windows.
+</P>
+
+</BODY>
+</HTML>

--- a/docs/index_pdf.html
+++ b/docs/index_pdf.html
@@ -104,7 +104,8 @@
      <LI><A HREF="file:oscplugin.html">OSC</A></LI>
      <LI><A HREF="file:peperonioutput.html">Peperoni</A></LI>
      <LI><A HREF="file:udmxoutput.html">uDMX</A></LI>
-     <LI><A HREF="file:vellemanoutput.html">Velleman</A></LI>    
+     <LI><A HREF="file:vellemanoutput.html">Velleman</A></LI>
+     <LI><A HREF="file:fx5output.html">FX5</A></LI>
     </UL>
   </LI>
 

--- a/plugins/fx5/fx5.pro
+++ b/plugins/fx5/fx5.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS += src

--- a/plugins/fx5/src/common/fx5.cpp
+++ b/plugins/fx5/src/common/fx5.cpp
@@ -1,0 +1,229 @@
+/*
+  Q Light Controller
+  fx5.cpp
+
+  Copyright (c) Florian Euchner
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QString>
+#include <QDebug>
+#include <QMessageBox>
+
+#include "fx5.h"
+
+/*****************************************************************************
+ * FX5 - QLCIOPlugin (QLC I/O Plugin Class)
+ *****************************************************************************/
+
+FX5::~FX5()
+{
+    CloseAllLinks();
+}
+
+void FX5::init()
+{
+    scanInterfaces();
+    RegisterInputChangeNotification(FX5::notifyInputWrapper, this);
+}
+
+QString FX5::name()
+{
+    return QString("FX5");
+}
+
+int FX5::capabilities() const
+{
+    return QLCIOPlugin::Output | QLCIOPlugin::Input;
+}
+
+/*****************************************************************************
+ * Outputs
+ *****************************************************************************/
+
+void FX5::openOutput(quint32 output)
+{
+    if (output < quint32(m_devices.size()))
+        m_devices.at(output)->openOutput();
+}
+
+void FX5::closeOutput(quint32 output)
+{
+    if (output < quint32(m_devices.size()))
+        m_devices.at(output)->closeOutput();
+}
+
+QStringList FX5::outputs()
+{
+    QStringList list;
+    int i = 1;
+
+    QListIterator <FX5Device*> it(m_devices);
+    while (it.hasNext() == true)
+        list << QString("%1: %2").arg(i++).arg(it.next()->getName());
+    return list;
+}
+
+QString FX5::pluginInfo()
+{
+    QString str;
+
+    str += QString("<HTML>");
+    str += QString("<HEAD>");
+    str += QString("<TITLE>%1</TITLE>").arg(name());
+    str += QString("</HEAD>");
+
+    str += QString("<BODY>");
+    str += QString("<P>");
+    str += QString("<H3>%1</H3>").arg(name());
+    str += tr("This plugin provides DMX output and input support for Digital Enlightenment / FX5 devices.");
+    str += QString("</P>");
+
+    return str;
+}
+
+QString FX5::outputInfo(quint32 output)
+{
+    QString str;
+
+    str += QString("<H4>" + tr("Outputs") + "</H4>");
+    if (output != QLCIOPlugin::invalidLine() && output < quint32(m_devices.size()))
+        str += m_devices.at(output)->getInfoText()  + tr(" as Output");
+
+    if (quint32(m_devices.size()) == 0)
+        str += tr("No output devices found.");
+
+    str += QString("</BODY>");
+    str += QString("</HTML>");
+
+    return str;
+}
+
+void FX5::writeUniverse(quint32 universe, quint32 output, const QByteArray &data)
+{
+    Q_UNUSED(universe)
+
+    if (output < quint32(m_devices.size()))
+        m_devices.at(output)->outputDMX(data);
+}
+
+void FX5::scanInterfaces()
+{
+    // Remove all interfaces and renew the list
+    m_devices.clear();
+
+    // Retrieve a list of connected interfaces
+    TSERIALLIST interfaces;
+    GetAllConnectedInterfaces(&interfaces);
+
+    for (quint32 port = 0; port < 32; ++port)
+    {
+        char str[17] = {};
+        str[16] = 0; // Null-Terminate string
+        memcpy(str, interfaces[port], 16);
+        QString serial(str);
+        quint32 version = GetDeviceVersion(interfaces[port]);
+
+        if (serial == "0000000000000000") break; // No more device found
+
+        m_devices.push_back(new FX5Device(str, version, port));
+    }
+
+    emit configurationChanged();
+}
+
+/*****************************************************************************
+ * Input
+ *****************************************************************************/
+void FX5::openInput(quint32 input)
+{
+    if (input < quint32(m_devices.size()))
+        m_devices.at(input)->openInput();
+}
+
+void FX5::closeInput(quint32 input)
+{
+    if (input < quint32(m_devices.size()))
+        m_devices.at(input)->closeInput();
+}
+
+QStringList FX5::inputs()
+{
+    // FX5 Outputs are Inputs at the same time
+    return outputs();
+}
+
+QString FX5::inputInfo(quint32 input)
+{
+    QString str;
+
+    str += QString("<H4>" + tr("Inputs") + "</H4>");
+    if (input != QLCIOPlugin::invalidLine() && input < quint32(m_devices.size()))
+        str += m_devices.at(input)->getInfoText() + tr(" as Input");
+
+    if (quint32(m_devices.size()) == 0)
+        str += tr("No input devices found.");
+
+    str += QString("</BODY>");
+    str += QString("</HTML>");
+
+    return str;
+}
+
+void FX5::notifyInput()
+{
+    /*
+        If this function is called, any of the FX5 interfaces has had an
+        input state change; so tell all of them to check for changes
+    */
+    QListIterator <FX5Device*> it(m_devices);
+    while (it.hasNext() == true)
+        it.next()->notifyInput(this);
+}
+
+void FX5::notifyInputWrapper(void *self)
+{
+    ((FX5*)self)->notifyInput();
+}
+
+void FX5::emitChangeValue(quint32 port, quint32 channel, uchar value)
+{
+    emit valueChanged(port, channel, value);
+}
+
+
+/*****************************************************************************
+ * Configuration
+ *****************************************************************************/
+
+void FX5::configure()
+{
+    int r = QMessageBox::question(NULL, name(),
+                tr("Do you wish to re-scan your hardware?"),
+                QMessageBox::Yes, QMessageBox::No);
+    if (r == QMessageBox::Yes)
+        scanInterfaces();
+}
+
+bool FX5::canConfigure()
+{
+    return true;
+}
+
+/*****************************************************************************
+ * Plugin export
+ ****************************************************************************/
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_EXPORT_PLUGIN2(fx5, FX5)
+#endif

--- a/plugins/fx5/src/common/fx5.h
+++ b/plugins/fx5/src/common/fx5.h
@@ -1,0 +1,124 @@
+/*
+  Q Light Controller
+  fx5.h
+
+  Copyright (c)	Florian Euchner
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef FX5_H
+#define FX5_H
+
+#include <QStringList>
+#include <QList>
+
+#include "qlcioplugin.h"
+#include "fx5device.h"
+
+class FX5 : public QLCIOPlugin
+{
+    Q_OBJECT
+    Q_INTERFACES(QLCIOPlugin)
+#if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID QLCIOPlugin_iid)
+#endif
+
+    /*********************************************************************
+     * Initialization
+     *********************************************************************/
+public:
+    /** @reimp */
+    virtual ~FX5();
+
+    /** @reimp */
+    void init();
+
+    /** @reimp */
+    QString name();
+
+    /** @reimp */
+    int capabilities() const;
+
+    /** @reimp */
+    QString pluginInfo();
+
+    /*********************************************************************
+     * Outputs
+     *********************************************************************/
+public:
+    /** @reimp */
+    void openOutput(quint32 output);
+
+    /** @reimp */
+    void closeOutput(quint32 output);
+
+    /** @reimp */
+    QStringList outputs();
+
+    /** @reimp */
+    QString outputInfo(quint32 output);
+
+    /** @reimp */
+    void writeUniverse(quint32 universe, quint32 output, const QByteArray& data);
+
+private:
+    /** Attempt to find all FX5 USB DMX Interfaces */
+    void scanInterfaces();
+
+private:
+    /** List of available devices */
+    QList <FX5Device*> m_devices;
+
+    /*************************************************************************
+     * Inputs
+     *************************************************************************/
+public:
+    /** @reimp */
+    void openInput(quint32 input);
+
+    /** @reimp */
+    void closeInput(quint32 input);
+
+    /** @reimp */
+    QStringList inputs();
+
+    /** @reimp */
+    QString inputInfo(quint32 input);
+
+    /** @reimp */
+    void emitChangeValue(quint32 port, quint32 channel, uchar value);
+
+    /** @reimp */
+    void sendFeedBack(quint32 input, quint32 channel, uchar value, const QString& key)
+        { Q_UNUSED(input); Q_UNUSED(channel); Q_UNUSED(value); Q_UNUSED(key); }
+
+private:
+    /* Input Callback for fx5driver, callid if any of the interfaces change */
+    void notifyInput();
+
+    /* Wrapper for notifyInput */
+    static void notifyInputWrapper(void *self);
+
+    /*********************************************************************
+     * Configuration
+     *********************************************************************/
+public:
+    /** @reimp */
+    void configure();
+
+    /** @reimp */
+    bool canConfigure();
+};
+
+#endif

--- a/plugins/fx5/src/common/fx5device.cpp
+++ b/plugins/fx5/src/common/fx5device.cpp
@@ -1,0 +1,145 @@
+/*
+  Q Light Controller
+  fx5device.cpp
+
+  Copyright (c) Florian Euchner
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QString>
+#include <QDebug>
+#include <QMessageBox>
+
+extern "C" {
+    #include "fx5driver.h"
+}
+
+#include "fx5.h"
+#include "fx5device.h"
+
+/*****************************************************************************
+ * FX5Device - Custom device class for each connected FX5 Interface
+ *****************************************************************************/
+
+FX5Device::FX5Device(char *serial, quint32 version, quint32 port) :
+m_version(version),
+m_port(port),
+m_mode(FX5_MODE_NONE),
+m_link_open(false)
+{
+    memcpy(m_serial, serial, 16);
+    memset(m_dmx_in , 0, sizeof(TDMXArray));
+    memset(m_dmx_out, 0, sizeof(TDMXArray));
+    memset(m_dmx_instate, 0, 512);
+
+    qDebug() << "FX5Device::FX5Device()";
+}
+
+QString FX5Device::getName()
+{
+    char str[17];
+
+    str[16] = 0; // Null-Terminate string
+    memcpy(str, m_serial, 16);
+
+    return QString(str);
+}
+
+QString FX5Device::getInfoText()
+{
+    QString infotext;
+
+    infotext = tr("FX5 USB-DMX Interface with serial number ") + getName()
+                    + tr(" and version ") + QString::number(m_version);
+
+    return infotext;
+}
+
+/*
+    Device Links & Mode Manager
+*/
+
+void FX5Device::updateMode()
+{
+    if (!m_link_open)
+    {
+        if(OpenLink(m_serial, &m_dmx_out, &m_dmx_in) != 1)
+        {
+            QMessageBox::warning(NULL, (tr("FX5 USB DMX Interface Error")),
+                (tr("Unable to open the FX5 Interface. Make sure the udev rule is installed.")),
+                 QMessageBox::AcceptRole, QMessageBox::AcceptRole);
+        }
+    }
+
+    int driver_mode = 0;
+    if (m_mode & FX5_MODE_OUTPUT)
+        driver_mode += 2;
+    if (m_mode & FX5_MODE_INPUT)
+        driver_mode += 4;
+
+    if (driver_mode == 0) // Neither input nor output are in use
+        CloseLink(m_serial);
+    else
+        SetInterfaceMode(m_serial, driver_mode);
+}
+
+/*****************************************************************************
+ * Output
+ *****************************************************************************/
+void FX5Device::openOutput()
+{
+    m_mode |= FX5_MODE_OUTPUT;
+    updateMode();    
+}
+
+void FX5Device::closeOutput()
+{
+    m_mode &= ~FX5_MODE_OUTPUT;
+    updateMode();    
+}
+
+void FX5Device::outputDMX(const QByteArray &universe)
+{
+    for (uint16_t i = 0; i<universe.size(); i++)
+        m_dmx_out[i] = universe[i];
+}
+
+/*****************************************************************************
+ * Input
+ *****************************************************************************/
+
+void FX5Device::openInput()
+{
+    m_mode |= FX5_MODE_INPUT;
+    updateMode();    
+}
+
+void FX5Device::closeInput()
+{
+    m_mode &= ~FX5_MODE_INPUT;
+    updateMode();    
+}
+
+void FX5Device::notifyInput(FX5 *sender)
+{
+    for (uint16_t chan = 0; chan<sizeof(m_dmx_instate); chan++)
+    {
+        if (m_dmx_instate[chan] != m_dmx_in[chan])
+        {
+            m_dmx_instate[chan] = m_dmx_in[chan];
+            sender->emitChangeValue(m_port, chan, m_dmx_in[chan]);
+        }
+    }
+}
+

--- a/plugins/fx5/src/common/fx5device.h
+++ b/plugins/fx5/src/common/fx5device.h
@@ -1,0 +1,85 @@
+/*
+  Q Light Controller
+  fx5device.h
+
+  Copyright (c)	Florian Euchner
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef FX5DEVICE_H
+#define FX5DEVICE_H
+
+#include <QString>
+#include <QDebug>
+
+extern "C" {
+    #include "fx5driver.h"
+}
+
+class FX5;
+
+class FX5Device : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    /*
+        Initialization
+    */
+
+    FX5Device(char *serial, quint32 version, quint32 port);
+    ~FX5Device();
+
+    /*
+        User Information
+    */
+    QString getName();
+    QString getInfoText();
+
+    /* The FX5Device class will automatically select the right mode for the interface
+       based on calls to openOutput / openInput / closeOutput / closeInput            */
+    void openOutput();
+    void openInput();
+
+    void closeOutput();
+    void closeInput();
+
+    void outputDMX(const QByteArray &universe);
+
+    void notifyInput(FX5 *sender);
+
+private:
+    void updateMode();
+
+    char m_serial[17]; // SN of the device
+    quint32 m_version; // Version of the device
+    quint32 m_port;    // Port number (from 0 - 32)
+
+    TDMXArray m_dmx_in;  // Input  Environment
+    TDMXArray m_dmx_out; // Output Environment
+    uint8_t m_dmx_instate[512]; // saves last known input environment
+
+    enum FX5mode
+    {
+        FX5_MODE_NONE   = 1 << 0,
+        FX5_MODE_OUTPUT = 1 << 1,
+        FX5_MODE_INPUT  = 1 << 2
+    };
+
+    int m_mode;
+    bool m_link_open; // saves if the interface Link has been established
+};
+
+#endif

--- a/plugins/fx5/src/common/fx5driver.c
+++ b/plugins/fx5/src/common/fx5driver.c
@@ -1,0 +1,458 @@
+/*
+Copyright (c) 2011, Frank Sievertsen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of FX5 nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fx5driver.h"
+#include "hidapi.h"
+#include <stdio.h>
+#include <sys/types.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <signal.h>
+
+#define MAX_OPENED 32
+
+#define THREAD_STATUS_RUN 0
+#define THREAD_STATUS_STOP 1
+#define THREAD_STATUS_STOPPED 2
+#define THREAD_STATUS_PAUSE 3
+#define THREAD_STATUS_PAUSED 4
+
+typedef struct  {
+    TSERIAL serial;
+    hid_device * handle;
+    pthread_t thread;
+    TDMXArray * dmx_in;
+    TDMXArray * dmx_out;
+    TDMXArray dmx_cmp;
+    volatile sig_atomic_t status;
+    volatile sig_atomic_t mode;
+    volatile unsigned char old_mode;
+} device_t;
+
+
+#define DMX_INTERFACE_VENDOR_ID 0x4B4
+#define DMX_INTERFACE_PRODUCT_ID 0xF1F
+#define DMX_INTERFACE_VENDOR_ID_2 0x16C0
+#define DMX_INTERFACE_PRODUCT_ID_2 0x88B
+
+
+void wserial_to_serial(const wchar_t * s1, char * s2) {
+    int i;
+    for(i=0;i<16;i++) {
+        s2[i] = s1[i];
+    }
+}
+void wserial_from_serial(wchar_t * s1, const char * s2) {
+    int i;
+    for(i=0;i<16;i++) {
+        s1[i] = s2[i];
+    }
+    s1[i] = 0;
+}
+
+void set_mode(hid_device * handle, unsigned char mode) {
+    unsigned char buffer[34];
+
+    memset(buffer, 0, 34);
+    buffer[1]=16;
+    buffer[2]=mode;
+    hid_write(handle, buffer, 34);
+}
+
+THOSTDEVICECHANGEPROC * callback_func;
+THOSTINPUTCHANGEPROCBLOCK * callback_func_block;
+void *additional_param;
+
+char NO_DEV[] = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+device_t open_devices[MAX_OPENED];
+
+int find_dev(TSERIAL serial) {
+    int i;
+    for(i=0; i<MAX_OPENED; i++) {
+        if(memcmp(serial, open_devices[i].serial, 16) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+void set_dev(int pos, char * serial) {
+    memcpy(open_devices[pos].serial, serial, 16);
+}
+
+USB_DMX_DLL void GetAllConnectedInterfaces(TSERIALLIST* SerialList) {
+    struct hid_device_info *devs, *cur_dev;
+    int pos = 0;
+
+    memset(SerialList, '0', sizeof(TSERIALLIST));
+    devs = hid_enumerate(0x0, 0x0);
+    cur_dev = devs;
+
+    while (cur_dev) {
+        if(
+            ((cur_dev->vendor_id == DMX_INTERFACE_VENDOR_ID)&&(cur_dev->product_id == DMX_INTERFACE_PRODUCT_ID)) ||
+            ((cur_dev->vendor_id == DMX_INTERFACE_VENDOR_ID_2)&&(cur_dev->product_id == DMX_INTERFACE_PRODUCT_ID_2))
+        ) {
+            wserial_to_serial(cur_dev->serial_number, SerialList[0][pos]);
+            pos ++;
+        }
+        cur_dev = cur_dev->next;
+    }
+    hid_free_enumeration(devs);
+}
+
+USB_DMX_DLL DWORD GetDeviceVersion(TSERIAL Serial) {
+    struct hid_device_info *devs, *cur_dev;
+    DWORD res = 0x100;
+
+    char serial_test[17];
+
+    devs = hid_enumerate(0x0, 0x0);
+
+    cur_dev = devs;
+
+    while (cur_dev) {
+        if(
+            ((cur_dev->vendor_id == DMX_INTERFACE_VENDOR_ID)&&(cur_dev->product_id == DMX_INTERFACE_PRODUCT_ID)) ||
+            ((cur_dev->vendor_id == DMX_INTERFACE_VENDOR_ID_2)&&(cur_dev->product_id == DMX_INTERFACE_PRODUCT_ID_2))
+        ) {
+            wserial_to_serial(cur_dev->serial_number, serial_test);
+            if(memcmp(Serial,serial_test,16)==0) {
+                res = cur_dev->release_number;
+            }
+        }
+        cur_dev = cur_dev->next;
+    }
+
+    hid_free_enumeration(devs);
+
+    return res;
+}
+
+USB_DMX_DLL void GetAllOpenedInterfaces(TSERIALLIST* SerialList) {
+    int pos;
+    int i;
+    pos = 0;
+    memset(SerialList, '0', sizeof(TSERIALLIST));
+    for(i=0; i<MAX_OPENED; i++) {
+        if(memcmp(open_devices[i].serial,NO_DEV,16)!=0) {
+            memcpy(SerialList[0][pos], open_devices[i].serial, 16);
+            pos ++;
+        }
+    }
+    wserial_to_serial(L"0000000000000000", SerialList[0][pos]);
+}
+
+USB_DMX_DLL DWORD SetInterfaceMode (TSERIAL Serial, unsigned char Mode) {
+    int pos;
+
+    pos = find_dev(Serial);
+    if (pos == -1) {
+        return 0;
+    }
+    open_devices[pos].mode = Mode;
+    while(open_devices[pos].mode != open_devices[pos].old_mode) {
+        usleep(10000);
+    }
+    return 1;
+}
+
+
+void *read_write_thread(void *pointer)
+{
+    device_t * device = (device_t *) pointer;
+    unsigned char buffer[35];
+    int size;
+    int i;
+    int res;
+    int changed;
+    int first_time = 1;
+    THOSTDEVICECHANGEPROC * tmp;
+    THOSTINPUTCHANGEPROCBLOCK * tmp2;
+
+    while(device->status != THREAD_STATUS_STOP) {
+        if (device->status == THREAD_STATUS_PAUSE) {
+            device->status = THREAD_STATUS_PAUSED;
+            while(device->status == THREAD_STATUS_PAUSED) {
+                usleep(10000);
+            }
+        }
+        if(device->old_mode != device->mode) {
+            device->old_mode = device->mode;
+            set_mode(device->handle, device->old_mode);
+        }
+        if(device->dmx_out) {
+            for(i=0; i<16; i++) {
+                if(first_time || (memcmp(device->dmx_cmp + (i * 32), (* device->dmx_out) + (i * 32), 32) != 0)) {
+                    memcpy(device->dmx_cmp + (i * 32), (* device->dmx_out) + (i * 32), 32);
+                    memcpy(buffer + 2, device->dmx_cmp + (i * 32), 32);
+                    buffer[0] = 0;
+                    buffer[1] = i;
+                    res = hid_write(device->handle, buffer, 34);
+                }
+            }
+        }
+        if(device->dmx_in) {
+            changed = 0;
+            while(1) {
+                size = hid_read(device->handle, buffer, 33);
+                if(size == 0) {
+                    break;
+                }
+                if(size < 0) {
+                    break;
+                }
+                if(size == 33) {
+                    memcpy(device->dmx_in[0]+buffer[0]*32, buffer+1, 32);
+                    changed = 1;
+                    tmp2 = callback_func_block;
+                    if(tmp2) {
+                        (*tmp2)(buffer[0]);
+                    }
+                }
+            }
+            tmp = callback_func;
+            if(changed && tmp) {
+                (*tmp)(additional_param);
+            }
+        }
+        first_time = 0;
+        usleep(10000);
+    }
+    device->status = THREAD_STATUS_STOPPED;
+
+    return NULL;
+}
+
+USB_DMX_DLL DWORD OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DMXInArray) {
+    hid_device *handle;
+    int pos;
+
+    wchar_t wserial[17];
+    wserial_from_serial(wserial, Serial);
+
+    pos = find_dev(Serial);
+    if(pos != -1) {
+        return 1;
+    }
+
+    pos = find_dev(NO_DEV);
+    if(pos == -1) {
+        return 0;
+    }
+    handle = hid_open(DMX_INTERFACE_VENDOR_ID, DMX_INTERFACE_PRODUCT_ID, wserial);
+    if(!handle) {
+        handle = hid_open(DMX_INTERFACE_VENDOR_ID_2, DMX_INTERFACE_PRODUCT_ID_2, wserial);
+    }
+    if (!handle) {
+        return 0;
+    }
+    hid_set_nonblocking(handle, 1);
+
+    memset(&open_devices[pos], 0, sizeof(device_t));
+    set_dev(pos, Serial);
+    open_devices[pos].handle = handle;
+    open_devices[pos].dmx_out = DMXOutArray;
+    open_devices[pos].dmx_in = DMXInArray;
+
+    set_mode(handle, 0);
+
+    pthread_create(&open_devices[pos].thread, NULL, read_write_thread, &open_devices[pos]);
+    return 1;
+}
+
+USB_DMX_DLL DWORD CloseLink (TSERIAL Serial) {
+    int pos;
+
+    pos = find_dev(Serial);
+    if(pos == -1) {
+        return 0;
+    }
+    open_devices[pos].status = THREAD_STATUS_STOP;
+    while(open_devices[pos].status != THREAD_STATUS_STOPPED) {
+        usleep(10000);
+    }
+    hid_close(open_devices[pos].handle);
+    set_dev(pos, NO_DEV);
+    return 1;
+}
+
+USB_DMX_DLL DWORD CloseAllLinks (void) {
+    int i;
+    int result = 1;
+    for(i=0; i<MAX_OPENED; i++) {
+        if(memcmp(open_devices[i].serial, NO_DEV, 16) != 0) {
+            if(0 == CloseLink(open_devices[i].serial)) {
+                result = 0;
+            }
+        }
+    }
+    return result;
+}
+
+USB_DMX_DLL DWORD RegisterInterfaceChangeNotification (THOSTDEVICECHANGEPROC Proc) {
+    // FIXME
+    return 1;
+}
+
+USB_DMX_DLL DWORD UnregisterInterfaceChangeNotification (void) {
+    // FIXME too
+    return 1;
+}
+
+USB_DMX_DLL DWORD RegisterInputChangeNotification (THOSTDEVICECHANGEPROC Proc, void *additional) {
+    callback_func = Proc;
+    additional_param = additional;
+    return 1;
+}
+
+USB_DMX_DLL DWORD UnregisterInputChangeNotification (void) {
+    callback_func = NULL;
+    return 1;
+}
+
+USB_DMX_DLL DWORD SetInterfaceAdvTxConfig(
+    TSERIAL Serial, unsigned char Control, uint16_t Breaktime, uint16_t Marktime,
+    uint16_t Interbytetime, uint16_t Interframetime, uint16_t Channelcount, uint16_t Startbyte
+) {
+    int pos;
+    unsigned char buffer[35];
+
+    pos = find_dev(Serial);
+    if (pos == -1) {
+        return 0;
+    }
+
+    if (Channelcount > 512) Channelcount = 512;
+
+    open_devices[pos].status = THREAD_STATUS_PAUSE;
+
+    while (open_devices[pos].status != THREAD_STATUS_PAUSED) {
+        usleep(10000);
+    }
+
+    memset(buffer, 0, 34);
+    buffer[0] = 0;
+    buffer[1] = 17;
+    buffer[2] = Control;
+    buffer[3] = Breaktime & 255;
+    buffer[4] = (Breaktime >> 8) & 255;
+    buffer[5] = Marktime & 255;
+    buffer[6] = (Marktime >> 8) & 255;
+    buffer[7] = Interbytetime & 255;
+    buffer[8] = (Interbytetime >> 8) & 255;
+    buffer[9] = Interframetime & 255;
+    buffer[10] = (Interframetime >> 8) & 255;
+    buffer[11] = Channelcount & 255;
+    buffer[12] = (Channelcount >> 8) & 255;
+    buffer[13] = Startbyte;
+
+    hid_write(open_devices[pos].handle, buffer, 34);
+
+    open_devices[pos].status = THREAD_STATUS_RUN;
+
+    return 1;
+}
+USB_DMX_DLL DWORD StoreInterfaceAdvTxConfig(TSERIAL Serial) {
+    int pos;
+    unsigned char buffer[35];
+
+    pos = find_dev(Serial);
+    if (pos == -1) {
+        return 0;
+    }
+
+    open_devices[pos].status = THREAD_STATUS_PAUSE;
+
+    while (open_devices[pos].status != THREAD_STATUS_PAUSED) {
+        usleep(10000);
+    }
+
+    memset(buffer, 0, 34);
+    buffer[0] = 0;
+    buffer[1] = 18;
+    buffer[2] = 1;
+
+    hid_write(open_devices[pos].handle, buffer, 34);
+
+    open_devices[pos].status = THREAD_STATUS_RUN;
+
+    return 1;
+}
+USB_DMX_DLL DWORD RegisterInputChangeBlockNotification(THOSTINPUTCHANGEPROCBLOCK Proc) {
+    callback_func_block = Proc;
+    return 1;
+}
+USB_DMX_DLL DWORD UnregisterInputChangeBlockNotification(void) {
+    callback_func_block = NULL;
+    return 1;
+}
+
+/// And the Functions from usbdmxsi.USB_DMX_DLL also
+
+USB_DMX_DLL DWORD OpenInterface(TDMXArray *DMXOutArray, TDMXArray *DMXInArray, unsigned char Mode) {
+    TSERIALLIST InterfaceList;
+
+    GetAllOpenedInterfaces(&InterfaceList);
+
+    if(memcmp(InterfaceList[0],"0000000000000000",16) != 0) {
+        return 1;
+    }
+
+    GetAllConnectedInterfaces(&InterfaceList);
+
+    if(memcmp(InterfaceList[0],"0000000000000000",16) == 0) {
+        return 0;
+    }
+    if(0 == OpenLink(InterfaceList[0], DMXOutArray, DMXInArray)) {
+        return 0;
+    }
+
+    if(0 == SetInterfaceMode(InterfaceList[0], Mode)) {
+        return 0;
+    }
+    return 1;
+}
+
+USB_DMX_DLL DWORD CloseInterface(void) {
+    TSERIALLIST InterfaceList;
+
+    GetAllOpenedInterfaces(&InterfaceList);
+
+    if(memcmp(InterfaceList[0],"0000000000000000",16) == 0) {
+        return 0;
+    }
+
+    if(0 == CloseLink(InterfaceList[0])) {
+        return 0;
+    }
+
+    return 1;
+}

--- a/plugins/fx5/src/common/fx5driver.h
+++ b/plugins/fx5/src/common/fx5driver.h
@@ -1,0 +1,75 @@
+#ifdef __cplusplus
+extern "C" { 
+#endif
+
+#include <stdint.h>
+
+#define DWORD uint32_t
+#ifdef WIN32
+    #define USB_DMX_DLL __declspec(dllexport) __stdcall
+    #define USB_DMX_CALLBACK __stdcall
+#else
+    #define USB_DMX_DLL
+    #define USB_DMX_CALLBACK
+#endif
+
+
+// types for library functions
+typedef unsigned char TDMXArray[512];
+typedef char TSERIAL[16];
+typedef TSERIAL TSERIALLIST[32];
+typedef void USB_DMX_CALLBACK (THOSTDEVICECHANGEPROC) (void *);
+typedef void USB_DMX_CALLBACK (THOSTINPUTCHANGEPROCBLOCK) (unsigned char blocknumber);
+
+
+// define library functions
+USB_DMX_DLL void GetAllConnectedInterfaces(TSERIALLIST* SerialList);
+USB_DMX_DLL void GetAllOpenedInterfaces(TSERIALLIST* SerialList);
+USB_DMX_DLL DWORD OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DMXInArray);
+USB_DMX_DLL DWORD CloseLink (TSERIAL Serial);
+USB_DMX_DLL DWORD CloseAllLinks (void);
+USB_DMX_DLL DWORD RegisterInterfaceChangeNotification (THOSTDEVICECHANGEPROC Proc);
+USB_DMX_DLL DWORD UnregisterInterfaceChangeNotification (void);
+USB_DMX_DLL DWORD RegisterInputChangeNotification (THOSTDEVICECHANGEPROC Proc, void *additional);
+USB_DMX_DLL DWORD UnregisterInputChangeNotification (void);
+
+USB_DMX_DLL DWORD SetInterfaceMode (TSERIAL Serial, unsigned char Mode);
+  // Modes:
+  // 0: Do nothing - Standby
+  // 1: DMX In -> DMX Out
+  // 2: PC Out -> DMX Out
+  // 3: DMX In + PC Out -> DMX Out
+  // 4: DMX In -> PC In
+  // 5: DMX In -> DMX Out & DMX In -> PC In
+  // 6: PC Out -> DMX Out & DMX In -> PC In
+  // 7: DMX In + PC Out -> DMX Out & DMX In -> PC In
+
+USB_DMX_DLL DWORD GetDeviceVersion(TSERIAL Serial);
+USB_DMX_DLL DWORD SetInterfaceAdvTxConfig(
+    TSERIAL Serial, unsigned char Control, uint16_t Breaktime, uint16_t Marktime,
+    uint16_t Interbytetime, uint16_t Interframetime, uint16_t Channelcount, uint16_t Startbyte
+);
+USB_DMX_DLL DWORD StoreInterfaceAdvTxConfig(TSERIAL Serial);
+USB_DMX_DLL DWORD RegisterInputChangeBlockNotification(THOSTINPUTCHANGEPROCBLOCK Proc);
+USB_DMX_DLL DWORD UnregisterInputChangeBlockNotification(void);
+
+/// And the Functions from usbdmxsi.USB_DMX_DLL also
+
+USB_DMX_DLL DWORD OpenInterface(TDMXArray * DMXOutArray, TDMXArray * DMXInArray, unsigned char Mode);
+  // Modes:
+  // 0: Do nothing - Standby
+  // 1: DMX In -> DMX Out
+  // 2: PC Out -> DMX Out
+  // 3: DMX In + PC Out -> DMX Out
+  // 4: DMX In -> PC In
+  // 5: DMX In -> DMX Out & DMX In -> PC In
+  // 6: PC Out -> DMX Out & DMX In -> PC In
+  // 7: DMX In + PC Out -> DMX Out & DMX In -> PC In
+
+USB_DMX_DLL DWORD CloseInterface(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/plugins/fx5/src/common/hidapi.h
+++ b/plugins/fx5/src/common/hidapi.h
@@ -1,0 +1,385 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 8/22/2009
+
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
+
+/** @file
+ * @defgroup API hidapi API
+ */
+
+#ifndef HIDAPI_H__
+#define HIDAPI_H__
+
+#include <wchar.h>
+
+#ifdef _WIN32
+      #define HID_API_EXPORT __declspec(dllexport)
+      #define HID_API_CALL
+#else
+      #define HID_API_EXPORT /**< API export macro */
+      #define HID_API_CALL /**< API call macro */
+#endif
+
+#define HID_API_EXPORT_CALL HID_API_EXPORT HID_API_CALL /**< API export and call macro*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+		struct hid_device_;
+		typedef struct hid_device_ hid_device; /**< opaque hidapi structure */
+
+		/** hidapi info structure */
+		struct hid_device_info {
+			/** Platform-specific device path */
+			char *path;
+			/** Device Vendor ID */
+			unsigned short vendor_id;
+			/** Device Product ID */
+			unsigned short product_id;
+			/** Serial Number */
+			wchar_t *serial_number;
+			/** Device Release Number in binary-coded decimal,
+			    also known as Device Version Number */
+			unsigned short release_number;
+			/** Manufacturer String */
+			wchar_t *manufacturer_string;
+			/** Product string */
+			wchar_t *product_string;
+			/** Usage Page for this Device/Interface
+			    (Windows/Mac only). */
+			unsigned short usage_page;
+			/** Usage for this Device/Interface
+			    (Windows/Mac only).*/
+			unsigned short usage;
+			/** The USB interface which this logical device
+			    represents. Valid on both Linux implementations
+			    in all cases, and valid on the Windows implementation
+			    only if the device contains more than one interface. */
+			int interface_number;
+
+			/** Pointer to the next device */
+			struct hid_device_info *next;
+		};
+
+
+		/** @brief Initialize the HIDAPI library.
+
+			This function initializes the HIDAPI library. Calling it is not
+			strictly necessary, as it will be called automatically by
+			hid_enumerate() and any of the hid_open_*() functions if it is
+			needed.  This function should be called at the beginning of
+			execution however, if there is a chance of HIDAPI handles
+			being opened by different threads simultaneously.
+			
+			@ingroup API
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_init(void);
+
+		/** @brief Finalize the HIDAPI library.
+
+			This function frees all of the static data associated with
+			HIDAPI. It should be called at the end of execution to avoid
+			memory leaks.
+
+			@ingroup API
+
+		    @returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_exit(void);
+
+		/** @brief Enumerate the HID Devices.
+
+			This function returns a linked list of all the HID devices
+			attached to the system which match vendor_id and product_id.
+			If @p vendor_id is set to 0 then any vendor matches.
+			If @p product_id is set to 0 then any product matches.
+			If @p vendor_id and @p product_id are both set to 0, then
+			all HID devices will be returned.
+
+			@ingroup API
+			@param vendor_id The Vendor ID (VID) of the types of device
+				to open.
+			@param product_id The Product ID (PID) of the types of
+				device to open.
+
+		    @returns
+		    	This function returns a pointer to a linked list of type
+		    	struct #hid_device, containing information about the HID devices
+		    	attached to the system, or NULL in the case of failure. Free
+		    	this linked list by calling hid_free_enumeration().
+		*/
+		struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id);
+
+		/** @brief Free an enumeration Linked List
+
+		    This function frees a linked list created by hid_enumerate().
+
+			@ingroup API
+		    @param devs Pointer to a list of struct_device returned from
+		    	      hid_enumerate().
+		*/
+		void  HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *devs);
+
+		/** @brief Open a HID device using a Vendor ID (VID), Product ID
+			(PID) and optionally a serial number.
+
+			If @p serial_number is NULL, the first device with the
+			specified VID and PID is opened.
+
+			@ingroup API
+			@param vendor_id The Vendor ID (VID) of the device to open.
+			@param product_id The Product ID (PID) of the device to open.
+			@param serial_number The Serial Number of the device to open
+				               (Optionally NULL).
+
+			@returns
+				This function returns a pointer to a #hid_device object on
+				success or NULL on failure.
+		*/
+		HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number);
+
+		/** @brief Open a HID device by its path name.
+
+			The path name be determined by calling hid_enumerate(), or a
+			platform-specific path name can be used (eg: /dev/hidraw0 on
+			Linux).
+
+			@ingroup API
+		    @param path The path name of the device to open
+
+			@returns
+				This function returns a pointer to a #hid_device object on
+				success or NULL on failure.
+		*/
+		HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path);
+
+		/** @brief Write an Output report to a HID device.
+
+			The first byte of @p data[] must contain the Report ID. For
+			devices which only support a single report, this must be set
+			to 0x0. The remaining bytes contain the report data. Since
+			the Report ID is mandatory, calls to hid_write() will always
+			contain one more byte than the report contains. For example,
+			if a hid report is 16 bytes long, 17 bytes must be passed to
+			hid_write(), the Report ID (or 0x0, for devices with a
+			single report), followed by the report data (16 bytes). In
+			this example, the length passed in would be 17.
+
+			hid_write() will send the data on the first OUT endpoint, if
+			one exists. If it does not, it will send the data through
+			the Control Endpoint (Endpoint 0).
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data The data to send, including the report number as
+				the first byte.
+			@param length The length in bytes of the data to send.
+
+			@returns
+				This function returns the actual number of bytes written and
+				-1 on error.
+		*/
+		int  HID_API_EXPORT HID_API_CALL hid_write(hid_device *device, const unsigned char *data, size_t length);
+
+		/** @brief Read an Input report from a HID device with timeout.
+
+			Input reports are returned
+			to the host through the INTERRUPT IN endpoint. The first byte will
+			contain the Report number if the device uses numbered reports.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data A buffer to put the read data into.
+			@param length The number of bytes to read. For devices with
+				multiple reports, make sure to read an extra byte for
+				the report number.
+			@param milliseconds timeout in milliseconds or -1 for blocking wait.
+
+			@returns
+				This function returns the actual number of bytes read and
+				-1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds);
+
+		/** @brief Read an Input report from a HID device.
+
+			Input reports are returned
+		    to the host through the INTERRUPT IN endpoint. The first byte will
+			contain the Report number if the device uses numbered reports.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data A buffer to put the read data into.
+			@param length The number of bytes to read. For devices with
+				multiple reports, make sure to read an extra byte for
+				the report number.
+
+			@returns
+				This function returns the actual number of bytes read and
+				-1 on error.
+		*/
+		int  HID_API_EXPORT HID_API_CALL hid_read(hid_device *device, unsigned char *data, size_t length);
+
+		/** @brief Set the device handle to be non-blocking.
+
+			In non-blocking mode calls to hid_read() will return
+			immediately with a value of 0 if there is no data to be
+			read. In blocking mode, hid_read() will wait (block) until
+			there is data to read before returning.
+
+			Nonblocking can be turned on and off at any time.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param nonblock enable or not the nonblocking reads
+			 - 1 to enable nonblocking
+			 - 0 to disable nonblocking.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int  HID_API_EXPORT HID_API_CALL hid_set_nonblocking(hid_device *device, int nonblock);
+
+		/** @brief Send a Feature report to the device.
+
+			Feature reports are sent over the Control endpoint as a
+			Set_Report transfer.  The first byte of @p data[] must
+			contain the Report ID. For devices which only support a
+			single report, this must be set to 0x0. The remaining bytes
+			contain the report data. Since the Report ID is mandatory,
+			calls to hid_send_feature_report() will always contain one
+			more byte than the report contains. For example, if a hid
+			report is 16 bytes long, 17 bytes must be passed to
+			hid_send_feature_report(): the Report ID (or 0x0, for
+			devices which do not use numbered reports), followed by the
+			report data (16 bytes). In this example, the length passed
+			in would be 17.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data The data to send, including the report number as
+				the first byte.
+			@param length The length in bytes of the data to send, including
+				the report number.
+
+			@returns
+				This function returns the actual number of bytes written and
+				-1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *device, const unsigned char *data, size_t length);
+
+		/** @brief Get a feature report from a HID device.
+
+			Make sure to set the first byte of @p data[] to the Report
+			ID of the report to be read.  Make sure to allow space for
+			this extra byte in @p data[].
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data A buffer to put the read data into, including
+				the Report ID. Set the first byte of @p data[] to the
+				Report ID of the report to be read.
+			@param length The number of bytes to read, including an
+				extra byte for the report ID. The buffer can be longer
+				than the actual report.
+
+			@returns
+				This function returns the number of bytes read and
+				-1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *device, unsigned char *data, size_t length);
+
+		/** @brief Close a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+		*/
+		void HID_API_EXPORT HID_API_CALL hid_close(hid_device *device);
+
+		/** @brief Get The Manufacturer String from a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *device, wchar_t *string, size_t maxlen);
+
+		/** @brief Get The Product String from a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_product_string(hid_device *device, wchar_t *string, size_t maxlen);
+
+		/** @brief Get The Serial Number String from a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *device, wchar_t *string, size_t maxlen);
+
+		/** @brief Get a string from a HID device, based on its string index.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string_index The index of the string to get.
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *device, int string_index, wchar_t *string, size_t maxlen);
+
+		/** @brief Get a string describing the last error which occurred.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+
+			@returns
+				This function returns a string containing the last error
+				which occurred or NULL if none has occurred.
+		*/
+		HID_API_EXPORT const wchar_t* HID_API_CALL hid_error(hid_device *device);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/plugins/fx5/src/linux/50-usbdmx.rules
+++ b/plugins/fx5/src/linux/50-usbdmx.rules
@@ -1,0 +1,2 @@
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0f1f", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="088b", MODE="0666"

--- a/plugins/fx5/src/linux/hid.c
+++ b/plugins/fx5/src/linux/hid.c
@@ -1,0 +1,786 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 8/22/2009
+ Linux Version - 6/2/2009
+
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
+
+/* C */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <locale.h>
+#include <errno.h>
+
+/* Unix */
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/utsname.h>
+#include <fcntl.h>
+#include <poll.h>
+
+/* Linux */
+#include <linux/hidraw.h>
+#include <linux/version.h>
+#include <linux/input.h>
+#include <libudev.h>
+
+#include "hidapi.h"
+
+/* Definitions from linux/hidraw.h. Since these are new, some distros
+   may not have header files which contain them. */
+#ifndef HIDIOCSFEATURE
+#define HIDIOCSFEATURE(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x06, len)
+#endif
+#ifndef HIDIOCGFEATURE
+#define HIDIOCGFEATURE(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x07, len)
+#endif
+
+
+/* USB HID device property names */
+const char *device_string_names[] = {
+	"manufacturer",
+	"product",
+	"serial",
+};
+
+/* Symbolic names for the properties above */
+enum device_string_id {
+	DEVICE_STRING_MANUFACTURER,
+	DEVICE_STRING_PRODUCT,
+	DEVICE_STRING_SERIAL,
+
+	DEVICE_STRING_COUNT,
+};
+
+struct hid_device_ {
+	int device_handle;
+	int blocking;
+	int uses_numbered_reports;
+};
+
+
+static __u32 kernel_version = 0;
+
+static hid_device *new_hid_device(void)
+{
+	hid_device *dev = calloc(1, sizeof(hid_device));
+	dev->device_handle = -1;
+	dev->blocking = 1;
+	dev->uses_numbered_reports = 0;
+
+	return dev;
+}
+
+
+/* The caller must free the returned string with free(). */
+static wchar_t *utf8_to_wchar_t(const char *utf8)
+{
+	wchar_t *ret = NULL;
+
+	if (utf8) {
+		size_t wlen = mbstowcs(NULL, utf8, 0);
+		if ((size_t) -1 == wlen) {
+			return wcsdup(L"");
+		}
+		ret = calloc(wlen+1, sizeof(wchar_t));
+		mbstowcs(ret, utf8, wlen+1);
+		ret[wlen] = 0x0000;
+	}
+
+	return ret;
+}
+
+/* Get an attribute value from a udev_device and return it as a whar_t
+   string. The returned string must be freed with free() when done.*/
+static wchar_t *copy_udev_string(struct udev_device *dev, const char *udev_name)
+{
+	return utf8_to_wchar_t(udev_device_get_sysattr_value(dev, udev_name));
+}
+
+/* uses_numbered_reports() returns 1 if report_descriptor describes a device
+   which contains numbered reports. */
+static int uses_numbered_reports(__u8 *report_descriptor, __u32 size) {
+	unsigned int i = 0;
+	int size_code;
+	int data_len, key_size;
+
+	while (i < size) {
+		int key = report_descriptor[i];
+
+		/* Check for the Report ID key */
+		if (key == 0x85/*Report ID*/) {
+			/* This device has a Report ID, which means it uses
+			   numbered reports. */
+			return 1;
+		}
+
+		//printf("key: %02hhx\n", key);
+
+		if ((key & 0xf0) == 0xf0) {
+			/* This is a Long Item. The next byte contains the
+			   length of the data section (value) for this key.
+			   See the HID specification, version 1.11, section
+			   6.2.2.3, titled "Long Items." */
+			if (i+1 < size)
+				data_len = report_descriptor[i+1];
+			else
+				data_len = 0; /* malformed report */
+			key_size = 3;
+		}
+		else {
+			/* This is a Short Item. The bottom two bits of the
+			   key contain the size code for the data section
+			   (value) for this key.  Refer to the HID
+			   specification, version 1.11, section 6.2.2.2,
+			   titled "Short Items." */
+			size_code = key & 0x3;
+			switch (size_code) {
+			case 0:
+			case 1:
+			case 2:
+				data_len = size_code;
+				break;
+			case 3:
+				data_len = 4;
+				break;
+			default:
+				/* Can't ever happen since size_code is & 0x3 */
+				data_len = 0;
+				break;
+			};
+			key_size = 1;
+		}
+
+		/* Skip over this key and it's associated data */
+		i += data_len + key_size;
+	}
+
+	/* Didn't find a Report ID key. Device doesn't use numbered reports. */
+	return 0;
+}
+
+/*
+ * The caller is responsible for free()ing the (newly-allocated) character
+ * strings pointed to by serial_number_utf8 and product_name_utf8 after use.
+ */
+static int
+parse_uevent_info(const char *uevent, int *bus_type,
+	unsigned short *vendor_id, unsigned short *product_id,
+	char **serial_number_utf8, char **product_name_utf8)
+{
+	char *tmp = strdup(uevent);
+	char *saveptr = NULL;
+	char *line;
+	char *key;
+	char *value;
+
+	int found_id = 0;
+	int found_serial = 0;
+	int found_name = 0;
+
+	line = strtok_r(tmp, "\n", &saveptr);
+	while (line != NULL) {
+		/* line: "KEY=value" */
+		key = line;
+		value = strchr(line, '=');
+		if (!value) {
+			goto next_line;
+		}
+		*value = '\0';
+		value++;
+
+		if (strcmp(key, "HID_ID") == 0) {
+			/**
+			 *        type vendor   product
+			 * HID_ID=0003:000005AC:00008242
+			 **/
+			int ret = sscanf(value, "%x:%hx:%hx", bus_type, vendor_id, product_id);
+			if (ret == 3) {
+				found_id = 1;
+			}
+		} else if (strcmp(key, "HID_NAME") == 0) {
+			/* The caller has to free the product name */
+			*product_name_utf8 = strdup(value);
+			found_name = 1;
+		} else if (strcmp(key, "HID_UNIQ") == 0) {
+			/* The caller has to free the serial number */
+			*serial_number_utf8 = strdup(value);
+			found_serial = 1;
+		}
+
+next_line:
+		line = strtok_r(NULL, "\n", &saveptr);
+	}
+
+	free(tmp);
+	return (found_id && found_name && found_serial);
+}
+
+
+static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t *string, size_t maxlen)
+{
+	struct udev *udev;
+	struct udev_device *udev_dev, *parent, *hid_dev;
+	struct stat s;
+	int ret = -1;
+        char *serial_number_utf8 = NULL;
+        char *product_name_utf8 = NULL;
+
+	/* Create the udev object */
+	udev = udev_new();
+	if (!udev) {
+		printf("Can't create udev\n");
+		return -1;
+	}
+
+	/* Get the dev_t (major/minor numbers) from the file handle. */
+	fstat(dev->device_handle, &s);
+	/* Open a udev device from the dev_t. 'c' means character device. */
+	udev_dev = udev_device_new_from_devnum(udev, 'c', s.st_rdev);
+	if (udev_dev) {
+		hid_dev = udev_device_get_parent_with_subsystem_devtype(
+			udev_dev,
+			"hid",
+			NULL);
+		if (hid_dev) {
+			unsigned short dev_vid;
+			unsigned short dev_pid;
+			int bus_type;
+			size_t retm;
+
+			ret = parse_uevent_info(
+			           udev_device_get_sysattr_value(hid_dev, "uevent"),
+			           &bus_type,
+			           &dev_vid,
+			           &dev_pid,
+			           &serial_number_utf8,
+			           &product_name_utf8);
+
+			if (bus_type == BUS_BLUETOOTH) {
+				switch (key) {
+					case DEVICE_STRING_MANUFACTURER:
+						wcsncpy(string, L"", maxlen);
+						ret = 0;
+						break;
+					case DEVICE_STRING_PRODUCT:
+						retm = mbstowcs(string, product_name_utf8, maxlen);
+						ret = (retm == (size_t)-1)? -1: 0;
+						break;
+					case DEVICE_STRING_SERIAL:
+						retm = mbstowcs(string, serial_number_utf8, maxlen);
+						ret = (retm == (size_t)-1)? -1: 0;
+						break;
+					case DEVICE_STRING_COUNT:
+					default:
+						ret = -1;
+						break;
+				}
+			}
+			else {
+				/* This is a USB device. Find its parent USB Device node. */
+				parent = udev_device_get_parent_with_subsystem_devtype(
+					   udev_dev,
+					   "usb",
+					   "usb_device");
+				if (parent) {
+					const char *str;
+					const char *key_str = NULL;
+
+					if (key >= 0 && key < DEVICE_STRING_COUNT) {
+						key_str = device_string_names[key];
+					} else {
+						ret = -1;
+						goto end;
+					}
+
+					str = udev_device_get_sysattr_value(parent, key_str);
+					if (str) {
+						/* Convert the string from UTF-8 to wchar_t */
+						retm = mbstowcs(string, str, maxlen);
+						ret = (retm == (size_t)-1)? -1: 0;
+						goto end;
+					}
+				}
+			}
+		}
+	}
+
+end:
+        free(serial_number_utf8);
+        free(product_name_utf8);
+
+	udev_device_unref(udev_dev);
+	/* parent and hid_dev don't need to be (and can't be) unref'd.
+	   I'm not sure why, but they'll throw double-free() errors. */
+	udev_unref(udev);
+
+	return ret;
+}
+
+int HID_API_EXPORT hid_init(void)
+{
+	const char *locale;
+
+	/* Set the locale if it's not set. */
+	locale = setlocale(LC_CTYPE, NULL);
+	if (!locale)
+		setlocale(LC_CTYPE, "");
+
+	return 0;
+}
+
+int HID_API_EXPORT hid_exit(void)
+{
+	/* Nothing to do for this in the Linux/hidraw implementation. */
+	return 0;
+}
+
+
+struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	struct udev *udev;
+	struct udev_enumerate *enumerate;
+	struct udev_list_entry *devices, *dev_list_entry;
+
+	struct hid_device_info *root = NULL; /* return object */
+	struct hid_device_info *cur_dev = NULL;
+	struct hid_device_info *prev_dev = NULL; /* previous device */
+
+	hid_init();
+
+	/* Create the udev object */
+	udev = udev_new();
+	if (!udev) {
+		printf("Can't create udev\n");
+		return NULL;
+	}
+
+	/* Create a list of the devices in the 'hidraw' subsystem. */
+	enumerate = udev_enumerate_new(udev);
+	udev_enumerate_add_match_subsystem(enumerate, "hidraw");
+	udev_enumerate_scan_devices(enumerate);
+	devices = udev_enumerate_get_list_entry(enumerate);
+	/* For each item, see if it matches the vid/pid, and if so
+	   create a udev_device record for it */
+	udev_list_entry_foreach(dev_list_entry, devices) {
+		const char *sysfs_path;
+		const char *dev_path;
+		const char *str;
+		struct udev_device *raw_dev; /* The device's hidraw udev node. */
+		struct udev_device *hid_dev; /* The device's HID udev node. */
+		struct udev_device *usb_dev; /* The device's USB udev node. */
+		struct udev_device *intf_dev; /* The device's interface (in the USB sense). */
+		unsigned short dev_vid;
+		unsigned short dev_pid;
+		char *serial_number_utf8 = NULL;
+		char *product_name_utf8 = NULL;
+		int bus_type;
+		int result;
+
+		/* Get the filename of the /sys entry for the device
+		   and create a udev_device object (dev) representing it */
+		sysfs_path = udev_list_entry_get_name(dev_list_entry);
+		raw_dev = udev_device_new_from_syspath(udev, sysfs_path);
+		dev_path = udev_device_get_devnode(raw_dev);
+
+		hid_dev = udev_device_get_parent_with_subsystem_devtype(
+			raw_dev,
+			"hid",
+			NULL);
+
+		if (!hid_dev) {
+			/* Unable to find parent hid device. */
+			goto next;
+		}
+
+		result = parse_uevent_info(
+			udev_device_get_sysattr_value(hid_dev, "uevent"),
+			&bus_type,
+			&dev_vid,
+			&dev_pid,
+			&serial_number_utf8,
+			&product_name_utf8);
+
+		if (!result) {
+			/* parse_uevent_info() failed for at least one field. */
+			goto next;
+		}
+
+		if (bus_type != BUS_USB && bus_type != BUS_BLUETOOTH) {
+			/* We only know how to handle USB and BT devices. */
+			goto next;
+		}
+
+		/* Check the VID/PID against the arguments */
+		if ((vendor_id == 0x0 || vendor_id == dev_vid) &&
+		    (product_id == 0x0 || product_id == dev_pid)) {
+			struct hid_device_info *tmp;
+
+			/* VID/PID match. Create the record. */
+			tmp = malloc(sizeof(struct hid_device_info));
+			if (cur_dev) {
+				cur_dev->next = tmp;
+			}
+			else {
+				root = tmp;
+			}
+			prev_dev = cur_dev;
+			cur_dev = tmp;
+
+			/* Fill out the record */
+			cur_dev->next = NULL;
+			cur_dev->path = dev_path? strdup(dev_path): NULL;
+
+			/* VID/PID */
+			cur_dev->vendor_id = dev_vid;
+			cur_dev->product_id = dev_pid;
+
+			/* Serial Number */
+			cur_dev->serial_number = utf8_to_wchar_t(serial_number_utf8);
+
+			/* Release Number */
+			cur_dev->release_number = 0x0;
+
+			/* Interface Number */
+			cur_dev->interface_number = -1;
+
+			switch (bus_type) {
+				case BUS_USB:
+					/* The device pointed to by raw_dev contains information about
+					   the hidraw device. In order to get information about the
+					   USB device, get the parent device with the
+					   subsystem/devtype pair of "usb"/"usb_device". This will
+					   be several levels up the tree, but the function will find
+					   it. */
+					usb_dev = udev_device_get_parent_with_subsystem_devtype(
+							raw_dev,
+							"usb",
+							"usb_device");
+
+					if (!usb_dev) {
+						/* Free this device */
+						free(cur_dev->serial_number);
+						free(cur_dev->path);
+						free(cur_dev);
+
+						/* Take it off the device list. */
+						if (prev_dev) {
+							prev_dev->next = NULL;
+							cur_dev = prev_dev;
+						}
+						else {
+							cur_dev = root = NULL;
+						}
+
+						goto next;
+					}
+
+					/* Manufacturer and Product strings */
+					cur_dev->manufacturer_string = copy_udev_string(usb_dev, device_string_names[DEVICE_STRING_MANUFACTURER]);
+					cur_dev->product_string = copy_udev_string(usb_dev, device_string_names[DEVICE_STRING_PRODUCT]);
+
+					/* Release Number */
+					str = udev_device_get_sysattr_value(usb_dev, "bcdDevice");
+					cur_dev->release_number = (str)? strtol(str, NULL, 16): 0x0;
+
+					/* Get a handle to the interface's udev node. */
+					intf_dev = udev_device_get_parent_with_subsystem_devtype(
+							raw_dev,
+							"usb",
+							"usb_interface");
+					if (intf_dev) {
+						str = udev_device_get_sysattr_value(intf_dev, "bInterfaceNumber");
+						cur_dev->interface_number = (str)? strtol(str, NULL, 16): -1;
+					}
+
+					break;
+
+				case BUS_BLUETOOTH:
+					/* Manufacturer and Product strings */
+					cur_dev->manufacturer_string = wcsdup(L"");
+					cur_dev->product_string = utf8_to_wchar_t(product_name_utf8);
+
+					break;
+
+				default:
+					/* Unknown device type - this should never happen, as we
+					 * check for USB and Bluetooth devices above */
+					break;
+			}
+		}
+
+	next:
+		free(serial_number_utf8);
+		free(product_name_utf8);
+		udev_device_unref(raw_dev);
+		/* hid_dev, usb_dev and intf_dev don't need to be (and can't be)
+		   unref()d.  It will cause a double-free() error.  I'm not
+		   sure why.  */
+	}
+	/* Free the enumerator and udev objects. */
+	udev_enumerate_unref(enumerate);
+	udev_unref(udev);
+
+	return root;
+}
+
+void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
+{
+	struct hid_device_info *d = devs;
+	while (d) {
+		struct hid_device_info *next = d->next;
+		free(d->path);
+		free(d->serial_number);
+		free(d->manufacturer_string);
+		free(d->product_string);
+		free(d);
+		d = next;
+	}
+}
+
+hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
+{
+	struct hid_device_info *devs, *cur_dev;
+	const char *path_to_open = NULL;
+	hid_device *handle = NULL;
+
+	devs = hid_enumerate(vendor_id, product_id);
+	cur_dev = devs;
+	while (cur_dev) {
+		if (cur_dev->vendor_id == vendor_id &&
+		    cur_dev->product_id == product_id) {
+			if (serial_number) {
+				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
+					path_to_open = cur_dev->path;
+					break;
+				}
+			}
+			else {
+				path_to_open = cur_dev->path;
+				break;
+			}
+		}
+		cur_dev = cur_dev->next;
+	}
+
+	if (path_to_open) {
+		/* Open the device */
+		handle = hid_open_path(path_to_open);
+	}
+
+	hid_free_enumeration(devs);
+
+	return handle;
+}
+
+hid_device * HID_API_EXPORT hid_open_path(const char *path)
+{
+	hid_device *dev = NULL;
+
+	hid_init();
+
+	dev = new_hid_device();
+
+	if (kernel_version == 0) {
+		struct utsname name;
+		int major, minor, release;
+		int ret;
+		uname(&name);
+		ret = sscanf(name.release, "%d.%d.%d", &major, &minor, &release);
+		if (ret == 3) {
+			kernel_version = major << 16 | minor << 8 | release;
+			//printf("Kernel Version: %d\n", kernel_version);
+		}
+		else {
+			printf("Couldn't sscanf() version string %s\n", name.release);
+		}
+	}
+
+	/* OPEN HERE */
+	dev->device_handle = open(path, O_RDWR);
+
+	/* If we have a good handle, return it. */
+	if (dev->device_handle > 0) {
+
+		/* Get the report descriptor */
+		int res, desc_size = 0;
+		struct hidraw_report_descriptor rpt_desc;
+
+		memset(&rpt_desc, 0x0, sizeof(rpt_desc));
+
+		/* Get Report Descriptor Size */
+		res = ioctl(dev->device_handle, HIDIOCGRDESCSIZE, &desc_size);
+		if (res < 0)
+			perror("HIDIOCGRDESCSIZE");
+
+
+		/* Get Report Descriptor */
+		rpt_desc.size = desc_size;
+		res = ioctl(dev->device_handle, HIDIOCGRDESC, &rpt_desc);
+		if (res < 0) {
+			perror("HIDIOCGRDESC");
+		} else {
+			/* Determine if this device uses numbered reports. */
+			dev->uses_numbered_reports =
+				uses_numbered_reports(rpt_desc.value,
+				                      rpt_desc.size);
+		}
+
+		return dev;
+	}
+	else {
+		/* Unable to open any devices. */
+		free(dev);
+		return NULL;
+	}
+}
+
+
+int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t length)
+{
+	int bytes_written;
+
+	bytes_written = write(dev->device_handle, data, length);
+
+	return bytes_written;
+}
+
+
+int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
+{
+	int bytes_read;
+
+	if (milliseconds >= 0) {
+		/* Milliseconds is either 0 (non-blocking) or > 0 (contains
+		   a valid timeout). In both cases we want to call poll()
+		   and wait for data to arrive.  Don't rely on non-blocking
+		   operation (O_NONBLOCK) since some kernels don't seem to
+		   properly report device disconnection through read() when
+		   in non-blocking mode.  */
+		int ret;
+		struct pollfd fds;
+
+		fds.fd = dev->device_handle;
+		fds.events = POLLIN;
+		fds.revents = 0;
+		ret = poll(&fds, 1, milliseconds);
+		if (ret == -1 || ret == 0) {
+			/* Error or timeout */
+			return ret;
+		}
+		else {
+			/* Check for errors on the file descriptor. This will
+			   indicate a device disconnection. */
+			if (fds.revents & (POLLERR | POLLHUP | POLLNVAL))
+				return -1;
+		}
+	}
+
+	bytes_read = read(dev->device_handle, data, length);
+	if (bytes_read < 0 && (errno == EAGAIN || errno == EINPROGRESS))
+		bytes_read = 0;
+
+	if (bytes_read >= 0 &&
+	    kernel_version < KERNEL_VERSION(2,6,34) &&
+	    dev->uses_numbered_reports) {
+		/* Work around a kernel bug. Chop off the first byte. */
+		memmove(data, data+1, bytes_read);
+		bytes_read--;
+	}
+
+	return bytes_read;
+}
+
+int HID_API_EXPORT hid_read(hid_device *dev, unsigned char *data, size_t length)
+{
+	return hid_read_timeout(dev, data, length, (dev->blocking)? -1: 0);
+}
+
+int HID_API_EXPORT hid_set_nonblocking(hid_device *dev, int nonblock)
+{
+	/* Do all non-blocking in userspace using poll(), since it looks
+	   like there's a bug in the kernel in some versions where
+	   read() will not return -1 on disconnection of the USB device */
+
+	dev->blocking = !nonblock;
+	return 0; /* Success */
+}
+
+
+int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length)
+{
+	int res;
+
+	res = ioctl(dev->device_handle, HIDIOCSFEATURE(length), data);
+	if (res < 0)
+		perror("ioctl (SFEATURE)");
+
+	return res;
+}
+
+int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
+{
+	int res;
+
+	res = ioctl(dev->device_handle, HIDIOCGFEATURE(length), data);
+	if (res < 0)
+		perror("ioctl (GFEATURE)");
+
+
+	return res;
+}
+
+
+void HID_API_EXPORT hid_close(hid_device *dev)
+{
+	if (!dev)
+		return;
+	close(dev->device_handle);
+	free(dev);
+}
+
+
+int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return get_device_string(dev, DEVICE_STRING_MANUFACTURER, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return get_device_string(dev, DEVICE_STRING_PRODUCT, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return get_device_string(dev, DEVICE_STRING_SERIAL, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
+{
+	return -1;
+}
+
+
+HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
+{
+	return NULL;
+}

--- a/plugins/fx5/src/src.pro
+++ b/plugins/fx5/src/src.pro
@@ -1,0 +1,47 @@
+include(../../../../variables.pri)
+
+TEMPLATE = lib
+LANGUAGE = C++
+TARGET   = fx5
+
+CONFIG      += plugin
+INCLUDEPATH += ../../interfaces
+DEPENDPATH  += ../../interfaces
+unix:CONFIG      += link_pkgconfig
+
+INCLUDEPATH += common
+!macx:!win32 {
+    # HID API Library Implementation (Linux)
+    SOURCES += linux/hid.c
+    INCLUDEPATH += linux
+}
+
+# HID API Library Header
+HEADERS += linux/hidapi.h
+
+# Original FX5 driver source:
+HEADERS += common/fx5driver.h
+SOURCES += common/fx5driver.c
+
+# Driver - Device class abstraction layer
+HEADERS += common/fx5device.h
+SOURCES += common/fx5device.cpp
+
+# High-Level FX5 Driver Class
+HEADERS += common/fx5.h
+SOURCES += common/fx5.cpp
+
+HEADERS += ../../../interfaces/qlcioplugin.h
+
+TRANSLATIONS += translations/fx5_de_DE.ts
+
+# Installation
+target.path = $$INSTALLROOT/$$PLUGINDIR
+INSTALLS   += target
+
+unix:!macx {
+    # Linux UDEV rule for the FX5 USB device
+    udev.path  = /etc/udev/rules.d
+    udev.files = linux/50-usbdmx.rules
+    INSTALLS  += udev
+}

--- a/plugins/fx5/src/translations/fx5_de_DE.ts
+++ b/plugins/fx5/src/translations/fx5_de_DE.ts
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="de_DE">
+<context>
+    <name>FX5</name>
+    <message>
+        <location filename="../common/fx5.cpp" line="90"/>
+        <source>This plugin provides DMX output and input support for Digital Enlightenment / FX5 devices.</source>
+        <translation type="unfinished">Dieses Plugin bietet DMX Output und Input für Digital Enlightenment / FX5 Geräte.</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="100"/>
+        <source>Outputs</source>
+        <translation type="unfinished">Outputs</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="102"/>
+        <source> as Output</source>
+        <translation type="unfinished">als Output</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="105"/>
+        <source>No output devices found.</source>
+        <translation type="unfinished">Keine Ausgabegeräte gefunden.</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="171"/>
+        <source>Inputs</source>
+        <translation type="unfinished">Inputs</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="173"/>
+        <source> as Input</source>
+        <translation type="unfinished">als Input</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="176"/>
+        <source>No input devices found.</source>
+        <translation type="unfinished">Keine Eingabegeräte gefunden.</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5.cpp" line="213"/>
+        <source>Do you wish to re-scan your hardware?</source>
+        <translation type="unfinished">Nach neuer Hardware suchen?</translation>
+    </message>
+</context>
+<context>
+    <name>FX5Device</name>
+    <message>
+        <location filename="../common/fx5device.cpp" line="63"/>
+        <source>FX5 USB-DMX Interface with serial number </source>
+        <translation type="unfinished">FX5 USB_DMX Interface mit Seriennummer </translation>
+    </message>
+    <message>
+        <location filename="../common/fx5device.cpp" line="64"/>
+        <source> and version </source>
+        <translation type="unfinished"> und Version </translation>
+    </message>
+    <message>
+        <location filename="../common/fx5device.cpp" line="79"/>
+        <source>FX5 USB DMX Interface Error</source>
+        <translation type="unfinished">FX5 USB-DMX Interface Fehler</translation>
+    </message>
+    <message>
+        <location filename="../common/fx5device.cpp" line="80"/>
+        <source>Unable to open the FX5 Interface. Make sure the udev rule is installed.</source>
+        <translation type="unfinished">Kann FX5 Interface nicht öffnen. Stellen Sie sicher, dass die udev-Regel installiert ist.</translation>
+    </message>
+</context>
+</TS>

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -13,3 +13,4 @@ SUBDIRS              += osc
 SUBDIRS              += artnet
 SUBDIRS              += E1.31
 !macx:!win32:SUBDIRS += spi
+!macx:!win32:SUBDIRS += fx5


### PR DESCRIPTION
AFAIK there is currently no direct way to use FX5 / Digital Enlightenment USB-DMX interfaces with QLC+, not even with ola or DMX4Linux. This pull request adds a driver for these devices directly integrated as plugin for QLC+.

Contains both input and output support, using the reference fx5 driver from https://github.com/fx5/usbdmx.git (which is under the BSD license, for this I made very few modifications to it so that improvements to the reference driver in the future can directly be implemented into QLC+).

Yet only works on Linux, but it should be possible to link to Mac / Windows implementations of the HID API as available from the reference driver repo, it propably only requires copying the implementations to subfolders and editing the .pro file.
Unfortunately, I do not own Windows or Mac machines to compile it on, but I could access machines of both platforms to test builds on.

Contains German translation and udev rule, the hidapi.h and hid.c implementation for Linux are included, so that no more external dependencies are created.
Please make sure the code is ok, I have never before used anything Qt.

Tested with a Digital Enlightenment device in Archlinux.
