### PR TITLE
Fixture update - Chauvet-SlimPAR-Pro-VW

### DIFF
--- a/resources/fixtures/Chauvet-SlimPAR-Pro-VW.qxf
+++ b/resources/fixtures/Chauvet-SlimPAR-Pro-VW.qxf
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://qlcplus.sourceforge.net/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.9.1</Version>
+  <Author>JL Griffin</Author>
+ </Creator>
+ <Manufacturer>Chauvet</Manufacturer>
+ <Model>SlimPAR Pro VW</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0-100%</Capability>
+ </Channel>
+ <Channel Name="Warm White">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">0-100%</Capability>
+ </Channel>
+ <Channel Name="Cool White">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">0-100%</Capability>
+ </Channel>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="9">No function</Capability>
+  <Capability Min="10" Max="255">0-20Hz, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Auto Program">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="51">No function</Capability>
+  <Capability Min="52" Max="101">1</Capability>
+  <Capability Min="102" Max="152">2</Capability>
+  <Capability Min="153" Max="203">3</Capability>
+  <Capability Min="204" Max="254">4</Capability>
+  <Capability Min="255" Max="255">5</Capability>
+ </Channel>
+ <Channel Name="Auto Program Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">0-100%, slow to fast</Capability>
+ </Channel>
+ <Channel Name="Dimming Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="51">Default</Capability>
+  <Capability Min="52" Max="101">Linear</Capability>
+  <Capability Min="102" Max="152">Non-linear 1</Capability>
+  <Capability Min="153" Max="203">Non-linear 2</Capability>
+  <Capability Min="204" Max="255">Non-linear 3</Capability>
+ </Channel>
+ <Mode Name="2-Channel">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type="LED"/>
+   <Dimensions Depth="87" Weight="2.8" Width="256" Height="285"/>
+   <Lens DegreesMax="21" Name="Other" DegreesMin="21"/>
+   <Focus PanMax="0" TiltMax="0" Type="Fixed"/>
+   <Technical PowerConsumption="83" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Warm White</Channel>
+  <Channel Number="1">Cool White</Channel>
+ </Mode>
+ <Mode Name="3-Channel">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type="LED"/>
+   <Dimensions Depth="87" Weight="2.8" Width="256" Height="285"/>
+   <Lens DegreesMax="21" Name="Other" DegreesMin="21"/>
+   <Focus PanMax="0" TiltMax="0" Type="Fixed"/>
+   <Technical PowerConsumption="83" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Warm White</Channel>
+  <Channel Number="2">Cool White</Channel>
+ </Mode>
+ <Mode Name="10-Channel">
+  <Physical>
+   <Bulb Lumens="0" ColourTemperature="0" Type="LED"/>
+   <Dimensions Depth="87" Weight="2.8" Width="256" Height="285"/>
+   <Lens DegreesMax="21" Name="Other" DegreesMin="21"/>
+   <Focus PanMax="0" TiltMax="0" Type="Fixed"/>
+   <Technical PowerConsumption="83" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Warm White</Channel>
+  <Channel Number="2">Cool White</Channel>
+  <Channel Number="3">Strobe</Channel>
+  <Channel Number="4">Auto Program</Channel>
+  <Channel Number="5">Auto Program Speed</Channel>
+  <Channel Number="6">Dimming Speed</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Updated physical info and added 7-channel mode and related channels. NOTE: I entered 10-channel instead of 7 as the mode. Please update before adding.

Datasheet

http://www.chauvetlighting.co.uk/slimpar-pro-vw.html