### PR TITLE
fix build with multiple threads

### DIFF
--- a/hotplugmonitor/hotplugmonitor.pro
+++ b/hotplugmonitor/hotplugmonitor.pro
@@ -1,3 +1,4 @@
 TEMPLATE = subdirs
+CONFIG  += ordered
 SUBDIRS += src
 SUBDIRS += test


### PR DESCRIPTION
Very small but annoying issue...
Build hotplugmonitor subdirs in order so `make -j10` does not fail at link time.
