### PR TITLE
New fixture - Acme-LED-MS50A-Genesis-Move

### DIFF
--- a/resources/fixtures/Acme-LED-MS50A-Genesis-Move.qxf
+++ b/resources/fixtures/Acme-LED-MS50A-Genesis-Move.qxf
@@ -1,0 +1,266 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
+  <Author>jaqueza@gmx.com</Author>
+ </Creator>
+ <Manufacturer>Acme</Manufacturer>
+ <Model>LED-MS50A Genesis Move</Model>
+ <Type>Moving Head</Type>
+ <Channel Name="Pan">
+  <Group Byte="0">Pan</Group>
+  <Capability Min="0" Max="255">0°-540°</Capability>
+ </Channel>
+ <Channel Name="Tilt">
+  <Group Byte="0">Tilt</Group>
+  <Capability Min="0" Max="255">0°-270°</Capability>
+ </Channel>
+ <Channel Name="Pan/Tilt Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Fast to slow</Capability>
+ </Channel>
+ <Channel Name="Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0%-100%</Capability>
+ </Channel>
+ <Channel Name="Shutter">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="7">Blackout</Capability>
+  <Capability Min="8" Max="15">Open</Capability>
+  <Capability Min="16" Max="131">Strobe, slow to fast</Capability>
+  <Capability Min="132" Max="139">Open</Capability>
+  <Capability Min="140" Max="181">Fast close, slow open</Capability>
+  <Capability Min="182" Max="189">Open</Capability>
+  <Capability Min="190" Max="231">Slow close, fast open</Capability>
+  <Capability Min="232" Max="239">Open</Capability>
+  <Capability Min="240" Max="247">Random strobe</Capability>
+  <Capability Min="248" Max="255">Open</Capability>
+ </Channel>
+ <Channel Name="No Function">
+  <Group Byte="0">Nothing</Group>
+ </Channel>
+ <Channel Name="Gobo 2">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="7">White</Capability>
+  <Capability Min="8" Res="Acme/gobo00008.png" Max="14">1</Capability>
+  <Capability Min="15" Res="Acme/gobo00009.png" Max="21">2</Capability>
+  <Capability Min="22" Res="Acme/gobo00010.png" Max="28">3</Capability>
+  <Capability Min="29" Res="Acme/gobo00011.png" Max="35">4</Capability>
+  <Capability Min="36" Res="Acme/gobo00012.png" Max="42">5</Capability>
+  <Capability Min="43" Res="Acme/gobo00013.png" Max="49">6</Capability>
+  <Capability Min="50" Res="Acme/gobo00014.png" Max="56">7</Capability>
+  <Capability Min="57" Res="Acme/gobo00015.png" Max="63">8</Capability>
+  <Capability Min="64" Max="71">1 shaking</Capability>
+  <Capability Min="72" Max="79">2 shaking</Capability>
+  <Capability Min="80" Max="87">3 shaking</Capability>
+  <Capability Min="88" Max="95">4 shaking</Capability>
+  <Capability Min="96" Max="103">5 shaking</Capability>
+  <Capability Min="104" Max="111">6 shaking</Capability>
+  <Capability Min="112" Max="119">7 shaking</Capability>
+  <Capability Min="120" Max="127">8 shaking</Capability>
+  <Capability Min="128" Max="189">Rotation clockwise, slow to fast</Capability>
+  <Capability Min="190" Max="193">Stop</Capability>
+  <Capability Min="194" Max="255">Rotation anticlockwise, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Gobo1 Rotation">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="127">Index</Capability>
+  <Capability Min="128" Max="189">Anticlockwise, fast to slow</Capability>
+  <Capability Min="190" Max="193">Stopped</Capability>
+  <Capability Min="200" Max="255">Clockwise, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Prism">
+  <Group Byte="0">Prism</Group>
+  <Capability Min="0" Max="7">Off</Capability>
+  <Capability Min="8" Max="255">On</Capability>
+ </Channel>
+ <Channel Name="Focus">
+  <Group Byte="0">Beam</Group>
+  <Capability Min="0" Max="255">Focus</Capability>
+ </Channel>
+ <Channel Name="Pan Fine">
+  <Group Byte="1">Pan</Group>
+  <Capability Min="0" Max="255">Pan Fine</Capability>
+ </Channel>
+ <Channel Name="Tilt Fine">
+  <Group Byte="1">Tilt</Group>
+  <Capability Min="0" Max="255">Tilt Fine</Capability>
+ </Channel>
+ <Channel Name="Function">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="69">No function</Capability>
+  <Capability Min="70" Max="79">Enable blackout while pan/tilt move</Capability>
+  <Capability Min="80" Max="89">Disable blackout while pan/tilt move</Capability>
+  <Capability Min="90" Max="99">Enable blackout while color change</Capability>
+  <Capability Min="100" Max="109">Disable blackout while color change</Capability>
+  <Capability Min="110" Max="119">Enable blackout while gobo change</Capability>
+  <Capability Min="120" Max="129">Disable blackout while gobo change</Capability>
+  <Capability Min="130" Max="199">No function</Capability>
+  <Capability Min="200" Max="209">Reset all</Capability>
+  <Capability Min="210" Max="249">No function</Capability>
+  <Capability Min="250" Max="255">Sound active</Capability>
+ </Channel>
+ <Channel Name="Prism Rotation">
+  <Group Byte="0">Prism</Group>
+  <Capability Min="0" Max="127">Stopped</Capability>
+  <Capability Min="128" Max="189">Anticlockwise, fast to slow</Capability>
+  <Capability Min="190" Max="193">Stopped</Capability>
+  <Capability Min="194" Max="255">Clockwise, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Color Wheel (Split Color)">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Color="#ffffff" Max="7">White</Capability>
+  <Capability Min="8" Color="#ffffff" Color2="#ffff00" Max="14">C1 white + yellow</Capability>
+  <Capability Min="15" Color="#ffff00" Max="22">C2 yellow</Capability>
+  <Capability Min="23" Color="#ffff00" Color2="#0055ff" Max="29">C3 yellow + light blue</Capability>
+  <Capability Min="30" Color="#0055ff" Max="37">C4 light blue</Capability>
+  <Capability Min="38" Color="#0055ff" Color2="#00ff00" Max="44">C5 light blue + green</Capability>
+  <Capability Min="45" Color="#00ff00" Max="52">C6 green</Capability>
+  <Capability Min="53" Color="#00ff00" Color2="#ff0000" Max="59">C7 green + red</Capability>
+  <Capability Min="60" Color="#ff0000" Max="67">C8 red</Capability>
+  <Capability Min="68" Color="#ff0000" Color2="#ff00ff" Max="74">C9 red + magenta</Capability>
+  <Capability Min="75" Color="#ff00ff" Max="82">C10 magenta</Capability>
+  <Capability Min="83" Color="#ff00ff" Color2="#0000ff" Max="89">C11 magenta + blue</Capability>
+  <Capability Min="90" Color="#0000ff" Max="97">C12 blue</Capability>
+  <Capability Min="98" Color="#0000ff" Color2="#ff5500" Max="104">C13 blue + orange</Capability>
+  <Capability Min="105" Color="#ff5500" Max="127">C14 orange</Capability>
+  <Capability Min="128" Max="189">Rotation anticlockwise, fast to slow</Capability>
+  <Capability Min="190" Max="193">Stop</Capability>
+  <Capability Min="194" Max="255">Rotation clockwise, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Colour Wheel (Normal)">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="14">White</Capability>
+  <Capability Min="15" Color="#ffff00" Max="28">C1 yellow</Capability>
+  <Capability Min="29" Color="#0055ff" Max="42">C2 light blue</Capability>
+  <Capability Min="43" Max="56">C3 green</Capability>
+  <Capability Min="57" Color="#ff0000" Max="70">C4 red</Capability>
+  <Capability Min="71" Color="#ff00ff" Max="84">C5 magenta</Capability>
+  <Capability Min="85" Color="#0000ff" Max="98">C6 blue</Capability>
+  <Capability Min="99" Color="#ff5500" Max="127">C7 orange</Capability>
+  <Capability Min="128" Max="189">Rotation anticlockwise, fast to slow</Capability>
+  <Capability Min="190" Max="193">Stop</Capability>
+  <Capability Min="194" Max="255">Rotation clockwise, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Gobo 1">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="7">White</Capability>
+  <Capability Min="8" Res="Acme/gobo00008.png" Max="15">1</Capability>
+  <Capability Min="16" Res="Acme/gobo00009.png" Max="23">2</Capability>
+  <Capability Min="24" Res="Acme/gobo00010.png" Max="31">3</Capability>
+  <Capability Min="32" Res="Acme/gobo00011.png" Max="39">4</Capability>
+  <Capability Min="40" Res="Acme/gobo00012.png" Max="47">5</Capability>
+  <Capability Min="48" Res="Acme/gobo00013.png" Max="55">6</Capability>
+  <Capability Min="56" Res="Acme/gobo00014.png" Max="63">7</Capability>
+  <Capability Min="64" Max="73">1 shaking</Capability>
+  <Capability Min="74" Max="82">2 shaking</Capability>
+  <Capability Min="83" Max="91">3 shaking</Capability>
+  <Capability Min="92" Max="100">4 shaking</Capability>
+  <Capability Min="101" Max="109">5 shaking</Capability>
+  <Capability Min="110" Max="118">6 shaking</Capability>
+  <Capability Min="119" Max="127">7 shaking</Capability>
+  <Capability Min="128" Max="189">Rotation clockwise, slow to fast</Capability>
+  <Capability Min="190" Max="193">Stop</Capability>
+  <Capability Min="194" Max="255">Rotation anticlockwise, slow to fast</Capability>
+ </Channel>
+ <Mode Name="16Ch Split Colour">
+  <Physical>
+   <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
+   <Dimensions Height="247" Weight="10.2" Depth="437" Width="299"/>
+   <Lens DegreesMax="17" DegreesMin="17" Name="Other"/>
+   <Focus Type="Fixed" PanMax="540" TiltMax="270"/>
+   <Technical PowerConsumption="130" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Tilt</Channel>
+  <Channel Number="2">Pan/Tilt Speed</Channel>
+  <Channel Number="3">Dimmer</Channel>
+  <Channel Number="4">Shutter</Channel>
+  <Channel Number="5">Color Wheel (Split Color)</Channel>
+  <Channel Number="6">No Function</Channel>
+  <Channel Number="7">Gobo 2</Channel>
+  <Channel Number="8">Gobo 1</Channel>
+  <Channel Number="9">Gobo1 Rotation</Channel>
+  <Channel Number="10">Prism</Channel>
+  <Channel Number="11">Prism Rotation</Channel>
+  <Channel Number="12">Focus</Channel>
+  <Channel Number="13">Pan Fine</Channel>
+  <Channel Number="14">Tilt Fine</Channel>
+  <Channel Number="15">Function</Channel>
+ </Mode>
+ <Mode Name="16Ch Normal Colour">
+  <Physical>
+   <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
+   <Dimensions Height="247" Weight="10.2" Depth="437" Width="299"/>
+   <Lens DegreesMax="17" DegreesMin="17" Name="Other"/>
+   <Focus Type="Fixed" PanMax="540" TiltMax="270"/>
+   <Technical PowerConsumption="130" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Tilt</Channel>
+  <Channel Number="2">Pan/Tilt Speed</Channel>
+  <Channel Number="3">Dimmer</Channel>
+  <Channel Number="4">Shutter</Channel>
+  <Channel Number="5">Colour Wheel (Normal)</Channel>
+  <Channel Number="6">No Function</Channel>
+  <Channel Number="7">Gobo 2</Channel>
+  <Channel Number="8">Gobo 1</Channel>
+  <Channel Number="9">Gobo1 Rotation</Channel>
+  <Channel Number="10">Prism</Channel>
+  <Channel Number="11">Prism Rotation</Channel>
+  <Channel Number="12">Focus</Channel>
+  <Channel Number="13">Pan Fine</Channel>
+  <Channel Number="14">Tilt Fine</Channel>
+  <Channel Number="15">Function</Channel>
+ </Mode>
+ <Mode Name="15Ch Split Colour">
+  <Physical>
+   <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
+   <Dimensions Height="247" Weight="10.2" Depth="437" Width="299"/>
+   <Lens DegreesMax="17" DegreesMin="17" Name="Other"/>
+   <Focus Type="Fixed" PanMax="540" TiltMax="270"/>
+   <Technical PowerConsumption="130" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Pan Fine</Channel>
+  <Channel Number="2">Tilt</Channel>
+  <Channel Number="3">Tilt Fine</Channel>
+  <Channel Number="4">Pan/Tilt Speed</Channel>
+  <Channel Number="5">Dimmer</Channel>
+  <Channel Number="6">Shutter</Channel>
+  <Channel Number="7">Color Wheel (Split Color)</Channel>
+  <Channel Number="8">Gobo 1</Channel>
+  <Channel Number="9">Gobo1 Rotation</Channel>
+  <Channel Number="10">Gobo 2</Channel>
+  <Channel Number="11">Prism</Channel>
+  <Channel Number="12">Prism Rotation</Channel>
+  <Channel Number="13">Focus</Channel>
+  <Channel Number="14">Function</Channel>
+ </Mode>
+ <Mode Name="15Ch Normal Colour">
+  <Physical>
+   <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
+   <Dimensions Height="247" Weight="10.2" Depth="437" Width="299"/>
+   <Lens DegreesMax="17" DegreesMin="17" Name="Other"/>
+   <Focus Type="Fixed" PanMax="540" TiltMax="270"/>
+   <Technical PowerConsumption="130" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Pan Fine</Channel>
+  <Channel Number="2">Tilt</Channel>
+  <Channel Number="3">Tilt Fine</Channel>
+  <Channel Number="4">Pan/Tilt Speed</Channel>
+  <Channel Number="5">Dimmer</Channel>
+  <Channel Number="6">Shutter</Channel>
+  <Channel Number="7">Colour Wheel (Normal)</Channel>
+  <Channel Number="8">Gobo 1</Channel>
+  <Channel Number="9">Gobo1 Rotation</Channel>
+  <Channel Number="10">Gobo 2</Channel>
+  <Channel Number="11">Prism</Channel>
+  <Channel Number="12">Prism Rotation</Channel>
+  <Channel Number="13">Focus</Channel>
+  <Channel Number="14">Function</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Original post here:

http://www.qlcplus.org/forum/viewtopic.php?f=3&t=9015

Datasheet pdf directly from google search.

I have removed the gobos from this definition. There are some images we could use but others are unique (see page 13).

This fixture is almost identical to the Acme MS350A apart from gobo colours and gobo ordering (I will add later)