### PR TITLE
Added initial support for StopActions

### DIFF
--- a/engine/src/scene.h
+++ b/engine/src/scene.h
@@ -39,6 +39,7 @@ class QDomElement;
 
 #define KXMLQLCFixtureValues "FixtureVal"
 #define KXMLQLCSceneChannelGroups "ChannelGroups"
+#define KXMLQLCSceneStopAction "StopAction"
 
 /**
  * Scene encapsulates the values of selected channels from one or more fixture
@@ -236,6 +237,49 @@ private:
 public:
     /** @reimpl */
     void adjustAttribute(qreal fraction, int attributeIndex);
+
+    /*********************************************************************
+     * Stop action
+     *********************************************************************/
+public:
+    enum StopAction { ResetToZero, ResetToStart, KeepCurrentValues };
+
+    /**
+     * Set this function's stopAction
+     *
+     * @param action This function's stopAction
+     */
+    void setStopAction(const Scene::StopAction& action);
+
+    /**
+     * Get this function's stopAction
+     */
+    Scene::StopAction stopAction() const;
+
+    /**
+     * Convert a stopAction to a string
+     *
+     * @param action stopAction to convert
+     */
+    static QString stopActionToString(const Scene::StopAction& action);
+
+    /**
+     * Convert a string to stopActoin
+     *
+     * @param str The string to convert
+     */
+    static Scene::StopAction stringToStopAction(const QString& str);
+
+protected:
+    /** Save function's stopAction in $doc, under $root */
+    bool saveXMLStopAction(QDomDocument* doc, QDomElement* root) const;
+
+    /** Load function's stopActoin from $root */
+    bool loadXMLStopAction(const QDomElement& root);
+
+private:
+    /** indicates whether the faders should reset to 0, reset to start value or stay at the current values when the scene is stopped */
+    StopAction m_stopAction;
 };
 
 /** @} */

--- a/ui/src/audioeditor.cpp
+++ b/ui/src/audioeditor.cpp
@@ -275,6 +275,8 @@ void AudioEditor::createSpeedDials()
     m_speedDials->setFadeOutSpeed(m_audio->fadeOutSpeed());
     m_speedDials->setDurationEnabled(false);
     m_speedDials->setDurationVisible(false);
+    m_speedDials->setStopActionEnabled(false);
+    m_speedDials->setStopActionVisible(false);
     connect(m_speedDials, SIGNAL(fadeInChanged(int)), this, SLOT(slotFadeInDialChanged(int)));
     connect(m_speedDials, SIGNAL(fadeOutChanged(int)), this, SLOT(slotFadeOutDialChanged(int)));
     connect(m_speedDials, SIGNAL(destroyed(QObject*)), this, SLOT(slotDialDestroyed(QObject*)));

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -943,6 +943,8 @@ void ChaserEditor::createSpeedDials()
     {
         m_speedDials = new SpeedDialWidget(this);
         m_speedDials->setAttribute(Qt::WA_DeleteOnClose);
+        m_speedDials->setStopActionEnabled(false);
+        m_speedDials->setStopActionVisible(false);
 
         connect(m_speedDials, SIGNAL(fadeInChanged(int)),
                 this, SLOT(slotFadeInDialChanged(int)));

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -548,6 +548,8 @@ void EFXEditor::createSpeedDials()
     {
         m_speedDials = new SpeedDialWidget(this);
         m_speedDials->setAttribute(Qt::WA_DeleteOnClose);
+        m_speedDials->setStopActionEnabled(false);
+        m_speedDials->setStopActionVisible(false);
         connect(m_speedDials, SIGNAL(fadeInChanged(int)), this, SLOT(slotFadeInChanged(int)));
         connect(m_speedDials, SIGNAL(fadeOutChanged(int)), this, SLOT(slotFadeOutChanged(int)));
         connect(m_speedDials, SIGNAL(holdChanged(int)), this, SLOT(slotHoldChanged(int)));

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -233,6 +233,8 @@ void RGBMatrixEditor::updateSpeedDials()
     m_speedDials->setAttribute(Qt::WA_DeleteOnClose);
     m_speedDials->setWindowTitle(m_matrix->name());
     m_speedDials->show();
+    m_speedDials->setStopActionEnabled(false);
+    m_speedDials->setStopActionVisible(false);
     m_speedDials->setFadeInSpeed(m_matrix->fadeInSpeed());
     m_speedDials->setFadeOutSpeed(m_matrix->fadeOutSpeed());
     if ((int)m_matrix->duration() < 0)

--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -1080,10 +1080,12 @@ void SceneEditor::createSpeedDials()
     m_speedDials->setWindowTitle(m_scene->name());
     m_speedDials->setFadeInSpeed(m_scene->fadeInSpeed());
     m_speedDials->setFadeOutSpeed(m_scene->fadeOutSpeed());
+    m_speedDials->setStopAction(Scene::stopActionToString(m_scene->stopAction()));
     m_speedDials->setDurationEnabled(false);
     m_speedDials->setDurationVisible(false);
     connect(m_speedDials, SIGNAL(fadeInChanged(int)), this, SLOT(slotFadeInChanged(int)));
     connect(m_speedDials, SIGNAL(fadeOutChanged(int)), this, SLOT(slotFadeOutChanged(int)));
+    connect(m_speedDials, SIGNAL(stopActionChanged(const QString&)), this, SLOT(slotStopActionChanged(const QString&)));
     connect(m_speedDials, SIGNAL(destroyed(QObject*)), this, SLOT(slotDialDestroyed(QObject*)));
     m_speedDials->show();
 }
@@ -1283,6 +1285,11 @@ void SceneEditor::slotFadeInChanged(int ms)
 void SceneEditor::slotFadeOutChanged(int ms)
 {
     m_scene->setFadeOutSpeed(ms);
+}
+
+void SceneEditor::slotStopActionChanged(const QString& action)
+{
+    m_scene->setStopAction(Scene::stringToStopAction(action));
 }
 
 void SceneEditor::slotEnableAllChannelGroups()

--- a/ui/src/sceneeditor.h
+++ b/ui/src/sceneeditor.h
@@ -149,6 +149,7 @@ private slots:
 
     void slotFadeInChanged(int ms);
     void slotFadeOutChanged(int ms);
+    void slotStopActionChanged(const QString &action);
     void slotDialDestroyed(QObject* dial);
 
 private:

--- a/ui/src/simpledesk.cpp
+++ b/ui/src/simpledesk.cpp
@@ -1020,6 +1020,8 @@ void SimpleDesk::createSpeedDials()
 
     m_speedDials = new SpeedDialWidget(this);
     m_speedDials->setAttribute(Qt::WA_DeleteOnClose);
+    m_speedDials->setStopActionEnabled(false);
+    m_speedDials->setStopActionVisible(false);
     connect(m_speedDials, SIGNAL(fadeInChanged(int)),
             this, SLOT(slotFadeInDialChanged(int)));
     connect(m_speedDials, SIGNAL(fadeOutChanged(int)),

--- a/ui/src/speeddialwidget.cpp
+++ b/ui/src/speeddialwidget.cpp
@@ -20,6 +20,7 @@
 #include <QSettings>
 #include <QGroupBox>
 #include <QLineEdit>
+#include <QComboBox>
 #include <QLayout>
 #include <QDebug>
 
@@ -27,6 +28,10 @@
 #include "mastertimer.h"
 #include "speeddial.h"
 #include "apputil.h"
+
+const QString KResetToZeroString       (       "ResetToZero" );
+const QString KResetToStartString      (      "ResetToStart" );
+const QString KKeepCurrentValuesString ( "KeepCurrentValues" );
 
 #define WINDOW_FLAGS Qt::WindowFlags( \
     (Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::Window | \
@@ -40,6 +45,8 @@ SpeedDialWidget::SpeedDialWidget(QWidget* parent)
     , m_fadeIn(NULL)
     , m_fadeOut(NULL)
     , m_hold(NULL)
+    , m_stopActionGroupBox(NULL)
+    , m_stopAction(NULL)
     , m_optionalTextGroup(NULL)
     , m_optionalTextEdit(NULL)
 {
@@ -74,6 +81,20 @@ SpeedDialWidget::SpeedDialWidget(QWidget* parent)
     layout()->addWidget(m_hold);
     connect(m_hold, SIGNAL(valueChanged(int)), this, SIGNAL(holdChanged(int)));
     connect(m_hold, SIGNAL(tapped()), this, SIGNAL(holdTapped()));
+
+    /* Stop action */
+    QVBoxLayout* stopActionVBox = new QVBoxLayout();
+    m_stopAction = new QComboBox(this);
+    m_stopAction->addItem(KResetToZeroString);
+    //TODO: m_stopAction->addItem(KResetToStartString);
+    m_stopAction->addItem(KKeepCurrentValuesString);
+    stopActionVBox->addWidget(m_stopAction);
+
+    m_stopActionGroupBox = new QGroupBox(tr("Stop action"), this);
+    m_stopActionGroupBox->setLayout(stopActionVBox);
+    layout()->addWidget(m_stopActionGroupBox);
+
+    connect(m_stopAction, SIGNAL(currentIndexChanged(const QString&)), this, SIGNAL(stopActionChanged(const QString&)));
 
     /* Optional text */
     m_optionalTextGroup = new QGroupBox(this);
@@ -177,6 +198,30 @@ void SpeedDialWidget::setDuration(int ms)
 int SpeedDialWidget::duration() const
 {
     return m_hold->value();
+}
+
+/************************************************************************
+ * Stop action
+ ************************************************************************/
+
+void SpeedDialWidget::setStopActionEnabled(bool enable)
+{
+    m_stopActionGroupBox->setEnabled(enable);
+}
+
+void SpeedDialWidget::setStopActionVisible(bool set)
+{
+    m_stopActionGroupBox->setVisible(set);
+}
+
+void SpeedDialWidget::setStopAction(const QString& action)
+{
+    m_stopAction->setCurrentText(action);
+}
+
+const QString SpeedDialWidget::stopAction()
+{
+    return m_stopAction->currentText();
 }
 
 /************************************************************************

--- a/ui/src/speeddialwidget.h
+++ b/ui/src/speeddialwidget.h
@@ -25,6 +25,7 @@
 class SpeedDial;
 class QGroupBox;
 class QLineEdit;
+class QComboBox;
 
 /** @addtogroup ui
  * @{
@@ -64,6 +65,11 @@ public:
     void setDuration(int ms);
     int duration() const;
 
+    void setStopActionEnabled(bool set);
+    void setStopActionVisible(bool set);
+    void setStopAction(const QString& action);
+    const QString stopAction();
+
 signals:
     void fadeInChanged(int ms);
     void fadeInTapped();
@@ -74,10 +80,15 @@ signals:
     void holdChanged(int ms);
     void holdTapped();
 
+    void stopActionChanged(const QString& action);
+
 private:
     SpeedDial* m_fadeIn;
     SpeedDial* m_fadeOut;
     SpeedDial* m_hold;
+
+    QGroupBox* m_stopActionGroupBox;
+    QComboBox* m_stopAction;
 
     /************************************************************************
      * Optional text

--- a/ui/src/virtualconsole/vcbuttonproperties.cpp
+++ b/ui/src/virtualconsole/vcbuttonproperties.cpp
@@ -249,6 +249,8 @@ void VCButtonProperties::slotSpeedDialToggle(bool state)
         m_speedDials->setFadeOutSpeed(m_button->stopAllFadeTime());
         m_speedDials->setDurationEnabled(false);
         m_speedDials->setDurationVisible(false);
+        m_speedDials->setStopActionEnabled(false);
+        m_speedDials->setStopActionVisible(false);
         connect(m_speedDials, SIGNAL(fadeOutChanged(int)), this, SLOT(slotFadeOutDialChanged(int)));
         connect(m_speedDials, SIGNAL(destroyed(QObject*)), this, SLOT(slotDialDestroyed(QObject*)));
         m_speedDials->show();


### PR DESCRIPTION
I added the option to select a stop action for a scene in the SpeedDialWindow.
This allows me to switch between scenes/chases without the pan/tilt channels to reset.
This is very useful when controlling QLC+ live.
See the discussion on the forum:
https://sourceforge.net/p/qlcplus/discussion/general/thread/5717245b

Regards,
Joep Admiraal