### PR TITLE
Try to detect DMX value changes and output a minimal changeset first, as...

### DIFF
--- a/plugins/udmx/src/udmxdevice.cpp
+++ b/plugins/udmx/src/udmxdevice.cpp
@@ -206,7 +206,8 @@ void UDMXDevice::run()
 {
     // One "official" DMX frame can take (1s/44Hz) = 23ms
     int frameTime = (int) floor(((double)1000 / m_frequency) + (double)0.5);
-    int r = 0;
+    int r = -1;
+    char last_dmx[512];
 
     // Wait for device to settle in case the device was opened just recently
     // Also measure, whether timer granularity is OK
@@ -221,22 +222,52 @@ void UDMXDevice::run()
     m_running = true;
     while (m_running == true)
     {
+        char dmx[512];
+        int len;
+        int start = 0;
+
         if (m_handle == NULL)
             goto framesleep;
 
         time.restart();
 
-        /* Write all 512 channels */
+        /* atomically(!) snapshot the data
+         * (this isn't actually atomic at all) */
+        memcpy(&dmx, m_universe.data(), len = m_universe.size());
+
+        /* If the previous write was successful, try to detect the smallest
+         * change window
+         */
+        if(r >= 0) {
+          while(len > 0 && dmx[len-1] == last_dmx[len-1])
+            len--;
+
+          while(start < len && dmx[start] == last_dmx[start])
+            start++;
+
+          if(start < len) {
+            len -= start;
+          }
+          else {
+            /* Didn't detect a change, so just output the whole lot anyway */
+            len   = m_universe.size();
+            start = 0;
+          }
+        }
+
         r = usb_control_msg(m_handle,
                             USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_OUT,
                             UDMX_SET_CHANNEL_RANGE,   /* Command */
-                            m_universe.size(),        /* Number of channels to set */
-                            0,                        /* Starting index */
-                            (char*)m_universe.data(), /* Values to set */
-                            m_universe.size(),        /* Size of values */
+                            len,                      /* Number of channels to set */
+                            start,                    /* Starting index */
+                            dmx + start,              /* Values to set */
+                            len,                      /* Size of values */
                             500);                     /* Timeout 0.5s */
         if (r < 0)
             qWarning() << "uDMX: unable to write universe:" << usb_strerror();
+
+        for(int i = start; i < len; i++)
+          last_dmx[i] = dmx[i];
 
 framesleep:
         // Sleep for the remainder of the DMX frame time


### PR DESCRIPTION
... it will be quicker

I have a fairly cheap clone of the uDMX hardware, and it turns out that it's quite slow to output a full DMX universe of 512 channels. I can only get about 3 or 4 frames per second out of it. This is too slow for smooth fades.

I find that if I make this change then my fades become a lot smoother when there's only a few fixtures affected, as the output range is smaller, so it outputs quicker.

I doubt this code is particularly well implemented so far, but it serves my purpose, and hopefully someone will be able to comment on how it can be improved.