### PR TITLE
Function startstop (rebased)

### DIFF
--- a/engine/src/chaser.cpp
+++ b/engine/src/chaser.cpp
@@ -704,7 +704,7 @@ void Chaser::write(MasterTimer* timer, QList<Universe *> universes)
         Q_ASSERT(m_runner != NULL);
 
         if (m_runner->write(timer, universes) == false)
-            stop(id());
+            stop(Source(Source::Function, id()));
     }
 
     incrementElapsed();

--- a/engine/src/chaser.cpp
+++ b/engine/src/chaser.cpp
@@ -704,7 +704,7 @@ void Chaser::write(MasterTimer* timer, QList<Universe *> universes)
         Q_ASSERT(m_runner != NULL);
 
         if (m_runner->write(timer, universes) == false)
-            stop();
+            stop(id());
     }
 
     incrementElapsed();

--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -106,7 +106,7 @@ void ChaserRunner::slotChaserChanged()
     }
     foreach(ChaserRunnerStep* step, delList)
     {
-        step->m_function->stop(m_chaser->id());
+        step->m_function->stop(Function::Source(Function::Source::Function, m_chaser->id()));
         delete step;
         m_runnerSteps.removeAll(step);
     }
@@ -246,7 +246,7 @@ void ChaserRunner::stopStep(int stepIndex)
         if (stepIndex == step->m_index && step->m_function != NULL)
         {
             qDebug() << "Stopping step idx:" << stepIndex << "(running:" << m_runnerSteps.count() << ")";
-            step->m_function->stop(m_chaser->id());
+            step->m_function->stop(Function::Source(Function::Source::Function, m_chaser->id()));
             step->m_function = NULL;
             m_runnerSteps.removeOne(step);
             delete step;
@@ -426,7 +426,7 @@ void ChaserRunner::clearRunningList()
     // empty the running queue
     foreach(ChaserRunnerStep *step, m_runnerSteps)
     {
-        step->m_function->stop(m_chaser->id());
+        step->m_function->stop(Function::Source(Function::Source::Function, m_chaser->id()));
         delete step;
     }
     m_runnerSteps.clear();
@@ -478,7 +478,7 @@ void ChaserRunner::startNewStep(int index, MasterTimer* timer, bool manualFade, 
         // might momentarily jump too high.
         newStep->m_function->adjustAttribute(m_intensity, Function::Intensity);
         // Start the fire up !
-        newStep->m_function->start(timer, m_chaser->id(), 0, newStep->m_fadeIn, newStep->m_fadeOut);
+        newStep->m_function->start(timer, Function::Source(Function::Source::Function, m_chaser->id()), 0, newStep->m_fadeIn, newStep->m_fadeOut);
         m_runnerSteps.append(newStep);
         m_roundTime->restart();
     }
@@ -625,7 +625,7 @@ bool ChaserRunner::write(MasterTimer* timer, QList<Universe *> universes)
             if (step->m_duration != 0)
                 prevStepRoundElapsed = step->m_elapsed % step->m_duration;
 
-            step->m_function->stop(m_chaser->id());
+            step->m_function->stop(Function::Source(Function::Source::Function, m_chaser->id()));
             delete step;
             m_runnerSteps.removeOne(step);
         }

--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -232,7 +232,7 @@ void ChaserRunner::stopStep(int stepIndex)
         if (stepIndex == step->m_index && step->m_function != NULL)
         {
             qDebug() << "Stopping step idx:" << stepIndex << "(running:" << m_runnerSteps.count() << ")";
-            step->m_function->stop();
+            step->m_function->stop(m_chaser->id());
             step->m_function = NULL;
             m_runnerSteps.removeOne(step);
             delete step;
@@ -412,11 +412,7 @@ void ChaserRunner::clearRunningList()
     // empty the running queue
     foreach(ChaserRunnerStep *step, m_runnerSteps)
     {
-        if (step->m_function != NULL && step->m_function->isRunning())
-        {
-            step->m_function->stop();
-            step->m_function = NULL;
-        }
+        step->m_function->stop(m_chaser->id());
         delete step;
     }
     m_runnerSteps.clear();
@@ -436,7 +432,7 @@ void ChaserRunner::startNewStep(int index, MasterTimer* timer, bool manualFade, 
 
     ChaserStep step(m_chaser->steps().at(index));
     Function *func = m_doc->function(step.fid);
-    if (func != NULL && func->stopped() == true)
+    if (func != NULL)
     {
         ChaserRunnerStep *newStep = new ChaserRunnerStep();
         newStep->m_index = index;
@@ -468,7 +464,7 @@ void ChaserRunner::startNewStep(int index, MasterTimer* timer, bool manualFade, 
         // might momentarily jump too high.
         newStep->m_function->adjustAttribute(m_intensity, Function::Intensity);
         // Start the fire up !
-        newStep->m_function->start(timer, true, 0, newStep->m_fadeIn, newStep->m_fadeOut);
+        newStep->m_function->start(timer, m_chaser->id(), 0, newStep->m_fadeIn, newStep->m_fadeOut);
         m_runnerSteps.append(newStep);
         m_roundTime->restart();
     }
@@ -612,17 +608,12 @@ bool ChaserRunner::write(MasterTimer* timer, QList<Universe *> universes)
         if (step->m_duration != Function::infiniteSpeed() &&
              step->m_elapsed >= step->m_duration)
         {
-            if (step->m_function != NULL && step->m_function->isRunning())
-            {
-                step->m_function->stop();
-                step->m_function = NULL;
-            }
-
             if (step->m_duration != 0)
                 prevStepRoundElapsed = step->m_elapsed % step->m_duration;
 
-            m_runnerSteps.removeOne(step);
+            step->m_function->stop(m_chaser->id());
             delete step;
+            m_runnerSteps.removeOne(step);
         }
         else
         {

--- a/engine/src/collection.cpp
+++ b/engine/src/collection.cpp
@@ -267,7 +267,7 @@ void Collection::write(MasterTimer* timer, QList<Universe *> universes)
                     this, SLOT(slotChildStopped(quint32)));
 
             function->adjustAttribute(getAttributeValue(Function::Intensity), Function::Intensity);
-            function->start(timer, true, 0, overrideFadeInSpeed(), overrideFadeOutSpeed(), overrideDuration());
+            function->start(timer, id(), 0, overrideFadeInSpeed(), overrideFadeOutSpeed(), overrideDuration());
         }
     }
 
@@ -279,7 +279,7 @@ void Collection::write(MasterTimer* timer, QList<Universe *> universes)
           return;
     }
 
-    stop();
+    stop(id());
 }
 
 void Collection::postRun(MasterTimer* timer, QList<Universe *> universes)
@@ -296,7 +296,7 @@ void Collection::postRun(MasterTimer* timer, QList<Universe *> universes)
         {
             Function* function = doc->function(it.next());
             Q_ASSERT(function != NULL);
-            function->stop();
+            function->stop(id());
         }
 
         m_runningChildren.clear();

--- a/engine/src/collection.cpp
+++ b/engine/src/collection.cpp
@@ -267,7 +267,7 @@ void Collection::write(MasterTimer* timer, QList<Universe *> universes)
                     this, SLOT(slotChildStopped(quint32)));
 
             function->adjustAttribute(getAttributeValue(Function::Intensity), Function::Intensity);
-            function->start(timer, id(), 0, overrideFadeInSpeed(), overrideFadeOutSpeed(), overrideDuration());
+            function->start(timer, Source(Source::Function, id()), 0, overrideFadeInSpeed(), overrideFadeOutSpeed(), overrideDuration());
         }
     }
 
@@ -279,7 +279,7 @@ void Collection::write(MasterTimer* timer, QList<Universe *> universes)
           return;
     }
 
-    stop(id());
+    stop(Source(Source::Function, id()));
 }
 
 void Collection::postRun(MasterTimer* timer, QList<Universe *> universes)
@@ -296,7 +296,7 @@ void Collection::postRun(MasterTimer* timer, QList<Universe *> universes)
         {
             Function* function = doc->function(it.next());
             Q_ASSERT(function != NULL);
-            function->stop(id());
+            function->stop(Source(Source::Function, id()));
         }
 
         m_runningChildren.clear();

--- a/engine/src/cuestack.cpp
+++ b/engine/src/cuestack.cpp
@@ -526,7 +526,7 @@ void CueStack::postRun(MasterTimer* timer)
             fc.setElapsed(0);
             fc.setReady(false);
             fc.setFadeTime(fadeOutSpeed());
-            timer->fader()->add(fc);
+            timer->faderAdd(fc);
         }
     }
 

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -937,7 +937,7 @@ bool Doc::checkStartupFunction()
         Function *func = function(m_startupFunctionId);
         if (func != NULL)
         {
-            func->start(masterTimer(), -1);
+            func->start(masterTimer(), Function::Source(Function::Source::God, 0));
             return true;
         }
     }

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -937,7 +937,7 @@ bool Doc::checkStartupFunction()
         Function *func = function(m_startupFunctionId);
         if (func != NULL)
         {
-            func->start(masterTimer());
+            func->start(masterTimer(), -1);
             return true;
         }
     }

--- a/engine/src/efx.cpp
+++ b/engine/src/efx.cpp
@@ -1106,7 +1106,7 @@ void EFX::write(MasterTimer* timer, QList<Universe*> universes)
 
     /* Check for stop condition */
     if (ready == m_fixtures.count())
-        stop();
+        stop(id());
     m_fader->write(universes);
 }
 

--- a/engine/src/efx.cpp
+++ b/engine/src/efx.cpp
@@ -1106,7 +1106,7 @@ void EFX::write(MasterTimer* timer, QList<Universe*> universes)
 
     /* Check for stop condition */
     if (ready == m_fixtures.count())
-        stop(id());
+        stop(Source(Source::Function, id()));
     m_fader->write(universes);
 }
 

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -467,7 +467,7 @@ void EFXFixture::stop(MasterTimer* timer, QList<Universe *> universes)
             fc.setCurrent(fc.start());
             fc.setTarget(0);
             // Give zero-fading to MasterTimer because EFX will stop after this call
-            timer->fader()->add(fc);
+            timer->faderAdd(fc);
             // Remove the previously up-faded channel from EFX's internal fader to allow
             // MasterTimer's fader take HTP precedence.
             m_parent->m_fader->remove(fc);

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -855,7 +855,7 @@ void Function::incrementElapsed()
 {
     // Don't wrap around. UINT_MAX is the maximum fade/hold time.
     // This check makes no sense. this will wrap around.
-    //if (m_elapsed < UINT_MAX)
+    if (m_elapsed <= UINT_MAX - MasterTimer::tick())
         m_elapsed += MasterTimer::tick();
 }
 

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -106,7 +106,6 @@ Function::Function(Doc* doc, Type t)
     , m_elapsed(0)
     , m_stop(true)
     , m_running(false)
-    , m_startedAsChild(false)
 {
     Q_ASSERT(doc != NULL);
     registerAttribute(tr("Intensity"));
@@ -800,8 +799,8 @@ void Function::preRun(MasterTimer* timer)
     Q_UNUSED(timer);
 
     qDebug() << "Function preRun. Name:" << m_name << "ID: " << m_id;
-    m_stop = false;
     m_running = true;
+    m_stop = false;
 
     emit running(m_id);
 }
@@ -819,12 +818,12 @@ void Function::postRun(MasterTimer* timer, QList<Universe *> universes)
 
     qDebug() << "Function postRun. Name:" << m_name << "ID: " << m_id;
     m_stopMutex.lock();
+    m_stop = true;
     resetElapsed();
     resetAttributes();
-    m_stop = true;
-    //m_overrideFadeInSpeed = defaultSpeed();
-    //m_overrideFadeOutSpeed = defaultSpeed();
-    //m_overrideDuration = defaultSpeed();
+    // m_overrideFadeInSpeed = defaultSpeed();
+    // m_overrideFadeOutSpeed = defaultSpeed();
+    // m_overrideDuration = defaultSpeed();
     m_functionStopped.wakeAll();
     m_stopMutex.unlock();
 
@@ -855,7 +854,8 @@ void Function::resetElapsed()
 void Function::incrementElapsed()
 {
     // Don't wrap around. UINT_MAX is the maximum fade/hold time.
-    if (m_elapsed < UINT_MAX)
+    // This check makes no sense. this will wrap around.
+    //if (m_elapsed < UINT_MAX)
         m_elapsed += MasterTimer::tick();
 }
 
@@ -872,12 +872,22 @@ void Function::roundElapsed(quint32 roundTime)
  * Start & Stop
  *****************************************************************************/
 
-void Function::start(MasterTimer* timer, bool child, quint32 startTime,
+void Function::start(MasterTimer* timer, quint32 parent, quint32 startTime,
                      uint overrideFadeIn, uint overrideFadeOut, uint overrideDuration)
 {
-    qDebug() << "Function start(). Name:" << m_name << "ID: " << m_id << ", startTime:" << startTime;
+    qDebug() << "Function start(). Name:" << m_name << "ID: " << m_id << "parent:" << parent << ", startTime:" << startTime;
+
     Q_ASSERT(timer != NULL);
-    m_startedAsChild = child;
+
+    {
+        QMutexLocker parentsLocker(&m_parentsMutex);
+        if (m_parents.contains(parent))
+            return;
+        m_parents.append(parent);
+        if (m_parents.size() > 1)
+            return;
+    }
+
     m_elapsed = startTime;
     m_overrideFadeInSpeed = overrideFadeIn;
     m_overrideFadeOutSpeed = overrideFadeOut;
@@ -885,15 +895,19 @@ void Function::start(MasterTimer* timer, bool child, quint32 startTime,
     timer->startFunction(this);
 }
 
-bool Function::startedAsChild() const
+void Function::stop(quint32 parent)
 {
-    return m_startedAsChild;
-}
+    qDebug() << "Function stop(). Name:" << m_name << "ID: " << m_id << "parent:" << parent;
 
-void Function::stop()
-{
-    qDebug() << "Function stop(). Name:" << m_name << "ID: " << m_id;
-    m_stop = true;
+    QMutexLocker parentsLocker(&m_parentsMutex);
+
+    if (parent == id() || parent == quint32(-1))
+        m_parents.clear();
+    else
+        m_parents.removeAll(parent);
+
+    if (m_parents.size() == 0)
+        m_stop = true;
 }
 
 bool Function::stopped() const
@@ -901,12 +915,18 @@ bool Function::stopped() const
     return m_stop;
 }
 
+bool Function::startedAsChild() const
+{
+    QMutexLocker parentsLocker(const_cast<QMutex*>(&m_parentsMutex));
+    return m_parents.size() > 2 || (!m_parents.contains(id()) && !m_parents.contains(-1));
+}
+
 bool Function::stopAndWait()
 {
     bool result = true;
 
     m_stopMutex.lock();
-    m_stop = true;
+    stop(id());
 
     QTime watchdog;
     watchdog.start();
@@ -1010,4 +1030,3 @@ QList<Attribute> Function::attributes()
 {
     return m_attributes;
 }
-

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -83,7 +83,6 @@ Function::Function(QObject *parent)
     , m_elapsed(0)
     , m_stop(true)
     , m_running(false)
-    , m_startedAsChild(false)
 {
 
 }

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -800,7 +800,6 @@ void Function::preRun(MasterTimer* timer)
 
     qDebug() << "Function preRun. Name:" << m_name << "ID: " << m_id;
     m_running = true;
-    m_stop = false;
 
     emit running(m_id);
 }
@@ -818,7 +817,6 @@ void Function::postRun(MasterTimer* timer, QList<Universe *> universes)
 
     qDebug() << "Function postRun. Name:" << m_name << "ID: " << m_id;
     m_stopMutex.lock();
-    m_stop = true;
     resetElapsed();
     resetAttributes();
     // m_overrideFadeInSpeed = defaultSpeed();
@@ -854,7 +852,6 @@ void Function::resetElapsed()
 void Function::incrementElapsed()
 {
     // Don't wrap around. UINT_MAX is the maximum fade/hold time.
-    // This check makes no sense. this will wrap around.
     if (m_elapsed <= UINT_MAX - MasterTimer::tick())
         m_elapsed += MasterTimer::tick();
 }
@@ -888,6 +885,7 @@ void Function::start(MasterTimer* timer, Source source, quint32 startTime,
             return;
     }
 
+    m_stop = false;
     m_elapsed = startTime;
     m_overrideFadeInSpeed = overrideFadeIn;
     m_overrideFadeOutSpeed = overrideFadeOut;

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -872,19 +872,19 @@ void Function::roundElapsed(quint32 roundTime)
  * Start & Stop
  *****************************************************************************/
 
-void Function::start(MasterTimer* timer, quint32 parent, quint32 startTime,
+void Function::start(MasterTimer* timer, Source source, quint32 startTime,
                      uint overrideFadeIn, uint overrideFadeOut, uint overrideDuration)
 {
-    qDebug() << "Function start(). Name:" << m_name << "ID: " << m_id << "parent:" << parent << ", startTime:" << startTime;
+    qDebug() << "Function start(). Name:" << m_name << "ID: " << m_id << "source:" << source.type() << source.id() << ", startTime:" << startTime;
 
     Q_ASSERT(timer != NULL);
 
     {
-        QMutexLocker parentsLocker(&m_parentsMutex);
-        if (m_parents.contains(parent))
+        QMutexLocker sourcesLocker(&m_sourcesMutex);
+        if (m_sources.contains(source))
             return;
-        m_parents.append(parent);
-        if (m_parents.size() > 1)
+        m_sources.append(source);
+        if (m_sources.size() > 1)
             return;
     }
 
@@ -895,18 +895,21 @@ void Function::start(MasterTimer* timer, quint32 parent, quint32 startTime,
     timer->startFunction(this);
 }
 
-void Function::stop(quint32 parent)
+void Function::stop(Source source)
 {
-    qDebug() << "Function stop(). Name:" << m_name << "ID: " << m_id << "parent:" << parent;
+    qDebug() << "Function stop(). Name:" << m_name << "ID: " << m_id << "source:" << source.type() << source.id();
 
-    QMutexLocker parentsLocker(&m_parentsMutex);
+    QMutexLocker sourcesLocker(&m_sourcesMutex);
 
-    if (parent == id() || parent == quint32(-1))
-        m_parents.clear();
+    if ((source.id() == id() && source.type() == Source::Function)
+            || (source.type() == Source::God)
+            || (source.type() == Source::ManualVCWidget)
+       )
+        m_sources.clear();
     else
-        m_parents.removeAll(parent);
+        m_sources.removeAll(source);
 
-    if (m_parents.size() == 0)
+    if (m_sources.size() == 0)
         m_stop = true;
 }
 
@@ -917,8 +920,13 @@ bool Function::stopped() const
 
 bool Function::startedAsChild() const
 {
-    QMutexLocker parentsLocker(const_cast<QMutex*>(&m_parentsMutex));
-    return m_parents.size() > 2 || (!m_parents.contains(id()) && !m_parents.contains(-1));
+    QMutexLocker sourcesLocker(const_cast<QMutex*>(&m_sourcesMutex));
+    foreach (Source source, m_sources)
+    {
+        if (source.type() == Source::Function && source.id() != id())
+            return true;
+    }
+    return false;
 }
 
 bool Function::stopAndWait()
@@ -926,7 +934,7 @@ bool Function::stopAndWait()
     bool result = true;
 
     m_stopMutex.lock();
-    stop(id());
+    stop(Source(Source::God, 0));
 
     QTime watchdog;
     watchdog.start();

--- a/engine/src/function.h
+++ b/engine/src/function.h
@@ -602,19 +602,10 @@ public:
      * @param overrideFadeOut Override the function's default fade out speed
      * @param overrideDuration Override the function's default duration
      */
-    void start(MasterTimer* timer, bool child = false, quint32 startTime = 0,
+    void start(MasterTimer* timer, quint32 parent, quint32 startTime = 0,
                uint overrideFadeIn = defaultSpeed(),
                uint overrideFadeOut = defaultSpeed(),
                uint overrideDuration = defaultSpeed());
-
-	/**
-     * Check, whether the function was started by another function i.e.
-     * as the other function's child.
-     *
-	 * @return true If the function was started by another function.
-     *              Otherwise false.
-	 */
-    bool startedAsChild() const;
 
     /**
      * Mark the function to be stopped ASAP. MasterTimer will stop running
@@ -622,7 +613,7 @@ public:
      * There is no way to cancel it, but the function can be started again
      * normally.
      */
-    void stop();
+    void stop(quint32 parent);
 
     /**
      * Check, whether the function should be stopped ASAP. Functions can use this
@@ -649,10 +640,14 @@ public:
      */
     bool isRunning() const;
 
+    bool startedAsChild() const;
+
 private:
     /** Stop flag, private to keep functions from modifying it. */
     bool m_stop;
     bool m_running;
+    QList<quint32> m_parents;
+    QMutex m_parentsMutex;
 
     QMutex m_stopMutex;
     QWaitCondition m_functionStopped;
@@ -727,7 +722,6 @@ signals:
     void attributeChanged(int index, qreal fraction);
 
 private:
-    bool m_startedAsChild;
     //qreal m_intensity;
     QList <Attribute> m_attributes;
 };

--- a/engine/src/function.h
+++ b/engine/src/function.h
@@ -114,7 +114,7 @@ public:
      */
     struct Source
     {
-        enum Type
+        enum SourceType
         {
             Function = 0,
             AutoVCWidget,
@@ -125,7 +125,7 @@ public:
 
         quint64 m_source;
 
-        explicit Source(Type type, quint32 id)
+        explicit Source(SourceType type, quint32 id)
         {
             m_source = quint64((quint64(type) & 0xffffffff) << 32)
                 | quint64(id & 0xffffffff);

--- a/engine/src/function.h
+++ b/engine/src/function.h
@@ -108,6 +108,45 @@ public:
         Intensity = 0,
     };
 
+
+    /**
+     * Running source
+     */
+    struct Source
+    {
+        enum Type
+        {
+            Function = 0,
+            AutoVCWidget,
+            ManualVCWidget,
+            God = 0xffffffff,
+            Mask = 0xffffffff,
+        };
+
+        quint64 m_source;
+
+        explicit Source(Type type, quint32 id)
+        {
+            m_source = quint64((quint64(type) & 0xffffffff) << 32)
+                | quint64(id & 0xffffffff);
+        };
+
+        bool operator ==(Source const& right) const
+        {
+            return m_source == right.m_source;
+        };
+
+        quint32 type() const
+        {
+            return (m_source >> 32) & 0xffffffff;
+        };
+
+        quint32 id() const
+        {
+            return m_source & 0xffffffff;
+        };
+    };
+
     /*********************************************************************
      * Initialization
      *********************************************************************/
@@ -602,7 +641,7 @@ public:
      * @param overrideFadeOut Override the function's default fade out speed
      * @param overrideDuration Override the function's default duration
      */
-    void start(MasterTimer* timer, quint32 parent, quint32 startTime = 0,
+    void start(MasterTimer* timer, Source source, quint32 startTime = 0,
                uint overrideFadeIn = defaultSpeed(),
                uint overrideFadeOut = defaultSpeed(),
                uint overrideDuration = defaultSpeed());
@@ -613,7 +652,7 @@ public:
      * There is no way to cancel it, but the function can be started again
      * normally.
      */
-    void stop(quint32 parent);
+    void stop(Source source);
 
     /**
      * Check, whether the function should be stopped ASAP. Functions can use this
@@ -646,8 +685,8 @@ private:
     /** Stop flag, private to keep functions from modifying it. */
     bool m_stop;
     bool m_running;
-    QList<quint32> m_parents;
-    QMutex m_parentsMutex;
+    QList<Source> m_sources;
+    QMutex m_sourcesMutex;
 
     QMutex m_stopMutex;
     QWaitCondition m_functionStopped;

--- a/engine/src/mastertimer.cpp
+++ b/engine/src/mastertimer.cpp
@@ -271,18 +271,22 @@ void MasterTimer::timerTickFunctions(QList<Universe *> universes)
 
     foreach (Function* f, m_startQueue)
     {
+        m_functionListMutex.unlock();
         //qDebug() << "[MasterTimer] Processing ID: " << f->id();
-        if (m_functionList.contains(f) == false)
+        if (m_functionList.contains(f))
+        {
+            f->postRun(this, universes);
+        }
+        else
         {
             m_functionList.append(f);
-            m_functionListMutex.unlock();
-            //qDebug() << "[MasterTimer] Starting up ID: " << f->id();
-            f->preRun(this);
-            f->write(this, universes);
-            emit functionListChanged();
-            emit functionStarted(f->id());
-            m_functionListMutex.lock();
         }
+        //qDebug() << "[MasterTimer] Starting up ID: " << f->id();
+        f->preRun(this);
+        f->write(this, universes);
+        emit functionListChanged();
+        emit functionStarted(f->id());
+        m_functionListMutex.lock();
         m_startQueue.removeOne(f);
     }
 

--- a/engine/src/mastertimer.cpp
+++ b/engine/src/mastertimer.cpp
@@ -160,8 +160,7 @@ void MasterTimer::stopAllFunctions()
     // the scope of this piece of code !!
     {
         /* Remove all generic fader's channels */
-        QMutexLocker functionLocker(&m_functionListMutex);
-        QMutexLocker dmxLocker(&m_dmxSourceListMutex);
+        QMutexLocker faderLocker(&m_faderMutex);
         fader()->removeAll();
     }
 
@@ -210,6 +209,7 @@ void MasterTimer::fadeAndStopAll(int timeout)
 
     // Instruct mastertimer to do a fade out of all
     // the intensity channels that can fade
+    QMutexLocker faderLocker(&m_faderMutex);
     foreach(FadeChannel fade, fcList)
         fader()->add(fade);
 }
@@ -224,15 +224,11 @@ void MasterTimer::timerTickFunctions(QList<Universe *> universes)
     // List of m_functionList indices that should be removed at the end of this
     // function. The functions at the indices have been stopped.
     QList <int> removeList;
+    bool functionListHasChanged = false;
 
-    /* Lock before accessing the running functions list. */
-    m_functionListMutex.lock();
     for (int i = 0; i < m_functionList.size(); i++)
     {
         Function* function = m_functionList.at(i);
-
-        /* No need to access function list on this round anymore */
-        m_functionListMutex.unlock();
 
         if (function != NULL)
         {
@@ -243,18 +239,15 @@ void MasterTimer::timerTickFunctions(QList<Universe *> universes)
             }
             else
             {
+                // Clear function's parentList
+                if (m_stopAllFunctions)
+                    function->stop(function->id());
                 /* Function should be stopped instead */
-                m_functionListMutex.lock();
                 function->postRun(this, universes);
-                //qDebug() << "[MasterTimer] Add function (ID: " << function->id() << ") to remove list ";
                 removeList << i; // Don't remove the item from the list just yet.
-                m_functionListMutex.unlock();
-                emit functionListChanged();
+                functionListHasChanged = true;
             }
         }
-
-        /* Lock function list for the next round. */
-        m_functionListMutex.lock();
     }
 
     // Remove functions that need to be removed AFTER all functions have been run
@@ -269,10 +262,13 @@ void MasterTimer::timerTickFunctions(QList<Universe *> universes)
     while (it.hasPrevious() == true)
         m_functionList.removeAt(it.previous());
 
-    foreach (Function* f, m_startQueue)
+    m_functionListMutex.lock();
+    QList<Function*> startQueue(m_startQueue);
+    m_startQueue.clear();
+    m_functionListMutex.unlock();
+
+    foreach (Function* f, startQueue)
     {
-        m_functionListMutex.unlock();
-        //qDebug() << "[MasterTimer] Processing ID: " << f->id();
         if (m_functionList.contains(f))
         {
             f->postRun(this, universes);
@@ -280,18 +276,15 @@ void MasterTimer::timerTickFunctions(QList<Universe *> universes)
         else
         {
             m_functionList.append(f);
+            functionListHasChanged = true;
         }
-        //qDebug() << "[MasterTimer] Starting up ID: " << f->id();
         f->preRun(this);
         f->write(this, universes);
-        emit functionListChanged();
         emit functionStarted(f->id());
-        m_functionListMutex.lock();
-        m_startQueue.removeOne(f);
     }
 
-    /* No more functions. Get out and wait for next timer event. */
-    m_functionListMutex.unlock();
+    if (functionListHasChanged)
+        emit functionListChanged();
 }
 
 /****************************************************************************
@@ -332,13 +325,12 @@ void MasterTimer::timerTickDMXSources(QList<Universe *> universes)
 {
     /* Lock before accessing the DMX sources list. */
     m_dmxSourceListMutex.lock();
-    for (int i = 0; i < m_dmxSourceList.size(); i++)
-    {
-        DMXSource* source = m_dmxSourceList.at(i);
-        Q_ASSERT(source != NULL);
+    QList<DMXSource*> dmxSourceList(m_dmxSourceList);
+    m_dmxSourceListMutex.unlock();
 
-        /* No need to access the list on this round anymore. */
-        m_dmxSourceListMutex.unlock();
+    foreach (DMXSource* source, dmxSourceList)
+    {
+        Q_ASSERT(source != NULL);
 
 #ifdef DEBUG_MASTERTIMER
         qDebug() << "[MasterTimer] ticking DMX source" << i;
@@ -346,13 +338,7 @@ void MasterTimer::timerTickDMXSources(QList<Universe *> universes)
 
         /* Get DMX data from the source */
         source->writeDMX(this, universes);
-
-        /* Lock for the next round. */
-        m_dmxSourceListMutex.lock();
     }
-
-    /* No more sources. Get out and wait for next timer event. */
-    m_dmxSourceListMutex.unlock();
 }
 
 /****************************************************************************
@@ -364,10 +350,30 @@ GenericFader* MasterTimer::fader() const
     return m_fader;
 }
 
+void MasterTimer::faderAdd(const FadeChannel& ch)
+{
+    QMutexLocker faderLocker(&m_faderMutex);
+
+    fader()->add(ch);
+}
+
+void MasterTimer::faderForceAdd(const FadeChannel& ch)
+{
+    QMutexLocker faderLocker(&m_faderMutex);
+
+    fader()->forceAdd(ch);
+}
+
+QHash<FadeChannel,FadeChannel> MasterTimer::faderChannels() const
+{
+    QMutexLocker faderLocker(const_cast<QMutex*>(&m_faderMutex));
+
+    return fader()->channels();
+}
+
 void MasterTimer::timerTickFader(QList<Universe *> universes)
 {
-    QMutexLocker functionLocker(&m_functionListMutex);
-    QMutexLocker dmxLocker(&m_dmxSourceListMutex);
+    QMutexLocker faderLocker(&m_faderMutex);
 
 #ifdef DEBUG_MASTERTIMER
         qDebug() << "[MasterTimer] ticking fader (channels:" << fader()->channels().count() << ")";

--- a/engine/src/mastertimer.cpp
+++ b/engine/src/mastertimer.cpp
@@ -241,7 +241,7 @@ void MasterTimer::timerTickFunctions(QList<Universe *> universes)
             {
                 // Clear function's parentList
                 if (m_stopAllFunctions)
-                    function->stop(function->id());
+                    function->stop(Function::Source(Function::Source::God, 0));
                 /* Function should be stopped instead */
                 function->postRun(this, universes);
                 removeList << i; // Don't remove the item from the list just yet.

--- a/engine/src/mastertimer.h
+++ b/engine/src/mastertimer.h
@@ -85,7 +85,8 @@ private:
      * Functions
      *********************************************************************/
 public:
-    /** Start running the given function */
+    /** Start the given function */
+    /** This should be called by the function itself */
     virtual void startFunction(Function* function);
 
     /** Stop all functions. Doesn't affect registered DMX sources. */

--- a/engine/src/mastertimer.h
+++ b/engine/src/mastertimer.h
@@ -20,6 +20,7 @@
 #ifndef MASTERTIMER_H
 #define MASTERTIMER_H
 
+#include <QHash>
 #include <QObject>
 #include <QMutex>
 #include <QList>
@@ -27,6 +28,7 @@
 
 class MasterTimerPrivate;
 class GenericFader;
+class FadeChannel;
 class DMXSource;
 class Function;
 class Universe;
@@ -114,7 +116,7 @@ private:
     QList <Function*> m_functionList;
     QList <Function*> m_startQueue;
 
-    /** Mutex that guards access to m_functionList & m_startQueue */
+    /** Mutex that guards access to m_startQueue */
     QMutex m_functionListMutex;
 
     /** Flag for stopping all functions */
@@ -160,19 +162,24 @@ private:
     /*************************************************************************
      * Generic Fader
      *************************************************************************/
-public:
+private:
     /**
      * Get a pointer to the MasterTimer's GenericFader. The pointer must not be
      * deleted. The fader can be used e.g. by Scene functions to gracefully fade
      * down such intensity (HTP) channels that are no longer in use.
      */
     GenericFader* fader() const;
+public:
+    void faderAdd(const FadeChannel& ch);
+    void faderForceAdd(const FadeChannel& ch);
+    QHash<FadeChannel,FadeChannel> faderChannels() const;
 
 private:
     /** Execute one timer tick for the GenericFader */
     void timerTickFader(QList<Universe *> universes);
 
 private:
+    QMutex m_faderMutex;
     GenericFader* m_fader;
 
 private:

--- a/engine/src/rgbmatrix.cpp
+++ b/engine/src/rgbmatrix.cpp
@@ -555,7 +555,7 @@ void RGBMatrix::write(MasterTimer* timer, QList<Universe *> universes)
     if (grp == NULL)
     {
         // No fixture group to control
-        stop(id());
+        stop(Source(Source::Function, id()));
         return;
     }
 
@@ -637,7 +637,7 @@ void RGBMatrix::roundCheck(const QSize& size)
         if (m_direction == Forward)
         {
             if (m_step >= m_algorithm->rgbMapStepCount(size) - 1)
-                stop(id());
+                stop(Source(Source::Function, id()));
             else
             {
                 m_step++;
@@ -647,7 +647,7 @@ void RGBMatrix::roundCheck(const QSize& size)
         else
         {
             if (m_step <= 0)
-                stop(id());
+                stop(Source(Source::Function, id()));
             else
             {
                 m_step--;

--- a/engine/src/rgbmatrix.cpp
+++ b/engine/src/rgbmatrix.cpp
@@ -555,7 +555,7 @@ void RGBMatrix::write(MasterTimer* timer, QList<Universe *> universes)
     if (grp == NULL)
     {
         // No fixture group to control
-        stop();
+        stop(id());
         return;
     }
 
@@ -637,7 +637,7 @@ void RGBMatrix::roundCheck(const QSize& size)
         if (m_direction == Forward)
         {
             if (m_step >= m_algorithm->rgbMapStepCount(size) - 1)
-                stop();
+                stop(id());
             else
             {
                 m_step++;
@@ -647,7 +647,7 @@ void RGBMatrix::roundCheck(const QSize& size)
         else
         {
             if (m_step <= 0)
-                stop();
+                stop(id());
             else
             {
                 m_step--;

--- a/engine/src/scene.cpp
+++ b/engine/src/scene.cpp
@@ -555,7 +555,7 @@ void Scene::write(MasterTimer* timer, QList<Universe*> ua)
 
     if (m_values.size() == 0)
     {
-        stop(id());
+        stop(Source(Source::Function, id()));
         return;
     }
 
@@ -599,7 +599,7 @@ void Scene::write(MasterTimer* timer, QList<Universe*> ua)
 
     // Fader has nothing to do. Stop.
     if (m_fader->channels().size() == 0)
-        stop(id());
+        stop(Source(Source::Function, id()));
 
     incrementElapsed();
 }

--- a/engine/src/scene.cpp
+++ b/engine/src/scene.cpp
@@ -555,7 +555,7 @@ void Scene::write(MasterTimer* timer, QList<Universe*> ua)
 
     if (m_values.size() == 0)
     {
-        stop();
+        stop(id());
         return;
     }
 
@@ -599,7 +599,7 @@ void Scene::write(MasterTimer* timer, QList<Universe*> ua)
 
     // Fader has nothing to do. Stop.
     if (m_fader->channels().size() == 0)
-        stop();
+        stop(id());
 
     incrementElapsed();
 }

--- a/engine/src/scene.cpp
+++ b/engine/src/scene.cpp
@@ -524,7 +524,7 @@ void Scene::writeDMX(MasterTimer* timer, QList<Universe *> ua)
             fc.setFlashing(true);
             // Force add this channel, since it will be removed
             // by MasterTimer once applied
-            timer->fader()->forceAdd(fc);
+            timer->faderForceAdd(fc);
         }
     }
     else
@@ -638,7 +638,7 @@ void Scene::postRun(MasterTimer* timer, QList<Universe *> ua)
                 fc.setFadeTime(overrideFadeOutSpeed());
             fc.setTarget(0);
         }
-        timer->fader()->add(fc);
+        timer->faderAdd(fc);
     }
 
     Q_ASSERT(m_fader != NULL);
@@ -651,7 +651,7 @@ void Scene::postRun(MasterTimer* timer, QList<Universe *> ua)
 void Scene::insertStartValue(FadeChannel& fc, const MasterTimer* timer,
                              const QList<Universe*> ua)
 {
-    const QHash <FadeChannel,FadeChannel>& channels(timer->fader()->channels());
+    QHash <FadeChannel,FadeChannel> channels(timer->faderChannels());
     QHash <FadeChannel,FadeChannel>::const_iterator existing_it = channels.find(fc);
     if (existing_it != channels.constEnd())
     {

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -285,7 +285,7 @@ void Script::write(MasterTimer* timer, QList<Universe *> universes)
 
             // In case wait() is the last command, don't stop the script prematurely
             if (m_currentCommand >= m_lines.size() && m_waitCount == 0)
-                stop();
+                stop(id());
         }
 
         // Handle GenericFader tasks (setltp/sethtp/setfixture)
@@ -298,7 +298,7 @@ void Script::postRun(MasterTimer* timer, QList<Universe *> universes)
 {
     // Stop all functions started by this script
     foreach (Function* function, m_startedFunctions)
-        function->stop();
+        function->stop(id());
     m_startedFunctions.clear();
 
     // Stops keeping HTP channels up
@@ -450,10 +450,7 @@ QString Script::handleStartFunction(const QList<QStringList>& tokens, MasterTime
     Function* function = doc->function(id);
     if (function != NULL)
     {
-        if (function->stopped() == true)
-            function->start(timer, true);
-        else
-            qWarning() << "Function (" << function->name() << ") is already running.";
+        function->start(timer, this->id());
 
         m_startedFunctions << function;
         return QString();
@@ -482,10 +479,7 @@ QString Script::handleStopFunction(const QList <QStringList>& tokens)
     Function* function = doc->function(id);
     if (function != NULL)
     {
-        if (function->stopped() == false)
-            function->stop();
-        else
-            qWarning() << "Function (" << function->name() << ") is not running.";
+        function->stop(this->id());
 
         m_startedFunctions.removeAll(function);
         return QString();

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -285,7 +285,7 @@ void Script::write(MasterTimer* timer, QList<Universe *> universes)
 
             // In case wait() is the last command, don't stop the script prematurely
             if (m_currentCommand >= m_lines.size() && m_waitCount == 0)
-                stop(id());
+                stop(Source(Source::Function, id()));
         }
 
         // Handle GenericFader tasks (setltp/sethtp/setfixture)
@@ -298,7 +298,7 @@ void Script::postRun(MasterTimer* timer, QList<Universe *> universes)
 {
     // Stop all functions started by this script
     foreach (Function* function, m_startedFunctions)
-        function->stop(id());
+        function->stop(Source(Source::Function, id()));
     m_startedFunctions.clear();
 
     // Stops keeping HTP channels up
@@ -450,7 +450,7 @@ QString Script::handleStartFunction(const QList<QStringList>& tokens, MasterTime
     Function* function = doc->function(id);
     if (function != NULL)
     {
-        function->start(timer, this->id());
+        function->start(timer, Source(Source::Function, this->id()));
 
         m_startedFunctions << function;
         return QString();
@@ -479,7 +479,7 @@ QString Script::handleStopFunction(const QList <QStringList>& tokens)
     Function* function = doc->function(id);
     if (function != NULL)
     {
-        function->stop(this->id());
+        function->stop(Source(Source::Function, this->id()));
 
         m_startedFunctions.removeAll(function);
         return QString();

--- a/engine/src/showrunner.cpp
+++ b/engine/src/showrunner.cpp
@@ -113,7 +113,7 @@ void ShowRunner::stop()
     m_elapsedTime = 0;
     m_currentFunctionIndex = 0;
     foreach (Function *f, m_runningQueue)
-        f->stop(m_show->id());
+        f->stop(Function::Source(Function::Source::Function, m_show->id()));
 
     m_runningQueue.clear();
     qDebug() << "ShowRunner stopped";
@@ -155,7 +155,7 @@ void ShowRunner::write()
                 }
             }
 
-            f->start(m_doc->masterTimer(), m_show->id(), functionTimeOffset);
+            f->start(m_doc->masterTimer(), Function::Source(Function::Source::Function, m_show->id()), functionTimeOffset);
             m_runningQueue.append(f);
             m_currentFunctionIndex++;
 
@@ -176,7 +176,7 @@ void ShowRunner::write()
         {
             //qDebug() << "elapsed:" << m_elapsedTime << "stopTime:" << m_stopTimeMap[f->id()];
             if (m_elapsedTime == m_stopTimeMap[f->id()])
-                f->stop(m_show->id());
+                f->stop(Function::Source(Function::Source::Function, m_show->id()));
         }
     }
     m_runningQueueMutex.unlock();
@@ -185,7 +185,7 @@ void ShowRunner::write()
     if (m_elapsedTime >= m_totalRunTime)
     {
         if (m_show != NULL)
-            m_show->stop(m_show->id());
+            m_show->stop(Function::Source(Function::Source::Function, m_show->id()));
         emit showFinished();
         return;
     }

--- a/engine/src/showrunner.cpp
+++ b/engine/src/showrunner.cpp
@@ -113,7 +113,7 @@ void ShowRunner::stop()
     m_elapsedTime = 0;
     m_currentFunctionIndex = 0;
     foreach (Function *f, m_runningQueue)
-        f->stop();
+        f->stop(m_show->id());
 
     m_runningQueue.clear();
     qDebug() << "ShowRunner stopped";
@@ -155,7 +155,7 @@ void ShowRunner::write()
                 }
             }
 
-            f->start(m_doc->masterTimer(), true, functionTimeOffset);
+            f->start(m_doc->masterTimer(), m_show->id(), functionTimeOffset);
             m_runningQueue.append(f);
             m_currentFunctionIndex++;
 
@@ -176,7 +176,7 @@ void ShowRunner::write()
         {
             //qDebug() << "elapsed:" << m_elapsedTime << "stopTime:" << m_stopTimeMap[f->id()];
             if (m_elapsedTime == m_stopTimeMap[f->id()])
-                f->stop();
+                f->stop(m_show->id());
         }
     }
     m_runningQueueMutex.unlock();
@@ -185,7 +185,7 @@ void ShowRunner::write()
     if (m_elapsedTime >= m_totalRunTime)
     {
         if (m_show != NULL)
-            m_show->stop();
+            m_show->stop(m_show->id());
         emit showFinished();
         return;
     }

--- a/engine/test/chaser/chaser_test.cpp
+++ b/engine/test/chaser/chaser_test.cpp
@@ -898,7 +898,7 @@ void Chaser_Test::write()
 
     QVERIFY(c->isRunning() == false);
     QVERIFY(c->stopped() == true);
-    c->start(&timer, -1);
+    c->start(&timer, Function::Source(Function::Source::God, 0));
 
     timer.timerTick();
     for (uint i = MasterTimer::tick(); i < c->duration(); i += MasterTimer::tick())

--- a/engine/test/chaser/chaser_test.cpp
+++ b/engine/test/chaser/chaser_test.cpp
@@ -898,7 +898,7 @@ void Chaser_Test::write()
 
     QVERIFY(c->isRunning() == false);
     QVERIFY(c->stopped() == true);
-    c->start(&timer);
+    c->start(&timer, -1);
 
     timer.timerTick();
     for (uint i = MasterTimer::tick(); i < c->duration(); i += MasterTimer::tick())

--- a/engine/test/chaser/chaser_test.cpp
+++ b/engine/test/chaser/chaser_test.cpp
@@ -961,4 +961,56 @@ void Chaser_Test::adjustIntensity()
     c->adjustAttribute(1.0, Function::Intensity);
 }
 
+void Chaser_Test::quickChaser()
+{
+    Fixture* fxi = new Fixture(m_doc);
+    fxi->setAddress(0);
+    fxi->setUniverse(0);
+    fxi->setChannels(1);
+    m_doc->addFixture(fxi);
+
+    Chaser* c = new Chaser(m_doc);
+    // A really quick chaser
+    c->setDuration(0);
+    m_doc->addFunction(c);
+
+    Scene* s1 = new Scene(m_doc);
+    s1->setValue(fxi->id(), 0, 255);
+    m_doc->addFunction(s1);
+    c->addStep(s1->id());
+
+    Scene* s2 = new Scene(m_doc);
+    s2->setValue(fxi->id(), 0, 127);
+    m_doc->addFunction(s2);
+    c->addStep(s2->id());
+
+    MasterTimer timer(m_doc);
+
+    QVERIFY(c->isRunning() == false);
+    QVERIFY(c->stopped() == true);
+    c->start(&timer, Function::Source(Function::Source::God, 0));
+
+    timer.timerTick();
+    for (uint i = 0; i < 12; ++i)
+    {
+        timer.timerTick();
+        QVERIFY(c->isRunning() == true);
+        QVERIFY(c->stopped() == false);
+        // always one function running while the other is not
+        QVERIFY(s1->isRunning() == true || s2->isRunning() == true);
+        QVERIFY(s1->stopped() == true || s2->stopped() == true);
+    }
+
+    c->stop(Function::Source(Function::Source::God, 0));
+
+    timer.timerTick();
+
+    QVERIFY(c->isRunning() == false);
+    QVERIFY(c->stopped() == true);
+    QVERIFY(s1->isRunning() == false);
+    QVERIFY(s1->stopped() == true);
+    QVERIFY(s2->isRunning() == false);
+    QVERIFY(s2->stopped() == true);
+}
+
 QTEST_MAIN(Chaser_Test)

--- a/engine/test/chaser/chaser_test.h
+++ b/engine/test/chaser/chaser_test.h
@@ -55,6 +55,8 @@ private slots:
     void postRun();
     void adjustIntensity();
 
+    void quickChaser();
+
 private:
     Doc* m_doc;
 };

--- a/engine/test/collection/collection_test.cpp
+++ b/engine/test/collection/collection_test.cpp
@@ -408,7 +408,7 @@ void Collection_Test::write()
     /* Collection starts all of its members immediately when it is started
        itself. */
     QVERIFY(c->stopped() == true);
-    c->start(mts, -1);
+    c->start(mts, Function::Source(Function::Source::God, 0));
     QVERIFY(c->stopped() == false);
 
     c->write(mts, ua);
@@ -488,7 +488,7 @@ void Collection_Test::stopNotOwnChildren()
     MasterTimerStub* mts = new MasterTimerStub(m_doc, ua);
 
     QVERIFY(c->stopped() == true);
-    c->start(mts, -1);
+    c->start(mts, Function::Source(Function::Source::God, 0));
     QVERIFY(c->stopped() == false);
 
     c->preRun(mts);
@@ -503,17 +503,17 @@ void Collection_Test::stopNotOwnChildren()
     QVERIFY(c->m_runningChildren.contains(s2->id()) == true);
 
     // Manually stop and re-start s1
-    s1->stop(s1->id());
+    s1->stop(Function::Source(Function::Source::Function, s1->id()));
     s1->write(mts, ua);
     s1->postRun(mts, ua);
-    s1->start(mts, s1->id());
+    s1->start(mts, Function::Source(Function::Source::Function, s1->id()));
     QVERIFY(s1->stopped() == false);
 
     // Collection should no longer be controlling s1
     QVERIFY(c->m_runningChildren.contains(s1->id()) == false);
     QVERIFY(c->m_runningChildren.contains(s2->id()) == true);
 
-    c->stop(-1);
+    c->stop(Function::Source(Function::Source::God, 0));
     c->write(mts, ua);
     c->postRun(mts, ua);
 

--- a/engine/test/collection/collection_test.cpp
+++ b/engine/test/collection/collection_test.cpp
@@ -408,7 +408,7 @@ void Collection_Test::write()
     /* Collection starts all of its members immediately when it is started
        itself. */
     QVERIFY(c->stopped() == true);
-    c->start(mts);
+    c->start(mts, -1);
     QVERIFY(c->stopped() == false);
 
     c->write(mts, ua);
@@ -488,7 +488,7 @@ void Collection_Test::stopNotOwnChildren()
     MasterTimerStub* mts = new MasterTimerStub(m_doc, ua);
 
     QVERIFY(c->stopped() == true);
-    c->start(mts);
+    c->start(mts, -1);
     QVERIFY(c->stopped() == false);
 
     c->preRun(mts);
@@ -503,17 +503,17 @@ void Collection_Test::stopNotOwnChildren()
     QVERIFY(c->m_runningChildren.contains(s2->id()) == true);
 
     // Manually stop and re-start s1
-    s1->stop();
+    s1->stop(s1->id());
     s1->write(mts, ua);
     s1->postRun(mts, ua);
-    s1->start(mts);
+    s1->start(mts, s1->id());
     QVERIFY(s1->stopped() == false);
 
     // Collection should no longer be controlling s1
     QVERIFY(c->m_runningChildren.contains(s1->id()) == false);
     QVERIFY(c->m_runningChildren.contains(s2->id()) == true);
 
-    c->stop();
+    c->stop(-1);
     c->write(mts, ua);
     c->postRun(mts, ua);
 

--- a/engine/test/mastertimer/mastertimer_stub.cpp
+++ b/engine/test/mastertimer/mastertimer_stub.cpp
@@ -42,6 +42,7 @@ void MasterTimerStub::startFunction(Function* function)
 
 void MasterTimerStub::stopFunction(Function* function)
 {
+    function->stop(Function::Source(Function::Source::God, 0));
     m_functionList.removeAll(function);
     function->postRun(this, m_universes);
 }

--- a/engine/test/mastertimer/mastertimer_stub.h
+++ b/engine/test/mastertimer/mastertimer_stub.h
@@ -37,7 +37,7 @@ public:
     MasterTimerStub(Doc* doc, QList<Universe *> universes);
     ~MasterTimerStub();
 
-    void startFunction(Function* function);
+    virtual void startFunction(Function* function);
     void stopFunction(Function* function);
     QList <Function*> m_functionList;
 

--- a/engine/test/mastertimer/mastertimer_test.cpp
+++ b/engine/test/mastertimer/mastertimer_test.cpp
@@ -116,7 +116,7 @@ void MasterTimer_Test::startStopFunction()
     QVERIFY(mt->runningFunctions() == 1);
 
     QTest::qWait(100);
-    fs.stop(-1);
+    fs.stop(Function::Source(Function::Source::God, 0));
     QTest::qWait(100);
 
     QVERIFY(mt->runningFunctions() == 0);
@@ -181,7 +181,7 @@ void MasterTimer_Test::interval()
     mt->start();
     QTest::qWait(100);
 
-    fs.start(mt, -1);
+    fs.start(mt, Function::Source(Function::Source::God, 0));
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
 
@@ -198,7 +198,7 @@ void MasterTimer_Test::interval()
     QVERIFY(dss.m_writeCalls >= 49 && dss.m_writeCalls <= 51);
 #endif
 
-    fs.stop(-1);
+    fs.stop(Function::Source(Function::Source::God, 0));
     QTest::qWait(1000);
     QVERIFY(mt->runningFunctions() == 0);
 
@@ -213,7 +213,7 @@ void MasterTimer_Test::functionInitiatedStop()
 
     mt->start();
 
-    fs.start(mt, -1);
+    fs.start(mt, Function::Source(Function::Source::God, 0));
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
 
@@ -221,7 +221,7 @@ void MasterTimer_Test::functionInitiatedStop()
     QTest::qWait(100);
 
     /* Stop the function after it has been running for a while */
-    fs.stop(-1);
+    fs.stop(Function::Source(Function::Source::God, 0));
 
     /* Wait a while so that the function stops */
     QTest::qWait(100);
@@ -240,17 +240,17 @@ void MasterTimer_Test::runMultipleFunctions()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt, -1);
+    fs1.start(mt, Function::Source(Function::Source::God, 0));
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt, -1);
+    fs2.start(mt, Function::Source(Function::Source::God, 0));
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 2);
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt, -1);
+    fs3.start(mt, Function::Source(Function::Source::God, 0));
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 3);
 
@@ -258,9 +258,9 @@ void MasterTimer_Test::runMultipleFunctions()
     QTest::qWait(100);
 
     /* Stop the functions after they have been running for a while */
-    fs1.stop(-1);
-    fs2.stop(-1);
-    fs3.stop(-1);
+    fs1.stop(Function::Source(Function::Source::God, 0));
+    fs2.stop(Function::Source(Function::Source::God, 0));
+    fs3.stop(Function::Source(Function::Source::God, 0));
 
     /* Wait a while so that the functions stop */
     QTest::qWait(100);
@@ -274,19 +274,19 @@ void MasterTimer_Test::stopAllFunctions()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt, -1);
+    fs1.start(mt, Function::Source(Function::Source::God, 0));
 
     DMXSource_Stub s1;
     mt->registerDMXSource(&s1, "s1");
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt, -1);
+    fs2.start(mt, Function::Source(Function::Source::God, 0));
 
     DMXSource_Stub s2;
     mt->registerDMXSource(&s2, "s2");
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt, -1);
+    fs3.start(mt, Function::Source(Function::Source::God, 0));
 
     QTest::qWait(60);
 
@@ -307,13 +307,13 @@ void MasterTimer_Test::stop()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt, -1);
+    fs1.start(mt, Function::Source(Function::Source::God, 0));
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt, -1);
+    fs2.start(mt, Function::Source(Function::Source::God, 0));
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt, -1);
+    fs3.start(mt, Function::Source(Function::Source::God, 0));
 
     QTest::qWait(60);
     QVERIFY(mt->runningFunctions() == 3);
@@ -330,13 +330,13 @@ void MasterTimer_Test::restart()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt, -1);
+    fs1.start(mt, Function::Source(Function::Source::God, 0));
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt, -1);
+    fs2.start(mt, Function::Source(Function::Source::God, 0));
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt, -1);
+    fs3.start(mt, Function::Source(Function::Source::God, 0));
 
     QTest::qWait(60);
     QVERIFY(mt->runningFunctions() == 3);
@@ -358,9 +358,9 @@ void MasterTimer_Test::restart()
     // QVERIFY(mt->m_running == true);
     QVERIFY(mt->m_stopAllFunctions == false);
 
-    fs1.start(mt, -1);
-    fs2.start(mt, -1);
-    fs3.start(mt, -1);
+    fs1.start(mt, Function::Source(Function::Source::God, 0));
+    fs2.start(mt, Function::Source(Function::Source::God, 0));
+    fs3.start(mt, Function::Source(Function::Source::God, 0));
     QTest::qWait(60);
     QVERIFY(mt->runningFunctions() == 3);
 

--- a/engine/test/mastertimer/mastertimer_test.cpp
+++ b/engine/test/mastertimer/mastertimer_test.cpp
@@ -111,14 +111,12 @@ void MasterTimer_Test::startStopFunction()
     mt->startFunction(&fs);
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
-    QVERIFY(fs.startedAsChild() == false);
 
     mt->startFunction(&fs);
     QVERIFY(mt->runningFunctions() == 1);
-    QVERIFY(fs.startedAsChild() == false);
 
     QTest::qWait(100);
-    fs.stop();
+    fs.stop(-1);
     QTest::qWait(100);
 
     QVERIFY(mt->runningFunctions() == 0);
@@ -183,7 +181,7 @@ void MasterTimer_Test::interval()
     mt->start();
     QTest::qWait(100);
 
-    fs.start(mt);
+    fs.start(mt, -1);
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
 
@@ -200,7 +198,7 @@ void MasterTimer_Test::interval()
     QVERIFY(dss.m_writeCalls >= 49 && dss.m_writeCalls <= 51);
 #endif
 
-    fs.stop();
+    fs.stop(-1);
     QTest::qWait(1000);
     QVERIFY(mt->runningFunctions() == 0);
 
@@ -215,7 +213,7 @@ void MasterTimer_Test::functionInitiatedStop()
 
     mt->start();
 
-    fs.start(mt);
+    fs.start(mt, -1);
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
 
@@ -223,7 +221,7 @@ void MasterTimer_Test::functionInitiatedStop()
     QTest::qWait(100);
 
     /* Stop the function after it has been running for a while */
-    fs.stop();
+    fs.stop(-1);
 
     /* Wait a while so that the function stops */
     QTest::qWait(100);
@@ -242,17 +240,17 @@ void MasterTimer_Test::runMultipleFunctions()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt);
+    fs1.start(mt, -1);
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 1);
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt);
+    fs2.start(mt, -1);
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 2);
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt);
+    fs3.start(mt, -1);
     mt->timerTick();
     QVERIFY(mt->runningFunctions() == 3);
 
@@ -260,9 +258,9 @@ void MasterTimer_Test::runMultipleFunctions()
     QTest::qWait(100);
 
     /* Stop the functions after they have been running for a while */
-    fs1.stop();
-    fs2.stop();
-    fs3.stop();
+    fs1.stop(-1);
+    fs2.stop(-1);
+    fs3.stop(-1);
 
     /* Wait a while so that the functions stop */
     QTest::qWait(100);
@@ -276,19 +274,19 @@ void MasterTimer_Test::stopAllFunctions()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt);
+    fs1.start(mt, -1);
 
     DMXSource_Stub s1;
     mt->registerDMXSource(&s1, "s1");
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt);
+    fs2.start(mt, -1);
 
     DMXSource_Stub s2;
     mt->registerDMXSource(&s2, "s2");
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt);
+    fs3.start(mt, -1);
 
     QTest::qWait(60);
 
@@ -309,13 +307,13 @@ void MasterTimer_Test::stop()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt);
+    fs1.start(mt, -1);
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt);
+    fs2.start(mt, -1);
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt);
+    fs3.start(mt, -1);
 
     QTest::qWait(60);
     QVERIFY(mt->runningFunctions() == 3);
@@ -332,13 +330,13 @@ void MasterTimer_Test::restart()
     mt->start();
 
     Function_Stub fs1(m_doc);
-    fs1.start(mt);
+    fs1.start(mt, -1);
 
     Function_Stub fs2(m_doc);
-    fs2.start(mt);
+    fs2.start(mt, -1);
 
     Function_Stub fs3(m_doc);
-    fs3.start(mt);
+    fs3.start(mt, -1);
 
     QTest::qWait(60);
     QVERIFY(mt->runningFunctions() == 3);
@@ -360,9 +358,9 @@ void MasterTimer_Test::restart()
     // QVERIFY(mt->m_running == true);
     QVERIFY(mt->m_stopAllFunctions == false);
 
-    fs1.start(mt);
-    fs2.start(mt);
-    fs3.start(mt);
+    fs1.start(mt, -1);
+    fs2.start(mt, -1);
+    fs3.start(mt, -1);
     QTest::qWait(60);
     QVERIFY(mt->runningFunctions() == 3);
 

--- a/engine/test/scene/scene_test.cpp
+++ b/engine/test/scene/scene_test.cpp
@@ -517,7 +517,7 @@ void Scene_Test::writeHTPZeroTicks()
     s1->setValue(fxi->id(), 2, 0);
     doc->addFunction(s1);
 
-    s1->start(&timer);
+    s1->start(&timer, -1);
     timer.timerTick();
     ua = doc->inputOutputMap()->claimUniverses();
     QVERIFY(ua[0]->preGMValues()[0] == (char) 255);
@@ -526,7 +526,7 @@ void Scene_Test::writeHTPZeroTicks()
     QVERIFY(s1->stopped() == false);
     doc->inputOutputMap()->releaseUniverses(false);
 
-    s1->stop();
+    s1->stop(-1);
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == true); // postRun has not been run yet, but..
     timer.timerTick();                // ..now it has.
@@ -572,7 +572,7 @@ void Scene_Test::writeHTPTwoTicks()
     doc->inputOutputMap()->releaseUniverses(false);
 
     QVERIFY(s1->stopped() == true);
-    s1->start(&timer);
+    s1->start(&timer, -1);
     timer.timerTick();
 
     QVERIFY(s1->stopped() == false);
@@ -607,7 +607,7 @@ void Scene_Test::writeHTPTwoTicks()
     QVERIFY(s1->stopped() == false);
     doc->inputOutputMap()->releaseUniverses(false);
 
-    s1->stop();
+    s1->stop(-1);
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == true);
 
@@ -664,7 +664,7 @@ void Scene_Test::writeHTPTwoTicksIntensity()
     s1->adjustAttribute(0.5, Function::Intensity);
 
     QVERIFY(s1->stopped() == true);
-    s1->start(&timer);
+    s1->start(&timer, -1);
     timer.timerTick();
 
     QVERIFY(s1->stopped() == false);
@@ -703,7 +703,7 @@ void Scene_Test::writeHTPTwoTicksIntensity()
     QVERIFY(s1->stopped() == false);
     doc->inputOutputMap()->releaseUniverses(false);
 
-    s1->stop();
+    s1->stop(-1);
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == true);
 
@@ -754,7 +754,7 @@ void Scene_Test::writeLTPReady()
 
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == false);
-    s1->start(&timer);
+    s1->start(&timer, -1);
 
     timer.timerTick();
     ua = doc->inputOutputMap()->claimUniverses();

--- a/engine/test/scene/scene_test.cpp
+++ b/engine/test/scene/scene_test.cpp
@@ -517,7 +517,7 @@ void Scene_Test::writeHTPZeroTicks()
     s1->setValue(fxi->id(), 2, 0);
     doc->addFunction(s1);
 
-    s1->start(&timer, -1);
+    s1->start(&timer, Function::Source(Function::Source::God, 0));
     timer.timerTick();
     ua = doc->inputOutputMap()->claimUniverses();
     QVERIFY(ua[0]->preGMValues()[0] == (char) 255);
@@ -526,7 +526,7 @@ void Scene_Test::writeHTPZeroTicks()
     QVERIFY(s1->stopped() == false);
     doc->inputOutputMap()->releaseUniverses(false);
 
-    s1->stop(-1);
+    s1->stop(Function::Source(Function::Source::God, 0));
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == true); // postRun has not been run yet, but..
     timer.timerTick();                // ..now it has.
@@ -572,7 +572,7 @@ void Scene_Test::writeHTPTwoTicks()
     doc->inputOutputMap()->releaseUniverses(false);
 
     QVERIFY(s1->stopped() == true);
-    s1->start(&timer, -1);
+    s1->start(&timer, Function::Source(Function::Source::God, 0));
     timer.timerTick();
 
     QVERIFY(s1->stopped() == false);
@@ -607,7 +607,7 @@ void Scene_Test::writeHTPTwoTicks()
     QVERIFY(s1->stopped() == false);
     doc->inputOutputMap()->releaseUniverses(false);
 
-    s1->stop(-1);
+    s1->stop(Function::Source(Function::Source::God, 0));
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == true);
 
@@ -664,7 +664,7 @@ void Scene_Test::writeHTPTwoTicksIntensity()
     s1->adjustAttribute(0.5, Function::Intensity);
 
     QVERIFY(s1->stopped() == true);
-    s1->start(&timer, -1);
+    s1->start(&timer, Function::Source(Function::Source::God, 0));
     timer.timerTick();
 
     QVERIFY(s1->stopped() == false);
@@ -703,7 +703,7 @@ void Scene_Test::writeHTPTwoTicksIntensity()
     QVERIFY(s1->stopped() == false);
     doc->inputOutputMap()->releaseUniverses(false);
 
-    s1->stop(-1);
+    s1->stop(Function::Source(Function::Source::God, 0));
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == true);
 
@@ -754,7 +754,7 @@ void Scene_Test::writeLTPReady()
 
     QVERIFY(s1->stopped() == true);
     QVERIFY(s1->isRunning() == false);
-    s1->start(&timer, -1);
+    s1->start(&timer, Function::Source(Function::Source::God, 0));
 
     timer.timerTick();
     ua = doc->inputOutputMap()->claimUniverses();

--- a/ui/src/audiobar.cpp
+++ b/ui/src/audiobar.cpp
@@ -26,8 +26,9 @@
 #include "vccuelist.h"
 #include "virtualconsole.h"
 
-AudioBar::AudioBar(int t, uchar v)
+AudioBar::AudioBar(int t, uchar v, quint32 parentId)
 {
+    m_parentId = parentId;
     m_type = t;
     m_value = v;
     m_tapped = false;
@@ -45,6 +46,7 @@ AudioBar::AudioBar(int t, uchar v)
 AudioBar *AudioBar::createCopy()
 {
     AudioBar *copy = new AudioBar();
+    copy->m_parentId = m_parentId;
     copy->m_type = m_type;
     copy->m_value = m_value;
     copy->m_name = m_name;
@@ -151,9 +153,21 @@ void AudioBar::checkFunctionThresholds(Doc *doc)
     if (m_function == NULL)
         return;
     if (m_value >= m_maxThreshold)
-        m_function->start(doc->masterTimer(), -1);
+    {
+        if (m_parentId != quint32(-1))
+            m_function->start(doc->masterTimer(),
+                    Function::Source(Function::Source::AutoVCWidget, m_parentId));
+        else
+            m_function->start(doc->masterTimer(),
+                    Function::Source(Function::Source::God, 0));
+    }
     else if (m_value < m_minThreshold)
-        m_function->stop(-1);
+    {
+        if (m_parentId != quint32(-1))
+            m_function->stop(Function::Source(Function::Source::AutoVCWidget, m_parentId));
+        else
+            m_function->stop(Function::Source(Function::Source::God, 0));
+    }
 }
 
 void AudioBar::checkWidgetFunctionality()

--- a/ui/src/audiobar.cpp
+++ b/ui/src/audiobar.cpp
@@ -150,10 +150,10 @@ void AudioBar::checkFunctionThresholds(Doc *doc)
 {
     if (m_function == NULL)
         return;
-    if (m_value >= m_maxThreshold && m_function->isRunning() == false)
-        m_function->start(doc->masterTimer());
-    else if (m_value < m_minThreshold && m_function->isRunning() == true)
-        m_function->stop();
+    if (m_value >= m_maxThreshold)
+        m_function->start(doc->masterTimer(), -1);
+    else if (m_value < m_minThreshold)
+        m_function->stop(-1);
 }
 
 void AudioBar::checkWidgetFunctionality()

--- a/ui/src/audiobar.h
+++ b/ui/src/audiobar.h
@@ -46,7 +46,7 @@ class AudioBar
 {
 public:
     /** Normal constructor */
-    AudioBar(int t = 0, uchar v = 0);
+    AudioBar(int t = 0, uchar v = 0, quint32 parentId = quint32(-1));
 
     /** Destructor */
     ~AudioBar() { }
@@ -87,6 +87,7 @@ public:
 public:
     QString m_name;
     int m_type;
+    quint32 m_parentId;
     uchar m_value;
     bool m_tapped;
 

--- a/ui/src/audioeditor.cpp
+++ b/ui/src/audioeditor.cpp
@@ -134,7 +134,7 @@ AudioEditor::AudioEditor(QWidget* parent, Audio *audio, Doc* doc)
 
 AudioEditor::~AudioEditor()
 {
-    m_audio->stop(-1);
+    m_audio->stop(Function::Source(Function::Source::God, 0));
 }
 
 void AudioEditor::slotNameEdited(const QString& text)
@@ -234,12 +234,12 @@ void AudioEditor::slotPreviewToggled(bool state)
 {
     if (state == true)
     {
-        m_audio->start(m_doc->masterTimer(), -1);
+        m_audio->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
         connect(m_audio, SIGNAL(stopped(quint32)),
                 this, SLOT(slotPreviewStopped(quint32)));
     }
     else
-        m_audio->stop(-1);
+        m_audio->stop(Function::Source(Function::Source::God, 0));
 }
 
 void AudioEditor::slotPreviewStopped(quint32 id)

--- a/ui/src/audioeditor.cpp
+++ b/ui/src/audioeditor.cpp
@@ -134,8 +134,7 @@ AudioEditor::AudioEditor(QWidget* parent, Audio *audio, Doc* doc)
 
 AudioEditor::~AudioEditor()
 {
-    if (m_audio->isRunning())
-       m_audio->stop();
+    m_audio->stop(-1);
 }
 
 void AudioEditor::slotNameEdited(const QString& text)
@@ -235,12 +234,12 @@ void AudioEditor::slotPreviewToggled(bool state)
 {
     if (state == true)
     {
-        m_audio->start(m_doc->masterTimer());
+        m_audio->start(m_doc->masterTimer(), -1);
         connect(m_audio, SIGNAL(stopped(quint32)),
                 this, SLOT(slotPreviewStopped(quint32)));
     }
     else
-        m_audio->stop();
+        m_audio->stop(-1);
 }
 
 void AudioEditor::slotPreviewStopped(quint32 id)

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -247,8 +247,7 @@ ChaserEditor::~ChaserEditor()
 
     // double check that the Chaser still exists !
     if (m_liveMode == false &&
-        m_doc->functions().contains(m_chaser) == true &&
-        m_chaser->stopped() == false)
+        m_doc->functions().contains(m_chaser) == true)
         m_chaser->stopAndWait();
 }
 
@@ -260,8 +259,7 @@ void ChaserEditor::showOrderAndDirection(bool show)
 
 void ChaserEditor::stopTest()
 {
-    if (m_chaser->stopped() == false)
-        m_chaser->stopAndWait();
+    m_chaser->stopAndWait();
 }
 
 void ChaserEditor::selectStepAtTime(quint32 time)
@@ -486,7 +484,7 @@ void ChaserEditor::slotSpeedDialToggle(bool state)
 
 void ChaserEditor::slotItemSelectionChanged()
 {
-    if (m_chaser->isRunning() == false)
+    if (!m_chaser->isRunning())
     {
         if (m_tree->selectedItems().count() > 0)
         {
@@ -1097,13 +1095,10 @@ void ChaserEditor::slotTestPlay()
     m_testPreviousButton->setEnabled(true);
     m_testNextButton->setEnabled(true);
 
-    if (m_chaser->stopped() == true)
-    {
-        int idx = getCurrentIndex();
-        if (idx >= 0)
-            m_chaser->setStepIndex(idx);
-        m_chaser->start(m_doc->masterTimer());
-    }
+    int idx = getCurrentIndex();
+    if (idx >= 0)
+        m_chaser->setStepIndex(idx);
+    m_chaser->start(m_doc->masterTimer(), -1);
 }
 
 void ChaserEditor::slotTestStop()
@@ -1111,8 +1106,7 @@ void ChaserEditor::slotTestStop()
     m_testPreviousButton->setEnabled(false);
     m_testNextButton->setEnabled(false);
 
-    if (m_chaser->stopped() == false)
-        m_chaser->stopAndWait();
+    m_chaser->stopAndWait();
 }
 
 void ChaserEditor::slotTestPreviousClicked()
@@ -1131,8 +1125,8 @@ void ChaserEditor::slotModeChanged(Doc::Mode mode)
     {
         m_testPlayButton->setEnabled(false);
         m_testStopButton->setEnabled(false);
-        if (m_liveMode == false && m_chaser->stopped() == false)
-            m_chaser->stop();
+        if (m_liveMode == false)
+            m_chaser->stop(-1);
     }
     else
     {
@@ -1146,30 +1140,6 @@ void ChaserEditor::slotStepChanged(int stepNumber)
     // Select only the item at step StepNumber
     // If stepNumber is outside of bounds, select nothing
     m_tree->setCurrentItem(m_tree->topLevelItem(stepNumber));
-}
-
-bool ChaserEditor::interruptRunning()
-{
-    if (m_chaser->stopped() == false)
-    {
-        m_chaser->stopAndWait();
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-void ChaserEditor::continueRunning(bool running)
-{
-    if (running == true)
-    {
-        if (m_doc->mode() == Doc::Operate)
-            m_chaser->start(m_doc->masterTimer());
-        else
-            m_testStopButton->click();
-    }
 }
 
 /****************************************************************************

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -1098,7 +1098,7 @@ void ChaserEditor::slotTestPlay()
     int idx = getCurrentIndex();
     if (idx >= 0)
         m_chaser->setStepIndex(idx);
-    m_chaser->start(m_doc->masterTimer(), -1);
+    m_chaser->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
 }
 
 void ChaserEditor::slotTestStop()
@@ -1126,7 +1126,7 @@ void ChaserEditor::slotModeChanged(Doc::Mode mode)
         m_testPlayButton->setEnabled(false);
         m_testStopButton->setEnabled(false);
         if (m_liveMode == false)
-            m_chaser->stop(-1);
+            m_chaser->stop(Function::Source(Function::Source::God, 0));
     }
     else
     {

--- a/ui/src/chasereditor.h
+++ b/ui/src/chasereditor.h
@@ -146,8 +146,6 @@ private slots:
     void slotStepChanged(int stepNumber);
 
 private:
-    bool interruptRunning();
-    void continueRunning(bool running);
     int getCurrentIndex();
 
     /************************************************************************
@@ -168,9 +166,6 @@ private:
 
     /** Update the step numbers (col 0) for each list item */
     void updateStepNumbers();
-
-    /** Update the contents of m_chaser */
-    //void updateChaserContents();
 
     /** Set cut,copy,paste buttons enabled/disabled */
     void updateClipboardButtons();

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -301,7 +301,7 @@ void EFXEditor::initMovementPage()
 void EFXEditor::slotTestClicked()
 {
     if (m_testButton->isChecked() == true)
-        m_efx->start(m_doc->masterTimer());
+        m_efx->start(m_doc->masterTimer(), -1);
     else
         m_efx->stopAndWait();
 }
@@ -320,8 +320,7 @@ void EFXEditor::slotModeChanged(Doc::Mode mode)
 {
     if (mode == Doc::Operate)
     {
-        if (m_efx->stopped() == false)
-            m_efx->stopAndWait();
+        m_efx->stopAndWait();
         m_testButton->setChecked(false);
         m_testButton->setEnabled(false);
     }
@@ -355,7 +354,7 @@ void EFXEditor::continueRunning(bool running)
     if (running == true)
     {
         if (m_doc->mode() == Doc::Operate)
-            m_efx->start(m_doc->masterTimer());
+            m_efx->start(m_doc->masterTimer(), -1);
         else
             m_testButton->click();
     }

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -301,7 +301,7 @@ void EFXEditor::initMovementPage()
 void EFXEditor::slotTestClicked()
 {
     if (m_testButton->isChecked() == true)
-        m_efx->start(m_doc->masterTimer(), -1);
+        m_efx->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
     else
         m_efx->stopAndWait();
 }
@@ -354,7 +354,7 @@ void EFXEditor::continueRunning(bool running)
     if (running == true)
     {
         if (m_doc->mode() == Doc::Operate)
-            m_efx->start(m_doc->masterTimer(), -1);
+            m_efx->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
         else
             m_testButton->click();
     }

--- a/ui/src/functionliveeditdialog.cpp
+++ b/ui/src/functionliveeditdialog.cpp
@@ -65,7 +65,7 @@ FunctionLiveEditDialog::FunctionLiveEditDialog(Doc *doc, quint32 fid, QWidget *p
         case Function::Scene:
         {
             bool blindMode = true;
-            if (func->isRunning() == true)
+            if (func->isRunning())
                 blindMode = false;
             SceneEditor *sceneEditor = new SceneEditor(m_scrollArea, qobject_cast<Scene*> (func), m_doc, true);
             sceneEditor->setBlindModeEnabled(blindMode);

--- a/ui/src/functionselection.cpp
+++ b/ui/src/functionselection.cpp
@@ -312,7 +312,7 @@ void FunctionSelection::refillTree()
     /* Fill the tree */
     foreach (Function* function, m_doc->functions())
     {
-        if (m_runningOnlyFlag == true && function->isRunning() == false)
+        if (m_runningOnlyFlag == true && !function->isRunning())
             continue;
 
         if (m_filter & function->type())

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -910,7 +910,7 @@ void RGBMatrixEditor::slotTestClicked()
     if (m_testButton->isChecked() == true)
     {
         m_previewTimer->stop();
-        m_matrix->start(m_doc->masterTimer());
+        m_matrix->start(m_doc->masterTimer(), -1);
     }
     else
     {

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -910,7 +910,7 @@ void RGBMatrixEditor::slotTestClicked()
     if (m_testButton->isChecked() == true)
     {
         m_previewTimer->stop();
-        m_matrix->start(m_doc->masterTimer(), -1);
+        m_matrix->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
     }
     else
     {

--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -812,13 +812,10 @@ void SceneEditor::slotBlindToggled(bool state)
 {
     if (m_doc->mode() == Doc::Operate)
     {
-        if (m_source != NULL)
-        {
-            delete m_source;
-            m_source = NULL;
-        }
+        delete m_source;
+        m_source = NULL;
 
-        if (m_scene != NULL && m_scene->isRunning() == false)
+        if (m_scene != NULL && !m_scene->isRunning())
         {
             m_source = new GenericDMXSource(m_doc);
             foreach(SceneValue scv, m_scene->values())

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -452,7 +452,7 @@ void ScriptEditor::slotCheckSyntax()
 void ScriptEditor::slotTestRun()
 {
     if (m_testPlayButton->isChecked() == true)
-        m_script->start(m_doc->masterTimer());
+        m_script->start(m_doc->masterTimer(), -1);
     else
         m_script->stopAndWait();
 }

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -452,7 +452,7 @@ void ScriptEditor::slotCheckSyntax()
 void ScriptEditor::slotTestRun()
 {
     if (m_testPlayButton->isChecked() == true)
-        m_script->start(m_doc->masterTimer(), -1);
+        m_script->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
     else
         m_script->stopAndWait();
 }

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -1174,7 +1174,7 @@ void ShowManager::slotStopPlayback()
 {
     if (m_show != NULL && m_show->isRunning())
     {
-        m_show->stop(-1);
+        m_show->stop(Function::Source(Function::Source::God, 0));
         return;
     }
     m_showview->rewindCursor();
@@ -1185,7 +1185,7 @@ void ShowManager::slotStartPlayback()
 {
     if (m_showsCombo->count() == 0 || m_show == NULL)
         return;
-    m_show->start(m_doc->masterTimer(), -1, m_showview->getTimeFromCursor());
+    m_show->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0), m_showview->getTimeFromCursor());
 }
 
 void ShowManager::slotShowStopped()

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -1174,7 +1174,7 @@ void ShowManager::slotStopPlayback()
 {
     if (m_show != NULL && m_show->isRunning())
     {
-        m_show->stop();
+        m_show->stop(-1);
         return;
     }
     m_showview->rewindCursor();
@@ -1185,7 +1185,7 @@ void ShowManager::slotStartPlayback()
 {
     if (m_showsCombo->count() == 0 || m_show == NULL)
         return;
-    m_show->start(m_doc->masterTimer(), false, m_showview->getTimeFromCursor());
+    m_show->start(m_doc->masterTimer(), -1, m_showview->getTimeFromCursor());
 }
 
 void ShowManager::slotShowStopped()

--- a/ui/src/simpledesk.cpp
+++ b/ui/src/simpledesk.cpp
@@ -882,7 +882,7 @@ void SimpleDesk::slotPlaybackStarted()
     CueStack* cueStack = m_engine->cueStack(pb);
     Q_ASSERT(cueStack != NULL);
 
-    if (cueStack->isRunning() == false)
+    if (!cueStack->isRunning())
         cueStack->nextCue();
 }
 
@@ -893,7 +893,7 @@ void SimpleDesk::slotPlaybackStopped()
     CueStack* cueStack = m_engine->cueStack(pb);
     Q_ASSERT(cueStack != NULL);
 
-    if (cueStack->isRunning() == true)
+    if (cueStack->isRunning())
         cueStack->stop();
 }
 

--- a/ui/src/simpledeskengine.cpp
+++ b/ui/src/simpledeskengine.cpp
@@ -290,16 +290,16 @@ void SimpleDeskEngine::writeDMX(MasterTimer* timer, QList<Universe *> ua)
         if (cueStack == NULL)
             continue;
 
-        if (cueStack->isRunning() == true)
+        if (cueStack->isRunning())
         {
-            if (cueStack->isStarted() == false)
+            if (!cueStack->isStarted())
                 cueStack->preRun();
 
             cueStack->write(ua);
         }
         else
         {
-            if (cueStack->isStarted() == true)
+            if (cueStack->isStarted())
                 cueStack->postRun(timer);
         }
     }

--- a/ui/src/videoeditor.cpp
+++ b/ui/src/videoeditor.cpp
@@ -105,8 +105,7 @@ VideoEditor::VideoEditor(QWidget* parent, Video *video, Doc* doc)
 
 VideoEditor::~VideoEditor()
 {
-    if (m_video->isRunning())
-       m_video->stop();
+    m_video->stopAndWait();
 /*
     disconnect(m_video, SIGNAL(totalTimeChanged(qint64)),
                this, SLOT(slotDurationChanged(qint64)));
@@ -157,8 +156,7 @@ void VideoEditor::slotSourceFileClicked()
     if (fn.isEmpty() == true)
         return;
 
-    if (m_video->isRunning())
-        m_video->stopAndWait();
+    m_video->stopAndWait();
 
     m_video->setSourceUrl(fn);
     m_filenameLabel->setText(m_video->sourceUrl());
@@ -208,12 +206,12 @@ void VideoEditor::slotPreviewToggled(bool state)
 {
     if (state == true)
     {
-        m_video->start(m_doc->masterTimer());
+        m_video->start(m_doc->masterTimer(), -1);
         connect(m_video, SIGNAL(stopped(quint32)),
                 this, SLOT(slotPreviewStopped(quint32)));
     }
     else
-        m_video->stop();
+        m_video->stop(-1);
 }
 
 void VideoEditor::slotPreviewStopped(quint32 id)

--- a/ui/src/videoeditor.cpp
+++ b/ui/src/videoeditor.cpp
@@ -206,12 +206,12 @@ void VideoEditor::slotPreviewToggled(bool state)
 {
     if (state == true)
     {
-        m_video->start(m_doc->masterTimer(), -1);
+        m_video->start(m_doc->masterTimer(), Function::Source(Function::Source::God, 0));
         connect(m_video, SIGNAL(stopped(quint32)),
                 this, SLOT(slotPreviewStopped(quint32)));
     }
     else
-        m_video->stop(-1);
+        m_video->stop(Function::Source(Function::Source::God, 0));
 }
 
 void VideoEditor::slotPreviewStopped(quint32 id)

--- a/ui/src/videoprovider.cpp
+++ b/ui/src/videoprovider.cpp
@@ -151,7 +151,7 @@ void VideoWidget::slotStatusChanged(QMediaPlayer::MediaStatus status)
             if (m_videoWidget != NULL)
                 m_videoWidget->hide();
 
-            m_video->stop(-1);
+            m_video->stop(Function::Source(Function::Source::God, 0));
             break;
         }
         case QMediaPlayer::InvalidMedia:
@@ -238,7 +238,7 @@ void VideoWidget::slotStopVideo()
     if (m_videoWidget != NULL)
         m_videoWidget->hide();
 
-    m_video->stop(-1);
+    m_video->stop(Function::Source(Function::Source::God, 0));
 }
 
 void VideoWidget::slotBrightnessAdjust(int value)

--- a/ui/src/videoprovider.cpp
+++ b/ui/src/videoprovider.cpp
@@ -151,8 +151,7 @@ void VideoWidget::slotStatusChanged(QMediaPlayer::MediaStatus status)
             if (m_videoWidget != NULL)
                 m_videoWidget->hide();
 
-            if (m_video->isRunning())
-                m_video->stop();
+            m_video->stop(-1);
             break;
         }
         case QMediaPlayer::InvalidMedia:
@@ -239,8 +238,7 @@ void VideoWidget::slotStopVideo()
     if (m_videoWidget != NULL)
         m_videoWidget->hide();
 
-    if (m_video->isRunning())
-        m_video->stop();
+    m_video->stop(-1);
 }
 
 void VideoWidget::slotBrightnessAdjust(int value)

--- a/ui/src/virtualconsole/vcaudiotriggers.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggers.cpp
@@ -103,10 +103,10 @@ VCAudioTriggers::VCAudioTriggers(QWidget* parent, Doc* doc)
 
     // create the  AudioBar items to hold the spectrum data.
     // To be loaded from the project
-    m_volumeBar = new AudioBar(AudioBar::None, 0);
+    m_volumeBar = new AudioBar(AudioBar::None, 0, id());
     for (int i = 0; i < m_inputCapture->defaultBarsNumber(); i++)
     {
-        AudioBar *asb = new AudioBar(AudioBar::None, 0);
+        AudioBar *asb = new AudioBar(AudioBar::None, 0, id());
         m_spectrumBars.append(asb);
     }
 
@@ -460,7 +460,7 @@ void VCAudioTriggers::setSpectrumBarsNumber(int num)
         int barsToAdd = num - m_spectrumBars.count();
         for (int i = 0 ; i < barsToAdd; i++)
         {
-            AudioBar *asb = new AudioBar(AudioBar::None, 0);
+            AudioBar *asb = new AudioBar(AudioBar::None, 0, id());
             m_spectrumBars.append(asb);
         }
     }

--- a/ui/src/virtualconsole/vcaudiotriggers.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggers.cpp
@@ -197,7 +197,7 @@ void VCAudioTriggers::enableCapture(bool enable)
         emit functionStarting(Function::invalidId());
         connect(m_inputCapture, SIGNAL(dataProcessed(double*,int,double,quint32)),
                 this, SLOT(slotDisplaySpectrum(double*,int,double,quint32)));
-        if (m_inputCapture->isRunning() == false)
+        if (!m_inputCapture->isRunning())
             m_inputCapture->start();
         m_button->blockSignals(true);
         m_button->setChecked(true);
@@ -337,7 +337,7 @@ void VCAudioTriggers::slotInputValueChanged(quint32 universe, quint32 channel, u
 
     if (checkInputSource(universe, (page() << 16) | channel, value, sender()))
     {
-        if (m_inputCapture->isRunning() == false && value > 0)
+        if (!m_inputCapture->isRunning() && value > 0)
             slotEnableButtonToggled(true);
         else
             slotEnableButtonToggled(false);

--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -404,7 +404,7 @@ void VCButton::notifyFunctionStarting(quint32 fid)
     {
         Function *f = m_doc->function(m_function);
         if (f != NULL)
-            f->stop(-1);
+            f->stop(Function::Source(Function::Source::ManualVCWidget, id()));
     }
 }
 
@@ -658,7 +658,7 @@ void VCButton::pressFunction()
             // functions off and start this one.
             if (isOn() == true && !(isChildOfSoloFrame() && f->startedAsChild()))
             {
-                f->stop(-1);
+                f->stop(Function::Source(Function::Source::ManualVCWidget, id()));
             }
             else
             {
@@ -667,7 +667,7 @@ void VCButton::pressFunction()
                 else
                     f->adjustAttribute(intensity(), Function::Intensity);
 
-                f->start(m_doc->masterTimer(), -1);
+                f->start(m_doc->masterTimer(), Function::Source(Function::Source::ManualVCWidget, id()));
                 emit functionStarting(m_function);
             }
         }

--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -403,8 +403,8 @@ void VCButton::notifyFunctionStarting(quint32 fid)
     if (m_function != Function::invalidId() && action() == VCButton::Toggle)
     {
         Function *f = m_doc->function(m_function);
-        if (f != NULL && !f->stopped())
-            f->stop();
+        if (f != NULL)
+            f->stop(-1);
     }
 }
 
@@ -454,8 +454,7 @@ void VCButton::updateOnState()
     {
         on = false;
         Function* function = m_doc->function(m_function);
-        if (function != NULL)
-            on = function->isRunning();
+        on = (function != NULL) && function->isRunning();
     }
     if (m_on != on)
         setOn(on);
@@ -657,10 +656,9 @@ void VCButton::pressFunction()
             // if the button is in a SoloFrame and the function is running but was
             // started by a different function (a chaser or collection), turn other
             // functions off and start this one.
-            //
             if (isOn() == true && !(isChildOfSoloFrame() && f->startedAsChild()))
             {
-                f->stop();
+                f->stop(-1);
             }
             else
             {
@@ -669,7 +667,7 @@ void VCButton::pressFunction()
                 else
                     f->adjustAttribute(intensity(), Function::Intensity);
 
-                f->start(m_doc->masterTimer());
+                f->start(m_doc->masterTimer(), -1);
                 emit functionStarting(m_function);
             }
         }

--- a/ui/src/virtualconsole/vcclock.cpp
+++ b/ui/src/virtualconsole/vcclock.cpp
@@ -199,7 +199,7 @@ void VCClock::slotUpdateTime()
                         Function *func = m_doc->function(fid);
                         if (func != NULL)
                         {
-                            func->start(m_doc->masterTimer());
+                            func->start(m_doc->masterTimer(), -1);
                             qDebug() << "VC Clock starting function:" << func->name();
                         }
                         m_scheduleIndex++;

--- a/ui/src/virtualconsole/vcclock.cpp
+++ b/ui/src/virtualconsole/vcclock.cpp
@@ -199,7 +199,7 @@ void VCClock::slotUpdateTime()
                         Function *func = m_doc->function(fid);
                         if (func != NULL)
                         {
-                            func->start(m_doc->masterTimer(), -1);
+                            func->start(m_doc->masterTimer(), Function::Source(Function::Source::AutoVCWidget, id()));
                             qDebug() << "VC Clock starting function:" << func->name();
                         }
                         m_scheduleIndex++;

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -345,7 +345,7 @@ void VCCueList::setChaser(quint32 id)
     updateStepList();
 
     /* Current status */
-    if (chaser != NULL && !chaser->stopped())
+    if (chaser != NULL && chaser->isRunning())
     {
         slotFunctionRunning(m_chaserID);
         slotCurrentStepChanged(chaser->currentStepIndex());
@@ -637,7 +637,7 @@ void VCCueList::slotFunctionStopped(quint32 fid)
 void VCCueList::slotProgressTimeout()
 {
     Chaser* ch = chaser();
-    if (ch == NULL || ch->stopped())
+    if (ch == NULL || !ch->isRunning())
         return;
 
     ChaserRunnerStep step(ch->currentRunningStep());
@@ -694,7 +694,7 @@ void VCCueList::startChaser(int startIndex)
     ch->setStepIndex(startIndex);
     ch->setStartIntensity((qreal)m_slider1->value() / 100.0);
     ch->adjustAttribute(intensity(), Function::Intensity);
-    ch->start(m_doc->masterTimer());
+    ch->start(m_doc->masterTimer(), -1);
     emit functionStarting(m_chaserID);
 }
 
@@ -703,7 +703,7 @@ void VCCueList::stopChaser()
     Chaser* ch = chaser();
     if (ch == NULL)
         return;
-    ch->stop();
+    ch->stop(-1);
 }
 
 /*****************************************************************************
@@ -712,7 +712,7 @@ void VCCueList::stopChaser()
 void VCCueList::setSlidersInfo(int index)
 {
     Chaser* ch = chaser();
-    if (ch == NULL || ch->stopped())
+    if (ch == NULL || !ch->isRunning())
         return;
 
     int tmpIndex = ch->computeNextStep(index);
@@ -753,7 +753,7 @@ void VCCueList::slotSlider1ValueChanged(int value)
         m_slider2->setValue(100 - value);
 
     Chaser* ch = chaser();
-    if (ch == NULL || ch->stopped())
+    if (ch == NULL || !ch->isRunning())
         return;
 
     ch->adjustIntensity((qreal)value / 100, m_primaryLeft ? m_primaryIndex: m_secondaryIndex);
@@ -796,7 +796,7 @@ void VCCueList::slotSlider2ValueChanged(int value)
         m_slider1->setValue(100 - value);
 
     Chaser* ch = chaser();
-    if (ch == NULL || ch->stopped())
+    if (ch == NULL || !ch->isRunning())
         return;
 
     ch->adjustIntensity((qreal)value / 100, m_primaryLeft ? m_secondaryIndex : m_primaryIndex);
@@ -1044,7 +1044,7 @@ void VCCueList::playCueAtIndex(int idx)
     if (ch == NULL)
         return;
 
-    if (!ch->stopped())
+    if (ch->isRunning())
     {
         ch->setCurrentStep(m_primaryIndex, (qreal)m_slider1->value() / 100);
     }

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -694,7 +694,7 @@ void VCCueList::startChaser(int startIndex)
     ch->setStepIndex(startIndex);
     ch->setStartIntensity((qreal)m_slider1->value() / 100.0);
     ch->adjustAttribute(intensity(), Function::Intensity);
-    ch->start(m_doc->masterTimer(), -1);
+    ch->start(m_doc->masterTimer(), Function::Source(Function::Source::ManualVCWidget, id()));
     emit functionStarting(m_chaserID);
 }
 
@@ -703,7 +703,7 @@ void VCCueList::stopChaser()
     Chaser* ch = chaser();
     if (ch == NULL)
         return;
-    ch->stop(-1);
+    ch->stop(Function::Source(Function::Source::ManualVCWidget, id()));
 }
 
 /*****************************************************************************

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -238,16 +238,14 @@ void VCMatrix::slotSliderMoved(int value)
 
     if (value == 0)
     {
-        if (function->stopped() == false)
-            function->stop();
+        function->stop(-1);
     }
     else
     {
         qreal pIntensity = qreal(value) / qreal(UCHAR_MAX);
         function->adjustAttribute(pIntensity * intensity(), Function::Intensity);
 
-        if (function->stopped() == true)
-            function->start(m_doc->masterTimer());
+        function->start(m_doc->masterTimer(), -1);
     }
 }
 

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -238,14 +238,14 @@ void VCMatrix::slotSliderMoved(int value)
 
     if (value == 0)
     {
-        function->stop(-1);
+        function->stop(Function::Source(Function::Source::ManualVCWidget, id()));
     }
     else
     {
         qreal pIntensity = qreal(value) / qreal(UCHAR_MAX);
         function->adjustAttribute(pIntensity * intensity(), Function::Intensity);
 
-        function->start(m_doc->masterTimer(), -1);
+        function->start(m_doc->masterTimer(), Function::Source(Function::Source::ManualVCWidget, id()));
     }
 }
 

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -978,11 +978,11 @@ void VCSlider::writeDMXPlayback(MasterTimer* timer, QList<Universe *> ua)
     {
         if (value == 0)
         {
-            function->stop(-1);
+            function->stop(Function::Source(Function::Source::ManualVCWidget, id()));
         }
         else
         {
-            function->start(timer, -1);
+            function->start(timer, Function::Source(Function::Source::ManualVCWidget, id()));
             emit functionStarting(m_playbackFunction);
             function->adjustAttribute(pIntensity * intensity(), Function::Intensity);
         }

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -978,16 +978,12 @@ void VCSlider::writeDMXPlayback(MasterTimer* timer, QList<Universe *> ua)
     {
         if (value == 0)
         {
-            if (function->stopped() == false)
-                function->stop();
+            function->stop(-1);
         }
         else
         {
-            if (function->stopped() == true)
-            {
-                function->start(timer);
-                emit functionStarting(m_playbackFunction);
-            }
+            function->start(timer, -1);
+            emit functionStarting(m_playbackFunction);
             function->adjustAttribute(pIntensity * intensity(), Function::Intensity);
         }
     }

--- a/variables.pri
+++ b/variables.pri
@@ -12,6 +12,7 @@ APPVERSION = 4.8.6 GIT
 
 # Treat all compiler warnings as errors
 QMAKE_CXXFLAGS += -Werror
+!macx:QMAKE_CXXFLAGS += -Wno-unused-local-typedefs # Fix to build with GCC 4.8
 CONFIG         += warn_on
 
 # Build everything in the order specified in .pro files

--- a/variables.pri
+++ b/variables.pri
@@ -12,7 +12,6 @@ APPVERSION = 4.8.6 GIT
 
 # Treat all compiler warnings as errors
 QMAKE_CXXFLAGS += -Werror
-!macx:QMAKE_CXXFLAGS += -Wno-unused-local-typedefs # Fix to build with GCC 4.8
 CONFIG         += warn_on
 
 # Build everything in the order specified in .pro files


### PR DESCRIPTION
This fixes the issue "scene in a very quick chaser may stay ON after the end of the chaser"

Also, if several "sources" start a function (a chaser, a collection, whatever), all the sources have to stop the function for the function to actually stop.

This allows having a function in several collections at the same time.
If several collections contain the function, they will have to all be stopped for the function to stop.
-> The function will not be stopped when stopping only one collection.