### PR TITLE
Filter out redondant input values.

### DIFF
--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -359,6 +359,18 @@ uchar InputOutputMap::grandMasterValue()
  * Patch
  *********************************************************************/
 
+void InputOutputMap::flushInputs()
+{
+    QMutexLocker locker(&m_universeMutex);
+
+    for (int i = 0; i < m_universeArray.count(); i++)
+    {
+        Universe *universe = m_universeArray.at(i);
+
+        universe->flushInput();
+    }
+}
+
 bool InputOutputMap::setInputPatch(quint32 universe, const QString &pluginName,
                                    quint32 input, const QString &profileName)
 {

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -212,7 +212,7 @@ public:
     /**
      * Retrieve the list of references of the Universe in the input/output map
      */
-    QList<Universe *>universes() const;
+    QList<Universe*> universes() const;
 
     /**
      * Claim access to a universe. This is declared virtual to make
@@ -304,6 +304,8 @@ private:
      *********************************************************************/
 
 public:
+    void flushInputs();
+
     /**
      * Patch the given universe to go through the given input plugin
      *

--- a/engine/src/inputpatch.cpp
+++ b/engine/src/inputpatch.cpp
@@ -201,7 +201,7 @@ QMap<QString, QVariant> InputPatch::getPluginParameters()
 
     return QMap<QString, QVariant>();
 }
- 
+
 void InputPatch::slotValueChanged(quint32 universe, quint32 input, quint32 channel,
                                   uchar value, const QString& key)
 {
@@ -210,7 +210,27 @@ void InputPatch::slotValueChanged(quint32 universe, quint32 input, quint32 chann
     if (input == m_pluginLine)
     {
         if (universe == UINT_MAX || (universe != UINT_MAX && universe == m_universe))
-            emit inputValueChanged(m_universe, channel, value, key);
+        {
+            QMutexLocker inputBufferLocker(&m_inputBufferMutex);
+            InputValue val(value, key);
+            if (m_inputBuffer.contains(channel))
+            {
+                InputValue const& curVal = m_inputBuffer.value(channel);
+                if (curVal.value != val.value)
+                {
+                    // Every ON/OFF changes must pass through
+                    if (curVal.value == 0 || val.value == 0)
+                    {
+                        emit inputValueChanged(m_universe, channel, curVal.value, curVal.key);
+                    }
+                    m_inputBuffer.insert(channel, val);
+                }
+            }
+            else
+            {
+                m_inputBuffer.insert(channel, val);
+            }
+        }
     }
 }
 
@@ -233,5 +253,18 @@ void InputPatch::setProfilePageControls()
                     m_pageSetCh = m_profile->channelNumber(ch);
             }
         }
+    }
+}
+
+void InputPatch::flush(quint32 universe)
+{
+    if (universe == UINT_MAX || (universe != UINT_MAX && universe == m_universe))
+    {
+        QMutexLocker inputBufferLocker(&m_inputBufferMutex);
+        for (QHash<quint32, InputValue>::const_iterator it = m_inputBuffer.begin(); it != m_inputBuffer.end(); ++it)
+        {
+            emit inputValueChanged(m_universe, it.key(), it.value().value, it.value().key);
+        }
+        m_inputBuffer.clear();
     }
 }

--- a/engine/src/inputpatch.h
+++ b/engine/src/inputpatch.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QMutex>
 
 #include "qlcinputprofile.h"
 
@@ -151,6 +152,22 @@ private:
 private:
     ushort m_nextPageCh, m_prevPageCh, m_pageSetCh;
 
+public:
+    void flush(quint32 universe);
+
+    struct InputValue
+    {
+        InputValue() {}
+        InputValue(uchar v, QString const& k)
+            : value(v)
+            , key(k)
+        {}
+        uchar value;
+        QString key;
+    };
+
+    QMutex m_inputBufferMutex;
+    QHash<quint32, InputValue> m_inputBuffer;
 };
 
 /** @} */

--- a/engine/src/mastertimer.cpp
+++ b/engine/src/mastertimer.cpp
@@ -104,6 +104,8 @@ void MasterTimer::timerTick()
     qDebug() << "[MasterTimer] *********** tick:" << ticksCount++ << "**********";
 #endif
 
+    doc->inputOutputMap()->flushInputs();
+
     QList<Universe *> universes = doc->inputOutputMap()->claimUniverses();
     for (int i = 0 ; i < universes.count(); i++)
     {

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -65,16 +65,9 @@ Universe::~Universe()
 {
     delete m_preGMValues;
     delete m_postGMValues;
-    if (m_inputPatch != NULL)
-        delete m_inputPatch;
-    if (m_outputPatch != NULL)
-        delete m_outputPatch;
-    if (m_fbPatch != NULL)
-        delete m_fbPatch;
-
-    m_inputPatch = NULL;
-    m_outputPatch = NULL;
-    m_fbPatch = NULL;
+    delete m_inputPatch;
+    delete m_outputPatch;
+    delete m_fbPatch;
 }
 
 void Universe::setName(QString name)
@@ -422,6 +415,14 @@ void Universe::dumpOutput(const QByteArray &data)
         m_totalChannelsChanged = false;
     }
     m_outputPatch->dump(m_id, data);
+}
+
+void Universe::flushInput()
+{
+    if (m_inputPatch == NULL)
+        return;
+
+    m_inputPatch->flush(m_id);
 }
 
 void Universe::slotInputValueChanged(quint32 universe, quint32 channel, uchar value, const QString &key)

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -216,6 +216,8 @@ public:
      */
     void dumpOutput(const QByteArray& data);
 
+    void flushInput();
+
 protected slots:
     /** Slot called every time an input patch sends data */
     void slotInputValueChanged(quint32 universe, quint32 channel, uchar value, const QString& key = 0);

--- a/engine/test/inputoutputmap/inputoutputmap_test.cpp
+++ b/engine/test/inputoutputmap/inputoutputmap_test.cpp
@@ -368,6 +368,8 @@ void InputOutputMap_Test::slotValueChanged()
 
     QSignalSpy spy(&im, SIGNAL(inputValueChanged(quint32, quint32, uchar, const QString&)));
     stub->emitValueChanged(UINT_MAX, 0, 15, UCHAR_MAX);
+    QVERIFY(spy.size() == 0);
+    im.flushInputs();
     QVERIFY(spy.size() == 1);
     QVERIFY(spy.at(0).at(0) == 0);
     QVERIFY(spy.at(0).at(1) == 15);
@@ -376,6 +378,8 @@ void InputOutputMap_Test::slotValueChanged()
     /* Invalid mapping for this plugin -> no signal */
     stub->emitValueChanged(UINT_MAX, 3, 15, UCHAR_MAX);
     QVERIFY(spy.size() == 1);
+    im.flushInputs();
+    QVERIFY(spy.size() == 1);
     QVERIFY(spy.at(0).at(0) == 0);
     QVERIFY(spy.at(0).at(1) == 15);
     QVERIFY(spy.at(0).at(2) == UCHAR_MAX);
@@ -383,11 +387,15 @@ void InputOutputMap_Test::slotValueChanged()
     /* Invalid mapping for this plugin -> no signal */
     stub->emitValueChanged(UINT_MAX, 1, 15, UCHAR_MAX);
     QVERIFY(spy.size() == 1);
+    im.flushInputs();
+    QVERIFY(spy.size() == 1);
     QVERIFY(spy.at(0).at(0) == 0);
     QVERIFY(spy.at(0).at(1) == 15);
     QVERIFY(spy.at(0).at(2) == UCHAR_MAX);
 
     stub->emitValueChanged(UINT_MAX, 0, 5, 127);
+    QVERIFY(spy.size() == 1);
+    im.flushInputs();
     QVERIFY(spy.size() == 2);
     QVERIFY(spy.at(0).at(0) == 0);
     QVERIFY(spy.at(0).at(1) == 15);
@@ -395,6 +403,34 @@ void InputOutputMap_Test::slotValueChanged()
     QVERIFY(spy.at(1).at(0) == 0);
     QVERIFY(spy.at(1).at(1) == 5);
     QVERIFY(spy.at(1).at(2) == 127);
+
+    stub->emitValueChanged(UINT_MAX, 0, 2, 0);
+    QVERIFY(spy.size() == 2);
+    stub->emitValueChanged(UINT_MAX, 0, 2, UCHAR_MAX);
+    QVERIFY(spy.size() == 3);
+    QVERIFY(spy.at(0).at(0) == 0);
+    QVERIFY(spy.at(0).at(1) == 15);
+    QVERIFY(spy.at(0).at(2) == UCHAR_MAX);
+    QVERIFY(spy.at(1).at(0) == 0);
+    QVERIFY(spy.at(1).at(1) == 5);
+    QVERIFY(spy.at(1).at(2) == 127);
+    QVERIFY(spy.at(2).at(0) == 0);
+    QVERIFY(spy.at(2).at(1) == 2);
+    QVERIFY(spy.at(2).at(2) == 0);
+    im.flushInputs();
+    QVERIFY(spy.size() == 4);
+    QVERIFY(spy.at(0).at(0) == 0);
+    QVERIFY(spy.at(0).at(1) == 15);
+    QVERIFY(spy.at(0).at(2) == UCHAR_MAX);
+    QVERIFY(spy.at(1).at(0) == 0);
+    QVERIFY(spy.at(1).at(1) == 5);
+    QVERIFY(spy.at(1).at(2) == 127);
+    QVERIFY(spy.at(2).at(0) == 0);
+    QVERIFY(spy.at(2).at(1) == 2);
+    QVERIFY(spy.at(2).at(2) == 0);
+    QVERIFY(spy.at(3).at(0) == 0);
+    QVERIFY(spy.at(3).at(1) == 2);
+    QVERIFY(spy.at(3).at(2) == UCHAR_MAX);
 }
 
 void InputOutputMap_Test::slotConfigurationChanged()


### PR DESCRIPTION
Example: When moving a (physical) slider fast from min to max, it's easy to receive up to 50 calls to slotValueChanged() during one single tick.
                
This means during this (20ms) tick, QLC+ has to process 50 different inputs values, but only the last one (that gives the final value of the slider) is really useful. This can cause some performance issue (processing an input value can mean changing a submaster acting on several functions...)



- Input values are buffered in InputPatch, and flushed each tick

- A value change from 0 to any other value will always be recorded
- Same for a value change from any value to 0