### PR TITLE
webaccess: fix crash when trying to update closed connection

### DIFF
--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -73,9 +73,9 @@ static int event_handler(struct mg_connection *conn, enum mg_event ev)
     {
         return MG_TRUE;
     }
-    else
+    else if (ev == MG_CLOSE)
     {
-        return MG_FALSE;
+        return s_instance->closeHandler(conn);
     }
 
     return MG_FALSE;
@@ -653,6 +653,13 @@ mg_result WebAccess::websocketDataHandler(mg_connection *conn)
     return MG_TRUE;
 }
 
+mg_result WebAccess::closeHandler(struct mg_connection* conn)
+{
+    (void)conn;
+    m_conn = NULL;
+    return MG_TRUE;
+}
+
 QString WebAccess::getWidgetHTML(VCWidget *widget)
 {
     QString str = "<div class=\"vcwidget\" style=\""
@@ -669,6 +676,9 @@ QString WebAccess::getWidgetHTML(VCWidget *widget)
 
 void WebAccess::slotFramePageChanged(int pageNum)
 {
+    if (m_conn == NULL)
+        return;
+
     VCWidget *frame = (VCWidget *)sender();
 
     QString wsMessage = QString("%1|FRAME|%2").arg(frame->id()).arg(pageNum);
@@ -761,6 +771,9 @@ QString WebAccess::getSoloFrameHTML(VCSoloFrame *frame)
 
 void WebAccess::slotButtonToggled(bool on)
 {
+    if (m_conn == NULL)
+        return;
+
     VCButton *btn = (VCButton *)sender();
 
     QString wsMessage = QString::number(btn->id());
@@ -798,6 +811,9 @@ QString WebAccess::getButtonHTML(VCButton *btn)
 
 void WebAccess::slotSliderValueChanged(QString val)
 {
+    if (m_conn == NULL)
+        return;
+
     VCSlider *slider = (VCSlider *)sender();
 
     QString wsMessage = QString("%1|SLIDER|%2").arg(slider->id()).arg(val);
@@ -881,6 +897,9 @@ QString WebAccess::getAudioTriggersHTML(VCAudioTriggers *triggers)
 
 void WebAccess::slotCueIndexChanged(int idx)
 {
+    if (m_conn == NULL)
+        return;
+
     VCCueList *cue = (VCCueList *)sender();
 
     QString wsMessage = QString("%1|CUE|%2").arg(cue->id()).arg(idx);
@@ -1161,5 +1180,3 @@ void WebAccess::slotVCLoaded()
 {
     m_pendingProjectLoaded = true;
 }
-
-

--- a/webaccess/src/webaccess.h
+++ b/webaccess/src/webaccess.h
@@ -49,6 +49,7 @@ public:
 
     mg_result beginRequestHandler(struct mg_connection *conn);
     mg_result websocketDataHandler(struct mg_connection *conn);
+    mg_result closeHandler(struct mg_connection* conn);
 
 private:
     QString loadXMLPost(struct mg_connection *conn, QString &filename);
@@ -100,9 +101,9 @@ signals:
     void toggleDocMode();
     void loadProject(QString xmlData);
     void storeAutostartProject(QString filename);
-    
+
 public slots:
-    
+
 };
 
 #endif // WEBACCESS_H


### PR DESCRIPTION
Webaccess does not handle well disconnections...

Steps for crashing : (in linux at least)
- Be in operate mode in QLC+
- Run firefox to 127.0.0.1:9999
- See a virtual console in firefox, be happy
- Close firefox
- In QLC+ virtual console, move a slider
  -> crash

Here we handle disconnection by setting m_conn to NULL in webaccess.
