### PR TITLE
vcwidget: make sure resize and accept children are properly copied

### DIFF
--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -241,6 +241,9 @@ bool VCWidget::copyFrom(const VCWidget* widget)
     setGeometry(widget->geometry());
     setCaption(widget->caption());
 
+    m_allowChildren = widget->m_allowChildren;
+    m_allowResize = widget->m_allowResize;
+
     QHashIterator <quint8, QLCInputSource*> it(widget->m_inputs);
     while (it.hasNext() == true)
     {


### PR DESCRIPTION
Simple issue reproduction:
- create a buttonMatrix
- it cannot be resized not accept children
- copy it
- the copy is resizable and accepts children

Both properties were simply not copied from the source widget.
