### PR TITLE
Rewritten ConsoleChannels: use properties to set style, and have only on...

### DIFF
--- a/ui/src/consolechannel.h
+++ b/ui/src/consolechannel.h
@@ -47,17 +47,33 @@ class ConsoleChannel : public QGroupBox
 {
     Q_OBJECT
     Q_DISABLE_COPY(ConsoleChannel)
+    Q_PROPERTY(bool overridden READ isOverridden WRITE setOverridden)
+    Q_PROPERTY(int channelType READ channelType)
+    Q_PROPERTY(bool selected READ isSelected)
+    Q_ENUMS(ChannelType)
+
+public:
+    enum ChannelType { Even, Odd, None };
 
     /*************************************************************************
      * Initialization
      *************************************************************************/
 public:
-    ConsoleChannel(QWidget *parent, Doc* doc, quint32 fixture, quint32 channel, bool isCheckable = true);
+    ConsoleChannel(QWidget *parent, Doc* doc, quint32 fixture, quint32 channel, bool isCheckable = true, ChannelType type = None);
 
     ~ConsoleChannel();
 
+    int channelType() const;
+
+    bool isOverridden() const;
+    void setOverridden(bool overriden);
+
 private:
     void init();
+
+private:
+    ChannelType m_channelType;
+    bool m_isOverridden;
 
     /*************************************************************************
      * Fixture & Channel

--- a/ui/src/fixtureconsole.cpp
+++ b/ui/src/fixtureconsole.cpp
@@ -46,26 +46,6 @@ FixtureConsole::FixtureConsole(QWidget* parent, Doc* doc, GroupType type, bool s
     m_layout = new QHBoxLayout(this);
     layout()->setSpacing(0);
     layout()->setContentsMargins(0, 1, 0, 1);
-
-    int topMargin = m_showCheckBoxes?16:1;
-
-    QString common = "QGroupBox::title {top:-15px; left: 12px; subcontrol-origin: border; background-color: transparent; } "
-                     "QGroupBox::indicator { width: 18px; height: 18px; } "
-                     "QGroupBox::indicator:checked { image: url(:/checkbox_full.png) } "
-                     "QGroupBox::indicator:unchecked { image: url(:/checkbox_empty.png) }";
-
-    if (m_groupType == GroupEven)
-        m_styleSheet = QString("QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #C3D1C9, stop: 1 #AFBBB4); "
-                             "border: 1px solid gray; border-radius: 4px; margin-top: %1px; margin-right: 1px; } " +
-                             (m_showCheckBoxes?common:"")).arg(topMargin);
-    else if (m_groupType == GroupOdd)
-        m_styleSheet = QString("QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #D6D5E0, stop: 1 #A7A6AF); "
-                             "border: 1px solid gray; border-radius: 4px; margin-top: %1px; margin-right: 1px; } " +
-                             (m_showCheckBoxes?common:"")).arg(topMargin);
-    else
-        m_styleSheet = QString("QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #D6D2D0, stop: 1 #AFACAB); "
-                             "border: 1px solid gray; border-radius: 4px; margin-top: %1px; margin-right: 1px; } " +
-                             (m_showCheckBoxes?common:"")).arg(topMargin);
 }
 
 FixtureConsole::~FixtureConsole()
@@ -75,6 +55,19 @@ FixtureConsole::~FixtureConsole()
 /*****************************************************************************
  * Fixture
  *****************************************************************************/
+
+static ConsoleChannel::ChannelType convert(FixtureConsole::GroupType type)
+{
+    switch(type)
+    {
+    case FixtureConsole::GroupOdd:
+        return ConsoleChannel::Odd;
+    case FixtureConsole::GroupEven:
+        return ConsoleChannel::Even;
+    default:
+        return ConsoleChannel::None;
+    }
+}
 
 void FixtureConsole::setFixture(quint32 id)
 {
@@ -96,8 +89,7 @@ void FixtureConsole::setFixture(quint32 id)
         if (ch->group() == QLCChannel::NoGroup)
             continue;
 
-        ConsoleChannel* cc = new ConsoleChannel(this, m_doc, id, i, m_showCheckBoxes);
-        cc->setStyleSheet(m_styleSheet);
+        ConsoleChannel* cc = new ConsoleChannel(this, m_doc, id, i, m_showCheckBoxes, convert(m_groupType));
 
         m_layout->addWidget(cc);
         m_channels.append(cc);
@@ -229,21 +221,21 @@ uchar FixtureConsole::value(quint32 ch) const
         return 0;
 }
 
-void FixtureConsole::setChannelStylesheet(quint32 ch, QString ss)
+void FixtureConsole::setChannelOverride(quint32 ch, bool override)
 {
     ConsoleChannel* cc = channel(ch);
     if (cc != NULL)
-        cc->setStyleSheet(ss);
+        cc->setOverridden(override);
 }
 
-void FixtureConsole::resetChannelsStylesheet()
+void FixtureConsole::resetChannelOverrides()
 {
     QListIterator <ConsoleChannel*> it(m_channels);
     while (it.hasNext() == true)
     {
         ConsoleChannel* cc = it.next();
         Q_ASSERT(cc != NULL);
-        cc->setStyleSheet(m_styleSheet);
+        cc->setOverridden(false);
     }
 }
 

--- a/ui/src/fixtureconsole.h
+++ b/ui/src/fixtureconsole.h
@@ -61,9 +61,9 @@ public:
 
 private:
     Doc* m_doc;
-    GroupType m_groupType;
+    const GroupType m_groupType;
     QHBoxLayout* m_layout;
-    bool m_showCheckBoxes;
+    const bool m_showCheckBoxes;
 
     /*********************************************************************
      * Fixture
@@ -107,10 +107,10 @@ public:
     uchar value(quint32 ch) const;
 
     /** Set the stylesheet of the ConsoleChannel at the given index */
-    void setChannelStylesheet(quint32 ch, QString ss);
+    void setChannelOverride(quint32 ch, bool override);
 
     /** Reset all the channels stylesheet to the original value */
-    void resetChannelsStylesheet();
+    void resetChannelOverrides();
 
 signals:
     /** Emitted when the value of a channel object changes (continuous) */
@@ -128,7 +128,6 @@ private:
 
 private:
     QList<ConsoleChannel*> m_channels;
-    QString m_styleSheet;
 };
 
 /** @} */

--- a/ui/src/simpledesk.cpp
+++ b/ui/src/simpledesk.cpp
@@ -60,15 +60,6 @@
 
 SimpleDesk* SimpleDesk::s_instance = NULL;
 
-QString ssEven =  "QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #C3D1C9, stop: 1 #AFBBB4); "
-                 " border: 1px solid gray; border-radius: 4px; }";
-QString ssOdd = "QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #D6D5E0, stop: 1 #A7A6AF); "
-                 " border: 1px solid gray; border-radius: 4px; }";
-QString ssNone = "QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #D6D2D0, stop: 1 #AFACAB); "
-                 " border: 1px solid gray; border-radius: 4px; }";
-QString ssOverride = "QGroupBox { background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #FF2D2D, stop: 1 #FF5050); "
-                     " border: 1px solid gray; border-radius: 4px; }";
-
 /*****************************************************************************
  * Initialization
  *****************************************************************************/
@@ -490,7 +481,7 @@ void SimpleDesk::initSliderView(bool fullMode)
                 {
                     SceneValue scv(fixture->id(), i, m_engine->value(absoluteAddr + i));
                     console->setSceneValue(scv);
-                    console->setChannelStylesheet(i, ssOverride);
+                    console->setChannelOverride(i, true);
                 }
             }
             fixturesLayout->addWidget(console);
@@ -621,24 +612,17 @@ void SimpleDesk::slotUniversePageChanged(int page)
         {
             slider = new ConsoleChannel(this, m_doc, Fixture::invalidId(), start + i, false);
             if (m_engine->hasChannel((m_currentUniverse << 9) + (start + i)))
-                slider->setStyleSheet(ssOverride);
+                slider->setOverridden(true);
             else
-                slider->setStyleSheet(ssNone);
+                slider->setOverridden(false);
         }
         else
         {
             uint ch = (absoluteAddr + i) - fx->universeAddress();
-            slider = new ConsoleChannel(this, m_doc, fx->id(), ch, false);
+            slider = new ConsoleChannel(this, m_doc, fx->id(), ch, false, (fx->id() % 2 == 0) ? ConsoleChannel::Odd : ConsoleChannel::Even);
             if (m_engine->hasChannel(absoluteAddr + i))
             {
-                slider->setStyleSheet(ssOverride);
-            }
-            else
-            {
-                if (fx->id() % 2 == 0)
-                    slider->setStyleSheet(ssOdd);
-                else
-                    slider->setStyleSheet(ssEven);
+                slider->setOverridden(true);
             }
         }
 
@@ -682,7 +666,7 @@ void SimpleDesk::slotUniverseResetClicked()
             it.next();
             FixtureConsole *fc = it.value();
             Q_ASSERT(fc != NULL);
-            fc->resetChannelsStylesheet();
+            fc->resetChannelOverrides();
         }
     }
 }
@@ -700,7 +684,7 @@ void SimpleDesk::slotUniverseSliderValueChanged(quint32 fid, quint32 chan, uchar
             if (chanAddr < (quint32)m_universeSliders.count())
             {
                 ConsoleChannel *chan = m_universeSliders.at(chanAddr);
-                chan->setStyleSheet(ssOverride);
+                chan->setOverridden(true);
             }
         }
         m_engine->setValue(chanAbsAddr, value);
@@ -719,7 +703,7 @@ void SimpleDesk::slotUniverseSliderValueChanged(quint32 fid, quint32 chan, uchar
             {
                 FixtureConsole *fc = m_consoleList[fid];
                 if (fc != NULL)
-                    fc->setChannelStylesheet(chan, ssOverride);
+                    fc->setChannelOverride(chan, true);
             }
             m_engine->setValue(chanAbsAddr, value);
 
@@ -759,7 +743,7 @@ void SimpleDesk::slotUniversesWritten(int idx, const QByteArray& ua)
                 {
                     cc->blockSignals(true);
                     cc->setValue(m_engine->value(absAddr), false);
-                    cc->setStyleSheet(ssOverride);
+                    cc->setOverridden(true);
                     cc->blockSignals(false);
                 }
                 continue;


### PR DESCRIPTION
...e stylesheet

This wasy all the stylesheets are in one place, and they can be placed in an external stylesheet if needed.
I tried to make the property channelType use proper enum, but I couldn't make it work.

This is preparation for resetting single channels in SimpleDesk.
