### PR TITLE
VCSpeedDial Presets

### DIFF
--- a/ui/src/speeddial.cpp
+++ b/ui/src/speeddial.cpp
@@ -241,6 +241,9 @@ void SpeedDial::setValue(int ms, bool emitValue)
     else
         m_infiniteCheck->setChecked(false);
 
+    // Time has changed, stop blinking
+    stopTimers(false, true);
+
     m_preventSignals = false;
 }
 

--- a/ui/src/src.pro
+++ b/ui/src/src.pro
@@ -146,6 +146,7 @@ HEADERS += virtualconsole/addvcbuttonmatrix.h \
            virtualconsole/vcsoloframeproperties.h \
            virtualconsole/vcspeeddial.h \
            virtualconsole/vcspeeddialfunction.h \
+           virtualconsole/vcspeeddialpreset.h \
            virtualconsole/vcspeeddialproperties.h \
            virtualconsole/vcwidget.h \
            virtualconsole/vcwidgetproperties.h \
@@ -316,6 +317,7 @@ SOURCES += virtualconsole/addvcbuttonmatrix.cpp \
            virtualconsole/vcsoloframeproperties.cpp \
            virtualconsole/vcspeeddial.cpp \
            virtualconsole/vcspeeddialfunction.cpp \
+           virtualconsole/vcspeeddialpreset.cpp \
            virtualconsole/vcspeeddialproperties.cpp \
            virtualconsole/vcwidget.cpp \
            virtualconsole/vcwidgetproperties.cpp \

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -555,6 +555,7 @@ void VCMatrix::addCustomControl(VCMatrixControl const& control)
         controlWidget = controlButton;
         controlButton->setStyleSheet(controlBtnSS.arg(control.m_color.name()));
         controlButton->setFixedWidth(36);
+        controlButton->setFocusPolicy(Qt::TabFocus);
         controlButton->setText("S");
     }
     else if (control.m_type == VCMatrixControl::EndColor)
@@ -563,6 +564,7 @@ void VCMatrix::addCustomControl(VCMatrixControl const& control)
         controlWidget = controlButton;
         controlButton->setStyleSheet(controlBtnSS.arg(control.m_color.name()));
         controlButton->setFixedWidth(36);
+        controlButton->setFocusPolicy(Qt::TabFocus);
         controlButton->setText("E");
     }
     else if (control.m_type == VCMatrixControl::ResetEndColor)
@@ -572,6 +574,7 @@ void VCMatrix::addCustomControl(VCMatrixControl const& control)
         controlButton->setStyleSheet(controlBtnSS.arg("#BBBBBB"));
         controlButton->setMinimumWidth(36);
         controlButton->setMaximumWidth(80);
+        controlButton->setFocusPolicy(Qt::TabFocus);
         QString btnLabel = tr("End Color Reset");
         controlButton->setToolTip(btnLabel);
         controlButton->setText(fontMetrics().elidedText(btnLabel, Qt::ElideRight, 72));
@@ -584,6 +587,7 @@ void VCMatrix::addCustomControl(VCMatrixControl const& control)
         controlButton->setStyleSheet(controlBtnSS.arg("#BBBBBB"));
         controlButton->setMinimumWidth(36);
         controlButton->setMaximumWidth(80);
+        controlButton->setFocusPolicy(Qt::TabFocus);
         QString btnLabel = control.m_resource;
         if (!control.m_properties.isEmpty())
         {
@@ -998,4 +1002,3 @@ bool VCMatrix::saveXML(QDomDocument *doc, QDomElement *vc_root)
 
     return true;
 }
-

--- a/ui/src/virtualconsole/vcmatrix.h
+++ b/ui/src/virtualconsole/vcmatrix.h
@@ -154,7 +154,7 @@ private slots:
     void slotUpdate();
 
 private:
-    /** timer for updating the step list */
+    /** timer for updating the controls */
     QTimer* m_updateTimer;
 
     /*********************************************************************

--- a/ui/src/virtualconsole/vcmatrixproperties.h
+++ b/ui/src/virtualconsole/vcmatrixproperties.h
@@ -105,8 +105,6 @@ protected:
 protected slots:
     /** @reimp */
     void accept();
-
-
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcspeeddial.h
+++ b/ui/src/virtualconsole/vcspeeddial.h
@@ -28,6 +28,8 @@ class QDomDocument;
 class QDomElement;
 class SpeedDial;
 class VCSpeedDialFunction;
+class VCSpeedDialPreset;
+class FlowLayout;
 
 /** @addtogroup ui_vc_props
  * @{
@@ -141,6 +143,7 @@ private slots:
 private:
     QList <VCSpeedDialFunction> m_functions;
     SpeedDial* m_dial;
+    FlowLayout* m_presetsLayout;
 
     /*********************************************************************
      * External input
@@ -194,6 +197,27 @@ public:
 
 private:
     ushort m_visibilityMask;
+
+    /*********************************************************************
+     * Presets
+     *********************************************************************/
+public:
+    void addPreset(VCSpeedDialPreset const& preset);
+    void resetPresets();
+    QList<VCSpeedDialPreset *> presets() const;
+
+protected slots:
+    void slotPresetClicked();
+
+protected:
+    QHash<QWidget*, VCSpeedDialPreset*> m_presets;
+
+private slots:
+    void slotUpdate();
+
+private:
+    /** timer for updating the preset buttons */
+    QTimer* m_updateTimer;
 
     /*************************************************************************
      * Load & Save

--- a/ui/src/virtualconsole/vcspeeddial.h
+++ b/ui/src/virtualconsole/vcspeeddial.h
@@ -42,10 +42,12 @@ class FlowLayout;
 #define KXMLQLCVCSpeedDialAbsoluteValueMax "Maximum"
 #define KXMLQLCVCSpeedDialTap "Tap"
 #define KXMLQLCVCSpeedDialTapKey "Key"
-#define KXMLQLCVCSpeedDialInfinite "Infinite"
-#define KXMLQLCVCSpeedDialInfiniteKey "InfiniteKey"
 #define KXMLQLCVCSpeedDialVisibilityMask "Visibility"
 #define KXMLQLCVCSpeedDialTime "Time"
+
+// Legacy: infinite checkbox
+#define KXMLQLCVCSpeedDialInfinite "Infinite"
+#define KXMLQLCVCSpeedDialInfiniteKey "InfiniteKey"
 
 class VCSpeedDial : public VCWidget
 {
@@ -55,7 +57,6 @@ class VCSpeedDial : public VCWidget
 public:
     static const quint8 absoluteInputSourceId;
     static const quint8 tapInputSourceId;
-    static const quint8 infiniteInputSourceId;
     static const QSize defaultSize;
 
     /************************************************************************
@@ -157,20 +158,17 @@ protected slots:
     void slotInputValueChanged(quint32 universe, quint32 channel, uchar value);
 
     /*********************************************************************
-     * Tap & infinite key sequence handler
+     * Tap & presets key sequence handler
      *********************************************************************/
 public:
     void setKeySequence(const QKeySequence& keySequence);
     QKeySequence keySequence() const;
-    void setInfiniteKeySequence(const QKeySequence& keySequence);
-    QKeySequence infiniteKeySequence() const;
 
 protected slots:
     void slotKeyPressed(const QKeySequence& keySequence);
 
 protected:
     QKeySequence m_tapKeySequence;
-    QKeySequence m_infiniteKeySequence;
 
     /************************************************************************
      * Absolute value range

--- a/ui/src/virtualconsole/vcspeeddialpreset.cpp
+++ b/ui/src/virtualconsole/vcspeeddialpreset.cpp
@@ -1,0 +1,170 @@
+/*
+  Q Light Controller Plus
+  vcspeeddialpreset.cpp
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QtGlobal>
+#include <QtXml>
+
+#include "vcspeeddialpreset.h"
+#include "vcwidget.h"
+#include "qlcfile.h"
+
+VCSpeedDialPreset::VCSpeedDialPreset(quint8 id)
+    : m_id(id)
+    , m_showName(false)
+    , m_value(1000)
+{
+}
+
+VCSpeedDialPreset::VCSpeedDialPreset(VCSpeedDialPreset const& preset)
+    : m_id(preset.m_id)
+    , m_name(preset.m_name)
+    , m_showName(preset.m_showName)
+    , m_value(preset.m_value)
+    , m_keySequence(preset.m_keySequence)
+{
+    if (preset.m_inputSource != NULL)
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(preset.m_inputSource->universe(),
+                                                       preset.m_inputSource->channel()));
+}
+
+VCSpeedDialPreset::~VCSpeedDialPreset()
+{
+}
+
+bool VCSpeedDialPreset::operator<(VCSpeedDialPreset const& right) const
+{
+    return m_id < right.m_id;
+}
+
+bool VCSpeedDialPreset::compare(VCSpeedDialPreset const* left, VCSpeedDialPreset const* right)
+{
+    return *left < *right;
+}
+
+bool VCSpeedDialPreset::loadXML(const QDomElement &root)
+{
+    QDomNode node;
+    QDomElement tag;
+
+    if (root.tagName() != KXMLQLCVCSpeedDialPreset)
+    {
+        qWarning() << Q_FUNC_INFO << "Speed Dial Preset node not found";
+        return false;
+    }
+
+    if (root.hasAttribute(KXMLQLCVCSpeedDialPresetID) == false)
+    {
+        qWarning() << Q_FUNC_INFO << "Speed Dial Preset ID not found";
+        return false;
+    }
+
+    m_id = root.attribute(KXMLQLCVCSpeedDialPresetID).toUInt();
+
+    /* Children */
+    node = root.firstChild();
+    while (node.isNull() == false)
+    {
+        tag = node.toElement();
+        if (tag.tagName() == KXMLQLCVCSpeedDialPresetName)
+        {
+            m_name = tag.text();
+        }
+        else if (tag.tagName() == KXMLQLCVCSpeedDialPresetShowName)
+        {
+            m_showName = (tag.text() == KXMLQLCTrue);
+        }
+        else if (tag.tagName() == KXMLQLCVCSpeedDialPresetValue)
+        {
+            m_value = tag.text().toInt();
+        }
+        else if (tag.tagName() == KXMLQLCVCSpeedDialPresetInput)
+        {
+            if (tag.hasAttribute(KXMLQLCVCSpeedDialPresetInputUniverse) &&
+                tag.hasAttribute(KXMLQLCVCSpeedDialPresetInputChannel))
+            {
+                quint32 uni = tag.attribute(KXMLQLCVCSpeedDialPresetInputUniverse).toUInt();
+                quint32 ch = tag.attribute(KXMLQLCVCSpeedDialPresetInputChannel).toUInt();
+                m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(uni, ch));
+            }
+        }
+        else if (tag.tagName() == KXMLQLCVCSpeedDialPresetKey)
+        {
+            m_keySequence = VCWidget::stripKeySequence(QKeySequence(tag.text()));
+        }
+        else
+        {
+            qWarning() << Q_FUNC_INFO << "Unknown VCSpeedDialPreset tag:" << tag.tagName();
+        }
+
+        node = node.nextSibling();
+    }
+
+    return true;
+}
+
+bool VCSpeedDialPreset::saveXML(QDomDocument *doc, QDomElement *mtx_root)
+{
+    QDomElement root;
+    QDomElement tag;
+    QDomText text;
+
+    Q_ASSERT(doc != NULL);
+    Q_ASSERT(mtx_root != NULL);
+
+    root = doc->createElement(KXMLQLCVCSpeedDialPreset);
+    root.setAttribute(KXMLQLCVCSpeedDialPresetID, m_id);
+    mtx_root->appendChild(root);
+
+    tag = doc->createElement(KXMLQLCVCSpeedDialPresetName);
+    root.appendChild(tag);
+    text = doc->createTextNode(m_name);
+    tag.appendChild(text);
+
+    tag = doc->createElement(KXMLQLCVCSpeedDialPresetShowName);
+    root.appendChild(tag);
+    text = doc->createTextNode(m_showName ? KXMLQLCTrue : KXMLQLCFalse);
+    tag.appendChild(text);
+
+    tag = doc->createElement(KXMLQLCVCSpeedDialPresetValue);
+    root.appendChild(tag);
+    text = doc->createTextNode(QString::number(m_value));
+    tag.appendChild(text);
+
+    /* External input source */
+    if (!m_inputSource.isNull() && m_inputSource->isValid())
+    {
+        tag = doc->createElement(KXMLQLCVCSpeedDialPresetInput);
+        tag.setAttribute(KXMLQLCVCSpeedDialPresetInputUniverse, QString("%1").arg(m_inputSource->universe()));
+        tag.setAttribute(KXMLQLCVCSpeedDialPresetInputChannel, QString("%1").arg(m_inputSource->channel()));
+        root.appendChild(tag);
+    }
+
+    /* Key sequence */
+    if (m_keySequence.isEmpty() == false)
+    {
+        tag = doc->createElement(KXMLQLCVCSpeedDialPresetKey);
+        root.appendChild(tag);
+        text = doc->createTextNode(m_keySequence.toString());
+        tag.appendChild(text);
+    }
+
+    return true;
+}
+
+

--- a/ui/src/virtualconsole/vcspeeddialpreset.h
+++ b/ui/src/virtualconsole/vcspeeddialpreset.h
@@ -1,0 +1,88 @@
+/*
+  Q Light Controller Plus
+  vcspeeddialpreset.h
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef VCSPEEDDIALPRESET_H
+#define VCSPEEDDIALPRESET_H
+
+#include <QKeySequence>
+
+#include "qlcinputsource.h"
+
+class QDomDocument;
+class QDomElement;
+
+/** @addtogroup ui_vc_widgets
+ * @{
+ */
+
+#define KXMLQLCVCSpeedDialPreset         "Preset"
+#define KXMLQLCVCSpeedDialPresetID       "ID"
+#define KXMLQLCVCSpeedDialPresetName     "Name"
+#define KXMLQLCVCSpeedDialPresetShowName "ShowName"
+#define KXMLQLCVCSpeedDialPresetValue    "Value"
+
+#define KXMLQLCVCSpeedDialPresetInput         "Input"
+#define KXMLQLCVCSpeedDialPresetInputUniverse "Universe"
+#define KXMLQLCVCSpeedDialPresetInputChannel  "Channel"
+
+#define KXMLQLCVCSpeedDialPresetKey "Key"
+
+class VCSpeedDialPreset
+{
+public:
+    explicit VCSpeedDialPreset(quint8 id);
+    explicit VCSpeedDialPreset(VCSpeedDialPreset const& preset);
+
+    /** Destructor */
+    ~VCSpeedDialPreset();
+
+public:
+    bool operator<(VCSpeedDialPreset const& right) const;
+    static bool compare(VCSpeedDialPreset const* left, VCSpeedDialPreset const* right);
+    /************************************************************************
+     * Load & Save
+     ***********************************************************************/
+public:
+    /** Load properties and contents from an XML tree */
+    bool loadXML(const QDomElement& root);
+
+    /** Save properties and contents to an XML document */
+    bool saveXML(QDomDocument* doc, QDomElement* mtx_root);
+
+public:
+    /**
+     * Preset unique ID
+     *  Note that ids 0-15 are reserved to SpeedDial base controls
+     */
+    quint8 m_id;
+
+    /** The preset name */
+    QString m_name;
+    bool m_showName;
+
+    /** The preset value */
+    int m_value;
+
+    QSharedPointer<QLCInputSource> m_inputSource;
+    QKeySequence m_keySequence;
+};
+
+/** @} */
+
+#endif // VCSPEEDDIALPRESET_H

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -45,7 +45,6 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
     : QDialog(dial)
     , m_dial(dial)
     , m_doc(doc)
-    , m_speedDialWidget(NULL)
 {
     Q_ASSERT(dial != NULL);
     Q_ASSERT(doc != NULL);
@@ -132,8 +131,9 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
             this, SLOT(slotShowPresetNameClicked()));
     connect(m_presetNameEdit, SIGNAL(textEdited(QString const&)),
             this, SLOT(slotPresetNameEdited(QString const&)));
-    connect(m_speedDialWidgetButton, SIGNAL(toggled(bool)),
-            this, SLOT(slotSpeedDialWidgetToggle(bool)));
+
+    connect(m_speedDialWidget, SIGNAL(valueChanged(int)),
+            this, SLOT(slotSpeedDialWidgetValueChanged(int)));
 
     connect(m_adPresetInputButton, SIGNAL(toggled(bool)),
             this, SLOT(slotAutoDetectPresetInputToggled(bool)));
@@ -508,8 +508,7 @@ void VCSpeedDialProperties::slotTreeSelectionChanged()
         m_showPresetNameCb->setChecked(preset->m_showName);
         m_showPresetNameCb->blockSignals(false);
         m_presetNameEdit->setText(preset->m_name);
-        if (m_speedDialWidget != NULL)
-            m_speedDialWidget->setDuration(preset->m_value);
+        m_speedDialWidget->setValue(preset->m_value);
     }
 }
 
@@ -535,49 +534,7 @@ void VCSpeedDialProperties::slotPresetNameEdited(QString const& newName)
     }
 }
 
-void VCSpeedDialProperties::slotSpeedDialWidgetToggle(bool state)
-{
-    if (state)
-    {
-        if (m_speedDialWidget == NULL)
-        {
-            m_speedDialWidget = new SpeedDialWidget(this);
-            m_speedDialWidget->setAttribute(Qt::WA_DeleteOnClose);
-            m_speedDialWidget->setWindowTitle(tr("%1 preset").arg(m_nameEdit->text()));
-            m_speedDialWidget->setDurationTitle("");
-            m_speedDialWidget->setFadeInEnabled(false);
-            m_speedDialWidget->setFadeInVisible(false);
-            m_speedDialWidget->setFadeOutEnabled(false);
-            m_speedDialWidget->setFadeOutVisible(false);
-            m_speedDialWidget->show();
-            connect(m_speedDialWidget, SIGNAL(holdChanged(int)),
-                    this, SLOT(slotSpeedDialWidgetDurationChanged(int)));
-            connect(m_speedDialWidget, SIGNAL(destroyed(QObject*)),
-                    this, SLOT(slotSpeedDialWidgetDestroyed(QObject*)));
-        }
-
-        VCSpeedDialPreset* preset = getSelectedPreset();
-        if (preset != NULL)
-        {
-            m_speedDialWidget->setDuration(preset->m_value);
-        }
-    }
-    else
-    {
-        if (m_speedDialWidget != NULL)
-        {
-            m_speedDialWidget->deleteLater();
-            m_speedDialWidget = NULL;
-        }
-    }
-}
-
-void VCSpeedDialProperties::slotSpeedDialWidgetDestroyed(QObject*)
-{
-    m_speedDialWidgetButton->setChecked(false);
-}
-
-void VCSpeedDialProperties::slotSpeedDialWidgetDurationChanged(int ms)
+void VCSpeedDialProperties::slotSpeedDialWidgetValueChanged(int ms)
 {
     VCSpeedDialPreset* preset = getSelectedPreset();
 

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -21,10 +21,12 @@
 
 #include "vcspeeddialproperties.h"
 #include "vcspeeddialfunction.h"
+#include "speeddialwidget.h"
 #include "selectinputchannel.h"
 #include "functionselection.h"
 #include "assignhotkey.h"
 #include "vcspeeddial.h"
+#include "vcspeeddialpreset.h"
 #include "inputpatch.h"
 #include "speeddial.h"
 #include "apputil.h"
@@ -43,11 +45,15 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
     : QDialog(dial)
     , m_dial(dial)
     , m_doc(doc)
+    , m_speedDialWidget(NULL)
 {
     Q_ASSERT(dial != NULL);
     Q_ASSERT(doc != NULL);
 
     setupUi(this);
+
+    // IDs 0-15 are reserved for speed dial base controls
+    m_lastAssignedID = 15;
 
     /* Name */
     m_nameEdit->setText(m_dial->caption());
@@ -97,6 +103,7 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
 
     updateInputSources();
 
+    /* Visibility */
     ushort dialMask = m_dial->visibilityMask();
     if (dialMask & SpeedDial::PlusMinus) m_pmCheck->setChecked(true);
     if (dialMask & SpeedDial::MultDiv) m_mdCheck->setChecked(true);
@@ -113,10 +120,46 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
     connect(m_detachKey, SIGNAL(clicked()), this, SLOT(slotDetachKey()));
     connect(m_attachInfiniteKey, SIGNAL(clicked()), this, SLOT(slotAttachInfiniteKey()));
     connect(m_detachInfiniteKey, SIGNAL(clicked()), this, SLOT(slotDetachInfiniteKey()));
+
+    /* Presets */
+    foreach(VCSpeedDialPreset const* preset, m_dial->presets())
+    {
+        m_presets.append(new VCSpeedDialPreset(*preset));
+        if (preset->m_id > m_lastAssignedID)
+            m_lastAssignedID = preset->m_id;
+    }
+    m_presetsTree->setSelectionMode(QAbstractItemView::SingleSelection);
+    updateTree();
+
+    connect(m_presetsTree, SIGNAL(itemClicked(QTreeWidgetItem*,int)),
+            this, SLOT(slotTreeSelectionChanged()));
+
+    connect(m_addPresetButton, SIGNAL(clicked()),
+            this, SLOT(slotAddPresetClicked()));
+    connect(m_removePresetButton, SIGNAL(clicked()),
+            this, SLOT(slotRemovePresetClicked()));
+    connect(m_showPresetNameCb, SIGNAL(clicked()),
+            this, SLOT(slotShowPresetNameClicked()));
+    connect(m_presetNameEdit, SIGNAL(textEdited(QString const&)),
+            this, SLOT(slotPresetNameEdited(QString const&)));
+    connect(m_speedDialWidgetButton, SIGNAL(toggled(bool)),
+            this, SLOT(slotSpeedDialWidgetToggle(bool)));
+
+    connect(m_adPresetInputButton, SIGNAL(toggled(bool)),
+            this, SLOT(slotAutoDetectPresetInputToggled(bool)));
+    connect(m_choosePresetInputButton, SIGNAL(clicked()),
+            this, SLOT(slotChoosePresetInputClicked()));
+
+    connect(m_attachPresetKey, SIGNAL(clicked()), this, SLOT(slotAttachPresetKey()));
+    connect(m_detachPresetKey, SIGNAL(clicked()), this, SLOT(slotDetachPresetKey()));
 }
 
 VCSpeedDialProperties::~VCSpeedDialProperties()
 {
+    foreach (VCSpeedDialPreset* preset, m_presets)
+    {
+        delete preset;
+    }
 }
 
 void VCSpeedDialProperties::accept()
@@ -142,6 +185,7 @@ void VCSpeedDialProperties::accept()
     m_dial->setInputSource(m_infiniteInputSource, VCSpeedDial::infiniteInputSourceId);
     m_dial->setInfiniteKeySequence(m_infiniteKeySequence);
 
+    /* Visibility */
     ushort dialMask = 0;
     if (m_pmCheck->isChecked()) dialMask |= SpeedDial::PlusMinus;
     if (m_mdCheck->isChecked()) dialMask |= SpeedDial::MultDiv;
@@ -153,8 +197,12 @@ void VCSpeedDialProperties::accept()
     if (m_secCheck->isChecked()) dialMask |= SpeedDial::Seconds;
     if (m_msCheck->isChecked()) dialMask |= SpeedDial::Milliseconds;
     if (m_infiniteCheck->isChecked()) dialMask |= SpeedDial::Infinite;
-
     m_dial->setVisibilityMask(dialMask);
+
+    /* Presets */
+    m_dial->resetPresets();
+    for (int i = 0; i < m_presets.count(); i++)
+        m_dial->addPreset(*m_presets.at(i));
 
     QDialog::accept();
 }
@@ -407,4 +455,271 @@ void VCSpeedDialProperties::slotDetachInfiniteKey()
 {
     m_infiniteKeySequence = QKeySequence();
     m_infiniteKeyEdit->setText(m_infiniteKeySequence.toString(QKeySequence::NativeText));
+}
+
+/*********************************************************************
+ * Presets
+ *********************************************************************/
+
+void VCSpeedDialProperties::updateTree()
+{
+    m_presetsTree->blockSignals(true);
+    m_presetsTree->clear();
+    foreach(VCSpeedDialPreset* preset, m_presets)
+    {
+        QTreeWidgetItem *item = new QTreeWidgetItem(m_presetsTree);
+        item->setData(0, Qt::UserRole, preset->m_id);
+        item->setText(0, preset->m_name);
+        item->setText(1, Function::speedToString(preset->m_value));
+    }
+    m_presetsTree->resizeColumnToContents(0);
+    m_presetsTree->blockSignals(false);
+}
+
+void VCSpeedDialProperties::updateTreeItem(VCSpeedDialPreset const& preset)
+{
+    m_presetsTree->blockSignals(true);
+    m_presetsTree->resizeColumnToContents(0);
+    for (int i = 0; i < m_presetsTree->topLevelItemCount(); ++i)
+    {
+        QTreeWidgetItem* treeItem = m_presetsTree->topLevelItem(i);
+        if (treeItem->data(0, Qt::UserRole).toUInt() == preset.m_id)
+        {
+            treeItem->setText(0, preset.m_name);
+            treeItem->setText(1, Function::speedToString(preset.m_value));
+            m_presetsTree->blockSignals(false);
+            return;
+        }
+    }
+    Q_ASSERT(false);
+}
+
+VCSpeedDialPreset* VCSpeedDialProperties::getSelectedPreset()
+{
+    if (m_presetsTree->selectedItems().isEmpty())
+        return NULL;
+
+    QTreeWidgetItem* item = m_presetsTree->selectedItems().first();
+    if (item != NULL)
+    {
+        quint8 presetID = item->data(0, Qt::UserRole).toUInt();
+        foreach(VCSpeedDialPreset* preset, m_presets)
+        {
+            if (preset->m_id == presetID)
+                return preset;
+        }
+    }
+
+    Q_ASSERT(false);
+    return NULL;
+}
+
+void VCSpeedDialProperties::addPreset(VCSpeedDialPreset *preset)
+{
+    m_presets.append(preset);
+}
+
+void VCSpeedDialProperties::removePreset(quint8 id)
+{
+    for(int i = 0; i < m_presets.count(); i++)
+    {
+        if (m_presets.at(i)->m_id == id)
+        {
+            m_presets.removeAt(i);
+            return;
+        }
+    }
+}
+
+void VCSpeedDialProperties::slotAddPresetClicked()
+{
+    VCSpeedDialPreset *newPreset = new VCSpeedDialPreset(++m_lastAssignedID);
+    newPreset->m_value = 1000;
+    newPreset->m_name = Function::speedToString(1000);
+    addPreset(newPreset);
+    updateTree();
+}
+
+void VCSpeedDialProperties::slotRemovePresetClicked()
+{
+    if (m_presetsTree->selectedItems().isEmpty())
+        return;
+    QTreeWidgetItem *selItem = m_presetsTree->selectedItems().first();
+    quint8 ctlID = selItem->data(0, Qt::UserRole).toUInt();
+    removePreset(ctlID);
+    updateTree();
+}
+
+void VCSpeedDialProperties::updatePresetInputSource(QSharedPointer<QLCInputSource> const& source)
+{
+    QString uniName;
+    QString chName;
+
+    if (m_doc->inputOutputMap()->inputSourceNames(source, uniName, chName) == false)
+    {
+        uniName = KInputNone;
+        chName = KInputNone;
+    }
+
+    m_presetInputUniverseEdit->setText(uniName);
+    m_presetInputChannelEdit->setText(chName);
+}
+
+void VCSpeedDialProperties::slotTreeSelectionChanged()
+{
+    VCSpeedDialPreset* preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        updatePresetInputSource(preset->m_inputSource);
+        m_presetKeyEdit->setText(preset->m_keySequence.toString(QKeySequence::NativeText));
+        m_showPresetNameCb->blockSignals(true);
+        m_showPresetNameCb->setChecked(preset->m_showName);
+        m_showPresetNameCb->blockSignals(false);
+        m_presetNameEdit->setText(preset->m_name);
+        if (m_speedDialWidget != NULL)
+            m_speedDialWidget->setDuration(preset->m_value);
+    }
+}
+
+void VCSpeedDialProperties::slotShowPresetNameClicked()
+{
+    VCSpeedDialPreset* preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        preset->m_showName = m_showPresetNameCb->isChecked();
+    }
+}
+
+void VCSpeedDialProperties::slotPresetNameEdited(QString const& newName)
+{
+    VCSpeedDialPreset* preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        preset->m_name = newName;
+
+        updateTreeItem(*preset);
+    }
+}
+
+void VCSpeedDialProperties::slotSpeedDialWidgetToggle(bool state)
+{
+    if (state)
+    {
+        if (m_speedDialWidget == NULL)
+        {
+            m_speedDialWidget = new SpeedDialWidget(this);
+            m_speedDialWidget->setAttribute(Qt::WA_DeleteOnClose);
+            m_speedDialWidget->setWindowTitle(tr("%1 preset").arg(m_nameEdit->text()));
+            m_speedDialWidget->setDurationTitle("");
+            m_speedDialWidget->setFadeInEnabled(false);
+            m_speedDialWidget->setFadeInVisible(false);
+            m_speedDialWidget->setFadeOutEnabled(false);
+            m_speedDialWidget->setFadeOutVisible(false);
+            m_speedDialWidget->show();
+            connect(m_speedDialWidget, SIGNAL(holdChanged(int)),
+                    this, SLOT(slotSpeedDialWidgetDurationChanged(int)));
+            connect(m_speedDialWidget, SIGNAL(destroyed(QObject*)),
+                    this, SLOT(slotSpeedDialWidgetDestroyed(QObject*)));
+        }
+
+        VCSpeedDialPreset* preset = getSelectedPreset();
+        if (preset != NULL)
+        {
+            m_speedDialWidget->setDuration(preset->m_value);
+        }
+    }
+    else
+    {
+        if (m_speedDialWidget != NULL)
+        {
+            m_speedDialWidget->deleteLater();
+            m_speedDialWidget = NULL;
+        }
+    }
+}
+
+void VCSpeedDialProperties::slotSpeedDialWidgetDestroyed(QObject*)
+{
+    m_speedDialWidgetButton->setChecked(false);
+}
+
+void VCSpeedDialProperties::slotSpeedDialWidgetDurationChanged(int ms)
+{
+    VCSpeedDialPreset* preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        preset->m_value = ms;
+
+        updateTreeItem(*preset);
+    }
+}
+
+void VCSpeedDialProperties::slotAutoDetectPresetInputToggled(bool checked)
+{
+    if (checked == true)
+    {
+        connect(m_doc->inputOutputMap(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
+                this, SLOT(slotPresetInputValueChanged(quint32,quint32)));
+    }
+    else
+    {
+        disconnect(m_doc->inputOutputMap(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
+                   this, SLOT(slotPresetInputValueChanged(quint32,quint32)));
+    }
+}
+
+void VCSpeedDialProperties::slotPresetInputValueChanged(quint32 universe, quint32 channel)
+{
+    VCSpeedDialPreset *preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        preset->m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
+        updatePresetInputSource(preset->m_inputSource);
+    }
+}
+
+void VCSpeedDialProperties::slotChoosePresetInputClicked()
+{
+    VCSpeedDialPreset *preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        SelectInputChannel sic(this, m_doc->inputOutputMap());
+        if (sic.exec() == QDialog::Accepted)
+        {
+            preset->m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
+            updatePresetInputSource(preset->m_inputSource);
+        }
+    }
+}
+
+void VCSpeedDialProperties::slotAttachPresetKey()
+{
+    VCSpeedDialPreset *preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        AssignHotKey ahk(this, preset->m_keySequence);
+        if (ahk.exec() == QDialog::Accepted)
+        {
+            preset->m_keySequence = QKeySequence(ahk.keySequence());
+            m_presetKeyEdit->setText(preset->m_keySequence.toString(QKeySequence::NativeText));
+        }
+    }
+}
+
+void VCSpeedDialProperties::slotDetachPresetKey()
+{
+    VCSpeedDialPreset *preset = getSelectedPreset();
+
+    if (preset != NULL)
+    {
+        preset->m_keySequence = QKeySequence();
+        m_presetKeyEdit->setText(preset->m_keySequence.toString(QKeySequence::NativeText));
+    }
 }

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -94,13 +94,6 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
     m_tapKeySequence = QKeySequence(dial->keySequence());
     m_keyEdit->setText(m_tapKeySequence.toString(QKeySequence::NativeText));
 
-    /* Infinite input */
-    m_infiniteInputSource = m_dial->inputSource(VCSpeedDial::infiniteInputSourceId);
-
-    /* Infinite key sequence */
-    m_infiniteKeySequence = QKeySequence(dial->infiniteKeySequence());
-    m_infiniteKeyEdit->setText(m_infiniteKeySequence.toString(QKeySequence::NativeText));
-
     updateInputSources();
 
     /* Visibility */
@@ -114,12 +107,9 @@ VCSpeedDialProperties::VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc)
     if (dialMask & SpeedDial::Minutes) m_minCheck->setChecked(true);
     if (dialMask & SpeedDial::Seconds) m_secCheck->setChecked(true);
     if (dialMask & SpeedDial::Milliseconds) m_msCheck->setChecked(true);
-    if (dialMask & SpeedDial::Infinite) m_infiniteCheck->setChecked(true);
 
     connect(m_attachKey, SIGNAL(clicked()), this, SLOT(slotAttachKey()));
     connect(m_detachKey, SIGNAL(clicked()), this, SLOT(slotDetachKey()));
-    connect(m_attachInfiniteKey, SIGNAL(clicked()), this, SLOT(slotAttachInfiniteKey()));
-    connect(m_detachInfiniteKey, SIGNAL(clicked()), this, SLOT(slotDetachInfiniteKey()));
 
     /* Presets */
     foreach(VCSpeedDialPreset const* preset, m_dial->presets())
@@ -182,9 +172,6 @@ void VCSpeedDialProperties::accept()
 
     m_dial->setKeySequence(m_tapKeySequence);
 
-    m_dial->setInputSource(m_infiniteInputSource, VCSpeedDial::infiniteInputSourceId);
-    m_dial->setInfiniteKeySequence(m_infiniteKeySequence);
-
     /* Visibility */
     ushort dialMask = 0;
     if (m_pmCheck->isChecked()) dialMask |= SpeedDial::PlusMinus;
@@ -196,7 +183,6 @@ void VCSpeedDialProperties::accept()
     if (m_minCheck->isChecked()) dialMask |= SpeedDial::Minutes;
     if (m_secCheck->isChecked()) dialMask |= SpeedDial::Seconds;
     if (m_msCheck->isChecked()) dialMask |= SpeedDial::Milliseconds;
-    if (m_infiniteCheck->isChecked()) dialMask |= SpeedDial::Infinite;
     m_dial->setVisibilityMask(dialMask);
 
     /* Presets */
@@ -302,15 +288,6 @@ void VCSpeedDialProperties::updateInputSources()
     }
     m_tapInputUniverseEdit->setText(uniName);
     m_tapInputChannelEdit->setText(chName);
-
-    // Infinite
-    if (m_doc->inputOutputMap()->inputSourceNames(m_infiniteInputSource, uniName, chName) == false)
-    {
-        uniName = KInputNone;
-        chName = KInputNone;
-    }
-    m_infiniteInputUniverseEdit->setText(uniName);
-    m_infiniteInputChannelEdit->setText(chName);
 }
 
 void VCSpeedDialProperties::slotAbsoluteInputValueChanged(quint32 universe, quint32 channel)
@@ -345,12 +322,6 @@ void VCSpeedDialProperties::slotAbsolutePrecisionCbChecked(bool checked)
         m_absoluteMaxSpin->setValue(m_absoluteMaxSpin->value() / (1000 / MS_DIV));
         m_absoluteMaxSpin->setMaximum(600);
     }
-}
-
-void VCSpeedDialProperties::slotInfiniteInputValueChanged(quint32 universe, quint32 channel)
-{
-    m_infiniteInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(universe, (m_dial->page() << 16) | channel));
-    updateInputSources();
 }
 
 void VCSpeedDialProperties::slotAutoDetectAbsoluteInputSourceToggled(bool checked)
@@ -401,30 +372,6 @@ void VCSpeedDialProperties::slotChooseTapInputSourceClicked()
     }
 }
 
-void VCSpeedDialProperties::slotAutoDetectInfiniteInputSourceToggled(bool checked)
-{
-    if (checked == true)
-    {
-        connect(m_doc->inputOutputMap(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
-                this, SLOT(slotInfiniteInputValueChanged(quint32,quint32)));
-    }
-    else
-    {
-        disconnect(m_doc->inputOutputMap(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
-                   this, SLOT(slotInfiniteInputValueChanged(quint32,quint32)));
-    }
-}
-
-void VCSpeedDialProperties::slotChooseInfiniteInputSourceClicked()
-{
-    SelectInputChannel sic(this, m_doc->inputOutputMap());
-    if (sic.exec() == QDialog::Accepted)
-    {
-        m_infiniteInputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
-        updateInputSources();
-    }
-}
-
 void VCSpeedDialProperties::slotAttachKey()
 {
     AssignHotKey ahk(this, m_tapKeySequence);
@@ -439,22 +386,6 @@ void VCSpeedDialProperties::slotDetachKey()
 {
     m_tapKeySequence = QKeySequence();
     m_keyEdit->setText(m_tapKeySequence.toString(QKeySequence::NativeText));
-}
-
-void VCSpeedDialProperties::slotAttachInfiniteKey()
-{
-    AssignHotKey ahk(this, m_infiniteKeySequence);
-    if (ahk.exec() == QDialog::Accepted)
-    {
-        m_infiniteKeySequence = QKeySequence(ahk.keySequence());
-        m_infiniteKeyEdit->setText(m_infiniteKeySequence.toString(QKeySequence::NativeText));
-    }
-}
-
-void VCSpeedDialProperties::slotDetachInfiniteKey()
-{
-    m_infiniteKeySequence = QKeySequence();
-    m_infiniteKeyEdit->setText(m_infiniteKeySequence.toString(QKeySequence::NativeText));
 }
 
 /*********************************************************************

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -21,11 +21,14 @@
 #define VCSPEEDDIALPROPERTIES_H
 
 #include <QDialog>
+
 #include "ui_vcspeeddialproperties.h"
 #include "qlcinputsource.h"
 
 class VCSpeedDial;
 class VCSpeedDialFunction;
+class VCSpeedDialPreset;
+class SpeedDialWidget;
 class Doc;
 
 /** @addtogroup ui_vc_props
@@ -35,9 +38,10 @@ class Doc;
 class VCSpeedDialProperties : public QDialog, public Ui_VCSpeedDialProperties
 {
     Q_OBJECT
+    Q_DISABLE_COPY(VCSpeedDialProperties)
 
 public:
-    VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc);
+    explicit VCSpeedDialProperties(VCSpeedDial* dial, Doc* doc);
     ~VCSpeedDialProperties();
 
 public slots:
@@ -95,6 +99,39 @@ private:
     QKeySequence m_tapKeySequence;
     QSharedPointer<QLCInputSource> m_infiniteInputSource;
     QKeySequence m_infiniteKeySequence;
+
+    /*********************************************************************
+     * Presets
+     *********************************************************************/
+private:
+    void updateTree();
+    void updateTreeItem(VCSpeedDialPreset const& preset);
+    VCSpeedDialPreset* getSelectedPreset();
+    void addPreset(VCSpeedDialPreset* control);
+    void removePreset(quint8 id);
+    void updatePresetInputSource(QSharedPointer<QLCInputSource> const& source);
+
+protected slots:
+    void slotTreeSelectionChanged();
+    void slotAddPresetClicked();
+    void slotRemovePresetClicked();
+    void slotShowPresetNameClicked();
+    void slotPresetNameEdited(QString const& newName);
+    void slotSpeedDialWidgetToggle(bool state);
+    void slotSpeedDialWidgetDestroyed(QObject* dial);
+    void slotSpeedDialWidgetDurationChanged(int ms);
+
+    void slotAutoDetectPresetInputToggled(bool checked);
+    void slotPresetInputValueChanged(quint32 universe, quint32 channel);
+    void slotChoosePresetInputClicked();
+
+    void slotAttachPresetKey();
+    void slotDetachPresetKey();
+
+protected:
+    quint8 m_lastAssignedID;
+    QList<VCSpeedDialPreset*> m_presets;
+    SpeedDialWidget* m_speedDialWidget;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -86,19 +86,10 @@ private slots:
     void slotAttachKey();
     void slotDetachKey();
 
-    void slotAutoDetectInfiniteInputSourceToggled(bool checked);
-    void slotChooseInfiniteInputSourceClicked();
-    void slotInfiniteInputValueChanged(quint32 universe, quint32 channel);
-
-    void slotAttachInfiniteKey();
-    void slotDetachInfiniteKey();
-
 private:
     QSharedPointer<QLCInputSource> m_absoluteInputSource;
     QSharedPointer<QLCInputSource> m_tapInputSource;
     QKeySequence m_tapKeySequence;
-    QSharedPointer<QLCInputSource> m_infiniteInputSource;
-    QKeySequence m_infiniteKeySequence;
 
     /*********************************************************************
      * Presets

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -108,9 +108,7 @@ protected slots:
     void slotRemovePresetClicked();
     void slotShowPresetNameClicked();
     void slotPresetNameEdited(QString const& newName);
-    void slotSpeedDialWidgetToggle(bool state);
-    void slotSpeedDialWidgetDestroyed(QObject* dial);
-    void slotSpeedDialWidgetDurationChanged(int ms);
+    void slotSpeedDialWidgetValueChanged(int ms);
 
     void slotAutoDetectPresetInputToggled(bool checked);
     void slotPresetInputValueChanged(quint32 universe, quint32 channel);
@@ -122,7 +120,6 @@ protected slots:
 protected:
     quint8 m_lastAssignedID;
     QList<VCSpeedDialPreset*> m_presets;
-    SpeedDialWidget* m_speedDialWidget;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -608,6 +608,246 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Presets</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout_10">
+         <item row="0" column="1" rowspan="9">
+          <widget class="QTreeWidget" name="m_presetsTree">
+           <column>
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QGroupBox" name="m_externalInputGroup">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>External Input</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <item row="2" column="0">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>298</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="1" colspan="2">
+             <widget class="QLineEdit" name="m_presetInputChannelEdit">
+              <property name="toolTip">
+               <string>The particular input channel within the input universe that sends data to this preset button</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QPushButton" name="m_choosePresetInputButton">
+              <property name="toolTip">
+               <string>Choose an external input universe &amp; channel that this preset button should listen to</string>
+              </property>
+              <property name="text">
+               <string>Choose...</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QPushButton" name="m_adPresetInputButton">
+              <property name="toolTip">
+               <string>When toggled, you can move an external control to assign it to this preset button</string>
+              </property>
+              <property name="text">
+               <string>Auto Detect</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1" colspan="2">
+             <widget class="QLineEdit" name="m_presetInputUniverseEdit">
+              <property name="toolTip">
+               <string>The input universe that sends data to this preset button</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="m_inputChannelLabel">
+              <property name="text">
+               <string>Input channel</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="m_inputUniverseLabel">
+              <property name="text">
+               <string>Input universe</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="m_addPresetButton">
+           <property name="text">
+            <string> Add preset</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../qlcui.qrc">
+             <normaloff>:/edit_add.png</normaloff>:/edit_add.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QPushButton" name="m_removePresetButton">
+           <property name="text">
+            <string> Remove</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../qlcui.qrc">
+             <normaloff>:/edit_remove.png</normaloff>:/edit_remove.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QCheckBox" name="m_showPresetNameCb">
+           <property name="text">
+            <string>Show preset name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLineEdit" name="m_presetNameEdit">
+           <property name="toolTip">
+            <string>Preset name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QToolButton" name="m_speedDialWidgetButton">
+           <property name="toolTip">
+            <string>Show/Hide speed dial window</string>
+           </property>
+           <property name="icon">
+            <iconset resource="qlcui.qrc">
+             <normaloff>:/speed.png</normaloff>:/speed.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>28</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="2">
+          <widget class="QGroupBox" name="groupBox_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Key combination</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <property name="leftMargin">
+             <number>3</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>3</number>
+            </property>
+            <item row="1" column="0">
+             <widget class="QToolButton" name="m_detachPresetKey">
+              <property name="toolTip">
+               <string>Remove the preset buttons's keyboard shortcut key</string>
+              </property>
+              <property name="text">
+               <string notr="true">...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../qlcui.qrc">
+                <normaloff>:/fileclose.png</normaloff>:/fileclose.png</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>32</width>
+                <height>32</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QToolButton" name="m_attachPresetKey">
+              <property name="toolTip">
+               <string>Set a key combination for this preset button</string>
+              </property>
+              <property name="text">
+               <string notr="true">...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../qlcui.qrc">
+                <normaloff>:/key_bindings.png</normaloff>:/key_bindings.png</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>32</width>
+                <height>32</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0" colspan="2">
+             <widget class="QLineEdit" name="m_presetKeyEdit">
+              <property name="toolTip">
+               <string>Keyboard combination that toggles this preset button</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item row="2" column="0" colspan="2">

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -476,7 +476,7 @@
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <layout class="QGridLayout" name="gridLayout_10">
-         <item row="0" column="1" rowspan="9">
+         <item row="0" column="0" rowspan="9">
           <widget class="QTreeWidget" name="m_presetsTree">
            <column>
             <property name="text">
@@ -490,7 +490,7 @@
            </column>
           </widget>
          </item>
-         <item row="9" column="1">
+         <item row="9" column="0">
           <widget class="QGroupBox" name="m_externalInputGroup">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -575,7 +575,7 @@
            </layout>
           </widget>
          </item>
-         <item row="0" column="2">
+         <item row="0" column="1">
           <widget class="QPushButton" name="m_addPresetButton">
            <property name="text">
             <string> Add preset</string>
@@ -586,7 +586,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
+         <item row="1" column="1">
           <widget class="QPushButton" name="m_removePresetButton">
            <property name="text">
             <string> Remove</string>
@@ -597,41 +597,25 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
+         <item row="2" column="1">
           <widget class="QCheckBox" name="m_showPresetNameCb">
            <property name="text">
             <string>Show preset name</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="2">
+         <item row="3" column="1">
           <widget class="QLineEdit" name="m_presetNameEdit">
            <property name="toolTip">
             <string>Preset name</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
-          <widget class="QToolButton" name="m_speedDialWidgetButton">
-           <property name="toolTip">
-            <string>Show/Hide speed dial window</string>
-           </property>
-           <property name="icon">
-            <iconset resource="qlcui.qrc">
-             <normaloff>:/speed.png</normaloff>:/speed.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>28</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
+         <item row="4" column="1">
+          <widget class="SpeedDial" name="m_speedDialWidget">
           </widget>
          </item>
-         <item row="9" column="2">
+         <item row="9" column="1">
           <widget class="QGroupBox" name="groupBox_8">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -372,138 +372,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="title">
-          <string>Infinite</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_8">
-          <property name="topMargin">
-           <number>4</number>
-          </property>
-          <property name="bottomMargin">
-           <number>4</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QGroupBox" name="groupBox_6">
-            <property name="title">
-             <string>External Input</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_7">
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="m_infiniteInputUniverseLabel">
-               <property name="text">
-                <string>Input Universe</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1" colspan="2">
-              <widget class="QLineEdit" name="m_infiniteInputUniverseEdit"/>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="m_infiniteInputChannelLabel">
-               <property name="text">
-                <string>Input Channel</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1" colspan="2">
-              <widget class="QLineEdit" name="m_infiniteInputChannelEdit"/>
-             </item>
-             <item row="2" column="1">
-              <widget class="QPushButton" name="m_autoDetectInfiniteInputButton">
-               <property name="text">
-                <string>Auto Detect</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QPushButton" name="m_chooseInfiniteInputButton">
-               <property name="text">
-                <string>Choose...</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QGroupBox" name="groupBox_7">
-            <property name="title">
-             <string>Key combination</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_9">
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item row="0" column="0" colspan="2">
-              <widget class="QLineEdit" name="m_infiniteKeyEdit">
-               <property name="toolTip">
-                <string>Keyboard combination to toggle the dial infinite checkbox</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QToolButton" name="m_attachInfiniteKey">
-               <property name="toolTip">
-                <string>Set a key combination for this dial infinite checkbox</string>
-               </property>
-               <property name="text">
-                <string notr="true">...</string>
-               </property>
-               <property name="icon">
-                <iconset resource="../qlcui.qrc">
-                 <normaloff>:/key_bindings.png</normaloff>:/key_bindings.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>32</width>
-                 <height>32</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QToolButton" name="m_detachInfiniteKey">
-               <property name="toolTip">
-                <string>Remove the dial's infinite button keyboard shortcut key</string>
-               </property>
-               <property name="text">
-                <string notr="true">...</string>
-               </property>
-               <property name="icon">
-                <iconset resource="../qlcui.qrc">
-                 <normaloff>:/fileclose.png</normaloff>:/fileclose.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>32</width>
-                 <height>32</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -583,13 +451,6 @@
         <widget class="QCheckBox" name="m_msCheck">
          <property name="text">
           <string>Show the milliseconds field</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="m_infiniteCheck">
-         <property name="text">
-          <string>Show the infinite option</string>
          </property>
         </widget>
        </item>
@@ -964,22 +825,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>m_chooseInfiniteInputButton</sender>
-   <signal>clicked()</signal>
-   <receiver>VCSpeedDialProperties</receiver>
-   <slot>slotChooseInfiniteInputSourceClicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>327</x>
-     <y>354</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>394</x>
-     <y>352</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>m_autoDetectAbsoluteInputButton</sender>
    <signal>toggled(bool)</signal>
    <receiver>VCSpeedDialProperties</receiver>
@@ -1011,31 +856,13 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>m_autoDetectInfiniteInputButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>VCSpeedDialProperties</receiver>
-   <slot>slotAutoDetectInfiniteInputSourceToggled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>195</x>
-     <y>355</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>3</x>
-     <y>349</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <slots>
   <slot>slotAddClicked()</slot>
   <slot>slotRemoveClicked()</slot>
   <slot>slotChooseAbsoluteInputSourceClicked()</slot>
   <slot>slotChooseTapInputSourceClicked()</slot>
-  <slot>slotChooseInfiniteInputSourceClicked()</slot>
   <slot>slotAutoDetectAbsoluteInputSourceToggled(bool)</slot>
   <slot>slotAutoDetectTapInputSourceClicked()</slot>
-  <slot>slotAutoDetectInfiniteInputSourceToggled(bool)</slot>
  </slots>
 </ui>


### PR DESCRIPTION
VCSpeedDialProperties: Add a tab to edit presets
When clicking on a preset, the speed dial value is changed
Like the VCAnimation, it's possible to assign an external input to each preset button

TODO:
- Add a button on the SpeedDial to "Save" current value in a new preset in live
- rework the multiplier functionnality ?