### PR TITLE
InputSources: wrap in QSharedPointer to avoid double frees.

### DIFF
--- a/engine/src/channelsgroup.h
+++ b/engine/src/channelsgroup.h
@@ -127,14 +127,14 @@ public:
      *
      * @param source The input source to set
      */
-    void setInputSource(QLCInputSource *source);
+    void setInputSource(QSharedPointer<QLCInputSource> const& source);
 
     /**
      * Get an assigned external input source
      *
      * @param id The id of the source to get
      */
-    QLCInputSource *inputSource() const;
+    QSharedPointer<QLCInputSource> const& inputSource() const;
 
 protected slots:
     /**
@@ -155,7 +155,7 @@ private:
     uchar m_masterValue;
     QList <SceneValue> m_channels;
 
-    QLCInputSource *m_input;
+    QSharedPointer<QLCInputSource> m_input;
 };
 
 /** @} */

--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -806,6 +806,12 @@ bool InputOutputMap::inputSourceNames(const QLCInputSource *src,
     return true;
 }
 
+bool InputOutputMap::inputSourceNames(QSharedPointer<QLCInputSource> const& src,
+                                QString& uniName, QString& chName) const
+{
+    return inputSourceNames(src.data(), uniName, chName);
+}
+
 QDir InputOutputMap::systemProfileDirectory()
 {
     return QLCFile::systemDirectory(QString(INPUTPROFILEDIR), QString(KExtInputProfile));

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -23,6 +23,7 @@
 #include <QObject>
 #include <QMutex>
 #include <QDir>
+#include <QSharedPointer>
 
 #include "qlcinputprofile.h"
 #include "grandmaster.h"

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -502,6 +502,8 @@ public:
      */
     bool inputSourceNames(const QLCInputSource *src,
                           QString& uniName, QString& chName) const;
+    bool inputSourceNames(QSharedPointer<QLCInputSource> const& src,
+                          QString& uniName, QString& chName) const;
 
     /**
      * Get the default system input profile directory that contains installed

--- a/ui/src/addchannelsgroup.cpp
+++ b/ui/src/addchannelsgroup.cpp
@@ -273,7 +273,7 @@ void AddChannelsGroup::slotAutoDetectInputToggled(bool checked)
 
 void AddChannelsGroup::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_inputSource.reset(new QLCInputSource(universe, channel));
+    m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, channel));
     updateInputSource();
 }
 
@@ -282,7 +282,7 @@ void AddChannelsGroup::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/addchannelsgroup.cpp
+++ b/ui/src/addchannelsgroup.cpp
@@ -273,7 +273,7 @@ void AddChannelsGroup::slotAutoDetectInputToggled(bool checked)
 
 void AddChannelsGroup::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_inputSource = new QLCInputSource(universe, channel);
+    m_inputSource.reset(new QLCInputSource(universe, channel));
     updateInputSource();
 }
 
@@ -282,7 +282,7 @@ void AddChannelsGroup::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_inputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }
@@ -301,5 +301,3 @@ void AddChannelsGroup::updateInputSource()
     m_inputUniverseEdit->setText(uniName);
     m_inputChannelEdit->setText(chName);
 }
-
-

--- a/ui/src/addchannelsgroup.h
+++ b/ui/src/addchannelsgroup.h
@@ -58,7 +58,7 @@ private:
     ChannelsGroup* m_chansGroup;
 
 protected:
-    QLCInputSource *m_inputSource;
+    QSharedPointer<QLCInputSource> m_inputSource;
 
     int m_checkedChannels;
     bool m_isUpdating;

--- a/ui/src/virtualconsole/vcaudiotriggersproperties.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggersproperties.cpp
@@ -437,7 +437,7 @@ void AudioTriggersConfiguration::slotAutoDetectInputToggled(bool checked)
 
 void AudioTriggersConfiguration::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_inputSource.reset(new QLCInputSource(universe, (m_triggers->page() << 16) | channel));
+    m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_triggers->page() << 16) | channel));
     updateInputSource();
 }
 
@@ -446,7 +446,7 @@ void AudioTriggersConfiguration::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/virtualconsole/vcaudiotriggersproperties.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggersproperties.cpp
@@ -437,9 +437,7 @@ void AudioTriggersConfiguration::slotAutoDetectInputToggled(bool checked)
 
 void AudioTriggersConfiguration::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    if (m_inputSource != NULL)
-        delete m_inputSource;
-    m_inputSource = new QLCInputSource(universe, (m_triggers->page() << 16) | channel);
+    m_inputSource.reset(new QLCInputSource(universe, (m_triggers->page() << 16) | channel));
     updateInputSource();
 }
 
@@ -448,9 +446,7 @@ void AudioTriggersConfiguration::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_inputSource != NULL)
-            delete m_inputSource;
-        m_inputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/virtualconsole/vcaudiotriggersproperties.h
+++ b/ui/src/virtualconsole/vcaudiotriggersproperties.h
@@ -73,7 +73,7 @@ private:
     VCAudioTriggers *m_triggers;
     int m_maxFrequency;
     QKeySequence m_keySequence;
-    QLCInputSource *m_inputSource;
+    QSharedPointer<QLCInputSource> m_inputSource;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcbuttonproperties.cpp
+++ b/ui/src/virtualconsole/vcbuttonproperties.cpp
@@ -187,9 +187,7 @@ void VCButtonProperties::slotAutoDetectInputToggled(bool checked)
 
 void VCButtonProperties::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    if (m_inputSource != NULL)
-        delete m_inputSource;
-    m_inputSource = new QLCInputSource(universe, (m_button->page() << 16) | channel);
+    m_inputSource.reset(new QLCInputSource(universe, (m_button->page() << 16) | channel));
     updateInputSource();
 }
 
@@ -198,9 +196,7 @@ void VCButtonProperties::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_inputSource != NULL)
-            delete m_inputSource;
-        m_inputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/virtualconsole/vcbuttonproperties.cpp
+++ b/ui/src/virtualconsole/vcbuttonproperties.cpp
@@ -187,7 +187,7 @@ void VCButtonProperties::slotAutoDetectInputToggled(bool checked)
 
 void VCButtonProperties::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_inputSource.reset(new QLCInputSource(universe, (m_button->page() << 16) | channel));
+    m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_button->page() << 16) | channel));
     updateInputSource();
 }
 
@@ -196,7 +196,7 @@ void VCButtonProperties::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/virtualconsole/vcbuttonproperties.h
+++ b/ui/src/virtualconsole/vcbuttonproperties.h
@@ -72,7 +72,7 @@ protected:
 
     QKeySequence m_keySequence;
     quint32 m_function;
-    QLCInputSource *m_inputSource;
+    QSharedPointer<QLCInputSource> m_inputSource;
 
     /************************************************************************
      * Speed dial

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -1093,7 +1093,7 @@ bool VCCueList::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), nextInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), nextInputSourceId);
                 }
                 else if (subTag.tagName() == KXMLQLCVCCueListKey)
                 {
@@ -1117,7 +1117,7 @@ bool VCCueList::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), previousInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), previousInputSourceId);
                 }
                 else if (subTag.tagName() == KXMLQLCVCCueListKey)
                 {
@@ -1141,7 +1141,7 @@ bool VCCueList::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), playbackInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), playbackInputSourceId);
                 }
                 else if (subTag.tagName() == KXMLQLCVCCueListKey)
                 {
@@ -1165,7 +1165,7 @@ bool VCCueList::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), cf1InputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), cf1InputSourceId);
                 }
             }
         }
@@ -1179,7 +1179,7 @@ bool VCCueList::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), cf2InputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), cf2InputSourceId);
                 }
             }
         }
@@ -1286,15 +1286,15 @@ bool VCCueList::saveXML(QDomDocument* doc, QDomElement* vc_root)
     saveXMLInput(doc, &tag, inputSource(playbackInputSourceId));
 
     /* Crossfade cue list */
-    QLCInputSource *cf1Src = inputSource(cf1InputSourceId);
-    if (cf1Src != NULL && cf1Src->isValid())
+    QSharedPointer<QLCInputSource> cf1Src = inputSource(cf1InputSourceId);
+    if (!cf1Src.isNull() && cf1Src->isValid())
     {
         tag = doc->createElement(KXMLQLCVCCueListCrossfadeLeft);
         root.appendChild(tag);
         saveXMLInput(doc, &tag, inputSource(cf1InputSourceId));
     }
-    QLCInputSource *cf2Src = inputSource(cf2InputSourceId);
-    if (cf2Src != NULL && cf2Src->isValid())
+    QSharedPointer<QLCInputSource> cf2Src = inputSource(cf2InputSourceId);
+    if (!cf2Src.isNull() && cf2Src->isValid())
     {
         tag = doc->createElement(KXMLQLCVCCueListCrossfadeRight);
         root.appendChild(tag);

--- a/ui/src/virtualconsole/vccuelistproperties.cpp
+++ b/ui/src/virtualconsole/vccuelistproperties.cpp
@@ -250,7 +250,7 @@ void VCCueListProperties::slotNextChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_nextInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_nextInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateNextInputSource();
     }
 }
@@ -271,7 +271,7 @@ void VCCueListProperties::slotNextAutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotNextInputValueChanged(quint32 uni, quint32 ch)
 {
-    m_nextInputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
+    m_nextInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updateNextInputSource();
 }
 
@@ -318,7 +318,7 @@ void VCCueListProperties::slotPreviousChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_previousInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_previousInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updatePreviousInputSource();
     }
 }
@@ -339,7 +339,7 @@ void VCCueListProperties::slotPreviousAutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotPreviousInputValueChanged(quint32 uni, quint32 ch)
 {
-    m_previousInputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
+    m_previousInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updatePreviousInputSource();
 }
 
@@ -386,7 +386,7 @@ void VCCueListProperties::slotPlaybackChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_playbackInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_playbackInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updatePlaybackInputSource();
     }
 }
@@ -407,7 +407,7 @@ void VCCueListProperties::slotPlaybackAutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotPlaybackInputValueChanged(quint32 uni, quint32 ch)
 {
-    m_playbackInputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
+    m_playbackInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updatePlaybackInputSource();
 }
 
@@ -438,7 +438,7 @@ void VCCueListProperties::slotCF1ChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_cf1InputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_cf1InputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateCrossfadeInputSource();
     }
 }
@@ -461,7 +461,7 @@ void VCCueListProperties::slotCF1AutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotCF1InputValueChanged(quint32 uni, quint32 ch)
 {
-    m_cf1InputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
+    m_cf1InputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updateCrossfadeInputSource();
 }
 
@@ -470,7 +470,7 @@ void VCCueListProperties::slotCF2ChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_cf2InputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_cf2InputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateCrossfadeInputSource();
     }
 }
@@ -493,7 +493,7 @@ void VCCueListProperties::slotCF2AutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotCF2InputValueChanged(quint32 uni, quint32 ch)
 {
-    m_cf2InputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
+    m_cf2InputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updateCrossfadeInputSource();
 }
 

--- a/ui/src/virtualconsole/vccuelistproperties.cpp
+++ b/ui/src/virtualconsole/vccuelistproperties.cpp
@@ -250,9 +250,7 @@ void VCCueListProperties::slotNextChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_nextInputSource != NULL)
-           delete m_nextInputSource;
-        m_nextInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_nextInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateNextInputSource();
     }
 }
@@ -273,9 +271,7 @@ void VCCueListProperties::slotNextAutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotNextInputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_nextInputSource != NULL)
-       delete m_nextInputSource;
-    m_nextInputSource = new QLCInputSource(uni, (m_cueList->page() << 16) | ch);
+    m_nextInputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updateNextInputSource();
 }
 
@@ -322,9 +318,7 @@ void VCCueListProperties::slotPreviousChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_previousInputSource != NULL)
-           delete m_previousInputSource;
-        m_previousInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_previousInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updatePreviousInputSource();
     }
 }
@@ -345,9 +339,7 @@ void VCCueListProperties::slotPreviousAutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotPreviousInputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_previousInputSource != NULL)
-       delete m_previousInputSource;
-    m_previousInputSource = new QLCInputSource(uni, (m_cueList->page() << 16) | ch);
+    m_previousInputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updatePreviousInputSource();
 }
 
@@ -394,9 +386,7 @@ void VCCueListProperties::slotPlaybackChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_playbackInputSource != NULL)
-           delete m_playbackInputSource;
-        m_playbackInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_playbackInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updatePlaybackInputSource();
     }
 }
@@ -417,9 +407,7 @@ void VCCueListProperties::slotPlaybackAutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotPlaybackInputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_playbackInputSource != NULL)
-       delete m_playbackInputSource;
-    m_playbackInputSource = new QLCInputSource(uni, (m_cueList->page() << 16) | ch);
+    m_playbackInputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updatePlaybackInputSource();
 }
 
@@ -450,9 +438,7 @@ void VCCueListProperties::slotCF1ChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_cf1InputSource != NULL)
-           delete m_cf1InputSource;
-        m_cf1InputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_cf1InputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateCrossfadeInputSource();
     }
 }
@@ -475,9 +461,7 @@ void VCCueListProperties::slotCF1AutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotCF1InputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_cf1InputSource != NULL)
-       delete m_cf1InputSource;
-    m_cf1InputSource = new QLCInputSource(uni, (m_cueList->page() << 16) | ch);
+    m_cf1InputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updateCrossfadeInputSource();
 }
 
@@ -486,9 +470,7 @@ void VCCueListProperties::slotCF2ChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_cf2InputSource != NULL)
-           delete m_cf2InputSource;
-        m_cf2InputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_cf2InputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateCrossfadeInputSource();
     }
 }
@@ -511,9 +493,7 @@ void VCCueListProperties::slotCF2AutoDetectInputToggled(bool checked)
 
 void VCCueListProperties::slotCF2InputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_cf2InputSource != NULL)
-       delete m_cf2InputSource;
-    m_cf2InputSource = new QLCInputSource(uni, (m_cueList->page() << 16) | ch);
+    m_cf2InputSource.reset(new QLCInputSource(uni, (m_cueList->page() << 16) | ch));
     updateCrossfadeInputSource();
 }
 

--- a/ui/src/virtualconsole/vccuelistproperties.h
+++ b/ui/src/virtualconsole/vccuelistproperties.h
@@ -84,7 +84,7 @@ protected:
 
 protected:
     QKeySequence m_nextKeySequence;
-    QLCInputSource *m_nextInputSource;
+    QSharedPointer<QLCInputSource> m_nextInputSource;
 
     /************************************************************************
      * Previous Cue
@@ -101,7 +101,7 @@ protected:
 
 protected:
     QKeySequence m_previousKeySequence;
-    QLCInputSource *m_previousInputSource;
+    QSharedPointer<QLCInputSource> m_previousInputSource;
 
     /************************************************************************
      * Cue List Playback
@@ -118,7 +118,7 @@ protected:
 
 protected:
     QKeySequence m_playbackKeySequence;
-    QLCInputSource *m_playbackInputSource;
+    QSharedPointer<QLCInputSource> m_playbackInputSource;
 
     /************************************************************************
      * Crossfade Cue List
@@ -135,8 +135,8 @@ protected:
     void updateCrossfadeInputSource();
 
 protected:
-    QLCInputSource *m_cf1InputSource;
-    QLCInputSource *m_cf2InputSource;
+    QSharedPointer<QLCInputSource> m_cf1InputSource;
+    QSharedPointer<QLCInputSource> m_cf2InputSource;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -822,7 +822,7 @@ bool VCFrame::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), enableInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), enableInputSourceId);
                 }
                 else if (subTag.tagName() == KXMLQLCVCFrameKey)
                 {
@@ -846,7 +846,7 @@ bool VCFrame::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), nextPageInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), nextPageInputSourceId);
                 }
                 else if (subTag.tagName() == KXMLQLCVCFrameKey)
                 {
@@ -870,7 +870,7 @@ bool VCFrame::loadXML(const QDomElement* root)
                 {
                     quint32 uni = 0, ch = 0;
                     if (loadXMLInput(subTag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), previousPageInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), previousPageInputSourceId);
                 }
                 else if (subTag.tagName() == KXMLQLCVCFrameKey)
                 {

--- a/ui/src/virtualconsole/vcframeproperties.cpp
+++ b/ui/src/virtualconsole/vcframeproperties.cpp
@@ -238,7 +238,7 @@ void VCFrameProperties::slotEnableChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_enableInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_enableInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateEnableInputSource();
     }
 }
@@ -259,7 +259,7 @@ void VCFrameProperties::slotEnableAutoDetectInputToggled(bool checked)
 
 void VCFrameProperties::slotEnableInputValueChanged(quint32 uni, quint32 ch)
 {
-    m_enableInputSource.reset(new QLCInputSource(uni, ch));
+    m_enableInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch));
     updateEnableInputSource();
 }
 
@@ -306,7 +306,7 @@ void VCFrameProperties::slotNextChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_nextInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_nextInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateNextInputSource();
     }
 }
@@ -327,7 +327,7 @@ void VCFrameProperties::slotNextAutoDetectInputToggled(bool checked)
 
 void VCFrameProperties::slotNextInputValueChanged(quint32 uni, quint32 ch)
 {
-    m_nextInputSource.reset(new QLCInputSource(uni, ch));
+    m_nextInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch));
     updateNextInputSource();
 }
 
@@ -374,7 +374,7 @@ void VCFrameProperties::slotPreviousChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_previousInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_previousInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updatePreviousInputSource();
     }
 }
@@ -395,7 +395,7 @@ void VCFrameProperties::slotPreviousAutoDetectInputToggled(bool checked)
 
 void VCFrameProperties::slotPreviousInputValueChanged(quint32 uni, quint32 ch)
 {
-    m_previousInputSource.reset(new QLCInputSource(uni, ch));
+    m_previousInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch));
     updatePreviousInputSource();
 }
 

--- a/ui/src/virtualconsole/vcframeproperties.cpp
+++ b/ui/src/virtualconsole/vcframeproperties.cpp
@@ -238,9 +238,7 @@ void VCFrameProperties::slotEnableChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_enableInputSource != NULL)
-           delete m_enableInputSource;
-        m_enableInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_enableInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateEnableInputSource();
     }
 }
@@ -261,9 +259,7 @@ void VCFrameProperties::slotEnableAutoDetectInputToggled(bool checked)
 
 void VCFrameProperties::slotEnableInputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_enableInputSource != NULL)
-       delete m_enableInputSource;
-    m_enableInputSource = new QLCInputSource(uni, ch);
+    m_enableInputSource.reset(new QLCInputSource(uni, ch));
     updateEnableInputSource();
 }
 
@@ -310,9 +306,7 @@ void VCFrameProperties::slotNextChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_nextInputSource != NULL)
-           delete m_nextInputSource;
-        m_nextInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_nextInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateNextInputSource();
     }
 }
@@ -333,9 +327,7 @@ void VCFrameProperties::slotNextAutoDetectInputToggled(bool checked)
 
 void VCFrameProperties::slotNextInputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_nextInputSource != NULL)
-       delete m_nextInputSource;
-    m_nextInputSource = new QLCInputSource(uni, ch);
+    m_nextInputSource.reset(new QLCInputSource(uni, ch));
     updateNextInputSource();
 }
 
@@ -382,9 +374,7 @@ void VCFrameProperties::slotPreviousChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_previousInputSource != NULL)
-           delete m_previousInputSource;
-        m_previousInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_previousInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updatePreviousInputSource();
     }
 }
@@ -405,9 +395,7 @@ void VCFrameProperties::slotPreviousAutoDetectInputToggled(bool checked)
 
 void VCFrameProperties::slotPreviousInputValueChanged(quint32 uni, quint32 ch)
 {
-    if (m_previousInputSource != NULL)
-       delete m_previousInputSource;
-    m_previousInputSource = new QLCInputSource(uni, ch);
+    m_previousInputSource.reset(new QLCInputSource(uni, ch));
     updatePreviousInputSource();
 }
 

--- a/ui/src/virtualconsole/vcframeproperties.h
+++ b/ui/src/virtualconsole/vcframeproperties.h
@@ -70,7 +70,7 @@ protected:
 
 protected:
     QKeySequence m_enableKeySequence;
-    QLCInputSource *m_enableInputSource;
+    QSharedPointer<QLCInputSource> m_enableInputSource;
 
     /************************************************************************
      * Next page
@@ -87,7 +87,7 @@ protected:
 
 protected:
     QKeySequence m_nextKeySequence;
-    QLCInputSource *m_nextInputSource;
+    QSharedPointer<QLCInputSource> m_nextInputSource;
 
     /************************************************************************
      * Previous page
@@ -104,7 +104,7 @@ protected:
 
 protected:
     QKeySequence m_previousKeySequence;
-    QLCInputSource *m_previousInputSource;
+    QSharedPointer<QLCInputSource> m_previousInputSource;
 
 public slots:
     void accept();

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -154,8 +154,6 @@ VCMatrix::~VCMatrix()
 {
     foreach(VCMatrixControl* control, m_controls)
     {
-        if (control->m_inputSource != NULL)
-            setInputSource(NULL, control->m_id);
         delete control;
     }
 }
@@ -656,7 +654,10 @@ void VCMatrix::addCustomControl(VCMatrixControl const& control)
     m_controls[controlWidget] = new VCMatrixControl(control);
     m_controlsLayout->addWidget(controlWidget);
 
-    setInputSource(m_controls[controlWidget]->m_inputSource, m_controls[controlWidget]->m_id);
+    if (m_controls[controlWidget]->m_inputSource != NULL)
+    {
+        setInputSource(m_controls[controlWidget]->m_inputSource, m_controls[controlWidget]->m_id);
+    }
 
     slotFunctionChanged(); // Start update timer
 }
@@ -666,9 +667,14 @@ void VCMatrix::resetCustomControls()
     for (QHash<QWidget *, VCMatrixControl *>::iterator it = m_controls.begin();
             it != m_controls.end(); ++it)
     {
-        m_controlsLayout->removeWidget(it.key());
-        delete it.key();
-        delete it.value();
+        QWidget* widget = it.key();
+        m_controlsLayout->removeWidget(widget);
+        delete widget;
+
+        VCMatrixControl* control = it.value();
+        if (!control->m_inputSource.isNull())
+            setInputSource(QSharedPointer<QLCInputSource>(), control->m_id);
+        delete control;
     }
     m_controls.clear();
 }

--- a/ui/src/virtualconsole/vcmatrixcontrol.cpp
+++ b/ui/src/virtualconsole/vcmatrixcontrol.cpp
@@ -39,7 +39,7 @@ VCMatrixControl::VCMatrixControl(VCMatrixControl const& vcmc)
     , m_keySequence(vcmc.m_keySequence)
 {
     if (vcmc.m_inputSource != NULL)
-        m_inputSource.reset(new QLCInputSource(vcmc.m_inputSource->universe(),
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(vcmc.m_inputSource->universe(),
                                                vcmc.m_inputSource->channel()));
 }
 
@@ -188,7 +188,7 @@ bool VCMatrixControl::loadXML(const QDomElement &root)
             {
                 quint32 uni = tag.attribute(KXMLQLCVCMatrixControlInputUniverse).toUInt();
                 quint32 ch = tag.attribute(KXMLQLCVCMatrixControlInputChannel).toUInt();
-                m_inputSource.reset(new QLCInputSource(uni, ch));
+                m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch));
             }
         }
         else if (tag.tagName() == KXMLQLCVCMatrixControlKey)

--- a/ui/src/virtualconsole/vcmatrixcontrol.cpp
+++ b/ui/src/virtualconsole/vcmatrixcontrol.cpp
@@ -28,7 +28,6 @@ VCMatrixControl::VCMatrixControl(quint8 id)
 {
     m_color = QColor();
     m_resource = QString();
-    m_inputSource = NULL;
 }
 
 VCMatrixControl::VCMatrixControl(VCMatrixControl const& vcmc)
@@ -39,16 +38,13 @@ VCMatrixControl::VCMatrixControl(VCMatrixControl const& vcmc)
     , m_properties(vcmc.m_properties)
     , m_keySequence(vcmc.m_keySequence)
 {
-    if (vcmc.m_inputSource == NULL)
-        m_inputSource = NULL;
-    else
-        m_inputSource = new QLCInputSource(vcmc.m_inputSource->universe(),
-                                           vcmc.m_inputSource->channel());
+    if (vcmc.m_inputSource != NULL)
+        m_inputSource.reset(new QLCInputSource(vcmc.m_inputSource->universe(),
+                                               vcmc.m_inputSource->channel()));
 }
 
 VCMatrixControl::~VCMatrixControl()
 {
-    delete m_inputSource;
 }
 
 quint8 VCMatrixControl::rgbToValue(QRgb color) const
@@ -192,7 +188,7 @@ bool VCMatrixControl::loadXML(const QDomElement &root)
             {
                 quint32 uni = tag.attribute(KXMLQLCVCMatrixControlInputUniverse).toUInt();
                 quint32 ch = tag.attribute(KXMLQLCVCMatrixControlInputChannel).toUInt();
-                m_inputSource = new QLCInputSource(uni, ch);
+                m_inputSource.reset(new QLCInputSource(uni, ch));
             }
         }
         else if (tag.tagName() == KXMLQLCVCMatrixControlKey)
@@ -258,7 +254,7 @@ bool VCMatrixControl::saveXML(QDomDocument *doc, QDomElement *mtx_root)
     }
 
     /* External input source */
-    if (m_inputSource != NULL && m_inputSource->isValid())
+    if (!m_inputSource.isNull() && m_inputSource->isValid())
     {
         tag = doc->createElement(KXMLQLCVCMatrixControlInput);
         tag.setAttribute(KXMLQLCVCMatrixControlInputUniverse, QString("%1").arg(m_inputSource->universe()));

--- a/ui/src/virtualconsole/vcmatrixcontrol.h
+++ b/ui/src/virtualconsole/vcmatrixcontrol.h
@@ -124,7 +124,7 @@ public:
     /** A map holding the requested script properties */
     QHash<QString, QString> m_properties;
 
-    QLCInputSource *m_inputSource;
+    QSharedPointer<QLCInputSource> m_inputSource;
     QKeySequence m_keySequence;
 };
 

--- a/ui/src/virtualconsole/vcmatrixproperties.cpp
+++ b/ui/src/virtualconsole/vcmatrixproperties.cpp
@@ -170,7 +170,7 @@ void VCMatrixProperties::slotAutoDetectSliderInputToggled(bool checked)
 
 void VCMatrixProperties::slotSliderInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_sliderInputSource.reset(new QLCInputSource(universe, (m_matrix->page() << 16) | channel));
+    m_sliderInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_matrix->page() << 16) | channel));
     updateSliderInputSource();
 }
 
@@ -179,7 +179,7 @@ void VCMatrixProperties::slotChooseSliderInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_sliderInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_sliderInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateSliderInputSource();
     }
 }
@@ -498,7 +498,7 @@ void VCMatrixProperties::slotControlInputValueChanged(quint32 universe, quint32 
 
     if (control != NULL)
     {
-        control->m_inputSource.reset(new QLCInputSource(universe, (m_matrix->page() << 16) | channel));
+        control->m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_matrix->page() << 16) | channel));
         updateControlInputSource(control->m_inputSource);
     }
 }
@@ -512,7 +512,7 @@ void VCMatrixProperties::slotChooseControlInputClicked()
 
         if (control != NULL)
         {
-            control->m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+            control->m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
             updateControlInputSource(control->m_inputSource);
         }
     }

--- a/ui/src/virtualconsole/vcmatrixproperties.cpp
+++ b/ui/src/virtualconsole/vcmatrixproperties.cpp
@@ -170,9 +170,7 @@ void VCMatrixProperties::slotAutoDetectSliderInputToggled(bool checked)
 
 void VCMatrixProperties::slotSliderInputValueChanged(quint32 universe, quint32 channel)
 {
-    if (m_sliderInputSource != NULL)
-        delete m_sliderInputSource;
-    m_sliderInputSource = new QLCInputSource(universe, (m_matrix->page() << 16) | channel);
+    m_sliderInputSource.reset(new QLCInputSource(universe, (m_matrix->page() << 16) | channel));
     updateSliderInputSource();
 }
 
@@ -181,9 +179,7 @@ void VCMatrixProperties::slotChooseSliderInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_sliderInputSource != NULL)
-            delete m_sliderInputSource;
-        m_sliderInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_sliderInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateSliderInputSource();
     }
 }
@@ -456,7 +452,7 @@ void VCMatrixProperties::slotRemoveClicked()
     updateTree();
 }
 
-void VCMatrixProperties::updateControlInputSource(QLCInputSource *source)
+void VCMatrixProperties::updateControlInputSource(QSharedPointer<QLCInputSource> const& source)
 {
     QString uniName;
     QString chName;
@@ -502,9 +498,7 @@ void VCMatrixProperties::slotControlInputValueChanged(quint32 universe, quint32 
 
     if (control != NULL)
     {
-        if (control->m_inputSource != NULL)
-            delete control->m_inputSource;
-        control->m_inputSource = new QLCInputSource(universe, (m_matrix->page() << 16) | channel);
+        control->m_inputSource.reset(new QLCInputSource(universe, (m_matrix->page() << 16) | channel));
         updateControlInputSource(control->m_inputSource);
     }
 }
@@ -518,9 +512,7 @@ void VCMatrixProperties::slotChooseControlInputClicked()
 
         if (control != NULL)
         {
-            if (control->m_inputSource != NULL)
-                delete control->m_inputSource;
-            control->m_inputSource = new QLCInputSource(sic.universe(), sic.channel());
+            control->m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
             updateControlInputSource(control->m_inputSource);
         }
     }

--- a/ui/src/virtualconsole/vcmatrixproperties.h
+++ b/ui/src/virtualconsole/vcmatrixproperties.h
@@ -67,7 +67,7 @@ protected:
     void updateSliderInputSource();
 
 protected:
-    QLCInputSource *m_sliderInputSource;
+    QSharedPointer<QLCInputSource> m_sliderInputSource;
 
     /*********************************************************************
      * Custom controls
@@ -78,7 +78,7 @@ private:
     VCMatrixControl *getSelectedControl();
     void addControl(VCMatrixControl *control);
     void removeControl(quint8 id);
-    void updateControlInputSource(QLCInputSource *source);
+    void updateControlInputSource(QSharedPointer<QLCInputSource> const& source);
 
 protected slots:
     void slotTreeSelectionChanged();

--- a/ui/src/virtualconsole/vcsliderproperties.cpp
+++ b/ui/src/virtualconsole/vcsliderproperties.cpp
@@ -268,9 +268,7 @@ void VCSliderProperties::slotAutoDetectInputToggled(bool checked)
 
 void VCSliderProperties::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    if (m_inputSource != NULL)
-        delete m_inputSource;
-    m_inputSource = new QLCInputSource(universe, (m_slider->page() << 16) | channel);
+    m_inputSource.reset(new QLCInputSource(universe, (m_slider->page() << 16) | channel));
     updateInputSource();
 }
 
@@ -279,9 +277,7 @@ void VCSliderProperties::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_inputSource != NULL)
-            delete m_inputSource;
-        m_inputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/virtualconsole/vcsliderproperties.cpp
+++ b/ui/src/virtualconsole/vcsliderproperties.cpp
@@ -268,7 +268,7 @@ void VCSliderProperties::slotAutoDetectInputToggled(bool checked)
 
 void VCSliderProperties::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_inputSource.reset(new QLCInputSource(universe, (m_slider->page() << 16) | channel));
+    m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_slider->page() << 16) | channel));
     updateInputSource();
 }
 
@@ -277,7 +277,7 @@ void VCSliderProperties::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_inputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSource();
     }
 }

--- a/ui/src/virtualconsole/vcsliderproperties.h
+++ b/ui/src/virtualconsole/vcsliderproperties.h
@@ -73,7 +73,7 @@ protected:
     void setSubmasterPageVisibility(bool visible);
 
 protected:
-    QLCInputSource *m_inputSource;
+    QSharedPointer<QLCInputSource> m_inputSource;
     int m_sliderMode;
 
     /*********************************************************************

--- a/ui/src/virtualconsole/vcspeeddial.cpp
+++ b/ui/src/virtualconsole/vcspeeddial.cpp
@@ -358,7 +358,7 @@ bool VCSpeedDial::loadXML(const QDomElement* root)
                     quint32 uni = QLCInputSource::invalidUniverse;
                     quint32 ch = QLCInputSource::invalidChannel;
                     if (loadXMLInput(subtag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), absoluteInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), absoluteInputSourceId);
                 }
                 else
                 {
@@ -380,7 +380,7 @@ bool VCSpeedDial::loadXML(const QDomElement* root)
                     quint32 uni = QLCInputSource::invalidUniverse;
                     quint32 ch = QLCInputSource::invalidChannel;
                     if (loadXMLInput(subtag, &uni, &ch) == true)
-                        setInputSource(new QLCInputSource(uni, ch), tapInputSourceId);
+                        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), tapInputSourceId);
                 }
                 else
                 {

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -229,17 +229,13 @@ void VCSpeedDialProperties::updateInputSources()
 
 void VCSpeedDialProperties::slotAbsoluteInputValueChanged(quint32 universe, quint32 channel)
 {
-    if (m_absoluteInputSource != NULL)
-        delete m_absoluteInputSource;
-    m_absoluteInputSource = new QLCInputSource(universe, (m_dial->page() << 16) | channel);
+    m_absoluteInputSource.reset(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
     updateInputSources();
 }
 
 void VCSpeedDialProperties::slotTapInputValueChanged(quint32 universe, quint32 channel)
 {
-    if (m_tapInputSource != NULL)
-        delete m_tapInputSource;
-    m_tapInputSource = new QLCInputSource(universe, (m_dial->page() << 16) | channel);
+    m_tapInputSource.reset(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
     updateInputSources();
 }
 
@@ -262,9 +258,7 @@ void VCSpeedDialProperties::slotChooseAbsoluteInputSourceClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_absoluteInputSource != NULL)
-            delete m_absoluteInputSource;
-        m_absoluteInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_absoluteInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSources();
     }
 }
@@ -288,9 +282,7 @@ void VCSpeedDialProperties::slotChooseTapInputSourceClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_tapInputSource != NULL)
-            delete m_tapInputSource;
-        m_tapInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_tapInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSources();
     }
 }

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -229,13 +229,13 @@ void VCSpeedDialProperties::updateInputSources()
 
 void VCSpeedDialProperties::slotAbsoluteInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_absoluteInputSource.reset(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
+    m_absoluteInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
     updateInputSources();
 }
 
 void VCSpeedDialProperties::slotTapInputValueChanged(quint32 universe, quint32 channel)
 {
-    m_tapInputSource.reset(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
+    m_tapInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
     updateInputSources();
 }
 
@@ -258,7 +258,7 @@ void VCSpeedDialProperties::slotChooseAbsoluteInputSourceClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_absoluteInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_absoluteInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSources();
     }
 }
@@ -282,7 +282,7 @@ void VCSpeedDialProperties::slotChooseTapInputSourceClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_tapInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_tapInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateInputSources();
     }
 }

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -81,8 +81,8 @@ private slots:
     void slotDetachKey();
 
 private:
-    QLCInputSource *m_absoluteInputSource;
-    QLCInputSource *m_tapInputSource;
+    QSharedPointer<QLCInputSource> m_absoluteInputSource;
+    QSharedPointer<QLCInputSource> m_tapInputSource;
     QKeySequence m_tapKeySequence;
 };
 

--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -98,8 +98,6 @@ VCWidget::VCWidget(QWidget* parent, Doc* doc)
 
 VCWidget::~VCWidget()
 {
-    qDeleteAll(m_inputs);
-    m_inputs.clear();
 }
 
 /*****************************************************************************
@@ -249,12 +247,12 @@ bool VCWidget::copyFrom(const VCWidget* widget)
     m_allowChildren = widget->m_allowChildren;
     m_allowResize = widget->m_allowResize;
 
-    QHashIterator <quint8, QLCInputSource*> it(widget->m_inputs);
+    QHashIterator <quint8, QSharedPointer<QLCInputSource> > it(widget->m_inputs);
     while (it.hasNext() == true)
     {
         it.next();
         quint8 id = it.key();
-        QLCInputSource *src = new QLCInputSource(it.value()->universe(), it.value()->channel());
+        QSharedPointer<QLCInputSource> src(new QLCInputSource(it.value()->universe(), it.value()->channel()));
         setInputSource(src, id);
     }
 
@@ -532,11 +530,8 @@ qreal VCWidget::intensity()
 bool VCWidget::checkInputSource(quint32 universe, quint32 channel,
                                 uchar value, QObject *sender, quint32 id)
 {
-    if (m_inputs.contains(id) == false)
-        return false;
-
-    QLCInputSource *src = m_inputs[id];
-    if (src == NULL)
+    QSharedPointer<QLCInputSource> const& src = m_inputs.value(id);
+    if (src.isNull())
         return false;
 
     if (src->isValid() && src->universe() == universe && src->channel() == channel)
@@ -556,10 +551,10 @@ bool VCWidget::checkInputSource(quint32 universe, quint32 channel,
     return false;
 }
 
-void VCWidget::setInputSource(QLCInputSource* source, quint8 id)
+void VCWidget::setInputSource(QSharedPointer<QLCInputSource> const& source, quint8 id)
 {
     // Connect when the first valid input source is set
-    if (m_inputs.isEmpty() == true && source != NULL && source->isValid() == true)
+    if (m_inputs.isEmpty() == true && !source.isNull() && source->isValid() == true)
     {
         connect(m_doc->inputOutputMap(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
                 this, SLOT(slotInputValueChanged(quint32,quint32,uchar)));
@@ -567,10 +562,18 @@ void VCWidget::setInputSource(QLCInputSource* source, quint8 id)
                 this, SLOT(slotInputProfileChanged(quint32,QString)));
     }
 
-    // Assign or clear
-    if (source != NULL && source->isValid() == true)
+    // Clear previous source
+    if (m_inputs.contains(id))
     {
-        m_inputs[id] = source;
+        disconnect(m_inputs.value(id).data(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
+                this, SLOT(slotInputValueChanged(quint32,quint32,uchar)));
+        m_inputs.remove(id);
+    }
+
+    // Assign
+    if (!source.isNull() && source->isValid() == true)
+    {
+        m_inputs.insert(id, source);
         // now check if the source is defined in the associated universe
         // profile and if it is in relative mode
         InputPatch *ip = m_doc->inputOutputMap()->inputPatch(source->universe());
@@ -585,15 +588,13 @@ void VCWidget::setInputSource(QLCInputSource* source, quint8 id)
                     {
                         source->setWorkingMode(QLCInputSource::Relative);
                         source->setSensitivity(ich->movementSensitivity());
-                        connect(source, SIGNAL(inputValueChanged(quint32,quint32,uchar)),
+                        connect(source.data(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
                                 this, SLOT(slotInputValueChanged(quint32,quint32,uchar)));
                     }
                 }
             }
         }
     }
-    else
-        m_inputs.remove(id);
 
     // Disconnect when there are no more input sources present
     if (m_inputs.isEmpty() == true)
@@ -605,19 +606,16 @@ void VCWidget::setInputSource(QLCInputSource* source, quint8 id)
     }
 }
 
-QLCInputSource *VCWidget::inputSource(quint8 id) const
+QSharedPointer<QLCInputSource> VCWidget::inputSource(quint8 id) const
 {
-    if (m_inputs.contains(id) == false)
-        return NULL;
-    else
-        return m_inputs[id];
+    return m_inputs.value(id);
 }
 
 void VCWidget::remapInputSources(int pgNum)
 {
     foreach(quint8 s, m_inputs.keys())
     {
-        QLCInputSource *src = m_inputs[s];
+        QSharedPointer<QLCInputSource> src(m_inputs.value(s));
         src->setPage(pgNum);
         setInputSource(src, s);
     }
@@ -626,8 +624,8 @@ void VCWidget::remapInputSources(int pgNum)
 void VCWidget::sendFeedback(int value, quint8 id)
 {
     /* Send input feedback */
-    QLCInputSource *src = inputSource(id);
-    if (src != NULL && src->isValid() == true)
+    QSharedPointer<QLCInputSource> src = inputSource(id);
+    if (!src.isNull() && src->isValid() == true)
     {
         // if in relative mode, send a "feedback" to this
         // input source so it can continue to emit values
@@ -665,9 +663,9 @@ void VCWidget::slotInputProfileChanged(quint32 universe, const QString &profileN
 
     QLCInputProfile *profile = m_doc->inputOutputMap()->profile(profileName);
 
-    foreach(QLCInputSource *source, m_inputs.values())
+    foreach(QSharedPointer<QLCInputSource> const& source, m_inputs.values())
     {
-        if (source != NULL && source->universe() == universe)
+        if (!source.isNull() && source->universe() == universe)
         {
             // if the profile has been unset, reset all the valid
             // input sources to work in absolute mode
@@ -819,7 +817,7 @@ bool VCWidget::loadXMLInput(const QDomElement* root)
     quint32 ch = 0;
     if (loadXMLInput(*root, &uni, &ch) == true)
     {
-        setInputSource(new QLCInputSource(uni, ch));
+        setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)));
         return true;
     }
     else
@@ -949,6 +947,12 @@ bool VCWidget::saveXMLInput(QDomDocument* doc, QDomElement* root,
     }
 
     return true;
+}
+
+bool VCWidget::saveXMLInput(QDomDocument* doc, QDomElement* root,
+                      QSharedPointer<QLCInputSource> const& src) const
+{
+    return saveXMLInput(doc, root, src.data());
 }
 
 bool VCWidget::saveXMLWindowState(QDomDocument* doc, QDomElement* root)

--- a/ui/src/virtualconsole/vcwidget.h
+++ b/ui/src/virtualconsole/vcwidget.h
@@ -393,7 +393,7 @@ public:
      * @param source The input source to set
      * @param id The id of the source (default: 0)
      */
-    void setInputSource(QLCInputSource *source, quint8 id = 0);
+    void setInputSource(QSharedPointer<QLCInputSource> const& source, quint8 id = 0);
 
     /**
      * Get an assigned external input source. Without parameters the
@@ -401,7 +401,7 @@ public:
      *
      * @param id The id of the source to get
      */
-    QLCInputSource *inputSource(quint8 id = 0) const;
+    QSharedPointer<QLCInputSource> inputSource(quint8 id = 0) const;
 
     /**
      * When cloning a widget on a multipage frame, this function
@@ -444,7 +444,7 @@ protected slots:
     virtual void slotInputProfileChanged(quint32 universe, const QString& profileName);
 
 protected:
-    QHash <quint8, QLCInputSource*> m_inputs;
+    QHash <quint8, QSharedPointer<QLCInputSource> > m_inputs;
 
     /*********************************************************************
      * Key sequence handler
@@ -494,6 +494,8 @@ protected:
     /** Save input source from $uni and $ch to $root */
     bool saveXMLInput(QDomDocument* doc, QDomElement* root,
                       const QLCInputSource *src) const;
+    bool saveXMLInput(QDomDocument* doc, QDomElement* root,
+                      QSharedPointer<QLCInputSource> const& src) const;
 
     /**
      * Write this widget's geometry and visibility to an XML document.

--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -547,14 +547,14 @@ bool VCXYPad::loadXML(const QDomElement* root)
             quint32 uni = 0, ch = 0;
             xpos = tag.attribute(KXMLQLCVCXYPadPosition).toInt();
             if (loadXMLInput(tag.firstChild().toElement(), &uni, &ch) == true)
-                setInputSource(new QLCInputSource(uni, ch), panInputSourceId);
+                setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), panInputSourceId);
         }
         else if (tag.tagName() == KXMLQLCVCXYPadTilt)
         {
             quint32 uni = 0, ch = 0;
             ypos = tag.attribute(KXMLQLCVCXYPadPosition).toInt();
             if (loadXMLInput(tag.firstChild().toElement(), &uni, &ch) == true)
-                setInputSource(new QLCInputSource(uni, ch), tiltInputSourceId);
+                setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch)), tiltInputSourceId);
         }
         else if (tag.tagName() == KXMLQLCVCXYPadRangeWindow)
         {

--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -297,7 +297,7 @@ void VCXYPadProperties::slotPanChooseClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_panInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_panInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updatePanInputSource();
     }
 }
@@ -312,12 +312,12 @@ void VCXYPadProperties::slotPanInputValueChanged(quint32 uni, quint32 ch)
         m_panInputSource->channel() != UINT_MAX &&
         tmpSource->channel() != m_panInputSource->channel())
     {
-        m_tiltInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
+        m_tiltInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
         updateTiltInputSource();
         return;
     }
 
-    m_panInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
+    m_panInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
     updatePanInputSource();
 }
 
@@ -344,7 +344,7 @@ void VCXYPadProperties::slotTiltChooseClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_tiltInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
+        m_tiltInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
         updateTiltInputSource();
     }
 }
@@ -358,12 +358,12 @@ void VCXYPadProperties::slotTiltInputValueChanged(quint32 uni, quint32 ch)
         m_tiltInputSource->channel() != UINT_MAX &&
         tmpSource->channel() != m_tiltInputSource->channel())
     {
-        m_panInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
+        m_panInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
         updatePanInputSource();
         return;
     }
 
-    m_tiltInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
+    m_tiltInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
     updateTiltInputSource();
 }
 

--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -297,34 +297,28 @@ void VCXYPadProperties::slotPanChooseClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_panInputSource != NULL)
-            delete m_panInputSource;
-        m_panInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_panInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updatePanInputSource();
     }
 }
 
 void VCXYPadProperties::slotPanInputValueChanged(quint32 uni, quint32 ch)
 {
-    QLCInputSource *tmpSource = new QLCInputSource(uni, (m_xypad->page() << 16) | ch);
+    QScopedPointer<QLCInputSource> tmpSource(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
+
     // if both Pan and Tilt come from the same external control, here's
     // where I will discover it
     if (m_panInputSource != NULL &&
         m_panInputSource->channel() != UINT_MAX &&
         tmpSource->channel() != m_panInputSource->channel())
     {
-        if (m_tiltInputSource != NULL)
-            delete m_tiltInputSource;
-        m_tiltInputSource = new QLCInputSource(uni, (m_xypad->page() << 16) | ch);
+        m_tiltInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
         updateTiltInputSource();
         return;
     }
 
-    if (m_panInputSource != NULL)
-        delete m_panInputSource;
-    m_panInputSource = new QLCInputSource(uni, (m_xypad->page() << 16) | ch);
+    m_panInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
     updatePanInputSource();
-    delete tmpSource;
 }
 
 void VCXYPadProperties::slotTiltAutoDetectToggled(bool toggled)
@@ -350,34 +344,27 @@ void VCXYPadProperties::slotTiltChooseClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        if (m_tiltInputSource != NULL)
-            delete m_tiltInputSource;
-        m_tiltInputSource = new QLCInputSource(sic.universe(), sic.channel());
+        m_tiltInputSource.reset(new QLCInputSource(sic.universe(), sic.channel()));
         updateTiltInputSource();
     }
 }
 
 void VCXYPadProperties::slotTiltInputValueChanged(quint32 uni, quint32 ch)
 {
-    QLCInputSource *tmpSource = new QLCInputSource(uni, (m_xypad->page() << 16) | ch);
+    QScopedPointer<QLCInputSource> tmpSource(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
     // if both Pan and Tilt come from the same external control, here's
     // where I will discover it
     if (m_tiltInputSource != NULL &&
         m_tiltInputSource->channel() != UINT_MAX &&
         tmpSource->channel() != m_tiltInputSource->channel())
     {
-        if (m_panInputSource != NULL)
-            delete m_panInputSource;
-        m_panInputSource = new QLCInputSource(uni, (m_xypad->page() << 16) | ch);
+        m_panInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
         updatePanInputSource();
         return;
     }
 
-    if (m_tiltInputSource != NULL)
-        delete m_tiltInputSource;
-    m_tiltInputSource = new QLCInputSource(uni, (m_xypad->page() << 16) | ch);
+    m_tiltInputSource.reset(new QLCInputSource(uni, (m_xypad->page() << 16) | ch));
     updateTiltInputSource();
-    delete tmpSource;
 }
 
 void VCXYPadProperties::updatePanInputSource()

--- a/ui/src/virtualconsole/vcxypadproperties.h
+++ b/ui/src/virtualconsole/vcxypadproperties.h
@@ -84,8 +84,8 @@ private:
     void updateTiltInputSource();
 
 private:
-    QLCInputSource *m_panInputSource;
-    QLCInputSource *m_tiltInputSource;
+    QSharedPointer<QLCInputSource> m_panInputSource;
+    QSharedPointer<QLCInputSource> m_tiltInputSource;
 
     /********************************************************************
      * OK/Cancel

--- a/ui/test/vcbutton/vcbutton_test.cpp
+++ b/ui/test/vcbutton/vcbutton_test.cpp
@@ -237,7 +237,7 @@ void VCButton_Test::on()
     QWidget w;
 
     VCButton btn(&w, m_doc);
-    btn.setInputSource(new QLCInputSource(0, 1));
+    btn.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(0, 1)));
 
     QCOMPARE(btn.isOn(), false);
 
@@ -579,7 +579,7 @@ void VCButton_Test::input()
     btn.setAction(VCButton::Flash);
     btn.enableStartupIntensity(true);
     btn.setStartupIntensity(qreal(1.0));
-    btn.setInputSource(new QLCInputSource(0, 0));
+    btn.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(0, 0)));
 
     btn.slotInputValueChanged(0, 0, 255);
     QCOMPARE(btn.isOn(), false);

--- a/ui/test/vccuelist/vccuelist_test.cpp
+++ b/ui/test/vccuelist/vccuelist_test.cpp
@@ -397,15 +397,15 @@ void VCCueList_Test::loadXML()
     QCOMPARE(cl.m_tree->topLevelItem(1)->text(1), s2->name());
     QCOMPARE(cl.m_tree->topLevelItem(2)->text(1), s3->name());
     QCOMPARE(cl.m_tree->topLevelItem(3)->text(1), c4->name());
-    QLCInputSource *ni = cl.inputSource(VCCueList::nextInputSourceId);
+    QSharedPointer<QLCInputSource> const& ni = cl.inputSource(VCCueList::nextInputSourceId);
     QCOMPARE(ni->universe(), quint32(0));
     QCOMPARE(ni->channel(), quint32(1));
     QCOMPARE(cl.nextKeySequence(), QKeySequence(keySequenceD));
-    QLCInputSource *pi = cl.inputSource(VCCueList::previousInputSourceId);
+    QSharedPointer<QLCInputSource> const& pi = cl.inputSource(VCCueList::previousInputSourceId);
     QCOMPARE(pi->universe(), quint32(2));
     QCOMPARE(pi->channel(), quint32(3));
     QCOMPARE(cl.previousKeySequence(), QKeySequence(keySequenceC));
-    QLCInputSource *pli = cl.inputSource(VCCueList::playbackInputSourceId);
+    QSharedPointer<QLCInputSource> const& pli = cl.inputSource(VCCueList::playbackInputSourceId);
     QCOMPARE(pli->universe(), quint32(4));
     QCOMPARE(pli->channel(), quint32(5));
     QCOMPARE(cl.playbackKeySequence(), QKeySequence(keySequenceA));
@@ -436,9 +436,9 @@ void VCCueList_Test::saveXML()
     cl.setChaser(c->id());
 
     cl.setCaption("Testing");
-    cl.setInputSource(new QLCInputSource(0, 1), VCCueList::nextInputSourceId);
-    cl.setInputSource(new QLCInputSource(1, 2), VCCueList::previousInputSourceId);
-    cl.setInputSource(new QLCInputSource(2, 3), VCCueList::playbackInputSourceId);
+    cl.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(0, 1)), VCCueList::nextInputSourceId);
+    cl.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(1, 2)), VCCueList::previousInputSourceId);
+    cl.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(2, 3)), VCCueList::playbackInputSourceId);
     cl.setNextKeySequence(QKeySequence(keySequenceB));
     cl.setPreviousKeySequence(QKeySequence(keySequenceA));
     cl.setPlaybackKeySequence(QKeySequence(keySequenceC));
@@ -818,9 +818,9 @@ void VCCueList_Test::input()
     c->setDuration(Function::infiniteSpeed());
     cl.setChaser(c->id());
 
-    cl.setInputSource(new QLCInputSource(0, 1), VCCueList::nextInputSourceId);
-    cl.setInputSource(new QLCInputSource(2, 3), VCCueList::previousInputSourceId);
-    cl.setInputSource(new QLCInputSource(4, 5), VCCueList::playbackInputSourceId);
+    cl.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(0, 1)), VCCueList::nextInputSourceId);
+    cl.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(2, 3)), VCCueList::previousInputSourceId);
+    cl.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(4, 5)), VCCueList::playbackInputSourceId);
 
     // Switch mode
     m_doc->setMode(Doc::Operate);

--- a/ui/test/vcwidget/vcwidget_test.cpp
+++ b/ui/test/vcwidget/vcwidget_test.cpp
@@ -295,11 +295,11 @@ void VCWidget_Test::frame()
 
 void VCWidget_Test::inputSource()
 {
-    QLCInputSource *src;
+    QSharedPointer<QLCInputSource> src;
     QWidget w;
 
     StubWidget stub(&w, m_doc);
-    stub.setInputSource(new QLCInputSource(1, 2));
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(1, 2)));
     src = stub.inputSource();
     QVERIFY(src->isValid() == true);
     QCOMPARE(src->universe(), quint32(1));
@@ -317,13 +317,13 @@ void VCWidget_Test::inputSource()
     src = stub.inputSource(42);
     QVERIFY(src == NULL);
 
-    stub.setInputSource(new QLCInputSource(3, 4), 0);
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(3, 4)), 0);
     src = stub.inputSource();
     QVERIFY(src->isValid() == true);
     QCOMPARE(src->universe(), quint32(3));
     QCOMPARE(src->channel(), quint32(4));
 
-    stub.setInputSource(new QLCInputSource());
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource()));
     src = stub.inputSource();
     QVERIFY(src == NULL);
 
@@ -345,9 +345,9 @@ void VCWidget_Test::copy()
     stub.setFrameStyle(KVCFrameStyleRaised);
     stub.move(QPoint(10, 20));
     stub.resize(QSize(20, 30));
-    stub.setInputSource(new QLCInputSource(0, 12));
-    stub.setInputSource(new QLCInputSource(1, 2), 15);
-    stub.setInputSource(new QLCInputSource(3, 4), 1);
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(0, 12)));
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(1, 2)), 15);
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(3, 4)), 1);
 
     StubWidget copy(&w, m_doc);
     copy.copyFrom(&stub);
@@ -507,7 +507,7 @@ void VCWidget_Test::saveInput()
     QVERIFY(stub.saveXMLInput(&xmldoc, &root) == false);
     QCOMPARE(root.childNodes().count(), 0);
 
-    stub.setInputSource(new QLCInputSource(34, 56));
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(34, 56)));
     QVERIFY(stub.saveXMLInput(&xmldoc, &root) == true);
     QCOMPARE(root.childNodes().count(), 1);
     QCOMPARE(root.firstChild().toElement().tagName(), QString("Input"));
@@ -516,7 +516,7 @@ void VCWidget_Test::saveInput()
 
     root.clear();
 
-    stub.setInputSource(new QLCInputSource(34, 56), 1);
+    stub.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(34, 56)), 1);
     QVERIFY(stub.saveXMLInput(&xmldoc, &root) == true);
     QCOMPARE(root.childNodes().count(), 0);
 }

--- a/ui/test/vcxypad/vcxypad_test.cpp
+++ b/ui/test/vcxypad/vcxypad_test.cpp
@@ -261,8 +261,8 @@ void VCXYPad_Test::saveXML()
     pad.resize(QSize(150, 200));
     pad.move(QPoint(10, 20));
     pad.m_area->setPosition(QPointF(23, 45));
-    pad.setInputSource(new QLCInputSource(0, 1), VCXYPad::panInputSourceId);
-    pad.setInputSource(new QLCInputSource(2, 3), VCXYPad::tiltInputSourceId);
+    pad.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(0, 1)), VCXYPad::panInputSourceId);
+    pad.setInputSource(QSharedPointer<QLCInputSource>(new QLCInputSource(2, 3)), VCXYPad::tiltInputSourceId);
     QCOMPARE(pad.m_area->position(), QPointF(23, 45));
     QCOMPARE(pad.m_area->position(), QPointF(23, 45));
 

--- a/variables.pri
+++ b/variables.pri
@@ -12,7 +12,6 @@ APPVERSION = 4.8.5 GIT
 
 # Treat all compiler warnings as errors
 QMAKE_CXXFLAGS += -Werror
-!macx:QMAKE_CXXFLAGS += -Wno-unused-local-typedefs # Fix to build with GCC 4.8
 CONFIG         += warn_on
 
 # Build everything in the order specified in .pro files

--- a/variables.pri
+++ b/variables.pri
@@ -12,6 +12,7 @@ APPVERSION = 4.8.5 GIT
 
 # Treat all compiler warnings as errors
 QMAKE_CXXFLAGS += -Werror
+!macx:QMAKE_CXXFLAGS += -Wno-unused-local-typedefs # Fix to build with GCC 4.8
 CONFIG         += warn_on
 
 # Build everything in the order specified in .pro files


### PR DESCRIPTION
(PR because quite big number of changed lines)

This fixes at least 2 crashes:
- A VCMatrix containing a Control connected QLCInputSource
    -> delete the Control, its QLCInputSource gets deleted
    -> delete the VCMatrix -> double free of the QLCInputSource

- Any widget in the virtual console connected to a QLCInputSource
    -> Go to the widget's properties, change the input
        (this deletes the current InputSource)
    -> Cancel the properties window
    -> the widget's InputSource is now pointing to freed memory

A simple QSharedPointer wrapping will avoid double frees and leaks.