### PR TITLE
DMX monitor: Show data from passthrough

### DIFF
--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -58,6 +58,7 @@ Universe::Universe(quint32 id, GrandMaster *gm, QObject *parent)
     , m_preGMValues(new QByteArray(UNIVERSE_SIZE, char(0)))
     , m_postGMValues(new QByteArray(UNIVERSE_SIZE, char(0)))
     , m_lastPostGMValues(new QByteArray(UNIVERSE_SIZE, char(0)))
+    , m_passthroughValues()
 {
     m_relativeValues.fill(0, UNIVERSE_SIZE);
     m_modifiers.fill(NULL, UNIVERSE_SIZE);
@@ -135,6 +136,17 @@ void Universe::setPassthrough(bool enable)
                        this, SLOT(slotInputValueChanged(quint32,quint32,uchar,const QString&)));
     }
 
+    if (enable && m_passthroughValues.isNull())
+    {
+        // When passthrough is disabled, we don't release the array, since it's only ~512 B and
+        // we would have to synchronize with other threads
+
+        // When enabling passthrough, make sure the array is allocated BEFORE m_passthrough is set to
+        // true. That way we only have to check for m_passthrough, and do not need to check 
+        // m_passthroughValues.isNull()
+        m_passthroughValues.reset(new QByteArray(UNIVERSE_SIZE, char(0)));
+    }
+
     m_passthrough = enable;
 
     if (m_inputPatch != NULL)
@@ -169,8 +181,7 @@ void Universe::slotGMValueChanged()
         for (int i = 0; i < m_intensityChannels.size(); ++i)
         {
             int channel = m_intensityChannels.at(i);
-            char chValue(m_preGMValues->at(channel));
-            write(channel, chValue);
+            updatePostGMValue(channel);
         }
     }
 
@@ -179,8 +190,7 @@ void Universe::slotGMValueChanged()
         for (int i = 0; i < m_nonIntensityChannels.size(); ++i)
         {
             int channel = m_nonIntensityChannels.at(i);
-            char chValue(m_preGMValues->at(channel));
-            write(channel, chValue);
+            updatePostGMValue(channel);
         }
     }
 }
@@ -192,10 +202,31 @@ void Universe::slotGMValueChanged()
 void Universe::reset()
 {
     m_preGMValues->fill(0);
-    m_postGMValues->fill(0);
+    if (m_passthrough)
+    {
+        (*m_postGMValues) = (*m_passthroughValues);
+    }
+    else
+    {
+        m_postGMValues->fill(0);
+    }
     zeroRelativeValues();
     m_modifiers.fill(NULL, UNIVERSE_SIZE);
-    m_passthrough = false;
+    m_passthrough = false; // not releasing m_passthroughValues, see comment in setPassthrough
+}
+
+void Universe::applyPassthroughValues(int address, int range)
+{
+    if (!m_passthrough)
+        return;
+
+    for (int i = address; i < address + range && i < UNIVERSE_SIZE; i++)
+    {
+        if (static_cast<uchar>(m_postGMValues->at(i)) < static_cast<uchar>(m_passthroughValues->at(i))) // HTP merge
+        {
+            (*m_postGMValues)[i] = (*m_passthroughValues)[i];
+        }
+    }
 }
 
 void Universe::reset(int address, int range)
@@ -208,6 +239,8 @@ void Universe::reset(int address, int range)
     memset(m_preGMValues->data() + address, 0, range * sizeof(*m_preGMValues->data()));
     memset(m_relativeValues.data() + address, 0, range * sizeof(*m_relativeValues.data()));
     memcpy(m_postGMValues->data() + address, m_modifiedZeroValues->data() + address, range * sizeof(*m_postGMValues->data()));
+
+    applyPassthroughValues(address, range);
 }
 
 void Universe::zeroIntensityChannels()
@@ -218,9 +251,8 @@ void Universe::zeroIntensityChannels()
     {
         short channel = channels[i] >> 16;
         short size = channels[i] & 0xffff;
-
-        memset(m_preGMValues->data() + channel, 0, size * sizeof(*m_preGMValues->data()));
-        memcpy(m_postGMValues->data() + channel, m_modifiedZeroValues->data() + channel, size * sizeof(*m_postGMValues->data()));
+        
+        reset(channel, size);
     }
 }
 
@@ -295,16 +327,24 @@ const QByteArray Universe::preGMValues() const
 uchar Universe::preGMValue(int address) const
 {
     if (address >= m_preGMValues->size())
-        return 0;
+        return 0U;
  
-    return uchar(m_preGMValues->at(address));
+    return static_cast<uchar>(m_preGMValues->at(address));
+}
+
+uchar Universe::applyRelative(int channel, uchar value)
+{
+    if (m_relativeValues[channel] != 0)
+    {
+        int val = m_relativeValues[channel] + value;
+        return CLAMP(val, 0, (int)UCHAR_MAX);
+    }
+
+    return value;
 }
 
 uchar Universe::applyGM(int channel, uchar value)
 {
-    if (value == 0)
-        return (uchar)(*m_modifiedZeroValues)[channel];
-
     if ((m_grandMaster->channelMode() == GrandMaster::Intensity && m_channelsMask->at(channel) & Intensity) ||
         (m_grandMaster->channelMode() == GrandMaster::AllChannels))
     {
@@ -314,10 +354,50 @@ uchar Universe::applyGM(int channel, uchar value)
             value = char(floor((double(value) * m_grandMaster->fraction()) + 0.5));
     }
 
+    return value;
+}
+
+uchar Universe::applyModifiers(int channel, uchar value)
+{
     if (m_modifiers.at(channel) != NULL)
-        value = m_modifiers.at(channel)->getValue(value);
+        return m_modifiers.at(channel)->getValue(value);
 
     return value;
+}
+
+uchar Universe::applyPassthrough(int channel, uchar value)
+{
+    if (m_passthrough)
+    {
+        const uchar passthroughValue = static_cast<uchar>(m_passthroughValues->at(channel));
+        if (value < passthroughValue) // HTP merge
+        {
+            return passthroughValue;
+        }
+    }
+
+    return value;
+}
+
+void Universe::updatePostGMValue(int channel)
+{
+    uchar value = preGMValue(channel);
+
+    value = applyRelative(channel, value);
+
+    if (value == 0)
+    {
+        value = static_cast<uchar>(m_modifiedZeroValues->at(channel));
+    }
+    else
+    {
+        value = applyGM(channel, value);
+        value = applyModifiers(channel, value);
+    }
+
+    value = applyPassthrough(channel, value);
+
+    (*m_postGMValues)[channel] = static_cast<char>(value);
 }
 
 /************************************************************************
@@ -343,7 +423,7 @@ bool Universe::setInputPatch(QLCIOPlugin *plugin,
             return true;
 
         m_inputPatch = new InputPatch(m_id, this);
-        if (passthrough() == false)
+        if (!m_passthrough)
             connect(m_inputPatch, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)),
                     this, SIGNAL(inputValueChanged(quint32,quint32,uchar,QString)));
         else
@@ -354,7 +434,7 @@ bool Universe::setInputPatch(QLCIOPlugin *plugin,
     {
         if (input == QLCIOPlugin::invalidLine())
         {
-            if (passthrough() == false)
+            if (!m_passthrough)
                 disconnect(m_inputPatch, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)),
                         this, SIGNAL(inputValueChanged(quint32,quint32,uchar,QString)));
             else
@@ -470,10 +550,22 @@ void Universe::flushInput()
 
 void Universe::slotInputValueChanged(quint32 universe, quint32 channel, uchar value, const QString &key)
 {
-    if (m_passthrough == true)
+    if (m_passthrough)
     {
         if (universe == m_id)
-            write(channel, value);
+        {
+            qDebug() << "write" << channel << value;
+
+            if (channel >= UNIVERSE_SIZE)
+                return;
+
+            if (channel >= m_usedChannels)
+                m_usedChannels = channel + 1;
+
+            (*m_passthroughValues)[channel] = value;
+
+            updatePostGMValue(channel);
+        }
     }
     else
         emit inputValueChanged(universe, channel, value, key);
@@ -616,13 +708,7 @@ bool Universe::write(int channel, uchar value, bool forceLTP)
 
     (*m_preGMValues)[channel] = char(value);
 
-    if (m_relativeValues[channel] != 0)
-    {
-        int val = m_relativeValues[channel] + value; // value == (uchar)m_preGMValues->at(channel)
-        value = CLAMP(val, 0, (int)UCHAR_MAX);
-    }
-
-    (*m_postGMValues)[channel] = applyGM(channel, value);
+    updatePostGMValue(channel);
 
     return true;
 }
@@ -639,11 +725,7 @@ bool Universe::writeRelative(int channel, uchar value)
 
     m_relativeValues[channel] += value - RELATIVE_ZERO;
 
-    int val = m_relativeValues[channel];
-    val += (uchar)m_preGMValues->at(channel);
-    value = CLAMP(val, 0, (int)UCHAR_MAX);
-
-    (*m_postGMValues)[channel] = applyGM(channel, value);
+    updatePostGMValue(channel);
 
     return true;
 }
@@ -694,7 +776,7 @@ bool Universe::writeBlended(int channel, uchar value, Universe::BlendMode blend)
         break;
     }
 
-    (*m_postGMValues)[channel] = applyGM(channel, value);
+    updatePostGMValue(channel);
 
     return true;
 }

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -167,6 +167,11 @@ protected:
      */
     uchar applyGM(int channel, uchar value);
 
+    uchar applyRelative(int channel, uchar value);
+    uchar applyModifiers(int channel, uchar value);
+    uchar applyPassthrough(int channel, uchar value);
+    void updatePostGMValue(int channel);
+
 signals:
     void nameChanged();
 
@@ -347,6 +352,9 @@ public:
     void zeroRelativeValues();
 
 protected:
+    void applyPassthroughValues(int address, int range);
+
+protected:
     /**
      * Number of channels used in this universe to optimize the dump to plugins.
      * This is a dynamic counter that can only increase depending on the
@@ -385,6 +393,9 @@ protected:
     QScopedPointer<QByteArray> m_postGMValues;
     /** Array of the last preGM values written before the zeroIntensityChannels call  */
     QScopedPointer<QByteArray> m_lastPostGMValues;
+
+    /** Array of values from input line, when passtrhough is enabled */
+    QScopedPointer<QByteArray> m_passthroughValues;
 
     QVector<short> m_relativeValues;
 


### PR DESCRIPTION
Change processing of DMX input data so that:
- the input data is not affected by the grandmaster and channel modifiers
- the input data is merged with QLC+ in a HTP fashion (for all channels, regardless of channel settings)
- the input data is shown in DMX monitor

Usage scenarios:
- QLC+ as DMX sniffer (this requires to patch enough dimmer channels)
- QLC+ as DMX visualizer (in 2D view mode, requires proper fixture patching)
- QLC+ on raspberry just forwards data from QLC+ on PC while programming scenes;
  when the workspace is transferred, Raspberry becomes main controller; the devices are
  always connected to RPi