### PR TITLE
New fixture - LiteCraft LED PAR 64 AT3

### DIFF
--- a/resources/fixtures/LiteCraft-LED-PAR-64-AT3.qxf
+++ b/resources/fixtures/LiteCraft-LED-PAR-64-AT3.qxf
@@ -1,0 +1,105 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
+  <Author>Mihai Andrei</Author>
+ </Creator>
+ <Manufacturer>Litecraft</Manufacturer>
+ <Model>LED PAR 64 AT3</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Red">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Max="255" Min="0">Dimmer</Capability>
+ </Channel>
+ <Channel Name="Green">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Max="255" Min="0">Dimmer</Capability>
+ </Channel>
+ <Channel Name="Blue">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Max="255" Min="0">Dimmer</Capability>
+ </Channel>
+ <Channel Name="Strobe/Speed">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="15" Min="0">No strobe</Capability>
+  <Capability Max="255" Min="16">16 speed values</Capability>
+ </Channel>
+ <Channel Name="Mode">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="35" Min="0">No function</Capability>
+  <Capability Max="71" Min="36">Automatic ramp up</Capability>
+  <Capability Max="107" Min="72">Automatic ramp down</Capability>
+  <Capability Max="143" Min="108">Automatic ramp up/down</Capability>
+  <Capability Max="179" Min="144">Automatic color mix mode</Capability>
+  <Capability Max="215" Min="180">Random 3-colors</Capability>
+  <Capability Max="251" Min="216">Random 7-colors</Capability>
+  <Capability Max="255" Min="252">Audio</Capability>
+ </Channel>
+ <Channel Name="Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Max="255" Min="0">Dimmer</Capability>
+ </Channel>
+ <Channel Name="Color Macro Mode (1/2-Channel Mode)">
+  <Group Byte="0">Colour</Group>
+  <Capability Max="255" Min="0">35 colors + black</Capability>
+ </Channel>
+ <Channel Name="Color Macro Mode (7-Channel Mode)">
+  <Group Byte="0">Colour</Group>
+  <Capability Max="13" Min="0">No macro</Capability>
+  <Capability Max="255" Min="14">Pre-programmed colors</Capability>
+ </Channel>
+ <Mode Name="1 Channel">
+  <Physical>
+   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
+   <Dimensions Width="274" Height="268" Depth="433" Weight="3.5"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="69"/>
+  </Physical>
+  <Channel Number="0">Color Macro Mode (1/2-Channel Mode)</Channel>
+ </Mode>
+ <Mode Name="2-Channel">
+  <Physical>
+   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
+   <Dimensions Width="274" Height="268" Depth="433" Weight="3.5"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="69"/>
+  </Physical>
+  <Channel Number="0">Color Macro Mode (1/2-Channel Mode)</Channel>
+  <Channel Number="1">Dimmer</Channel>
+ </Mode>
+ <Mode Name="3-Channel">
+  <Physical>
+   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
+   <Dimensions Width="274" Height="268" Depth="433" Weight="3.5"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="69"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+ </Mode>
+ <Mode Name="4-Channel">
+  <Physical>
+   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
+   <Dimensions Width="274" Height="268" Depth="433" Weight="3.5"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="69"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">Color Macro Mode (7-Channel Mode)</Channel>
+  <Channel Number="4">Strobe/Speed</Channel>
+  <Channel Number="5">Mode</Channel>
+  <Channel Number="6">Dimmer</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Another simple fixture. There are two 'Color Macro Modes' since the manual is not clear they behave the same and the maths doesn't add up

First description (1/2-channel mode): 35 colours + black => 7 each (245) + 11 for black?
Second description (7-channel mode): 0-13: No macro (RGB mode), 14-255: pre-programmed colors => 35 does not go into this number but 22 would (11 values per colour??).

http://www.qlcplus.org/forum/viewtopic.php?f=3&t=8987