### PR TITLE
Fixture update - Chauvet-SlimPAR-Pro-RGBA

### DIFF
--- a/resources/fixtures/Chauvet-SlimPAR-Pro-RGBA.qxf
+++ b/resources/fixtures/Chauvet-SlimPAR-Pro-RGBA.qxf
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
+  <Author>JL Griffin</Author>
+ </Creator>
+ <Manufacturer>Chauvet</Manufacturer>
+ <Model>SlimPAR Pro RGBA</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Master Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0%~100%</Capability>
+ </Channel>
+ <Channel Name="Red">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">0%~100%</Capability>
+ </Channel>
+ <Channel Name="Green">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">0%~100%</Capability>
+ </Channel>
+ <Channel Name="Blue">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">0%~100%</Capability>
+ </Channel>
+ <Channel Name="Amber">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Amber</Colour>
+  <Capability Min="0" Max="255">0%~100%</Capability>
+ </Channel>
+ <Channel Name="Color Macro">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="10">No function</Capability>
+  <Capability Min="11" Max="30" Color="#ff0000" Color2="#ffff00">Red 100%, green (0~100%), blue 0%</Capability>
+  <Capability Min="31" Max="50" Color="#ffff00" Color2="#00ff00">Red (100~0%), green 100%, blue 0%</Capability>
+  <Capability Min="51" Max="70" Color="#00ff00" Color2="#00ffff">Red 0%, green 100%, blue (0~100%)</Capability>
+  <Capability Min="71" Max="90" Color="#00ffff" Color2="#0000ff">Red 0%, green (100~0%), blue 100%</Capability>
+  <Capability Min="91" Max="110" Color="#0000ff" Color2="#ff00ff">Red (0~100%), green 0%, blue 100%</Capability>
+  <Capability Min="111" Max="130" Color="#ff00ff" Color2="#ff0000">Red 100%, green 0%, blue (100~0%)</Capability>
+  <Capability Min="131" Max="150" Color="#ffff00" Color2="#ff00ff">Red 100%, green (100~0%), blue (0~100%)</Capability>
+  <Capability Min="151" Max="170" Color="#ffff00" Color2="#0000ff">Red (100~0%), green (100~0%), blue 100%</Capability>
+  <Capability Min="171" Max="200" Color="#ffdf80">Red 100%, green 100%, blue 100%, amber 100%</Capability>
+  <Capability Min="201" Max="205" Color="#ffbc76">White 1: 3,200 K</Capability>
+  <Capability Min="206" Max="210" Color="#ffc07f">White 2: 3,400 K</Capability>
+  <Capability Min="211" Max="215" Color="#ffd3a7">White 3: 4,200 K</Capability>
+  <Capability Min="216" Max="220" Color="#ffe5ce">White 4: 4,900 K</Capability>
+  <Capability Min="221" Max="225" Color="#fff1ea">White 5: 5,600 K</Capability>
+  <Capability Min="226" Max="230" Color="#fff1ea">White 6: 5,900 K</Capability>
+  <Capability Min="231" Max="235" Color="#fff9ff">White 7: 6,500 K</Capability>
+  <Capability Min="236" Max="240" Color="#e0e7ff">White 8: 7,200 K</Capability>
+  <Capability Min="241" Max="245" Color="#e0e7ff">White 9: 8,000 K</Capability>
+  <Capability Min="246" Max="250" Color="#e0e7ff">White 10: 8,500 K</Capability>
+  <Capability Min="251" Max="255" Color="#e0e7ff">White 11: 10,000 K</Capability>
+ </Channel>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="9">No function</Capability>
+  <Capability Min="10" Max="255">1~20 Hz (slow~fast)</Capability>
+ </Channel>
+ <Channel Name="Auto Program">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="51">No function</Capability>
+  <Capability Min="52" Max="101">1</Capability>
+  <Capability Min="102" Max="152">2</Capability>
+  <Capability Min="153" Max="203">3</Capability>
+  <Capability Min="204" Max="254">4</Capability>
+  <Capability Min="255" Max="255">5</Capability>
+ </Channel>
+ <Channel Name="Auto Program speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">0%~100% (slow~fast)</Capability>
+ </Channel>
+ <Channel Name="Dimmer Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="51">Default</Capability>
+  <Capability Min="52" Max="101">Linear</Capability>
+  <Capability Min="102" Max="152">Non-linear 1</Capability>
+  <Capability Min="153" Max="203">Non-linear 2</Capability>
+  <Capability Min="204" Max="255">Non-linear 3</Capability>
+ </Channel>
+ <Mode Name="4-Ch">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type="LED"/>
+   <Dimensions Depth="87" Weight="2.8" Width="256" Height="290"/>
+   <Lens DegreesMax="15" Name="Other" DegreesMin="15"/>
+   <Focus PanMax="0" TiltMax="0" Type="Fixed"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">Amber</Channel>
+ </Mode>
+ <Mode Name="5-Ch">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type="LED"/>
+   <Dimensions Depth="87" Weight="2.8" Width="256" Height="290"/>
+   <Lens DegreesMax="15" Name="Other" DegreesMin="15"/>
+   <Focus PanMax="0" TiltMax="0" Type="Fixed"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">Red</Channel>
+  <Channel Number="2">Green</Channel>
+  <Channel Number="3">Blue</Channel>
+  <Channel Number="4">Amber</Channel>
+ </Mode>
+ <Mode Name="10-Ch">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type="LED"/>
+   <Dimensions Depth="87" Weight="2.8" Width="256" Height="290"/>
+   <Lens DegreesMax="15" Name="Other" DegreesMin="15"/>
+   <Focus PanMax="0" TiltMax="0" Type="Fixed"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">Red</Channel>
+  <Channel Number="2">Green</Channel>
+  <Channel Number="3">Blue</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">Color Macro</Channel>
+  <Channel Number="6">Strobe</Channel>
+  <Channel Number="7">Auto Program</Channel>
+  <Channel Number="8">Auto Program speed</Channel>
+  <Channel Number="9">Dimmer Speed</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Added physical data and missing 10-channel mode with associated channels.

Datasheet:
http://www.chauvetlighting.co.uk/slim-par-pro-rgba.html