### PR TITLE
Fix issue with function staying ON in a fast running chaser

### DIFF
--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -404,7 +404,7 @@ void ChaserRunner::clearRunningList()
     // empty the running queue
     foreach(ChaserRunnerStep *step, m_runnerSteps)
     {
-        if (step->m_function != NULL && step->m_function->isRunning())
+        if (step->m_function != NULL && !step->m_function->stopped())
         {
             step->m_function->stop();
             step->m_function = NULL;
@@ -601,7 +601,7 @@ bool ChaserRunner::write(MasterTimer* timer, QList<Universe *> universes)
         if (step->m_duration != Function::infiniteSpeed() &&
              step->m_elapsed >= step->m_duration)
         {
-            if (step->m_function != NULL && step->m_function->isRunning())
+            if (step->m_function != NULL && !step->m_function->stopped())
             {
                 step->m_function->stop();
                 step->m_function = NULL;

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -748,7 +748,6 @@ void Function::preRun(MasterTimer* timer)
     Q_UNUSED(timer);
 
     qDebug() << "Function preRun. Name:" << m_name << "ID: " << m_id;
-    m_stop = false;
     m_running = true;
 
     emit running(m_id);
@@ -815,6 +814,7 @@ void Function::start(MasterTimer* timer, bool child, quint32 startTime,
     m_overrideFadeInSpeed = overrideFadeIn;
     m_overrideFadeOutSpeed = overrideFadeOut;
     m_overrideDuration = overrideDuration;
+    m_stop = false;
     timer->startFunction(this);
 }
 


### PR DESCRIPTION
... aaaand last one in this PR salvo :)

Problem with a function staying ON:
- Have a "classic" chaser (with some scenes in it)
- Create a second chaser containing this chaser + any other function, with duration set to 0
- go to operate mode, start the second chaser and then stop it
- the first function of the "classic" chaser will stay ON.

I stumble upon this with an audiotriggers + singleshot chaser, but it is easier to reproduce with the steps above.

Here the issue is fixed by a different handling of the 'stopped' or 'is running' steps
- isRunning() means the function is between preRun() and postRun()
- stopped() means the function is either stopped or in its way to being stopped. This can happen before preRun() has been called.
