### PR TITLE
Fix build order again

### DIFF
--- a/engine/test/test.pro
+++ b/engine/test/test.pro
@@ -1,5 +1,4 @@
 TEMPLATE = subdirs
-CONFIG  += ordered
 SUBDIRS += bus
 SUBDIRS += chaser
 SUBDIRS += chaserrunner

--- a/plugins/dmxusb/dmxusb.pro
+++ b/plugins/dmxusb/dmxusb.pro
@@ -1,2 +1,3 @@
 TEMPLATE = subdirs
+CONFIG  += ordered
 SUBDIRS += src

--- a/plugins/enttecwing/enttecwing.pro
+++ b/plugins/enttecwing/enttecwing.pro
@@ -1,3 +1,4 @@
 TEMPLATE = subdirs
+CONFIG  += ordered
 SUBDIRS += src
 SUBDIRS += test

--- a/plugins/udmx/udmx.pro
+++ b/plugins/udmx/udmx.pro
@@ -1,2 +1,3 @@
 TEMPLATE = subdirs
+CONFIG  += ordered
 SUBDIRS += src


### PR DESCRIPTION
Build of enttecwing failed.
Sorry, the fix was not complete the first time.

CONFIG += ordered  in all plugins .pro files added, in case of test folder added later.
CONFIG -= ordered  in test.pro, because tests don't depend on each other.

This time I checked all the .pro files, and tested by building everything from scratch with -j33... 4 times.
