### PR TITLE
Add manual sort for presets on vcxypad

### DIFF
--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -524,10 +524,11 @@ void VCXYPadProperties::selectItemOnPresetsTree(quint8 presetId)
         if (treeItem->data(0, Qt::UserRole).toUInt() == presetId)
         {
             treeItem->setSelected(true);
-            m_presetsTree->blockSignals(false);
-            return;
+            break;
         }
     }
+
+    m_presetsTree->blockSignals(false);
 }
 
 void VCXYPadProperties::updateTreeItem(const VCXYPadPreset &preset)

--- a/ui/src/virtualconsole/vcxypadproperties.h
+++ b/ui/src/virtualconsole/vcxypadproperties.h
@@ -97,9 +97,16 @@ public:
 
 private:
     void updatePresetsTree();
+    void selectItemOnPresetsTree(quint8 presetId);
     void updateTreeItem(VCXYPadPreset const& preset);
     VCXYPadPreset *getSelectedPreset();
     void removePreset(quint8 id);
+
+    //move preset up and swap id with previous preset. Return new preset id.
+    quint8 moveUpPreset(quint8 id);
+
+    //move preset down and swap id with the next preset. Return new preset id.
+    quint8 moveDownPreset(quint8 id);
 
 protected slots:
     void slotAddPositionClicked();
@@ -107,6 +114,8 @@ protected slots:
     void slotAddSceneClicked();
     void slotAddFixtureGroupClicked();
     void slotRemovePresetClicked();
+    void slotMoveUpPresetClicked();
+    void slotMoveDownPresetClicked();
     void slotPresetNameEdited(QString const& newName);
     void slotPresetSelectionChanged();
     void slotXYPadPositionChanged(const QPointF& pt);

--- a/ui/src/virtualconsole/vcxypadproperties.ui
+++ b/ui/src/virtualconsole/vcxypadproperties.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
+    <width>546</width>
     <height>472</height>
    </rect>
   </property>
@@ -27,7 +27,7 @@
    <item row="1" column="0">
     <widget class="QTabWidget" name="m_tab">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="general">
       <attribute name="title">
@@ -360,6 +360,28 @@
              <property name="icon">
               <iconset resource="../qlcui.qrc">
                <normaloff>:/edit_remove.png</normaloff>:/edit_remove.png</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="m_moveUpPresetButton">
+             <property name="text">
+              <string>Move Up</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../qlcui.qrc">
+               <normaloff>:/up.png</normaloff>:/up.png</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="m_moveDownPresetButton">
+             <property name="text">
+              <string>Move Down</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../qlcui.qrc">
+               <normaloff>:/down.png</normaloff>:/down.png</iconset>
              </property>
             </widget>
            </item>

--- a/ui/src/virtualconsole/vcxypadproperties.ui
+++ b/ui/src/virtualconsole/vcxypadproperties.ui
@@ -27,7 +27,7 @@
    <item row="1" column="0">
     <widget class="QTabWidget" name="m_tab">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="general">
       <attribute name="title">


### PR DESCRIPTION
Hi everyone, this pull request add the possibility to manual sorting presets on vcxypad, that is very usefull for widgets with a high preset number.
I have implemented the behaviour and look & feel with up/down buttons similar to other components.

![preset sorting](https://cloud.githubusercontent.com/assets/11348993/10885565/2d9cf202-817e-11e5-9938-57547c2a15e3.png)
