### PR TITLE
Added APC40 MIDI SysEx init message

### DIFF
--- a/miditemplates/APC40.qxm
+++ b/miditemplates/APC40.qxm
@@ -1,0 +1,9 @@
+<!DOCTYPE MidiTemplate>
+<MidiTemplate>
+ <Creator>
+  <Author>Joep Admiraal</Author>
+ </Creator>
+ <Description>Sets the APC40 into Ableton mode 2. This is needed to control the button led's.</Description>
+ <Name>APC40 Ableton mode 2</Name>
+ <InitMessage>F0 47 00 73 60 00 04 41 09 00 05 F7</InitMessage>
+</MidiTemplate>

--- a/miditemplates/miditemplates.pro
+++ b/miditemplates/miditemplates.pro
@@ -4,6 +4,7 @@ TEMPLATE = subdirs
 TARGET = templates
 
 templates.files += APC20.qxm
+templates.files += APC40.qxm
 
 templates.path = $$INSTALLROOT/$$MIDITEMPLATEDIR
 INSTALLS += templates


### PR DESCRIPTION
Adds an init message for the APC40 midi controller.
Without this the led feedback of the APC40 is not working correctly.
