### PR TITLE
VCSpeedial: put mult/div buttons outside of the dial

### DIFF
--- a/ui/src/speeddial.h
+++ b/ui/src/speeddial.h
@@ -68,7 +68,6 @@ class SpeedDial : public QGroupBox
     Q_DISABLE_COPY(SpeedDial)
 
 public:
-
     enum Visibility
     {
         None         = 0,
@@ -80,8 +79,6 @@ public:
         Seconds      = 1 << 5,
         Milliseconds = 1 << 6,
         Infinite     = 1 << 7,
-        MultDiv      = 1 << 8,
-        Apply        = 1 << 9,
     };
 
     SpeedDial(QWidget* parent);
@@ -122,7 +119,6 @@ private:
 private slots:
     void slotPlusMinus();
     void slotPlusMinusTimeout();
-    void slotMultiplierDivisor();
     void slotDialChanged(int value);
     void slotHoursChanged();
     void slotMinutesChanged();
@@ -131,7 +127,6 @@ private slots:
     void slotInfiniteChecked(bool state);
     void slotSpinFocusGained();
     void slotTapClicked();
-    void slotApplyClicked();
     void slotTapTimeout();
 
 private:
@@ -139,45 +134,38 @@ private:
     QDial* m_dial;
     QToolButton* m_plus;
     QToolButton* m_minus;
-    QToolButton* m_mult;
-    QToolButton* m_div;
-    QLabel* m_mulDivFactor;
     FocusSpinBox* m_hrs;
     FocusSpinBox* m_min;
     FocusSpinBox* m_sec;
     FocusSpinBox* m_ms;
     QCheckBox* m_infiniteCheck;
     QPushButton* m_tap;
-    QPushButton* m_apply;
     FocusSpinBox* m_focus;
 
     int m_previousDialValue;
     bool m_preventSignals;
     int m_value;
-    int m_originalValue;
 
     QTime* m_tapTime;
     QTimer* m_tapTickTimer;
     bool m_tapTick;
-
-    int m_currentFactor;
 
     /*************************************************************************
      * Elements visibility
      *************************************************************************/
 public:
     /** Return the widget's elements default visibility bitmask */
-    static ushort defaultVisibilityMask();
+    static quint16 defaultVisibilityMask();
 
     /** Return the widget's elements visibility bitmask */
-    ushort visibilityMask();
+    quint16 visibilityMask();
 
     /** Set the visibility of the widget's elements
       * according to the provided bitmask */
-    void setVisibilityMask(ushort mask);
+    void setVisibilityMask(quint16 mask);
 
 private:
-    ushort m_visibilityMask;
+    quint16 m_visibilityMask;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vccuelistproperties.cpp
+++ b/ui/src/virtualconsole/vccuelistproperties.cpp
@@ -61,7 +61,7 @@ VCCueListProperties::VCCueListProperties(VCCueList* cueList, Doc* doc)
      * Playback Cue List page
      ************************************************************************/
 
-    m_playInputWidget = new InputSelectionWidget(m_doc, this);
+    m_playInputWidget = new InputSelectionWidget(m_doc);
     m_playInputWidget->setKeySequence(m_cueList->playbackKeySequence());
     m_playInputWidget->setInputSource(m_cueList->inputSource(VCCueList::playbackInputSourceId));
     m_playInputWidget->setWidgetPage(m_cueList->page());
@@ -72,7 +72,7 @@ VCCueListProperties::VCCueListProperties(VCCueList* cueList, Doc* doc)
      * Next Cue page
      ************************************************************************/
 
-    m_nextInputWidget = new InputSelectionWidget(m_doc, this);
+    m_nextInputWidget = new InputSelectionWidget(m_doc);
     m_nextInputWidget->setKeySequence(m_cueList->nextKeySequence());
     m_nextInputWidget->setInputSource(m_cueList->inputSource(VCCueList::nextInputSourceId));
     m_nextInputWidget->setWidgetPage(m_cueList->page());
@@ -83,7 +83,7 @@ VCCueListProperties::VCCueListProperties(VCCueList* cueList, Doc* doc)
      * Previous Cue page
      ************************************************************************/
 
-    m_prevInputWidget = new InputSelectionWidget(m_doc, this);
+    m_prevInputWidget = new InputSelectionWidget(m_doc);
     m_prevInputWidget->setKeySequence(m_cueList->previousKeySequence());
     m_prevInputWidget->setInputSource(m_cueList->inputSource(VCCueList::previousInputSourceId));
     m_prevInputWidget->setWidgetPage(m_cueList->page());
@@ -99,7 +99,7 @@ VCCueListProperties::VCCueListProperties(VCCueList* cueList, Doc* doc)
     else
         m_crossFadeRadio->setChecked(true);
 
-    m_crossfade1InputWidget = new InputSelectionWidget(m_doc, this);
+    m_crossfade1InputWidget = new InputSelectionWidget(m_doc);
     m_crossfade1InputWidget->setTitle(tr("Left Fader"));
     m_crossfade1InputWidget->setKeyInputVisibility(false);
     m_crossfade1InputWidget->setInputSource(m_cueList->inputSource(VCCueList::cf1InputSourceId));
@@ -109,7 +109,7 @@ VCCueListProperties::VCCueListProperties(VCCueList* cueList, Doc* doc)
     connect(m_crossfade1InputWidget, SIGNAL(autoDetectToggled(bool)),
             this, SLOT(slotCF1AutoDetectionToggled(bool)));
 
-    m_crossfade2InputWidget = new InputSelectionWidget(m_doc, this);
+    m_crossfade2InputWidget = new InputSelectionWidget(m_doc);
     m_crossfade2InputWidget->setTitle(tr("Right Fader"));
     m_crossfade2InputWidget->setKeyInputVisibility(false);
     m_crossfade2InputWidget->setInputSource(m_cueList->inputSource(VCCueList::cf2InputSourceId));

--- a/ui/src/virtualconsole/vcspeeddial.h
+++ b/ui/src/virtualconsole/vcspeeddial.h
@@ -30,6 +30,9 @@ class SpeedDial;
 class VCSpeedDialFunction;
 class VCSpeedDialPreset;
 class FlowLayout;
+class QLabel;
+class QPushButton;
+class QToolButton;
 
 /** @addtogroup ui_vc_props
  * @{
@@ -41,7 +44,14 @@ class FlowLayout;
 #define KXMLQLCVCSpeedDialAbsoluteValueMin "Minimum"
 #define KXMLQLCVCSpeedDialAbsoluteValueMax "Maximum"
 #define KXMLQLCVCSpeedDialTap "Tap"
+#define KXMLQLCVCSpeedDialMult "Mult"
+#define KXMLQLCVCSpeedDialDiv "Div"
+#define KXMLQLCVCSpeedDialMultDivReset "MultDivReset"
 #define KXMLQLCVCSpeedDialTapKey "Key"
+#define KXMLQLCVCSpeedDialMultKey "MultKey"
+#define KXMLQLCVCSpeedDialDivKey "DivKey"
+#define KXMLQLCVCSpeedDialMultDivResetKey "MultDivResetKey"
+#define KXMLQLCVCSpeedDialResetFactorOnDialChange "ResetFactorOnDialChange"
 #define KXMLQLCVCSpeedDialVisibilityMask "Visibility"
 #define KXMLQLCVCSpeedDialTime "Time"
 
@@ -55,8 +65,19 @@ class VCSpeedDial : public VCWidget
     Q_DISABLE_COPY(VCSpeedDial)
 
 public:
+    // 0xffff mask is used by SpeedDial.
+    // VCSpeedDial uses the 0xffff0000 mask.
+    enum Visibility
+    {
+        MultDiv    = 0x10000 << 0,
+        Apply      = 0x10000 << 1,
+    };
+
     static const quint8 absoluteInputSourceId;
     static const quint8 tapInputSourceId;
+    static const quint8 multInputSourceId;
+    static const quint8 divInputSourceId;
+    static const quint8 multDivResetInputSourceId;
     static const QSize defaultSize;
 
     /************************************************************************
@@ -136,7 +157,7 @@ public:
 
 private slots:
     /** Catch dial value changes and patch them to controlled functions */
-    void slotDialValueChanged(int ms);
+    void slotDialValueChanged();
 
     /** Catch dial tap button clicks and patch them to controlled functions */
     void slotDialTapped();
@@ -144,7 +165,30 @@ private slots:
 private:
     QList <VCSpeedDialFunction> m_functions;
     SpeedDial* m_dial;
+    QWidget* m_multDivTopSpacer;
+    QToolButton* m_multButton;
+    QLabel* m_multDivLabel;
+    QToolButton* m_divButton;
+    QPushButton* m_multDivResetButton;
+    QLabel* m_multDivResultLabel;
+    QPushButton* m_applyButton;
     FlowLayout* m_presetsLayout;
+
+protected slots:
+    void slotMult();
+    void slotDiv();
+    void slotMultDivReset();
+    void slotMultDivChanged();
+    void slotFactoredValueChanged();
+
+private:
+    qint32 m_currentFactor;
+    qint32 m_factoredValue;
+    bool m_resetFactorOnDialChange;
+
+public:
+    void setResetFactorOnDialChange(bool value);
+    bool resetFactorOnDialChange() const;
 
     /*********************************************************************
      * External input
@@ -161,14 +205,23 @@ protected slots:
      * Tap & presets key sequence handler
      *********************************************************************/
 public:
-    void setKeySequence(const QKeySequence& keySequence);
-    QKeySequence keySequence() const;
+    void setTapKeySequence(const QKeySequence& keySequence);
+    QKeySequence tapKeySequence() const;
+    void setMultKeySequence(const QKeySequence& keySequence);
+    QKeySequence multKeySequence() const;
+    void setDivKeySequence(const QKeySequence& keySequence);
+    QKeySequence divKeySequence() const;
+    void setMultDivResetKeySequence(const QKeySequence& keySequence);
+    QKeySequence multDivResetKeySequence() const;
 
 protected slots:
     void slotKeyPressed(const QKeySequence& keySequence);
 
 protected:
     QKeySequence m_tapKeySequence;
+    QKeySequence m_multKeySequence;
+    QKeySequence m_divKeySequence;
+    QKeySequence m_multDivResetKeySequence;
 
     /************************************************************************
      * Absolute value range
@@ -179,22 +232,22 @@ public:
     uint absoluteValueMax() const;
 
 private:
-    uint m_absoluteValueMin;
-    uint m_absoluteValueMax;
+    quint32 m_absoluteValueMin;
+    quint32 m_absoluteValueMax;
 
     /*************************************************************************
      * Elements visibility
      *************************************************************************/
 public:
     /** Return the widget's elements visibility bitmask */
-    ushort visibilityMask() const;
+    quint32 visibilityMask() const;
 
     /** Set the visibility of the widget's elements
       * according to the provided bitmask */
-    void setVisibilityMask(ushort mask);
+    void setVisibilityMask(quint32 mask);
 
 private:
-    ushort m_visibilityMask;
+    quint32 m_visibilityMask;
 
     /*********************************************************************
      * Presets

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -25,6 +25,7 @@
 #include "ui_vcspeeddialproperties.h"
 #include "qlcinputsource.h"
 
+class InputSelectionWidget;
 class VCSpeedDial;
 class VCSpeedDialFunction;
 class VCSpeedDialPreset;
@@ -69,27 +70,16 @@ private:
     /************************************************************************
      * Input page
      ************************************************************************/
-private:
-    void updateInputSources();
-
 private slots:
-    void slotAutoDetectAbsoluteInputSourceToggled(bool checked);
-    void slotChooseAbsoluteInputSourceClicked();
-    void slotAbsoluteInputValueChanged(quint32 universe, quint32 channel);
-
-    void slotAutoDetectTapInputSourceToggled(bool checked);
-    void slotChooseTapInputSourceClicked();
-    void slotTapInputValueChanged(quint32 universe, quint32 channel);
-
     void slotAbsolutePrecisionCbChecked(bool checked);
 
-    void slotAttachKey();
-    void slotDetachKey();
-
 private:
-    QSharedPointer<QLCInputSource> m_absoluteInputSource;
-    QSharedPointer<QLCInputSource> m_tapInputSource;
-    QKeySequence m_tapKeySequence;
+    InputSelectionWidget *m_absoluteInputWidget;
+    InputSelectionWidget *m_tapInputWidget;
+
+    InputSelectionWidget *m_multInputWidget;
+    InputSelectionWidget *m_divInputWidget;
+    InputSelectionWidget *m_multDivResetInputWidget;
 
     /*********************************************************************
      * Presets

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -171,51 +171,6 @@
           <property name="bottomMargin">
            <number>4</number>
           </property>
-          <item row="1" column="0">
-           <widget class="QLabel" name="m_absoluteInputUniverseLabel">
-            <property name="text">
-             <string>Input Universe</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QLineEdit" name="m_absoluteInputUniverseEdit">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="m_absoluteInputChannelLabel">
-            <property name="text">
-             <string>Input Channel</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QLineEdit" name="m_absoluteInputChannelEdit">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QPushButton" name="m_autoDetectAbsoluteInputButton">
-            <property name="text">
-             <string>Auto Detect</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QPushButton" name="m_chooseAbsoluteInputButton">
-            <property name="text">
-             <string>Choose...</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="m_absoluteRangeLabel">
             <property name="text">
@@ -236,6 +191,9 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0" colspan="3">
+           <layout class="QHBoxLayout" name="m_absoluteInputLayout"/>
+          </item>
          </layout>
         </widget>
        </item>
@@ -244,131 +202,7 @@
          <property name="title">
           <string>Tap</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <property name="topMargin">
-           <number>4</number>
-          </property>
-          <property name="bottomMargin">
-           <number>4</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QGroupBox" name="groupBox">
-            <property name="title">
-             <string>External Input</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_3">
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="m_tapInputUniverseLabel">
-               <property name="text">
-                <string>Input Universe</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1" colspan="2">
-              <widget class="QLineEdit" name="m_tapInputUniverseEdit"/>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="m_tapInputChannelLabel">
-               <property name="text">
-                <string>Input Channel</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1" colspan="2">
-              <widget class="QLineEdit" name="m_tapInputChannelEdit"/>
-             </item>
-             <item row="2" column="1">
-              <widget class="QPushButton" name="m_autoDetectTapInputButton">
-               <property name="text">
-                <string>Auto Detect</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QPushButton" name="m_chooseTapInputButton">
-               <property name="text">
-                <string>Choose...</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QGroupBox" name="groupBox_4">
-            <property name="title">
-             <string>Key combination</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_6">
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item row="0" column="0" colspan="2">
-              <widget class="QLineEdit" name="m_keyEdit">
-               <property name="toolTip">
-                <string>Keyboard combination to control the dial tap</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QToolButton" name="m_attachKey">
-               <property name="toolTip">
-                <string>Set a key combination for this dial</string>
-               </property>
-               <property name="text">
-                <string notr="true">...</string>
-               </property>
-               <property name="icon">
-                <iconset resource="../qlcui.qrc">
-                 <normaloff>:/key_bindings.png</normaloff>:/key_bindings.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>32</width>
-                 <height>32</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QToolButton" name="m_detachKey">
-               <property name="toolTip">
-                <string>Remove the dial's keyboard shortcut key</string>
-               </property>
-               <property name="text">
-                <string notr="true">...</string>
-               </property>
-               <property name="icon">
-                <iconset resource="../qlcui.qrc">
-                 <normaloff>:/fileclose.png</normaloff>:/fileclose.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>32</width>
-                 <height>32</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
+         <layout class="QHBoxLayout" name="m_tapInputLayout"/>
         </widget>
        </item>
        <item>
@@ -386,7 +220,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="Appearance">
       <attribute name="title">
        <string>Appearance</string>
       </attribute>
@@ -395,13 +229,6 @@
         <widget class="QCheckBox" name="m_pmCheck">
          <property name="text">
           <string>Show plus and minus buttons</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="m_mdCheck">
-         <property name="text">
-          <string>Show multiplier and divisor buttons</string>
          </property>
         </widget>
        </item>
@@ -416,13 +243,6 @@
         <widget class="QCheckBox" name="m_tapCheck">
          <property name="text">
           <string>Show the tap button</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="m_applyCheck">
-         <property name="text">
-          <string>Show the apply button</string>
          </property>
         </widget>
        </item>
@@ -455,6 +275,20 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="m_mdCheck">
+         <property name="text">
+          <string>Show multiplier and divisor buttons</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="m_applyCheck">
+         <property name="text">
+          <string>Show the apply button</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -464,6 +298,36 @@
            <width>20</width>
            <height>256</height>
           </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="MultDiv">
+      <attribute name="title">
+       <string>Multiplier</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QCheckBox" name="m_resetFactorOnDialChangeCb">
+         <property name="text">
+          <string>Reset multiplier factor when the dial value changes</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="m_multInputLayout"/>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="m_divInputLayout"/>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="m_multDivResetInputLayout"/>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
         </spacer>
        </item>
@@ -776,77 +640,9 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>m_chooseAbsoluteInputButton</sender>
-   <signal>clicked()</signal>
-   <receiver>VCSpeedDialProperties</receiver>
-   <slot>slotChooseAbsoluteInputSourceClicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>345</x>
-     <y>215</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>394</x>
-     <y>215</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_chooseTapInputButton</sender>
-   <signal>clicked()</signal>
-   <receiver>VCSpeedDialProperties</receiver>
-   <slot>slotChooseTapInputSourceClicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>327</x>
-     <y>354</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>394</x>
-     <y>352</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_autoDetectAbsoluteInputButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>VCSpeedDialProperties</receiver>
-   <slot>slotAutoDetectAbsoluteInputSourceToggled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>200</x>
-     <y>220</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>3</x>
-     <y>209</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_autoDetectTapInputButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>VCSpeedDialProperties</receiver>
-   <slot>slotAutoDetectTapInputSourceToggled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>195</x>
-     <y>355</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>3</x>
-     <y>349</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <slots>
   <slot>slotAddClicked()</slot>
   <slot>slotRemoveClicked()</slot>
-  <slot>slotChooseAbsoluteInputSourceClicked()</slot>
-  <slot>slotChooseTapInputSourceClicked()</slot>
-  <slot>slotAutoDetectAbsoluteInputSourceToggled(bool)</slot>
-  <slot>slotAutoDetectTapInputSourceClicked()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
- The multi/div buttons are applied AFTER the dial's value

- The resulting value is displayed on the side

- There is a reset button to reset the current factor

- There is a checkbox that makes the factor reset when
the dial value changes (example: click on the +/- button
or select a preset)

The speed dial:
![speeddial](https://cloud.githubusercontent.com/assets/428240/10284547/d30bc3e0-6b84-11e5-9b0e-29f4de2f5a97.png)
The properties:
![speeddialproperties](https://cloud.githubusercontent.com/assets/428240/10284548/d3449da0-6b84-11e5-8bc0-8fee415deaa7.png)

- An input can be assigned to each button




I'm not sure about the style, it looks kinda big and ugly, and the result label is not visible enough. (translation: it looks like shit)
But the behavior is less random than the current implementation :)