### PR TITLE
Fixture update - Chauvet-DMX-Mega-Strobe-III

### DIFF
--- a/resources/fixtures/Chauvet-DMX-Mega-Strobe-III.qxf
+++ b/resources/fixtures/Chauvet-DMX-Mega-Strobe-III.qxf
@@ -1,51 +1,33 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE FixtureDefinition>
-<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
  <Creator>
-  <Name>Q Light Controller</Name>
-  <Version>3.0.7</Version>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
   <Author>eklynx</Author>
  </Creator>
  <Manufacturer>Chauvet</Manufacturer>
  <Model>DMX Mega Strobe III</Model>
  <Type>Strobe</Type>
- <Channel Name="Speed / Mode (DMX)">
-  <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="211">Slow -&gt; Fast</Capability>
-  <Capability Min="212" Max="255">Sound Triggered</Capability>
+ <Channel Name="Speed/Mode/Blinder Function">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="42">Slow &lt;-> fast/No function</Capability>
+  <Capability Min="43" Max="211">Slow &lt;-> fast/Blinder (requires ch. 2 to be at DMX value 000)</Capability>
+  <Capability Min="212" Max="255">Sound triggered/No function</Capability>
  </Channel>
- <Channel Name="Dimmer (DMX)">
+ <Channel Name="Dimmer">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Low -&gt; High</Capability>
+  <Capability Min="0" Max="255">Low &lt;-> high (0 for Blinder effect)</Capability>
  </Channel>
- <Channel Name="Speed / Mode (Blinder)">
-  <Group Byte="0">Speed</Group>
-  <Capability Min="43" Max="211">Blinder</Capability>
- </Channel>
- <Channel Name="Dimmer (Blinder)">
-  <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="0">MUST be 0 for Blinder</Capability>
- </Channel>
- <Mode Name="Standard DMX">
+ <Mode Name="Standard">
   <Physical>
-   <Bulb Lumens="0" Type="" ColourTemperature="0"/>
-   <Dimensions Width="0" Height="0" Weight="0" Depth="0"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="0" DmxConnector="5-pin"/>
+   <Bulb Type="CH-750B" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Depth="147" Width="330" Weight="4.2" Height="211"/>
+   <Lens DegreesMax="0" DegreesMin="0" Name="Other"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="75" DmxConnector="3-pin"/>
   </Physical>
-  <Channel Number="0">Speed / Mode (DMX)</Channel>
-  <Channel Number="1">Dimmer (DMX)</Channel>
- </Mode>
- <Mode Name="Blinder Mode">
-  <Physical>
-   <Bulb Lumens="0" Type="CH-750B 750W" ColourTemperature="0"/>
-   <Dimensions Width="330" Height="211" Weight="5" Depth="147"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="0" DmxConnector="3-pin"/>
-  </Physical>
-  <Channel Number="0">Speed / Mode (Blinder)</Channel>
-  <Channel Number="1">Dimmer (Blinder)</Channel>
+  <Channel Number="0">Speed/Mode/Blinder Function</Channel>
+  <Channel Number="1">Dimmer</Channel>
  </Mode>
 </FixtureDefinition>


### PR DESCRIPTION
Added physical data, deleted Blaster Modes (it's an effect, not a mode).

Entered power as 75W (1/10th of bulb power - guessed).

Google:

chauvet dmx medastrobe iii