### PR TITLE
EFX gradient size should be 256x256

### DIFF
--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -37,6 +37,7 @@
 /*****************************************************************************
  * Initialization
  *****************************************************************************/
+QImage EFXFixture::m_rgbGradient = QImage();
 
 EFXFixture::EFXFixture(const EFX* parent)
     : m_parent(parent)
@@ -56,6 +57,9 @@ EFXFixture::EFXFixture(const EFX* parent)
     , m_intensity(1.0)
 {
     Q_ASSERT(parent != NULL);
+
+    if(m_rgbGradient.isNull ())
+        m_rgbGradient = Gradient::getRGBGradient (256, 256);
 }
 
 void EFXFixture::copyFrom(const EFXFixture* ef)
@@ -530,7 +534,7 @@ void EFXFixture::setPointRGB(QList<Universe *> universes, float x, float y)
     /* Don't write dimmer data directly to universes but use FadeChannel to avoid steps at EFX loop restart */
     if (rgbChannels.size () >= 3)
     {
-        QColor pixel = Gradient::getRGBColor (x, y);
+        QColor pixel = m_rgbGradient.pixel (x, y);
 
         setFadeChannel(rgbChannels[0], pixel.red ());
         setFadeChannel(rgbChannels[1], pixel.green ());

--- a/engine/src/efxfixture.h
+++ b/engine/src/efxfixture.h
@@ -30,6 +30,7 @@ class EFXFixture;
 class Scene;
 class EFX;
 class Doc;
+class QImage;
 
 /** @addtogroup engine_functions Functions
  * @{
@@ -230,6 +231,7 @@ public:
 
 private:
     qreal m_intensity;
+    static QImage m_rgbGradient;
 
     void setFadeChannel(quint32 nChannel, uchar val);
 };

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -62,7 +62,7 @@ void Gradient::initialize()
     if( m_rgb.isNull() == false )
         return;
 
-    m_rgb = QImage(252, 256, QImage::Format_RGB32);
+    m_rgb = QImage(256, 256, QImage::Format_RGB32);
     QPainter painter(&m_rgb);
 
     int x = 0;

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -37,7 +37,7 @@ QColor Gradient::getRGBColor(const quint32 x, const quint32 y)
 {
     initialize();
 
-    return QColor(m_rgb.pixel(qMin(x, (quint32)255), qMin(y,(quint32)255)));
+    return QColor(m_rgb.pixel(qMin(x, (quint32)m_rgb.width ()-1), qMin(y,(quint32)m_rgb.height ()-1)));
 }
 
 void Gradient::fillWithGradient(int r, int g, int b, QPainter *painter, int x)

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -33,11 +33,11 @@ QImage Gradient::getRGBGradient()
     return m_rgb;
 }
 
-QColor Gradient::getRGBColor(const quint32 x, const quint32 y)
+QImage Gradient::getRGBGradient(const int width, const int height)
 {
     initialize();
 
-    return QColor(m_rgb.pixel(qMin(x, (quint32)m_rgb.width ()-1), qMin(y,(quint32)m_rgb.height ()-1)));
+    return m_rgb.scaled (width, height);
 }
 
 void Gradient::fillWithGradient(int r, int g, int b, QPainter *painter, int x)

--- a/engine/src/gradient.h
+++ b/engine/src/gradient.h
@@ -29,8 +29,11 @@ class QPainter;
 class Gradient
 {
 public:
+    /** Get a gradient of default size (252x256) */
     static QImage getRGBGradient();
-    static QColor getRGBColor(const quint32 x, const quint32 y);
+
+    /** Get a gradient of input size */
+    static QImage getRGBGradient(const int width, const int height);
 
 private:
     static QImage m_rgb;

--- a/ui/src/clickandgowidget.cpp
+++ b/ui/src/clickandgowidget.cpp
@@ -76,7 +76,7 @@ void ClickAndGoWidget::setupColorPicker()
 {
     int cw = 15;
 
-    m_width = 252 + 30;
+    m_width = 256 + 30;
     m_height = 256;
     m_image = QImage(m_width, m_height, QImage::Format_RGB32);
     QPainter painter(&m_image);

--- a/ui/src/efxpreviewarea.cpp
+++ b/ui/src/efxpreviewarea.cpp
@@ -111,7 +111,7 @@ void EFXPreviewArea::paintEvent(QPaintEvent* e)
     QColor color;
 
     if (m_colorBg)
-        painter.drawImage(painter.window(), Gradient::getRGBGradient());
+        painter.drawImage(painter.window(), Gradient::getRGBGradient(256, 256));
 
     /* Crosshairs */
     color = palette().color(QPalette::Mid);


### PR DESCRIPTION
Gradient size should be 255x255 because it is accessed by EFX when RGB mode is used.
After my initial commit, gradient x size was changed to 252 to reflect the ClickAndGoWidget size.

Now I have correct the Gradient and the  ClickAndGoWidget x size to 255.