### PR TITLE
Enttec Playbackwing using Feedback to sync widget values and playbackwing sliders 

### DIFF
--- a/plugins/enttecwing/src/enttecwing.cpp
+++ b/plugins/enttecwing/src/enttecwing.cpp
@@ -53,7 +53,7 @@ QString EnttecWing::name()
 
 int EnttecWing::capabilities() const
 {
-    return QLCIOPlugin::Input;
+    return QLCIOPlugin::Output | QLCIOPlugin::Input | QLCIOPlugin::Feedback;
 }
 
 bool EnttecWing::reBindSocket()
@@ -72,6 +72,19 @@ bool EnttecWing::reBindSocket()
         m_errorString.clear();
     }
     return true;
+}
+
+/*****************************************************************************
+ * Outputs
+ *****************************************************************************/
+
+QStringList EnttecWing::outputs()
+{
+    QStringList list;
+    QListIterator <Wing*> it(m_devices);
+    while (it.hasNext() == true)
+        list << it.next()->name();
+    return list;
 }
 
 /*****************************************************************************

--- a/plugins/enttecwing/src/enttecwing.h
+++ b/plugins/enttecwing/src/enttecwing.h
@@ -72,13 +72,13 @@ public:
      *************************************************************************/
 public:
     /** @reimp */
-    bool openOutput(quint32 output) { Q_UNUSED(output); return false; }
+    bool openOutput(quint32 output) { Q_UNUSED(output); return true; }
 
     /** @reimp */
     void closeOutput(quint32 output) { Q_UNUSED(output); }
 
     /** @reimp */
-    QStringList outputs() { return QStringList(); }
+    QStringList outputs();
 
     /** @reimp */
     void writeUniverse(quint32 universe, quint32 output, const QByteArray& data)

--- a/plugins/enttecwing/src/playbackwing.cpp
+++ b/plugins/enttecwing/src/playbackwing.cpp
@@ -161,7 +161,7 @@ PlaybackWing::PlaybackWing(QObject* parent, const QHostAddress& address,
     m_channelMap[38] = 33 + WING_PLAYBACK_SLIDER_SIZE;
     m_channelMap[39] = 32 + WING_PLAYBACK_SLIDER_SIZE;
 
-    m_needSync = false;
+    m_needSync = true;
 
     /* Take initial values from the first received datagram packet.
        The plugin hasn't yet connected to valueChanged() signal, so this
@@ -240,7 +240,7 @@ void PlaybackWing::parseData(const QByteArray& data)
             if (!m_feedbackDiffs.contains(page()))
                 m_feedbackDiffs.insert(page(), QVector<int>(WING_PLAYBACK_SLIDER_SIZE, 0));
 
-            m_feedbackDiffs[page()][slider] = quint8(m_feedbackValues[page()][slider]) - quint8(data[WING_PLAYBACK_BYTE_SLIDER + slider]);
+            m_feedbackDiffs[page()][slider] = quint8(m_feedbackValues[page()][slider]) - quint8(cacheValue(slider));
         }
 
         int diff = 0;
@@ -253,6 +253,8 @@ void PlaybackWing::parseData(const QByteArray& data)
         {
             //check sync status
             int curdiff = quint8(m_feedbackValues[page()][slider]) - quint8(data[WING_PLAYBACK_BYTE_SLIDER + slider]);
+
+            // send input after crossing widget values ( sign of diff is changing)
             if (curdiff == 0 || (curdiff > 0 && diff < 0)  || (curdiff < 0 && diff > 0))
             {
                 setCacheValue(slider, value);

--- a/plugins/enttecwing/src/playbackwing.cpp
+++ b/plugins/enttecwing/src/playbackwing.cpp
@@ -161,6 +161,8 @@ PlaybackWing::PlaybackWing(QObject* parent, const QHostAddress& address,
     m_channelMap[38] = 33 + WING_PLAYBACK_SLIDER_SIZE;
     m_channelMap[39] = 32 + WING_PLAYBACK_SLIDER_SIZE;
 
+    m_needSync = false;
+
     /* Take initial values from the first received datagram packet.
        The plugin hasn't yet connected to valueChanged() signal, so this
        won't cause any input events. */
@@ -232,9 +234,38 @@ void PlaybackWing::parseData(const QByteArray& data)
     /* Read the state of each slider. Each value takes all 8 bits. */
     for (int slider = 0; slider < WING_PLAYBACK_SLIDER_SIZE; slider++)
     {
+        if (m_needSync)
+        {
+            // store value diffs to sync qlcplus widgets and wing slider
+            if (!m_feedbackDiffs.contains(page()))
+                m_feedbackDiffs.insert(page(), QVector<int>(WING_PLAYBACK_SLIDER_SIZE, 0));
+
+            m_feedbackDiffs[page()][slider] = quint8(m_feedbackValues[page()][slider]) - quint8(data[WING_PLAYBACK_BYTE_SLIDER + slider]);
+        }
+
+        int diff = 0;
+        if (m_feedbackDiffs.contains(page()))
+            diff = m_feedbackDiffs[page()][slider];
+
         char value = data[WING_PLAYBACK_BYTE_SLIDER + slider];
-        setCacheValue(slider, value);
+
+        if (m_feedbackValues.contains(page()) && diff != 0)
+        {
+            //check sync status
+            int curdiff = quint8(m_feedbackValues[page()][slider]) - quint8(data[WING_PLAYBACK_BYTE_SLIDER + slider]);
+            if (curdiff == 0 || (curdiff > 0 && diff < 0)  || (curdiff < 0 && diff > 0))
+            {
+                setCacheValue(slider, value);
+                if (m_feedbackDiffs.contains(page()))
+                    m_feedbackDiffs[page()][slider] = 0;
+            }
+        }
+        else
+        {
+            setCacheValue(slider, value);
+        }
     }
+    m_needSync = false;
 }
 
 void PlaybackWing::applyExtraButtons(const QByteArray& data)
@@ -293,8 +324,30 @@ void PlaybackWing::sendPageData()
     QByteArray sendData(42, char(0));
     sendData.replace(0, sizeof(WING_HEADER_INPUT), WING_HEADER_INPUT);
     sendData[WING_PLAYBACK_INPUT_BYTE_VERSION] = WING_PLAYBACK_INPUT_VERSION;
-    sendData[WING_PLAYBACK_INPUT_BYTE_PAGE] = toBCD(page());
+    sendData[WING_PLAYBACK_INPUT_BYTE_PAGE] = toBCD(page() + 1);
 
     QUdpSocket sock(this);
     sock.writeDatagram(sendData, address(), Wing::UDPPort);
+}
+
+void PlaybackWing::feedBack(quint32 channel, uchar value)
+{
+    quint16 pageChan = channel & 0xFF;
+    quint16 pageNum = channel >> 16;
+
+    // create new byte array for page, to store values, if it not exists
+    if (!m_feedbackValues.contains(pageNum))
+        m_feedbackValues.insert(pageNum, QByteArray(WING_PLAYBACK_SLIDER_SIZE, 0));
+
+    // store slider values for later use
+    if (pageChan < WING_PLAYBACK_SLIDER_SIZE)
+        m_feedbackValues[pageNum][pageChan] = value;
+
+    //set page
+    if (pageChan == WING_PLAYBACK_BUTTON_PAGEDOWN || pageChan == WING_PLAYBACK_BUTTON_PAGEUP)
+    {
+        m_needSync = true;
+        m_page = value;
+        sendPageData();
+    }
 }

--- a/plugins/enttecwing/src/playbackwing.cpp
+++ b/plugins/enttecwing/src/playbackwing.cpp
@@ -326,7 +326,7 @@ void PlaybackWing::sendPageData()
     QByteArray sendData(42, char(0));
     sendData.replace(0, sizeof(WING_HEADER_INPUT), WING_HEADER_INPUT);
     sendData[WING_PLAYBACK_INPUT_BYTE_VERSION] = WING_PLAYBACK_INPUT_VERSION;
-    sendData[WING_PLAYBACK_INPUT_BYTE_PAGE] = toBCD(page() + 1);
+    sendData[WING_PLAYBACK_INPUT_BYTE_PAGE] = page() + 1;
 
     QUdpSocket sock(this);
     sock.writeDatagram(sendData, address(), Wing::UDPPort);

--- a/plugins/enttecwing/src/playbackwing.cpp
+++ b/plugins/enttecwing/src/playbackwing.cpp
@@ -341,9 +341,15 @@ void PlaybackWing::feedBack(quint32 channel, uchar value)
     if (!m_feedbackValues.contains(pageNum))
         m_feedbackValues.insert(pageNum, QByteArray(WING_PLAYBACK_SLIDER_SIZE, 0));
 
-    // store slider values for later use
     if (pageChan < WING_PLAYBACK_SLIDER_SIZE)
+    {
+        // store widget values for later use
         m_feedbackValues[pageNum][pageChan] = value;
+
+        // check sync
+        if (value != cacheValue(pageChan))
+            m_needSync = true;
+    }
 
     //set page
     if (pageChan == WING_PLAYBACK_BUTTON_PAGEDOWN || pageChan == WING_PLAYBACK_BUTTON_PAGEUP)

--- a/plugins/enttecwing/src/playbackwing.h
+++ b/plugins/enttecwing/src/playbackwing.h
@@ -72,6 +72,9 @@ public:
     /** Send current page number back to the wing */
     void sendPageData();
 
+    /*** receive feedback to sync wing with widget ***/
+    void feedBack(quint32 channel, uchar value);
+
 protected:
     /**
      * Since some of the channels in a playback wing seem to be in a weird
@@ -79,6 +82,16 @@ protected:
      * order.
      */
     QMap <int,int> m_channelMap;
+
+    /**
+     * stores slider values received by feedback,
+     * used to handle page changes
+     */
+    QMap <int, QByteArray> m_feedbackValues;
+    QMap <int, QVector<int> > m_feedbackDiffs;
+
+private:
+    bool m_needSync;
 };
 
 #endif

--- a/plugins/enttecwing/src/wing.h
+++ b/plugins/enttecwing/src/wing.h
@@ -37,7 +37,7 @@
 #define WING_HEADER_OUTPUT "WODD"
 #define WING_HEADER_INPUT  "WIDD"
 #define WING_PAGE_MIN      0
-#define WING_PAGE_MAX      99
+#define WING_PAGE_MAX      98
 
 /****************************************************************************
  * Status data common to all wings
@@ -172,7 +172,8 @@ public:
     void previousPage();
     uchar page() const;
 
-private:
+protected:
+    //TODO: add a method, which is reimpl for playbackwing and "empty" for the rest
     uchar m_page;
 
     /********************************************************************
@@ -234,6 +235,7 @@ signals:
 
 protected:
     QByteArray m_values;
+
 };
 
 #endif

--- a/plugins/enttecwing/test/wing_test.cpp
+++ b/plugins/enttecwing/test/wing_test.cpp
@@ -149,7 +149,7 @@ void Wing_Test::page()
     WingStub es(this, addr, ba);
 
     uchar i;
-    for (i = 0; i < 99; i++)
+    for (i = 0; i < 98; i++)
     {
         QCOMPARE(es.page(), i);
         es.nextPage();
@@ -159,16 +159,16 @@ void Wing_Test::page()
     QCOMPARE(es.page(), uchar(0));
 
     es.previousPage();
-    QCOMPARE(es.page(), uchar(99));
+    QCOMPARE(es.page(), uchar(98));
 
-    for (i = 99; i > 0; i--)
+    for (i = 98; i > 0; i--)
     {
         QCOMPARE(es.page(), i);
         es.previousPage();
     }
 
     es.previousPage();
-    QCOMPARE(es.page(), uchar(99));
+    QCOMPARE(es.page(), uchar(98));
 }
 
 void Wing_Test::bcd()

--- a/resources/inputprofiles/Enttec-PlaybackWing.qxi
+++ b/resources/inputprofiles/Enttec-PlaybackWing.qxi
@@ -1,13 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE InputProfile>
-<InputProfile>
+<InputProfile xmlns="http://qlcplus.sourceforge.net/InputProfile">
  <Creator>
-  <Name>Q Light Controller</Name>
-  <Version>3.0.6</Version>
-  <Author>hjunnila</Author>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.8.5 GIT</Version>
+  <Author>Thomas Achtner</Author>
  </Creator>
  <Manufacturer>Enttec</Manufacturer>
  <Model>Playback Wing</Model>
- <Type>Enntec</Type>
+ <Type>Enttec</Type>
  <Channel Number="0">
   <Name>Slider 1</Name>
   <Type>Slider</Type>
@@ -208,5 +209,20 @@
   <Name>Button 10</Name>
   <Type>Button</Type>
  </Channel>
+ <Channel Number="50">
+  <Name>Go</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="51">
+  <Name>Back</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="52">
+  <Name>Page Down</Name>
+  <Type>Previous Page</Type>
+ </Channel>
+ <Channel Number="53">
+  <Name>Page Up</Name>
+  <Type>Next Page</Type>
+ </Channel>
 </InputProfile>
-

--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -444,6 +444,7 @@ void VCFrame::slotPreviousPage()
         slotSetPage(m_totalPagesNumber - 1);
     else
         slotSetPage(m_currentPage - 1);
+    sendFeedback(m_currentPage, previousPageInputSourceId);
 }
 
 void VCFrame::slotNextPage()
@@ -452,6 +453,8 @@ void VCFrame::slotNextPage()
         slotSetPage(0);
     else
         slotSetPage(m_currentPage + 1);
+
+    sendFeedback(m_currentPage, nextPageInputSourceId);
 }
 
 void VCFrame::slotSetPage(int pageNum)
@@ -483,13 +486,6 @@ void VCFrame::slotSetPage(int pageNum)
         }
         m_doc->setModified();
         emit pageChanged(m_currentPage);
-
-        // __offtools__ (enttec playbackwing)
-        // needed to receive page changes from the widget,
-        // only sends nextPage channel, with page number as value,
-        // also when prevPage is clicked.
-        // Strange, but enough to handle pages on the wing
-        sendFeedback(m_currentPage);
     }
 }
 

--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -483,6 +483,13 @@ void VCFrame::slotSetPage(int pageNum)
         }
         m_doc->setModified();
         emit pageChanged(m_currentPage);
+
+        // __offtools__ (enttec playbackwing)
+        // needed to receive page changes from the widget,
+        // only sends nextPage channel, with page number as value,
+        // also when prevPage is clicked.
+        // Strange, but enough to handle pages on the wing
+        sendFeedback(m_currentPage);
     }
 }
 

--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -643,12 +643,13 @@ void VCWidget::sendFeedback(int value, quint8 id)
             QLCInputProfile* profile = pat->profile();
             if (profile != NULL)
             {
-                QLCInputChannel* ich = profile->channel(src->channel());
+                // __offtools__ send correct channel names
+                //QLCInputChannel* ich = profile->channel(src->channel());
+                QLCInputChannel* ich = profile->channel( (src->channel() & 0xFF) );
                 if (ich != NULL)
                     chName = ich->name();
             }
         }
-
         m_doc->inputOutputMap()->sendFeedBack(src->universe(), src->channel(), value, chName);
     }
 }

--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -643,9 +643,7 @@ void VCWidget::sendFeedback(int value, quint8 id)
             QLCInputProfile* profile = pat->profile();
             if (profile != NULL)
             {
-                // __offtools__ send correct channel names
-                //QLCInputChannel* ich = profile->channel(src->channel());
-                QLCInputChannel* ich = profile->channel( (src->channel() & 0xFF) );
+                QLCInputChannel* ich = profile->channel(src->channel());
                 if (ich != NULL)
                     chName = ich->name();
             }


### PR DESCRIPTION
Finally implemented syncing between widgets in the virtual console and sliders of the playbackwing by using Feedback.

If wing sliders and widget values in the virtual console differ, in case of page changes or changing stuff with the mouse, the wing slider have to fetch the current values in the virtual console, before sending new input. This prevents jumping of the output values.

With this commit also pages/page changes are fully supported for the playbackwing, when using the frame widget. Page changes work in booth directions (qlcplus -> wing, wing -> qlcplus). 

I only had to make two little changes outside the plugin (vcframe.cpp, vcwidget.cpp). Hope this is ok, I added some comments there for review.

offtools
