### PR TITLE
Language fixes

### DIFF
--- a/etc/qlcplus-fixtureeditor.desktop
+++ b/etc/qlcplus-fixtureeditor.desktop
@@ -2,6 +2,7 @@
 Type=Application
 Name=QLC+ Fixture Editor
 GenericName=Edit fixtures
+GenericName[cz]=Editor definicí zařízení
 GenericName[de]=Gerätedefinitionen bearbeiten
 GenericName[fi]=Muokkaa valaisimia
 GenericName[fr]=Edition des Projecteurs

--- a/etc/qlcplus.desktop
+++ b/etc/qlcplus.desktop
@@ -2,6 +2,7 @@
 Type=Application
 Name=Q Light Controller Plus
 GenericName=Lighting control
+GenericName[cz]=Řízení světel
 GenericName[de]=Lichtsteuerung
 GenericName[fi]=Valojen ohjaus
 GenericName[fr]=Controlleur d'éclairages

--- a/etc/qlcplus.nsi
+++ b/etc/qlcplus.nsi
@@ -27,6 +27,7 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "German"
 !insertmacro MUI_LANGUAGE "Spanish"
 !insertmacro MUI_LANGUAGE "SpanishInternational"
+!insertmacro MUI_LANGUAGE "Czech"
 
 !define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
 

--- a/etc/qlcplus.nsi
+++ b/etc/qlcplus.nsi
@@ -28,6 +28,10 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "Spanish"
 !insertmacro MUI_LANGUAGE "SpanishInternational"
 !insertmacro MUI_LANGUAGE "Czech"
+!insertmacro MUI_LANGUAGE "French"
+!insertmacro MUI_LANGUAGE "Finnish"
+!insertmacro MUI_LANGUAGE "Japanese"
+!insertmacro MUI_LANGUAGE "Catalan"
 
 !define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
 

--- a/etc/qlcplus.xml
+++ b/etc/qlcplus.xml
@@ -6,6 +6,7 @@
 			<match type="string" offset="0:100" value="&lt;!DOCTYPE Workspace&gt;"/>
 		</magic>
 		<glob pattern="*.qxw"/>
+		<comment xml:lang="cz">QLC+ pracoviště</comment>
 		<comment xml:lang="de">QLC+ Arbeitsbereich</comment>
 		<comment xml:lang="en">QLC+ workspace</comment>
 		<comment xml:lang="fr">Espace de travail QLC+</comment>
@@ -19,6 +20,7 @@
 			<match type="string" offset="0:100" value="&lt;!DOCTYPE FixtureDefinition&gt;"/>
 		</magic>
 		<glob pattern="*.qxf"/>
+		<comment xml:lang="cz">QLC+ definice zařízení</comment>
 		<comment xml:lang="de">QLC+ Gerätedefinition</comment>
 		<comment xml:lang="en">QLC+ fixture definition</comment>
 		<comment xml:lang="fr">QLC+ définitions des projecteurs</comment>
@@ -32,6 +34,7 @@
 			<match type="string" offset="0:100" value="&lt;!DOCTYPE InputProfile&gt;"/>
 		</magic>
 		<glob pattern="*.qxi"/>
+		<comment xml:lang="cz">QLC+ vstupní profil</comment>
 		<comment xml:lang="de">QLC+ Eingangsprofil</comment>
 		<comment xml:lang="en">QLC+ input profile</comment>
 		<comment xml:lang="fr">QLC+ profil d'entrée</comment>

--- a/etc/qlcplus.xml
+++ b/etc/qlcplus.xml
@@ -42,4 +42,22 @@
 		<comment xml:lang="it">Profilo di input QLC+</comment>
 		<comment xml:lang="nl">QLC+ invoerprofiel</comment>
 	</mime-type>
+	<mime-type type="application/x-qlc-miditemplate">
+		<sub-class-of type="application/xml"/>
+		<magic priority="80">
+			<match type="string" offset="0:100" value="&lt;!DOCTYPE MidiTemplate&gt;"/>
+		</magic>
+		<glob pattern="*.qxm"/>
+		<comment xml:lang="cz">QLC+ MIDI šablona</comment>
+		<comment xml:lang="en">QLC+ MIDI template</comment>
+	</mime-type>
+	<mime-type type="application/x-qlc-channelmodifier">
+		<sub-class-of type="application/xml"/>
+		<magic priority="80">
+			<match type="string" offset="0:100" value="&lt;!DOCTYPE ChannelModifier&gt;"/>
+		</magic>
+		<glob pattern="*.qxmt"/>
+		<comment xml:lang="cz">QLC+ šablona modifikátoru kanálu</comment>
+		<comment xml:lang="en">QLC+ channel modifier template</comment>
+	</mime-type>
 </mime-info>

--- a/etc/qlcplusQt5.nsi
+++ b/etc/qlcplusQt5.nsi
@@ -27,6 +27,7 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "German"
 !insertmacro MUI_LANGUAGE "Spanish"
 !insertmacro MUI_LANGUAGE "SpanishInternational"
+!insertmacro MUI_LANGUAGE "Czech"
 
 !define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
 

--- a/etc/qlcplusQt5.nsi
+++ b/etc/qlcplusQt5.nsi
@@ -28,6 +28,10 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "Spanish"
 !insertmacro MUI_LANGUAGE "SpanishInternational"
 !insertmacro MUI_LANGUAGE "Czech"
+!insertmacro MUI_LANGUAGE "French"
+!insertmacro MUI_LANGUAGE "Finnish"
+!insertmacro MUI_LANGUAGE "Japanese"
+!insertmacro MUI_LANGUAGE "Catalan"
 
 !define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
 


### PR DESCRIPTION
1. added Czech to various files like NSIS installer, linux desktop files, etc.
2. added all languages that have translation to NSIS installer
3. added new types (qxi, qxmt) to mime-types definition

I suggest that translators have a look at these files as well - many of the translations are missing.

I didn't test NSIS installer how it looks like with these changes.