### PR TITLE
New modes for the EFX editor

### DIFF
--- a/engine/src/efx.cpp
+++ b/engine/src/efx.cpp
@@ -621,18 +621,22 @@ bool EFX::addFixture(EFXFixture* ef)
 {
     Q_ASSERT(ef != NULL);
 
-    /* Search for an existing fixture with the same ID to prevent multiple
-       entries of the same fixture. */
-    QListIterator <EFXFixture*> it(m_fixtures);
-    while (it.hasNext() == true)
+    /* Search for an existing fixture with the same ID and append at last but do
+     * not prevent multiple entries because a fixture can have multiple efx. */
+    //! @todo Prevent multiple entries using head & mode
+    int i;
+    for(i = 0; i < m_fixtures.size (); i++)
     {
-        /* Found the same fixture. Don't add the new one. */
-        if (it.next()->head() == ef->head())
-            return false;
+        if (m_fixtures[i]->head() == ef->head())
+        {
+            m_fixtures.insert(i, ef);
+            break;
+        }
     }
 
-    /* Put the EFXFixture object into our list */
-    m_fixtures.append(ef);
+    /* If not inserted, put the EFXFixture object into our list */
+    if(i >= m_fixtures.size())
+        m_fixtures.append(ef);
 
     emit changed(this->id());
 

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -21,10 +21,6 @@
 #include <QDomElement>
 #include <QDebug>
 #include <math.h>
-#include <QImage>
-#include <QLinearGradient>
-#include <QPainter>
-#include <QRgb>
 
 #include "genericfader.h"
 #include "mastertimer.h"
@@ -391,7 +387,6 @@ uint EFXFixture::timeOffset() const
 /*****************************************************************************
  * Running
  *****************************************************************************/
-#include <stdio.h>
 void EFXFixture::nextStep(MasterTimer* timer, QList<Universe *> universes)
 {
     m_elapsed += MasterTimer::tick();

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -144,7 +144,6 @@ uchar EFXFixture::fadeIntensity() const
 bool EFXFixture::isValid() const
 {
     Fixture* fxi = doc()->fixture(head().fxi);
-    Q_ASSERT(fxi != NULL);
 
     if (fxi == NULL)
         return false;

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -21,6 +21,10 @@
 #include <QDomElement>
 #include <QDebug>
 #include <math.h>
+#include <QImage>
+#include <QLinearGradient>
+#include <QPainter>
+#include <QRgb>
 
 #include "genericfader.h"
 #include "mastertimer.h"
@@ -31,6 +35,8 @@
 #include "scene.h"
 #include "efx.h"
 #include "doc.h"
+#include "gradient.h"
+
 
 /*****************************************************************************
  * Initialization
@@ -41,6 +47,7 @@ EFXFixture::EFXFixture(const EFX* parent)
     , m_head()
     , m_direction(Function::Forward)
     , m_startOffset(0)
+    , m_mode(EFXFixture::PanTilt)
     , m_fadeIntensity(255)
 
     , m_serialNumber(0)
@@ -62,6 +69,7 @@ void EFXFixture::copyFrom(const EFXFixture* ef)
     m_head = ef->m_head;
     m_direction = ef->m_direction;
     m_startOffset = ef->m_startOffset;
+    m_mode = ef->m_mode;
     m_fadeIntensity = ef->m_fadeIntensity;
 
     m_serialNumber = ef->m_serialNumber;
@@ -113,6 +121,16 @@ int EFXFixture::startOffset() const
     return m_startOffset;
 }
 
+void EFXFixture::setMode(Mode mode)
+{
+    m_mode = mode;
+}
+
+EFXFixture::Mode EFXFixture::mode() const
+{
+    return m_mode;
+}
+
 void EFXFixture::setFadeIntensity(uchar value)
 {
     m_fadeIntensity = value;
@@ -126,12 +144,18 @@ uchar EFXFixture::fadeIntensity() const
 bool EFXFixture::isValid() const
 {
     Fixture* fxi = doc()->fixture(head().fxi);
+    Q_ASSERT(fxi != NULL);
+
     if (fxi == NULL)
         return false;
     else if (head().head >= fxi->heads())
         return false;
-    else if (fxi->panMsbChannel(head().head) == QLCChannel::invalid() && // Maybe a device can pan OR tilt
+    else if (m_mode == PanTilt && fxi->panMsbChannel(head().head) == QLCChannel::invalid() && // Maybe a device can pan OR tilt
              fxi->tiltMsbChannel(head().head) == QLCChannel::invalid())   // but not both. Teh sux0r.
+        return false;
+    else if (m_mode == Dimmer && fxi->masterIntensityChannel(head().head) == QLCChannel::invalid() )
+        return false;
+    else if (m_mode == RGB && fxi->rgbChannels(head().head).size () == 0)
         return false;
     else
         return true;
@@ -154,6 +178,52 @@ void EFXFixture::durationChanged()
             m_elapsed += m_parent->duration();
         m_elapsed -= timeOffset();
     }
+}
+
+QStringList EFXFixture::modeList()
+{
+    Fixture* fxi = doc()->fixture(head().fxi);
+    Q_ASSERT(fxi != NULL);
+
+    QStringList modes;
+
+    if((fxi->panMsbChannel(head().head) != QLCChannel::invalid()) &&
+            (fxi->tiltMsbChannel(head().head) != QLCChannel::invalid()) )
+        modes << KXMLQLCEFXFixtureModePanTilt;
+
+    if((fxi->masterIntensityChannel(head().head) != QLCChannel::invalid()))
+        modes << KXMLQLCEFXFixtureModeDimmer;
+
+    if((fxi->rgbChannels (head().head).size () >= 3))
+        modes << KXMLQLCEFXFixtureModeRGB;
+
+    return modes;
+}
+
+QString EFXFixture::modeToString(Mode mode)
+{
+    switch (mode)
+    {
+        default:
+        case PanTilt:
+            return QString(KXMLQLCEFXFixtureModePanTilt);
+        case Dimmer:
+            return QString(KXMLQLCEFXFixtureModeDimmer);
+        case RGB:
+            return QString(KXMLQLCEFXFixtureModeRGB);
+    }
+}
+
+EFXFixture::Mode EFXFixture::stringToMode(const QString& str)
+{
+    if (str == QString(KXMLQLCEFXFixtureModePanTilt))
+        return PanTilt;
+    else if (str == QString(KXMLQLCEFXFixtureModeDimmer))
+        return Dimmer;
+    else if (str == QString(KXMLQLCEFXFixtureModeRGB))
+        return RGB;
+    else
+        return PanTilt;
 }
 
 /*****************************************************************************
@@ -185,6 +255,11 @@ bool EFXFixture::loadXML(const QDomElement& root)
         {
             /* Fixture Head */
             head.head = tag.text().toInt();
+        }
+        else if (tag.tagName() == KXMLQLCEFXFixtureMode)
+        {
+            /* Fixture Mode */
+            setMode ((Mode) tag.text().toInt());
         }
         else if (tag.tagName() == KXMLQLCEFXFixtureDirection)
         {
@@ -238,6 +313,12 @@ bool EFXFixture::saveXML(QDomDocument* doc, QDomElement* efx_root) const
     subtag = doc->createElement(KXMLQLCEFXFixtureHead);
     tag.appendChild(subtag);
     text = doc->createTextNode(QString("%1").arg(head().head));
+    subtag.appendChild(text);
+
+    /* Mode */
+    subtag = doc->createElement(KXMLQLCEFXFixtureMode);
+    tag.appendChild(subtag);
+    text = doc->createTextNode(QString::number(mode ()));
     subtag.appendChild(text);
 
     /* Direction */
@@ -311,7 +392,7 @@ uint EFXFixture::timeOffset() const
 /*****************************************************************************
  * Running
  *****************************************************************************/
-
+#include <stdio.h>
 void EFXFixture::nextStep(MasterTimer* timer, QList<Universe *> universes)
 {
     m_elapsed += MasterTimer::tick();
@@ -339,17 +420,31 @@ void EFXFixture::nextStep(MasterTimer* timer, QList<Universe *> universes)
                            qreal(0), qreal(m_parent->duration()),
                            qreal(0), qreal(M_PI * 2));
 
-    qreal pan = 0;
-    qreal tilt = 0;
+    qreal valX = 0;
+    qreal valY = 0;
 
     if ((m_parent->propagationMode() == EFX::Serial &&
         m_elapsed < (m_parent->duration() + timeOffset()))
         || m_elapsed < m_parent->duration())
     {
-        m_parent->calculatePoint(m_runTimeDirection, m_startOffset, m_currentAngle, &pan, &tilt);
+        m_parent->calculatePoint(m_runTimeDirection, m_startOffset, m_currentAngle, &valX, &valY);
 
         /* Write this fixture's data to universes. */
-        setPoint(universes, pan, tilt);
+        switch(m_mode)
+        {
+        case PanTilt:
+            setPointPanTilt(universes, valX, valY);
+            break;
+
+        case RGB:
+            setPointRGB (universes, valX, valY);
+            break;
+
+        case Dimmer:
+            //Use Y for coherence with RGB gradient.
+            setPointDimmer (universes, valY);
+            break;
+        }
     }
     else
     {
@@ -372,7 +467,7 @@ void EFXFixture::nextStep(MasterTimer* timer, QList<Universe *> universes)
     }
 }
 
-void EFXFixture::setPoint(QList<Universe *> universes, qreal pan, qreal tilt)
+void EFXFixture::setPointPanTilt(QList<Universe *> universes, qreal pan, qreal tilt)
 {
     Fixture* fxi = doc()->fixture(head().fxi);
     Q_ASSERT(fxi != NULL);
@@ -412,6 +507,40 @@ void EFXFixture::setPoint(QList<Universe *> universes, qreal pan, qreal tilt)
             universes[fxi->universe()]->writeRelative(fxi->address() + fxi->tiltLsbChannel(head().head), value);
         else
             universes[fxi->universe()]->write(fxi->address() + fxi->tiltLsbChannel(head().head), value);
+    }
+}
+
+void EFXFixture::setPointDimmer(QList<Universe *> universes, qreal dimmer)
+{
+    Q_UNUSED(universes);
+
+    Fixture* fxi = doc()->fixture(head().fxi);
+    Q_ASSERT(fxi != NULL);
+
+    /* Don't write dimmer data directly to universes but use FadeChannel to avoid steps at EFX loop restart */
+    if (fxi->masterIntensityChannel(head().head) != QLCChannel::invalid())
+    {
+        setFadeChannel(fxi->masterIntensityChannel(head().head),  dimmer);
+    }
+}
+
+void EFXFixture::setPointRGB(QList<Universe *> universes, qreal x, qreal y)
+{
+    Q_UNUSED(universes);
+
+    Fixture* fxi = doc()->fixture(head().fxi);
+    Q_ASSERT(fxi != NULL);
+
+    QVector<quint32> rgbChannels = fxi->rgbChannels(head().head);
+
+    /* Don't write dimmer data directly to universes but use FadeChannel to avoid steps at EFX loop restart */
+    if (rgbChannels.size () >= 3)
+    {
+        QColor pixel = Gradient::getRGBColor (x, y);
+
+        setFadeChannel(rgbChannels[0], pixel.red ());
+        setFadeChannel(rgbChannels[1], pixel.green ());
+        setFadeChannel(rgbChannels[2], pixel.blue ());
     }
 }
 
@@ -493,4 +622,18 @@ void EFXFixture::adjustIntensity(qreal fraction)
 qreal EFXFixture::intensity() const
 {
     return m_intensity;
+}
+
+
+/*****************************************************************************
+ * Helper Function
+ *****************************************************************************/
+void EFXFixture::setFadeChannel(quint32 nChannel, uchar val)
+{
+    FadeChannel fc;
+    fc.setFixture(doc(), head().fxi);
+    fc.setChannel(nChannel);
+
+    fc.setTarget(val);
+    m_parent->m_fader->forceAdd(fc);
 }

--- a/engine/src/efxfixture.h
+++ b/engine/src/efxfixture.h
@@ -20,6 +20,7 @@
 #ifndef EFXFIXTURE_H
 #define EFXFIXTURE_H
 
+#include <QImage>
 #include "function.h"
 #include "grouphead.h"
 
@@ -37,13 +38,26 @@ class Doc;
 #define KXMLQLCEFXFixture "Fixture"
 #define KXMLQLCEFXFixtureID "ID"
 #define KXMLQLCEFXFixtureHead "Head"
+#define KXMLQLCEFXFixtureMode "Mode"
 #define KXMLQLCEFXFixtureDirection "Direction"
 #define KXMLQLCEFXFixtureStartOffset "StartOffset"
 #define KXMLQLCEFXFixtureIntensity "Intensity"
 
+#define KXMLQLCEFXFixtureModePanTilt "Pan & Tilt"
+#define KXMLQLCEFXFixtureModeDimmer "Dimmer"
+#define KXMLQLCEFXFixtureModeRGB "RGB"
+
 class EFXFixture
 {
     friend class EFX;
+
+public:
+    enum Mode
+    {
+        PanTilt,
+        Dimmer,
+        RGB
+    };
 
     /*************************************************************************
      * Initialization
@@ -84,6 +98,13 @@ public:
     /** Get this fixture's start offset */
     int startOffset() const;
 
+    /** Set the parameter(s) that this efx will animate (ie. dimmer, RGB, ...) */
+    void setMode(Mode mode);
+
+    /** Get the parameter(s) that this efx will animate (ie. dimmer, RGB, ...) */
+    Mode mode() const;
+
+
     /**
      * Set a value to fade the fixture's intensity channel(s) to
      * during start().
@@ -103,11 +124,22 @@ public:
     bool isValid() const;
 
     void durationChanged();
+
+public:
+    /** Get the supported mode for this fixture in a string list */
+    QStringList modeList();
+
+    /** Convert a mode to a string */
+    static QString modeToString(Mode algo);
+
+    /** Convert a string to an mode type */
+    static Mode stringToMode(const QString& str);
  
 private:
     GroupHead m_head;
     Function::Direction m_direction;
     int m_startOffset;
+    Mode m_mode;
     uchar m_fadeIntensity;
 
     /*************************************************************************
@@ -168,7 +200,9 @@ private:
     void nextStep(MasterTimer* timer, QList<Universe *> universes);
 
     /** Write this EFXFixture's channel data to universes */
-    void setPoint(QList<Universe *> universes, qreal pan, qreal tilt);
+    void setPointPanTilt(QList<Universe *> universes, qreal pan, qreal tilt);
+    void setPointDimmer(QList<Universe *> universes, qreal dimmer);
+    void setPointRGB (QList<Universe *> universes, qreal x, qreal y);
 
     /* Run the start scene if necessary */
     void start(MasterTimer* timer, QList<Universe *> universes);
@@ -196,6 +230,8 @@ public:
 
 private:
     qreal m_intensity;
+
+    void setFadeChannel(quint32 nChannel, uchar val);
 };
 
 /** @} */

--- a/engine/src/efxfixture.h
+++ b/engine/src/efxfixture.h
@@ -43,7 +43,7 @@ class Doc;
 #define KXMLQLCEFXFixtureStartOffset "StartOffset"
 #define KXMLQLCEFXFixtureIntensity "Intensity"
 
-#define KXMLQLCEFXFixtureModePanTilt "Pan & Tilt"
+#define KXMLQLCEFXFixtureModePanTilt "Position"
 #define KXMLQLCEFXFixtureModeDimmer "Dimmer"
 #define KXMLQLCEFXFixtureModeRGB "RGB"
 

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -1,3 +1,22 @@
+/*
+  Q Light Controller Plus
+  gradient.cpp
+
+  Copyright (c) Giorgio Rebecchi
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 #include "gradient.h"
 
 #include <QImage>

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -15,9 +15,6 @@ QImage Gradient::getRGBGradient()
 
 QColor Gradient::getRGBColor(const quint32 x, const quint32 y)
 {
-    Q_ASSERT(x < 255);
-    Q_ASSERT(y < 255);
-
     initialize();
 
     return QColor(m_rgb.pixel (qMin(x, (quint32)255), qMin(y,(quint32)255)));

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -1,0 +1,118 @@
+#include "gradient.h"
+
+#include <QImage>
+#include <QColor>
+#include <QPainter>
+
+QImage Gradient::m_rgb = QImage();
+
+QImage Gradient::getRGBGradient()
+{
+    initialize();
+
+    return m_rgb;
+}
+
+QColor Gradient::getRGBColor(const quint32 x, const quint32 y)
+{
+    Q_ASSERT(x < 255);
+    Q_ASSERT(y < 255);
+
+    initialize();
+
+    return QColor(m_rgb.pixel (qMin(x, (quint32)255), qMin(y,(quint32)255)));
+}
+
+void Gradient::fillWithGradient(int r, int g, int b, QPainter *painter, int x)
+{
+    QColor top = Qt::black;
+    QColor col(r, g , b);
+    QColor bottom = Qt::white;
+
+    QLinearGradient blackGrad(QPointF(0,0), QPointF(0, 127));
+    blackGrad.setColorAt(0, top);
+    blackGrad.setColorAt(1, col);
+    QLinearGradient whiteGrad(QPointF(0,128), QPointF(0, 255));
+    whiteGrad.setColorAt(0, col);
+    whiteGrad.setColorAt(1, bottom);
+
+    painter->fillRect(x, 0, x, 128, blackGrad);
+    painter->fillRect(x, 128, x, 256, whiteGrad);
+}
+
+void Gradient::initialize ()
+{
+    if( m_rgb.isNull () == false )
+        return;
+
+    //m_rgb = QImage(252, 256, QImage::Format_RGB32);
+    m_rgb = QImage(256, 256, QImage::Format_RGB32);
+
+    int r = 0xFF;
+    int g = 0;
+    int b = 0;
+    int x = 0;
+    int i = 0;
+
+    QPainter painter(&m_rgb);
+
+    // R: 255  G:  0  B:   0
+    for (i = x; i < x + 42; i++)
+    {
+        fillWithGradient(r, g, b, &painter, i);
+        g+=6;
+        if (g == 252) g = 255;
+    }
+    x+=42;
+
+    // R: 255  G: 255  B:   0
+    for (i = x; i < x + 42; i++)
+    {
+        fillWithGradient(r, g, b, &painter, i);
+        r-=6;
+        if (r < 6) r = 0;
+    }
+    x+=42;
+
+    // R: 0  G: 255  B:  0
+    for (i = x; i < x + 43; i++)
+    {
+        fillWithGradient(r, g, b, &painter, i);
+        b+=6;
+        if (b == 252) b = 255;
+    }
+    x+=43;
+
+    // R: 0  G: 255  B:  255
+    r=0; g=255;b=255;
+    for (i = x; i < x + 43; i++)
+    {
+        fillWithGradient(r, g, b, &painter, i);
+        g-=6;
+        if (g < 6) g = 0;
+    }
+    x+=43;
+
+    // R: 0  G:  0  B:  255
+    r=0; g=0;b=255;
+    for (i = x; i < x + 43; i++)
+    {
+        fillWithGradient(r, g, b, &painter, i);
+        r+=6;
+        if (r == 252) r = 255;
+    }
+    x+=43;
+
+    // R: 255  G:  0  B:  255
+    r=255; g=0;b=255;
+    for (i = x; i < x + 43; i++)
+    {
+        fillWithGradient(r, g, b, &painter, i);
+        b-=6;
+        if (b < 6) b = 0;
+    }
+    x+=43;
+    // R: 255  G:  0  B:  0
+}
+
+

--- a/engine/src/gradient.h
+++ b/engine/src/gradient.h
@@ -1,0 +1,42 @@
+/*
+  Q Light Controller Plus
+  gradient.h
+
+  Copyright (c) Giorgio Rebecchi
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef GRADIENT_H
+#define GRADIENT_H
+
+#include <QObject>
+
+class QImage;
+class QColor;
+class QPainter;
+
+class Gradient
+{
+public:
+    static QImage getRGBGradient();
+    static QColor getRGBColor(const quint32 x, const quint32 y);
+
+private:
+    static QImage m_rgb;
+
+    static void initialize();
+    static void fillWithGradient(int r, int g, int b, QPainter *painter, int x);
+};
+
+#endif // GRADIENT_H

--- a/engine/src/src.pro
+++ b/engine/src/src.pro
@@ -50,7 +50,8 @@ HEADERS += avolitesd4parser.h \
            qlcinputprofile.h \
            qlcinputsource.h \
            qlcmodifierscache.h \
-           qlcphysical.h
+           qlcphysical.h \
+           gradient.h
 
 # Audio
 HEADERS += audio/audio.h \
@@ -137,7 +138,8 @@ SOURCES += avolitesd4parser.cpp \
            qlcinputprofile.cpp \
            qlcinputsource.cpp \
            qlcmodifierscache.cpp \
-           qlcphysical.cpp
+           qlcphysical.cpp \
+           gradient.cpp
 
 # Audio
 SOURCES += audio/audio.cpp \

--- a/engine/src/src.pro
+++ b/engine/src/src.pro
@@ -50,8 +50,7 @@ HEADERS += avolitesd4parser.h \
            qlcinputprofile.h \
            qlcinputsource.h \
            qlcmodifierscache.h \
-           qlcphysical.h \
-           gradient.h
+           qlcphysical.h
 
 # Audio
 HEADERS += audio/audio.h \
@@ -92,6 +91,7 @@ HEADERS += bus.h \
            functionuistate.h \
            genericdmxsource.h \
            genericfader.h \
+           gradient.h \
            grandmaster.h \
            grouphead.h \
            inputoutputmap.h \
@@ -138,8 +138,8 @@ SOURCES += avolitesd4parser.cpp \
            qlcinputprofile.cpp \
            qlcinputsource.cpp \
            qlcmodifierscache.cpp \
-           qlcphysical.cpp \
-           gradient.cpp
+           qlcphysical.cpp
+
 
 # Audio
 SOURCES += audio/audio.cpp \
@@ -191,6 +191,7 @@ SOURCES += bus.cpp \
            functionuistate.cpp \
            genericdmxsource.cpp \
            genericfader.cpp \
+           gradient.cpp \
            grandmaster.cpp \
            grouphead.cpp \
            inputoutputmap.cpp \

--- a/engine/test/efx/efx_test.cpp
+++ b/engine/test/efx/efx_test.cpp
@@ -2954,7 +2954,7 @@ void EFX_Test::loadWrongRoot()
 
 void EFX_Test::loadDuplicateFixture()
 {
-    QSKIP("Duplicate fixture are allowed because can animate differents parameters (RGB, dimmer, etc.)", QTest::SkipSingle);
+    QSKIP("Duplicate fixture are allowed because can animate differents parameters (RGB, dimmer, etc.)", SkipSingle);
 
     QDomDocument doc;
 

--- a/engine/test/efx/efx_test.cpp
+++ b/engine/test/efx/efx_test.cpp
@@ -458,9 +458,9 @@ void EFX_Test::fixtures()
     QCOMPARE(e->fixtures().size(), 2);
 
     /* Must not be able to add the same fixture twice */
-    QVERIFY(!e->addFixture(ef1));
-    QVERIFY(!e->addFixture(ef2));
-    QCOMPARE(e->fixtures().size(), 2);
+    //QVERIFY(!e->addFixture(ef1));
+    //QVERIFY(!e->addFixture(ef2));
+    //QCOMPARE(e->fixtures().size(), 2);
 
     /* Try to remove a non-member fixture */
     EFXFixture* ef3 = new EFXFixture(e);
@@ -2954,6 +2954,8 @@ void EFX_Test::loadWrongRoot()
 
 void EFX_Test::loadDuplicateFixture()
 {
+    QSKIP("Duplicate fixture are allowed because can animate differents parameters (RGB, dimmer, etc.)", QTest::SkipSingle);
+
     QDomDocument doc;
 
     QDomElement root = doc.createElement("Function");
@@ -3171,6 +3173,7 @@ void EFX_Test::save()
             int expectHead = 0;
             bool expectBackward = false;
             int expectIntensity = 255;
+            int expectedMode = 0;
             int expectStartOffset = 0;
 
             QDomNode subnode = tag.firstChild();
@@ -3231,6 +3234,11 @@ void EFX_Test::save()
                 else if (subtag.tagName() == "Intensity")
                 {
                     QCOMPARE(subtag.text().toInt(), expectIntensity);
+                    intensity = true;
+                }
+                else if (subtag.tagName() == "Mode")
+                {
+                    QCOMPARE(subtag.text().toInt(), expectedMode);
                     intensity = true;
                 }
                 else

--- a/engine/test/efxfixture/efxfixture_test.cpp
+++ b/engine/test/efxfixture/efxfixture_test.cpp
@@ -435,7 +435,7 @@ void EFXFixture_Test::setPoint8bit()
 
     QList<Universe*> ua;
     ua.append(new Universe(0, new GrandMaster()));
-    ef.setPoint(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
+    ef.setPointPanTilt (ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
     QCOMPARE((int)ua[0]->preGMValues()[0], 5);
     QCOMPARE((int)ua[0]->preGMValues()[1], 1);
     QCOMPARE((int)ua[0]->preGMValues()[2], 0); /* No LSB channels */
@@ -450,7 +450,7 @@ void EFXFixture_Test::setPoint16bit()
 
     QList<Universe*> ua;
     ua.append(new Universe(0, new GrandMaster()));
-    ef.setPoint(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
+    ef.setPointPanTilt(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
     QCOMPARE((int)ua[0]->preGMValues()[0], 5);
     QCOMPARE((int)ua[0]->preGMValues()[1], 1);
     QCOMPARE((int)ua[0]->preGMValues()[2], 102); /* 255 * 0.4 */
@@ -465,7 +465,7 @@ void EFXFixture_Test::setPointPanOnly()
 
     QList<Universe*> ua;
     ua.append(new Universe(0, new GrandMaster()));
-    ef.setPoint(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
+    ef.setPointPanTilt(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
     QCOMPARE((int)ua[0]->preGMValues()[0], 5); /* Pan */
     QCOMPARE((int)ua[0]->preGMValues()[1], 0);
     QCOMPARE((int)ua[0]->preGMValues()[2], 0);
@@ -480,7 +480,7 @@ void EFXFixture_Test::setPointLedBar()
 
     QList<Universe*> ua;
     ua.append(new Universe(0, new GrandMaster()));
-    ef.setPoint(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
+    ef.setPointPanTilt(ua, 5.4, 1.5); // PMSB: 5, PLSB: 0.4, TMSB: 1 (102), TLSB: 0.5(127)
     QCOMPARE((int)ua[0]->preGMValues()[0], 1); /* Tilt */
     QCOMPARE((int)ua[0]->preGMValues()[1], 0);
     QCOMPARE((int)ua[0]->preGMValues()[2], 0);

--- a/engine/test/efxfixture/efxfixture_test.cpp
+++ b/engine/test/efxfixture/efxfixture_test.cpp
@@ -318,6 +318,10 @@ void EFXFixture_Test::save()
     QVERIFY(tag.text() == "7");
 
     tag = tag.nextSibling().toElement();
+    QVERIFY(tag.tagName() == "Mode");
+    QVERIFY(tag.text() == "0");
+
+    tag = tag.nextSibling().toElement();
     QVERIFY(tag.tagName() == "Direction");
     QVERIFY(tag.text() == "Backward");
 }

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -684,6 +684,8 @@ void EFXEditor::slotFixtureStartOffsetChanged(int startOffset)
     Q_ASSERT(ef != NULL);
     ef->setStartOffset(startOffset);
 
+    redrawPreview();
+
     // Restart the test after the latest intensity change, delayed
     m_testTimer.start();
 }

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -501,7 +501,10 @@ void EFXEditor::updateModeColumn(QTreeWidgetItem* item, EFXFixture* ef)
         combo->setAutoFillBackground (true);
 
         combo->addItems (ef->modeList ());
-        combo->setCurrentText (ef->modeToString (ef->mode ()));
+
+        const int index = combo->findText ( ef->modeToString (ef->mode ()) );
+        combo->setCurrentIndex (index);
+        //combo->setCurrentText (ef->modeToString (ef->mode ()));
 
         m_tree->setItemWidget(item, KColumnMode, combo);
         combo->setProperty(PROPERTY_FIXTURE, (qulonglong) ef);

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -49,9 +49,10 @@
 
 #define KColumnNumber  0
 #define KColumnName    1
-#define KColumnReverse 2
-#define KColumnStartOffset 3
-#define KColumnIntensity 4
+#define KColumnMode    2
+#define KColumnReverse 3
+#define KColumnStartOffset 4
+#define KColumnIntensity 5
 
 #define PROPERTY_FIXTURE "fixture"
 
@@ -302,7 +303,12 @@ void EFXEditor::initMovementPage()
 void EFXEditor::slotTestClicked()
 {
     if (m_testButton->isChecked() == true)
+    {
         m_efx->start(m_doc->masterTimer());
+
+        //Restart animation so preview it is in sync with real test
+        m_previewArea->restart();
+    }
     else
         m_efx->stopAndWait();
 }
@@ -335,6 +341,10 @@ void EFXEditor::slotModeChanged(Doc::Mode mode)
 void EFXEditor::slotTabChanged(int tab)
 {
     efxUiState()->setCurrentTab(tab);
+
+    //When preview animation is opened restart animation but avoid restart if test is running.
+    if(tab == 1 && (m_testButton->isChecked () == false))
+        m_previewArea->restart ();
 }
 
 bool EFXEditor::interruptRunning()
@@ -379,6 +389,7 @@ void EFXEditor::updateFixtureTree()
         addFixtureItem(it.next());
     m_tree->resizeColumnToContents(KColumnNumber);
     m_tree->resizeColumnToContents(KColumnName);
+    m_tree->resizeColumnToContents(KColumnMode);
     m_tree->resizeColumnToContents(KColumnReverse);
     m_tree->resizeColumnToContents(KColumnStartOffset);
     m_tree->resizeColumnToContents(KColumnIntensity);
@@ -460,6 +471,7 @@ void EFXEditor::addFixtureItem(EFXFixture* ef)
     else
         item->setCheckState(KColumnReverse, Qt::Unchecked);
 
+    updateModeColumn (item, ef);
     updateIntensityColumn(item, ef);
     updateStartOffsetColumn(item, ef);
 
@@ -472,9 +484,30 @@ void EFXEditor::addFixtureItem(EFXFixture* ef)
 
     m_tree->resizeColumnToContents(KColumnNumber);
     m_tree->resizeColumnToContents(KColumnName);
+    m_tree->resizeColumnToContents(KColumnMode);
     m_tree->resizeColumnToContents(KColumnReverse);
     m_tree->resizeColumnToContents(KColumnStartOffset);
     m_tree->resizeColumnToContents(KColumnIntensity);
+}
+
+void EFXEditor::updateModeColumn(QTreeWidgetItem* item, EFXFixture* ef)
+{
+    Q_ASSERT(item != NULL);
+    Q_ASSERT(ef != NULL);
+
+    if (m_tree->itemWidget(item, KColumnMode) == NULL)
+    {
+        QComboBox* combo = new QComboBox(m_tree);
+        combo->setAutoFillBackground (true);
+
+        combo->addItems (ef->modeList ());
+        combo->setCurrentText (ef->modeToString (ef->mode ()));
+
+        m_tree->setItemWidget(item, KColumnMode, combo);
+        combo->setProperty(PROPERTY_FIXTURE, (qulonglong) ef);
+        connect(combo, SIGNAL(currentIndexChanged(int)),
+                this, SLOT(slotFixtureModeChanged(int)));
+    }
 }
 
 void EFXEditor::updateIntensityColumn(QTreeWidgetItem* item, EFXFixture* ef)
@@ -533,6 +566,7 @@ void EFXEditor::removeFixtureItem(EFXFixture* ef)
 
     m_tree->resizeColumnToContents(KColumnNumber);
     m_tree->resizeColumnToContents(KColumnName);
+    m_tree->resizeColumnToContents(KColumnMode);
     m_tree->resizeColumnToContents(KColumnReverse);
     m_tree->resizeColumnToContents(KColumnStartOffset);
     m_tree->resizeColumnToContents(KColumnIntensity);
@@ -609,8 +643,22 @@ void EFXEditor::slotFixtureItemChanged(QTreeWidgetItem* item, int column)
         else
             ef->setDirection(Function::Forward);
 
-	redrawPreview();
+        redrawPreview();
     }
+}
+
+void EFXEditor::slotFixtureModeChanged(int index)
+{
+    QComboBox* combo = qobject_cast<QComboBox*>(QObject::sender());
+    Q_ASSERT(combo != NULL);
+
+    EFXFixture* ef = (EFXFixture*) combo->property(PROPERTY_FIXTURE).toULongLong();
+    Q_ASSERT(ef != NULL);
+
+    ef->setMode ( ef->stringToMode (combo->itemText(index)) );
+
+    // Restart the test after the latest mode change, delayed
+    m_testTimer.start();
 }
 
 void EFXEditor::slotFixtureIntensityChanged(int intensity)
@@ -639,10 +687,14 @@ void EFXEditor::slotFixtureStartOffsetChanged(int startOffset)
 
 void EFXEditor::slotAddFixtureClicked()
 {
+    /* The following code is the original QLC+ code (EFX with only Pan-Tilt).
+     * Now, with modes, the same fixture could be duplicated. */
+
     /* Put all fixtures already present into a list of fixtures that
        will be disabled in the fixture selection dialog */
     QList <GroupHead> disabled;
     QTreeWidgetItemIterator twit(m_tree);
+    /*
     while (*twit != NULL)
     {
         EFXFixture* ef = reinterpret_cast <EFXFixture*>
@@ -652,8 +704,10 @@ void EFXEditor::slotAddFixtureClicked()
         disabled.append(ef->head());
         twit++;
     }
+    */
 
-    /* Disable all fixtures that don't have pan OR tilt channels */
+    /* Disable all fixtures that don't have pan OR tilt, dimmer or RGB channels */
+    /*
     QListIterator <Fixture*> fxit(m_doc->fixtures());
     while (fxit.hasNext() == true)
     {
@@ -683,6 +737,7 @@ void EFXEditor::slotAddFixtureClicked()
             }
         }
     }
+    */
 
     /* Get a list of new fixtures to add to the scene */
     FixtureSelection fs(this, m_doc);
@@ -1046,3 +1101,4 @@ void EFXEditor::redrawPreview()
 
     m_previewArea->draw(m_efx->duration() / points.size());
 }
+

--- a/ui/src/efxeditor.h
+++ b/ui/src/efxeditor.h
@@ -95,6 +95,7 @@ private:
     const QList <EFXFixture*> selectedFixtures() const;
     void updateIndices(int from, int to);
     void addFixtureItem(EFXFixture* ef);
+    void updateModeColumn(QTreeWidgetItem* item, EFXFixture* ef);
     void updateIntensityColumn(QTreeWidgetItem* item, EFXFixture* ef);
     void updateStartOffsetColumn(QTreeWidgetItem* item, EFXFixture* ef);
     void removeFixtureItem(EFXFixture* ef);
@@ -105,6 +106,7 @@ private slots:
     void slotNameEdited(const QString &text);
     void slotSpeedDialToggle(bool state);
     void slotFixtureItemChanged(QTreeWidgetItem* item, int column);
+    void slotFixtureModeChanged(int index);
     void slotFixtureIntensityChanged(int intensity);
     void slotFixtureStartOffsetChanged(int intensity);
     void slotAddFixtureClicked();

--- a/ui/src/efxeditor.ui
+++ b/ui/src/efxeditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>480</width>
+    <width>487</width>
     <height>577</height>
    </rect>
   </property>
@@ -166,6 +166,11 @@
          <column>
           <property name="text">
            <string>Fixture</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Mode</string>
           </property>
          </column>
          <column>

--- a/ui/src/efxpreviewarea.cpp
+++ b/ui/src/efxpreviewarea.cpp
@@ -24,6 +24,7 @@
 
 #include "efxpreviewarea.h"
 #include "qlcmacros.h"
+#include "gradient.h"
 
 EFXPreviewArea::EFXPreviewArea(QWidget* parent)
     : QWidget(parent)
@@ -108,6 +109,9 @@ void EFXPreviewArea::paintEvent(QPaintEvent* e)
     QPoint point;
     QColor color;
 
+    //painter.drawImage(QPoint(0, 0), Gradient::getRGBGradient ());
+    painter.drawImage(painter.window (), Gradient::getRGBGradient ());
+
     /* Crosshairs */
     color = palette().color(QPalette::Mid);
     painter.setPen(color);
@@ -137,7 +141,7 @@ void EFXPreviewArea::paintEvent(QPaintEvent* e)
         */
 
         painter.setBrush(Qt::white);
-	pen.setColor(Qt::black);
+        pen.setColor(Qt::black);
 
         // draw fixture positions
 
@@ -152,6 +156,14 @@ void EFXPreviewArea::paintEvent(QPaintEvent* e)
     }
     else
     {
-        m_timer.stop();
+        //m_timer.stop();
+
+        //Change old behaviour from stop to restart
+        restart();
     }
+}
+
+void EFXPreviewArea::restart ()
+{
+    m_iter = 0;
 }

--- a/ui/src/efxpreviewarea.h
+++ b/ui/src/efxpreviewarea.h
@@ -69,6 +69,9 @@ public:
     /** Scale the points in the given polygon of size [0, 255] to the given target size */
     static QPolygon scale(const QPolygon& poly, const QSize& target);
 
+    /** Restart animation. */
+    void restart();
+
 protected:
     /** @reimp */
     void resizeEvent(QResizeEvent* e);

--- a/ui/test/efxpreviewarea/efxpreviewarea_test.cpp
+++ b/ui/test/efxpreviewarea/efxpreviewarea_test.cpp
@@ -76,9 +76,9 @@ void EFXPreviewArea_Test::draw()
     QCOMPARE(area.m_timer.isActive(), true);
     QCOMPARE(area.m_timer.interval(), 20);
 
-    QTest::qWait(300);
-    QVERIFY(area.m_iter >= 5);
-    QCOMPARE(area.m_timer.isActive(), false);
+    //QTest::qWait(300);
+    //QVERIFY(area.m_iter >= 5);
+    //QCOMPARE(area.m_timer.isActive(), false);
 }
 
 QTEST_MAIN(EFXPreviewArea_Test)


### PR DESCRIPTION
I have implemented an improved version of EFX generator to support more parameters other than classic Pan & Tilt.

This version has the following improvements:
- support RGB, Dimmer and Pan & Tilt for each fixture; 
- support parameters mix inside the same EFX;
- has a better EFX preview with RGB feedback and better preview on efx test;
