### PR TITLE
New fixture - XStatic X-240Bar RGB IRC

### DIFF
--- a/resources/fixtures/XStatic-X-240Bar-RGB-IRC.qxf
+++ b/resources/fixtures/XStatic-X-240Bar-RGB-IRC.qxf
@@ -1,0 +1,383 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
+  <Author>Nathan Durnan</Author>
+ </Creator>
+ <Manufacturer>XStatic</Manufacturer>
+ <Model>X-240Bar RGB IRC</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Red 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Max="255" Min="0">Dimmer (0 - off)</Capability>
+ </Channel>
+ <Channel Name="Red 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Red 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Red 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Red 5">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 5">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 5">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Red 6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Red 7">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 7">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 7">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Red 8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Green 8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Blue 8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimming</Capability>
+ </Channel>
+ <Channel Name="Flash">
+  <Group Byte="0">Shutter</Group>
+  <Capability Max="255" Min="0">Flash frequency</Capability>
+ </Channel>
+ <Channel Name="Speed/Sensitivity">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="255" Min="0">No use (ch. 5 in color mode)/speed (ch. 5 in program mode)/sensitivity (ch. 5 in sound mode)</Capability>
+ </Channel>
+ <Channel Name="Function">
+  <Group Byte="0">Colour</Group>
+  <Capability Max="7" Min="0">OFF/Color</Capability>
+  <Capability Color="#ff0000" Max="15" Min="8">Red</Capability>
+  <Capability Color="#ffff00" Max="23" Min="16">Yellow</Capability>
+  <Capability Color="#00ff00" Max="31" Min="24">Green</Capability>
+  <Capability Color="#00ffff" Max="39" Min="32">Cyan</Capability>
+  <Capability Color="#0000ff" Max="47" Min="40">Blue</Capability>
+  <Capability Color="#ff00ff" Max="55" Min="48">Purple</Capability>
+  <Capability Color="#ffffff" Max="63" Min="56">White</Capability>
+  <Capability Max="71" Res="Others/rainbow.png" Min="64">Program 02</Capability>
+  <Capability Max="79" Res="Others/rainbow.png" Min="72">Program 03</Capability>
+  <Capability Max="87" Res="Others/rainbow.png" Min="80">Program 04</Capability>
+  <Capability Max="95" Res="Others/rainbow.png" Min="88">Program 05</Capability>
+  <Capability Max="103" Res="Others/rainbow.png" Min="96">Program 06</Capability>
+  <Capability Max="111" Res="Others/rainbow.png" Min="104">Program 07</Capability>
+  <Capability Color="#ffffff" Max="119" Min="112">Program 08</Capability>
+  <Capability Max="127" Res="Others/rainbow.png" Min="120">Program 09</Capability>
+  <Capability Max="135" Res="Others/rainbow.png" Min="128">Program 10</Capability>
+  <Capability Max="143" Res="Others/rainbow.png" Min="136">Program 11</Capability>
+  <Capability Max="151" Res="Others/rainbow.png" Min="144">Program 12</Capability>
+  <Capability Max="159" Res="Others/rainbow.png" Min="152">Program 13</Capability>
+  <Capability Max="167" Res="Others/rainbow.png" Min="160">Program 14</Capability>
+  <Capability Max="175" Res="Others/rainbow.png" Min="168">Program 15</Capability>
+  <Capability Max="183" Res="Others/rainbow.png" Min="176">Program 16</Capability>
+  <Capability Max="191" Res="Others/rainbow.png" Min="184">Program 17</Capability>
+  <Capability Max="199" Res="Others/rainbow.png" Min="192">Program 18</Capability>
+  <Capability Max="207" Res="Others/rainbow.png" Min="200">Program 19</Capability>
+  <Capability Max="215" Res="Others/rainbow.png" Min="208">Program 20</Capability>
+  <Capability Color="#ff0000" Max="223" Min="216" Color2="#00ff00">Program 21</Capability>
+  <Capability Color="#ff0000" Max="231" Min="224" Color2="#00ff00">Program 22</Capability>
+  <Capability Max="255" Res="Others/gobo00069.png" Min="232">Sound Mode</Capability>
+ </Channel>
+ <Mode Name="2 Channel">
+  <Physical>
+   <Bulb Lumens="740" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="2.6" Height="65" Width="1064" Depth="88"/>
+   <Lens DegreesMax="30" Name="Other" DegreesMin="30"/>
+   <Focus TiltMax="0" Type="Fixed" PanMax="0"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="30"/>
+  </Physical>
+  <Channel Number="0">Function</Channel>
+  <Channel Number="1">Speed/Sensitivity</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="3 Channel">
+  <Physical>
+   <Bulb Lumens="740" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="2.6" Height="65" Width="1064" Depth="88"/>
+   <Lens DegreesMax="30" Name="Other" DegreesMin="30"/>
+   <Focus TiltMax="0" Type="Fixed" PanMax="0"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="30"/>
+  </Physical>
+  <Channel Number="0">Red 1</Channel>
+  <Channel Number="1">Green 1</Channel>
+  <Channel Number="2">Blue 1</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="4 Channel">
+  <Physical>
+   <Bulb Lumens="740" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="2.6" Height="65" Width="1064" Depth="88"/>
+   <Lens DegreesMax="30" Name="Other" DegreesMin="30"/>
+   <Focus TiltMax="0" Type="Fixed" PanMax="0"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="30"/>
+  </Physical>
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Red 1</Channel>
+  <Channel Number="2">Green 1</Channel>
+  <Channel Number="3">Blue 1</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+   <Channel>3</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="7 Channel">
+  <Physical>
+   <Bulb Lumens="740" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="2.6" Height="65" Width="1064" Depth="88"/>
+   <Lens DegreesMax="30" Name="Other" DegreesMin="30"/>
+   <Focus TiltMax="0" Type="Fixed" PanMax="0"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="30"/>
+  </Physical>
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Red 1</Channel>
+  <Channel Number="2">Green 1</Channel>
+  <Channel Number="3">Blue 1</Channel>
+  <Channel Number="4">Function</Channel>
+  <Channel Number="5">Speed/Sensitivity</Channel>
+  <Channel Number="6">Flash</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+   <Channel>3</Channel>
+   <Channel>4</Channel>
+   <Channel>5</Channel>
+   <Channel>6</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="14 Channel">
+  <Physical>
+   <Bulb Lumens="740" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="2.6" Height="65" Width="1064" Depth="88"/>
+   <Lens DegreesMax="30" Name="Other" DegreesMin="30"/>
+   <Focus TiltMax="0" Type="Fixed" PanMax="0"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="30"/>
+  </Physical>
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Red 1</Channel>
+  <Channel Number="2">Green 1</Channel>
+  <Channel Number="3">Blue 1</Channel>
+  <Channel Number="4">Red 2</Channel>
+  <Channel Number="5">Green 2</Channel>
+  <Channel Number="6">Blue 2</Channel>
+  <Channel Number="7">Red 3</Channel>
+  <Channel Number="8">Green 3</Channel>
+  <Channel Number="9">Blue 3</Channel>
+  <Channel Number="10">Red 4</Channel>
+  <Channel Number="11">Green 4</Channel>
+  <Channel Number="12">Blue 4</Channel>
+  <Channel Number="13">Flash</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+   <Channel>3</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>4</Channel>
+   <Channel>5</Channel>
+   <Channel>6</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>8</Channel>
+   <Channel>9</Channel>
+   <Channel>7</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>12</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="26 Channel">
+  <Physical>
+   <Bulb Lumens="740" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="2.6" Height="65" Width="1064" Depth="88"/>
+   <Lens DegreesMax="30" Name="Other" DegreesMin="30"/>
+   <Focus TiltMax="0" Type="Fixed" PanMax="0"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="30"/>
+  </Physical>
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Red 1</Channel>
+  <Channel Number="2">Green 1</Channel>
+  <Channel Number="3">Blue 1</Channel>
+  <Channel Number="4">Red 2</Channel>
+  <Channel Number="5">Green 2</Channel>
+  <Channel Number="6">Blue 2</Channel>
+  <Channel Number="7">Red 3</Channel>
+  <Channel Number="8">Green 3</Channel>
+  <Channel Number="9">Blue 3</Channel>
+  <Channel Number="10">Red 4</Channel>
+  <Channel Number="11">Green 4</Channel>
+  <Channel Number="12">Blue 4</Channel>
+  <Channel Number="13">Red 5</Channel>
+  <Channel Number="14">Green 5</Channel>
+  <Channel Number="15">Blue 5</Channel>
+  <Channel Number="16">Red 6</Channel>
+  <Channel Number="17">Green 6</Channel>
+  <Channel Number="18">Blue 6</Channel>
+  <Channel Number="19">Red 7</Channel>
+  <Channel Number="20">Green 7</Channel>
+  <Channel Number="21">Blue 7</Channel>
+  <Channel Number="22">Red 8</Channel>
+  <Channel Number="23">Green 8</Channel>
+  <Channel Number="24">Blue 8</Channel>
+  <Channel Number="25">Flash</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+   <Channel>3</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>4</Channel>
+   <Channel>5</Channel>
+   <Channel>6</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>8</Channel>
+   <Channel>9</Channel>
+   <Channel>7</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>12</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>16</Channel>
+   <Channel>17</Channel>
+   <Channel>18</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>19</Channel>
+   <Channel>20</Channel>
+   <Channel>21</Channel>
+  </Head>
+  <Head>
+   <Channel>23</Channel>
+   <Channel>0</Channel>
+   <Channel>24</Channel>
+   <Channel>22</Channel>
+  </Head>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Created on 22/08/15. Corrected absence of capabilities for RGB modes.

Manual that matches the fixture is found at:

http://www.qlcplus.org/forum/viewtopic.php?f=3&t=8829