### PR TITLE
Allow compile-time override of OLA plugin starting universe

### DIFF
--- a/plugins/ola/olaio.cpp
+++ b/plugins/ola/olaio.cpp
@@ -30,6 +30,10 @@
 #define SETTINGS_EMBEDDED "OlaIO/embedded"
 #define UNIVERSE_COUNT 4
 
+#ifndef QLC_OLA_FIRST_UNIVERSE
+#define QLC_OLA_FIRST_UNIVERSE 1
+#endif
+
 /****************************************************************************
  * Initialization
  ****************************************************************************/
@@ -54,9 +58,8 @@ void OlaIO::init()
     m_thread = NULL;
     ola::InitLogging(ola::OLA_LOG_WARN, new ola::QLCLogDestination());
     // TODO: load this from a savefile at some point
-    // For now, start counting at OLA universe #0
     for (unsigned int i = 0; i < UNIVERSE_COUNT; ++i)
-        m_outputs.append(i);
+        m_outputs.append(i + QLC_OLA_FIRST_UNIVERSE);
 
     bool es = false;
     QSettings settings;

--- a/plugins/ola/olaio.cpp
+++ b/plugins/ola/olaio.cpp
@@ -54,7 +54,8 @@ void OlaIO::init()
     m_thread = NULL;
     ola::InitLogging(ola::OLA_LOG_WARN, new ola::QLCLogDestination());
     // TODO: load this from a savefile at some point
-    for (unsigned int i = 1; i <= UNIVERSE_COUNT; ++i)
+    // For now, start counting at OLA universe #0
+    for (unsigned int i = 0; i < UNIVERSE_COUNT; ++i)
         m_outputs.append(i);
 
     bool es = false;
@@ -140,7 +141,7 @@ QStringList OlaIO::outputs()
 {
     QStringList list;
     for (int i = 0; i < m_outputs.size(); ++i)
-        list << QString("%1: OLA Universe %1").arg(i + 1);
+        list << QString("%1: OLA Universe %2").arg(i + 1).arg(m_outputs[i]);
     return list;
 }
 
@@ -170,7 +171,7 @@ QString OlaIO::outputInfo(quint32 output)
     {
         str += QString("<H3>%1</H3>").arg(outputs()[output]);
         str += QString("<P>");
-        str += tr("This is the output for OLA universe %1").arg(output + 1);
+        str += tr("This is the output for OLA universe %1").arg(m_outputs[output]);
         str += QString("</P>");
     }
 

--- a/plugins/ola/olaoutthread.cpp
+++ b/plugins/ola/olaoutthread.cpp
@@ -104,10 +104,20 @@ void OlaOutThread::run()
  */
 int OlaOutThread::write_dmx(unsigned int universe, const QByteArray& data)
 {
-    m_data.universe = universe;
-    memcpy(m_data.data, data.data(), data.size());
     if (m_pipe)
+    {
+        const unsigned int src_sz = data.size();
+        Q_ASSERT(src_sz <= sizeof(m_data.data));
+
+        m_data.universe = universe;
+        memcpy(m_data.data, data.data(), src_sz);
+
+        // if a full src buffer was not provided, fill the rest of the dst buffer with zeroes.
+        if (src_sz < (int)sizeof(m_data.data))
+            memset(m_data.data+src_sz, 0, sizeof(m_data.data)-src_sz);
+
         m_pipe->Send((uint8_t*) &m_data, sizeof(m_data));
+    }
     return 0;
 }
 

--- a/plugins/ola/olaoutthread.cpp
+++ b/plugins/ola/olaoutthread.cpp
@@ -104,20 +104,10 @@ void OlaOutThread::run()
  */
 int OlaOutThread::write_dmx(unsigned int universe, const QByteArray& data)
 {
+    m_data.universe = universe;
+    memcpy(m_data.data, data.data(), data.size());
     if (m_pipe)
-    {
-        const unsigned int src_sz = data.size();
-        Q_ASSERT(src_sz <= sizeof(m_data.data));
-
-        m_data.universe = universe;
-        memcpy(m_data.data, data.data(), src_sz);
-
-        // if a full src buffer was not provided, fill the rest of the dst buffer with zeroes.
-        if (src_sz < (int)sizeof(m_data.data))
-            memset(m_data.data+src_sz, 0, sizeof(m_data.data)-src_sz);
-
         m_pipe->Send((uint8_t*) &m_data, sizeof(m_data));
-    }
     return 0;
 }
 


### PR DESCRIPTION
Same as last pull request for changing the starting OLA plugin universe, but now leave it as the same previous behavior (universe 1 is start).  Allow for a compile-time override using QLC_OLA_FIRST_UNIVERSE preprocessor symbol.  TBD is to allow for a user config for this value.