### PR TITLE
added compile option to change OLA plugin starting universe

### DIFF
--- a/plugins/ola/olaio.cpp
+++ b/plugins/ola/olaio.cpp
@@ -30,6 +30,10 @@
 #define SETTINGS_EMBEDDED "OlaIO/embedded"
 #define UNIVERSE_COUNT 4
 
+#ifndef QLC_OLA_FIRST_UNIVERSE
+#define QLC_OLA_FIRST_UNIVERSE 1
+#endif
+
 /****************************************************************************
  * Initialization
  ****************************************************************************/
@@ -54,8 +58,8 @@ void OlaIO::init()
     m_thread = NULL;
     ola::InitLogging(ola::OLA_LOG_WARN, new ola::QLCLogDestination());
     // TODO: load this from a savefile at some point
-    for (unsigned int i = 1; i <= UNIVERSE_COUNT; ++i)
-        m_outputs.append(i);
+    for (unsigned int i = 0; i < UNIVERSE_COUNT; ++i)
+        m_outputs.append(i + QLC_OLA_FIRST_UNIVERSE);
 
     bool es = false;
     QSettings settings;
@@ -140,7 +144,7 @@ QStringList OlaIO::outputs()
 {
     QStringList list;
     for (int i = 0; i < m_outputs.size(); ++i)
-        list << QString("%1: OLA Universe %1").arg(i + 1);
+        list << QString("%1: OLA Universe %2").arg(i + 1).arg(m_outputs[i]);
     return list;
 }
 
@@ -170,7 +174,7 @@ QString OlaIO::outputInfo(quint32 output)
     {
         str += QString("<H3>%1</H3>").arg(outputs()[output]);
         str += QString("<P>");
-        str += tr("This is the output for OLA universe %1").arg(output + 1);
+        str += tr("This is the output for OLA universe %1").arg(m_outputs[output]);
         str += QString("</P>");
     }
 


### PR DESCRIPTION
Added a compiler preprocessing macro, QLC_OLA_FIRST_UNIVERSE, which allows the OLA plugin to be built with a different starting universe number.  Also, updates code for user display of universe number.  This commit does not represent any user-facing changes unless the module is compiled with a different starting universe number.