### PR TITLE
fix crash when changing input while a vcaudiotrigger is running

### DIFF
--- a/ui/src/virtualconsole/vcaudiotriggers.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggers.cpp
@@ -187,6 +187,9 @@ void VCAudioTriggers::enableCapture(bool enable)
     }
     else
     {
+        // in case the audio input device has been changed in the meantime...
+        m_inputCapture = m_doc->audioInputCapture();
+
         if (m_inputCapture->isRunning())
             m_inputCapture->stop();
 


### PR DESCRIPTION
- Be in operate mode, have a running vcaudiotrigger
- Go to input/output tab, change audio input
- Go back to virtual console, disable/enable the vcaudiotriggers
  -> Crash
  sometimes it does not crash but just hangs forever...
