### PR TITLE
Add Address Tool to "Add Fixture" dialog for DMX address input

### DIFF
--- a/ui/src/addfixture.cpp
+++ b/ui/src/addfixture.cpp
@@ -35,6 +35,7 @@
 #include "qlcfixturemode.h"
 #include "qlcfixturedef.h"
 
+#include "addresstool.h"
 #include "outputpatch.h"
 #include "addfixture.h"
 #include "apputil.h"
@@ -87,6 +88,8 @@ AddFixture::AddFixture(QWidget* parent, const Doc* doc, const Fixture* fxi)
             this, SLOT(slotAmountSpinChanged(int)));
     connect(m_searchEdit, SIGNAL(textChanged(QString)),
             this, SLOT(slotSearchFilterChanged(QString)));
+    connect(m_diptoolButton, SIGNAL(clicked()),
+            this, SLOT(slotDiptoolButtonClicked()));
 
     /* Fill fixture definition tree (and select a fixture def) */
     if (fxi != NULL && fxi->isDimmer() == false)
@@ -673,4 +676,11 @@ void AddFixture::slotTreeDoubleClicked(QTreeWidgetItem* item)
     slotSelectionChanged();
     if (item != NULL && item->parent() != NULL)
         accept();
+}
+
+void AddFixture::slotDiptoolButtonClicked()
+{
+    AddressTool at(this, m_addressSpin->value());
+    at.exec();
+    m_addressSpin->setValue(at.getAddress());
 }

--- a/ui/src/addfixture.h
+++ b/ui/src/addfixture.h
@@ -190,6 +190,9 @@ protected slots:
 
     /** Callback for fixture search filter changes */
     void slotSearchFilterChanged(QString filter);
+
+    /** Callback for button to open the Address Tool */
+    void slotDiptoolButtonClicked();
 };
 
 /** @} */

--- a/ui/src/addfixture.ui
+++ b/ui/src/addfixture.ui
@@ -150,23 +150,38 @@
        </widget>
       </item>
       <item row="4" column="2">
-       <widget class="QSpinBox" name="m_addressSpin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>The starting address of the (first) added fixture</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>512</number>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QSpinBox" name="m_addressSpin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>The starting address of the (first) added fixture</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>512</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="m_diptoolButton">
+          <property name="icon">
+           <iconset resource="qlcui.qrc">
+            <normaloff>:/diptool.png</normaloff>:/diptool.png</iconset>
+          </property>
+          <property name="toolTip">
+           <string>Address Tool</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="m_channelsLabel">

--- a/ui/src/addresstool.cpp
+++ b/ui/src/addresstool.cpp
@@ -24,7 +24,7 @@
 #include <QPixmap>
 #include <QMouseEvent>
 
-AddressTool::AddressTool(QWidget *parent) :
+AddressTool::AddressTool(QWidget *parent, int presetValue) :
     QDialog(parent)
   , ui(new Ui::AddressTool)
   , m_dipSwitch(NULL)
@@ -41,7 +41,9 @@ AddressTool::AddressTool(QWidget *parent) :
     px.fill(Qt::black);
     ui->m_blackBtn->setIcon(QIcon(px));
 
-    m_dipSwitch = new DIPSwitchWidget(this);
+    ui->m_addressSpin->setValue(presetValue);
+
+    m_dipSwitch = new DIPSwitchWidget(this, presetValue);
     ui->m_gridLayout->addWidget(m_dipSwitch, 0, 0, 1, 5);
     m_dipSwitch->setMinimumHeight(80);
 
@@ -59,6 +61,11 @@ AddressTool::AddressTool(QWidget *parent) :
 AddressTool::~AddressTool()
 {
     delete ui;
+}
+
+int AddressTool::getAddress()
+{
+    return (ui->m_addressSpin->value());
 }
 
 void AddressTool::slotChangeColor()
@@ -80,10 +87,10 @@ void AddressTool::slotChangeColor()
  *
  ***************************************************************************/
 
-DIPSwitchWidget::DIPSwitchWidget(QWidget *parent) :
+DIPSwitchWidget::DIPSwitchWidget(QWidget *parent, int presetValue) :
     QWidget(parent)
 {
-    m_value = 1;
+    m_value = presetValue;
     m_backCol = QColor("#0165DF");
     m_verticalReverse = false;
     m_horizontalReverse = false;

--- a/ui/src/addresstool.h
+++ b/ui/src/addresstool.h
@@ -53,7 +53,7 @@ class DIPSwitchWidget: public QWidget
     Q_OBJECT
 
 public:
-    DIPSwitchWidget(QWidget *parent = 0);
+    DIPSwitchWidget(QWidget *parent = 0, int presetValue = 1);
     ~DIPSwitchWidget();
 
     void setColor(QColor col);
@@ -87,8 +87,10 @@ class AddressTool : public QDialog
     Q_OBJECT
     
 public:
-    explicit AddressTool(QWidget *parent = 0);
+    explicit AddressTool(QWidget *parent = 0, int presetValue = 1);
     ~AddressTool();
+
+    int getAddress();
     
 private:
     Ui::AddressTool *ui;

--- a/ui/src/addresstool.ui
+++ b/ui/src/addresstool.ui
@@ -107,7 +107,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Add a button next to the address spin in the "Add Fixture" dialog that can be clicked
to display the required DIP switch configuration for the given address or to change
the address by modifying the sliders positions.
Once again, I think this makes it easier to enter a given configuration if you don't know binary, or to look at the slider's positions right when entering them.

![bildschirmfoto vom 2014-04-27 12 17 05](https://cloud.githubusercontent.com/assets/1311964/2810961/537796a4-cdf6-11e3-81d4-aaa9833b42cf.png)

![bildschirmfoto vom 2014-04-27 12 17 36](https://cloud.githubusercontent.com/assets/1311964/2810960/53776de6-cdf6-11e3-84bf-6e084b4234d5.png)
