### PR TITLE
Collection: pass down intensity

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ qlcplus (4.8.5) stable; urgency=low
 
   * Engine: it is now possible to flash LTP channels as well
   * RGB Scripts: added new "Balls" script (thanks to Tim Cullingworth)
+  * Collections: Pass down the intensity attribute to a collection's functions (David Garyga)
   * Function Manager: fix crash // disable Add Sequence button when function selection is empty (David Garyga)
   * Chaser Editor: fix cutting of several steps at the same time (David Garyga)
   * Chaser Editor: fix crash when trying to paste a removed function (David Garyga)

--- a/engine/src/collection.cpp
+++ b/engine/src/collection.cpp
@@ -266,6 +266,7 @@ void Collection::write(MasterTimer* timer, QList<Universe *> universes)
             connect(function, SIGNAL(stopped(quint32)),
                     this, SLOT(slotChildStopped(quint32)));
 
+            function->adjustAttribute(getAttributeValue(Function::Intensity), Function::Intensity);
             function->start(timer, true, 0, overrideFadeInSpeed(), overrideFadeOutSpeed(), overrideDuration());
         }
     }


### PR DESCRIPTION
As of now, the intensity of a collection is not passed down to it's member functions.