### PR TITLE
Missing build-dep 'libfftw3-dev' in Debian / control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Priority: optional
 Maintainer: Massimo Callegari <massimocallegari@yahoo.it>
 Build-Depends: debhelper (>= 7.0.50), libqt4-dev (>= 4.6.0), libasound2-dev (>= 1.0.16),
                libusb-dev (>= 2:0.1.12), libftdi-dev (>= 0.17), shared-mime-info (>= 0.71),
-               make, g++, libstdc++-dev, libudev-dev, libmad0-dev, libsndfile1-dev, liblo-dev
+               make, g++, libstdc++-dev, libudev-dev, libmad0-dev, libsndfile1-dev, liblo-dev,
+               libfftw3-dev
 Standards-Version: 3.7.3
 Homepage: http://qlcplus.sourceforge.net/
 


### PR DESCRIPTION
My first build failed with

```
audio/audiocapture.cpp:26:19: fatal error: fftw3.h: No such file or directory
#include "fftw3.h"
```

This patch adds the proper dependency.
