### PR TITLE
rgbmatrix: fix backward oneshot

### DIFF
--- a/engine/src/rgbmatrix.cpp
+++ b/engine/src/rgbmatrix.cpp
@@ -504,15 +504,20 @@ void RGBMatrix::roundCheck(const QSize& size)
             if (m_step >= m_algorithm->rgbMapStepCount(size) - 1)
                 stop();
             else
+            {
                 m_step++;
-            updateStepColor(m_direction);
+                updateStepColor(m_direction);
+            }
         }
         else
         {
             if (m_step <= 0)
                 stop();
             else
+            {
                 m_step--;
+                updateStepColor(m_direction);
+            }
         }
     }
     else


### PR DESCRIPTION
An rbgmatrix in Backward run order will block at the first step when in single shot mode.
Fix is simple, I think those line were simply missing.. ? (all the cases are handled in this function except this one)
