### PR TITLE
New fixture - Kam-iLink-All-Colour-Models

### DIFF
--- a/resources/fixtures/Kam-iLink-All-Colour-Models.qxf
+++ b/resources/fixtures/Kam-iLink-All-Colour-Models.qxf
@@ -1,0 +1,214 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
+  <Author>boxr</Author>
+ </Creator>
+ <Manufacturer>Kam</Manufacturer>
+ <Model>iLink - All Colour Models</Model>
+ <Type>Laser</Type>
+ <Channel Name="Mode - Single Colour">
+  <Group Byte="0">Effect</Group>
+  <Capability Color="#000000" Max="63" Min="0">Laser black out</Capability>
+  <Capability Max="127" Min="64">Auto show</Capability>
+  <Capability Max="191" Min="128" Res="Others/Laser/note.png">Sound activated show (music)</Capability>
+  <Capability Max="255" Min="192">DMX mode (other channels activated)</Capability>
+ </Channel>
+ <Channel Name="Patterns">
+  <Group Byte="0">Gobo</Group>
+  <Capability Max="255" Min="0">32 patterns as shown in pattern list</Capability>
+ </Channel>
+ <Channel Name="Zooming">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="127" Min="0" Res="Others/Laser/gradient_down.png">100%-5% size</Capability>
+  <Capability Max="169" Min="128">Zooming in</Capability>
+  <Capability Max="209" Min="170">Zooming out</Capability>
+  <Capability Max="255" Min="210">Zooming in and out</Capability>
+ </Channel>
+ <Channel Name="Y-axis rolling">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="127" Min="0" Res="Others/Laser/gradient_up.png">0-359 degree fixed Y axis rolled</Capability>
+  <Capability Max="191" Min="128" Res="Others/Laser/clockwise.png">Clockwise rolling</Capability>
+  <Capability Max="255" Min="192" Res="Others/Laser/anticlockwise.png">Anticlockwise rolling</Capability>
+ </Channel>
+ <Channel Name="X-axis rolling">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="127" Min="0" Res="Others/Laser/gradient_up.png">0-359 degree fixed X axis rolled</Capability>
+  <Capability Max="191" Min="128" Res="Others/Laser/clockwise.png">Clockwise rolling</Capability>
+  <Capability Max="255" Min="192" Res="Others/Laser/anticlockwise.png">Anticlockwise rolling</Capability>
+ </Channel>
+ <Channel Name="Z-axis rotating">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="127" Min="0" Res="Others/Laser/gradient_up.png">0-359 degree fixed Z axis rotate</Capability>
+  <Capability Max="191" Min="128" Res="Others/Laser/clockwise.png">Clockwise rotating</Capability>
+  <Capability Max="255" Min="192" Res="Others/Laser/anticlockwise.png">Anticlockwise rotating</Capability>
+ </Channel>
+ <Channel Name="X-axis moving">
+  <Group Byte="0">Pan</Group>
+  <Capability Max="128" Min="0">128 different fixed positions on X</Capability>
+  <Capability Max="191" Min="129">Clockwise moving</Capability>
+  <Capability Max="255" Min="192">Anticlockwise moving</Capability>
+ </Channel>
+ <Channel Name="Y-axis moving">
+  <Group Byte="0">Tilt</Group>
+  <Capability Max="127" Min="0">128 different fixed positions on Y</Capability>
+  <Capability Max="191" Min="128">Clockwise moving</Capability>
+  <Capability Max="255" Min="192">Anticlockwise moving</Capability>
+ </Channel>
+ <Channel Name="Mode - red, blue, purple (RBP)">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="29" Min="0">Automatic show with original preprogrammed colour</Capability>
+  <Capability Color="#ff0000" Max="59" Min="30">Auto show with red (colour 1)</Capability>
+  <Capability Color="#0000ff" Max="89" Min="60">Auto show with blue (colour 2)</Capability>
+  <Capability Color="#ff00ff" Max="119" Min="90">Auto show with purple (colour 3)</Capability>
+  <Capability Max="149" Min="120" Res="Others/Laser/note.png">Sound activated show with original preprogrammed colour</Capability>
+  <Capability Max="179" Min="150" Res="Others/Laser/note_red.png">Sound activated show with red (colour 1)</Capability>
+  <Capability Max="209" Min="180" Res="Others/Laser/note_blue.png">Sound activated show with blue (colour 2)</Capability>
+  <Capability Max="239" Min="210" Res="Others/Laser/note_purple.png">Sound activated show with purple (colour 3)</Capability>
+  <Capability Max="255" Min="240">DMX mode</Capability>
+ </Channel>
+ <Channel Name="Colour - red, blue, purple (RBP)">
+  <Group Byte="0">Colour</Group>
+  <Capability Color="#000000" Max="24" Min="0">Blackout</Capability>
+  <Capability Max="49" Min="25">Original preprogrammed colour</Capability>
+  <Capability Color="#ff0000" Max="74" Min="50">Red (colour 1)</Capability>
+  <Capability Color="#0000ff" Max="99" Min="75">Blue (colour 2)</Capability>
+  <Capability Color="#ff00ff" Max="124" Min="100">Purple (colour 3)</Capability>
+  <Capability Color="#ff0000" Max="149" Color2="#0000ff" Min="125">Alternate red (colour 1) and blue (colour 2)</Capability>
+  <Capability Color="#0000ff" Max="174" Color2="#ff00ff" Min="150">Alternate blue (colour 2) and purple (colour 3)</Capability>
+  <Capability Color="#ff0000" Max="199" Color2="#ff00ff" Min="175">Alternate red (colour 1) and purple (colour 3)</Capability>
+  <Capability Max="224" Min="200" Res="Others/Laser/RBP.png">Alternate red (colour 1), blue (colour 2) and purple (colour 3)</Capability>
+  <Capability Max="255" Min="225" Res="Others/Laser/RBP_rolling.png">Colour rolling</Capability>
+ </Channel>
+ <Channel Name="Colour speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Max="4" Min="0">Stop</Capability>
+  <Capability Max="255" Min="5">Slow to fast</Capability>
+ </Channel>
+ <Channel Name="Mode - red, green, yellow (RGY)">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="29" Min="0">Automatic show with original preprogrammed colour</Capability>
+  <Capability Color="#ff0000" Max="59" Min="30">Auto show with red (colour 1)</Capability>
+  <Capability Color="#00ff00" Max="89" Min="60">Auto show with green (colour 2)</Capability>
+  <Capability Color="#ffff00" Max="119" Min="90">Auto show with yellow (colour 3)</Capability>
+  <Capability Max="149" Min="120" Res="Others/Laser/note.png">Sound activated show with original preprogrammed colour</Capability>
+  <Capability Max="179" Min="150" Res="C:/Documents/lights/icons/note_red.png">Sound activated show with red (colour 1)</Capability>
+  <Capability Max="209" Min="180" Res="Others/Laser/note_green.png">Sound activated show with green (colour 2)</Capability>
+  <Capability Max="239" Min="210" Res="Others/Laser/note_yellow.png">Sound activated show with yellow (colour 3)</Capability>
+  <Capability Max="255" Min="240">DMX mode</Capability>
+ </Channel>
+ <Channel Name="Colour - red, green, yellow (RGY)">
+  <Group Byte="0">Colour</Group>
+  <Capability Color="#000000" Max="24" Min="0">Blackout</Capability>
+  <Capability Max="49" Min="25">Original preprogrammed colour</Capability>
+  <Capability Color="#ff0000" Max="74" Min="50">Red (colour 1)</Capability>
+  <Capability Color="#00ff00" Max="99" Min="75">Green (colour 2)</Capability>
+  <Capability Color="#ffff00" Max="124" Min="100">Yellow (colour 3)</Capability>
+  <Capability Color="#ff0000" Max="149" Color2="#00ff00" Min="125">Alternate red (colour 1) and green (colour 2)</Capability>
+  <Capability Color="#00ff00" Max="174" Color2="#ffff00" Min="150">Alternate green (colour 2) and yellow (colour 3)</Capability>
+  <Capability Color="#ff0000" Max="199" Color2="#ffff00" Min="175">Alternate red (colour 1) and yellow (colour 3)</Capability>
+  <Capability Max="224" Min="200" Res="C:/Documents/lights/icons/RGY.png">Alternate red (colour 1), green (colour 2) and yellow (colour 3)</Capability>
+  <Capability Max="255" Min="225" Res="C:/Documents/lights/icons/RGY_rolling.png">Colour rolling</Capability>
+ </Channel>
+ <Channel Name="Mode - green, blue, cyan (GBC)">
+  <Group Byte="0">Effect</Group>
+  <Capability Max="29" Min="0">Automatic show with original preprogrammed colour</Capability>
+  <Capability Color="#00ff00" Max="59" Min="30">Auto show with green (colour 1)</Capability>
+  <Capability Color="#0000ff" Max="89" Min="60">Auto show with blue (colour 2)</Capability>
+  <Capability Color="#00ffff" Max="119" Min="90">Auto show with cyan (colour 3)</Capability>
+  <Capability Max="149" Min="120" Res="Others/Laser/note.png">Sound activated show with original preprogrammed colour</Capability>
+  <Capability Max="179" Min="150" Res="Others/Laser/note_green.png">Sound activated show with green (colour 1)</Capability>
+  <Capability Max="209" Min="180" Res="Others/Laser/note_blue.png">Sound activated show with blue (colour 2)</Capability>
+  <Capability Max="239" Min="210" Res="Others/Laser/note_cyan.png">Sound activated show with cyan (colour 3)</Capability>
+  <Capability Max="255" Min="240">DMX mode</Capability>
+ </Channel>
+ <Channel Name="Colour - green, blue, cyan (GBC)">
+  <Group Byte="0">Colour</Group>
+  <Capability Color="#000000" Max="24" Min="0">Blackout</Capability>
+  <Capability Max="49" Min="25">Original preprogrammed colour</Capability>
+  <Capability Color="#00ff00" Max="74" Min="50">Green (colour 1)</Capability>
+  <Capability Color="#0000ff" Max="99" Min="75">Blue (colour 2)</Capability>
+  <Capability Color="#00ffff" Max="124" Min="100">Cyan (colour 3)</Capability>
+  <Capability Color="#00ff00" Max="149" Color2="#0000ff" Min="125">Alternate green (colour 1) and blue (colour 2)</Capability>
+  <Capability Color="#0000ff" Max="174" Color2="#00ffff" Min="150">Alternate blue (colour 2) and cyan (colour 3)</Capability>
+  <Capability Color="#00ff00" Max="199" Color2="#00ffff" Min="175">Alternate green (colour 1) and cyan (colour 3)</Capability>
+  <Capability Max="224" Min="200" Res="Others/Laser/GBC.png">Alternate green (colour 1), blue (colour 2) and cyan (colour 3)</Capability>
+  <Capability Max="255" Min="225" Res="Others/Laser/GBC_rolling.png">Colour rolling</Capability>
+ </Channel>
+ <Mode Name="Single colour">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type=""/>
+   <Dimensions Height="80" Width="165" Depth="145" Weight="1.5"/>
+   <Lens DegreesMin="0" Name="Other" DegreesMax="0"/>
+   <Focus PanMax="90" TiltMax="90" Type="Fixed"/>
+   <Technical PowerConsumption="12" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Mode - Single Colour</Channel>
+  <Channel Number="1">Patterns</Channel>
+  <Channel Number="2">Zooming</Channel>
+  <Channel Number="3">Y-axis rolling</Channel>
+  <Channel Number="4">X-axis rolling</Channel>
+  <Channel Number="5">Z-axis rotating</Channel>
+  <Channel Number="6">X-axis moving</Channel>
+  <Channel Number="7">Y-axis moving</Channel>
+ </Mode>
+ <Mode Name="Multi-colour - red, blue, purple (RBP)">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type=""/>
+   <Dimensions Height="80" Width="165" Depth="145" Weight="1.5"/>
+   <Lens DegreesMin="0" Name="Other" DegreesMax="0"/>
+   <Focus PanMax="90" TiltMax="90" Type="Fixed"/>
+   <Technical PowerConsumption="12" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Mode - red, blue, purple (RBP)</Channel>
+  <Channel Number="1">Patterns</Channel>
+  <Channel Number="2">Colour - red, blue, purple (RBP)</Channel>
+  <Channel Number="3">Colour speed</Channel>
+  <Channel Number="4">Zooming</Channel>
+  <Channel Number="5">X-axis moving</Channel>
+  <Channel Number="6">Y-axis moving</Channel>
+  <Channel Number="7">Y-axis rolling</Channel>
+  <Channel Number="8">X-axis rolling</Channel>
+  <Channel Number="9">Z-axis rotating</Channel>
+ </Mode>
+ <Mode Name="Multi-colour - green, blue, cyan (GBC)">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type=""/>
+   <Dimensions Height="80" Width="165" Depth="145" Weight="1.5"/>
+   <Lens DegreesMin="0" Name="Other" DegreesMax="0"/>
+   <Focus PanMax="90" TiltMax="90" Type="Fixed"/>
+   <Technical PowerConsumption="12" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Mode - green, blue, cyan (GBC)</Channel>
+  <Channel Number="1">Patterns</Channel>
+  <Channel Number="2">Colour - green, blue, cyan (GBC)</Channel>
+  <Channel Number="3">Colour speed</Channel>
+  <Channel Number="4">Zooming</Channel>
+  <Channel Number="5">X-axis moving</Channel>
+  <Channel Number="6">Y-axis moving</Channel>
+  <Channel Number="7">Y-axis rolling</Channel>
+  <Channel Number="8">X-axis rolling</Channel>
+  <Channel Number="9">Z-axis rotating</Channel>
+ </Mode>
+ <Mode Name="Multi-colour - red, green, yellow (RGY)">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type=""/>
+   <Dimensions Height="80" Width="165" Depth="145" Weight="1.5"/>
+   <Lens DegreesMin="0" Name="Other" DegreesMax="0"/>
+   <Focus PanMax="90" TiltMax="90" Type="Fixed"/>
+   <Technical PowerConsumption="12" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Mode - red, green, yellow (RGY)</Channel>
+  <Channel Number="1">Patterns</Channel>
+  <Channel Number="2">Colour - red, green, yellow (RGY)</Channel>
+  <Channel Number="3">Colour speed</Channel>
+  <Channel Number="4">Zooming</Channel>
+  <Channel Number="5">X-axis moving</Channel>
+  <Channel Number="6">Y-axis moving</Channel>
+  <Channel Number="7">Y-axis rolling</Channel>
+  <Channel Number="8">X-axis rolling</Channel>
+  <Channel Number="9">Z-axis rotating</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
I created this definition ages ago but never submitted it...

This covers 5 fixtures: iLink Blue 500, Green, GBC, RBP, RGY

http://www.kam.co.uk/index.php?action=product_category&category_id=30