### PR TITLE
Fixture update - Showtec-Spectral-CYC650

### DIFF
--- a/resources/fixtures/Showtec-Spectral-CYC650.qxf
+++ b/resources/fixtures/Showtec-Spectral-CYC650.qxf
@@ -1,190 +1,190 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE FixtureDefinition>
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
   <Name>Q Light Controller Plus</Name>
-  <Version>4.6.0</Version>
+  <Version>4.10.1</Version>
   <Author>NiKoyes</Author>
  </Creator>
  <Manufacturer>Showtec</Manufacturer>
  <Model>Spectral CYC650</Model>
- <Type>Effect</Type>
- <Channel Name="Dimmer">
+ <Type>Color Changer</Type>
+ <Channel Name="Master Dimmer">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Dimmer</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 1 Red">
+ <Channel Name="Block 1 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 1 Green">
+ <Channel Name="Block 1 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 1 Blue">
+ <Channel Name="Block 1 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 2 Red">
+ <Channel Name="Block 2 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 3 Red">
+ <Channel Name="Block 3 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 4 Red">
+ <Channel Name="Block 4 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 5 Red">
+ <Channel Name="Block 5 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 6 Red">
+ <Channel Name="Block 6 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 7 Red">
+ <Channel Name="Block 7 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 8 Red">
+ <Channel Name="Block 8 Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Red</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 2 Green">
+ <Channel Name="Block 2 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 3 Green">
+ <Channel Name="Block 3 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 4 Green">
+ <Channel Name="Block 4 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 5 Green">
+ <Channel Name="Block 5 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 6 Green">
+ <Channel Name="Block 6 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 7 Green">
+ <Channel Name="Block 7 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 8 Green">
+ <Channel Name="Block 8 Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 2 Blue">
+ <Channel Name="Block 2 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 3 Blue">
+ <Channel Name="Block 3 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 4 Blue">
+ <Channel Name="Block 4 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 5 Blue">
+ <Channel Name="Block 5 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 6 Blue">
+ <Channel Name="Block 6 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 7 Blue">
+ <Channel Name="Block 7 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Pixel 8 Blue">
+ <Channel Name="Block 8 Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Red">
+ <Channel Name="Red/Step Time">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255"/>
+  <Capability Min="0" Max="255">0 - 100%/Step time, if ch7 is set to custom 01-10 (only if ch7 161-255)</Capability>
  </Channel>
- <Channel Name="Green">
+ <Channel Name="Green/Fade Time">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255"/>
+  <Capability Min="0" Max="255">0 - 100%/Fade time, if ch7 is set to custom 01-10 (only if ch7 161-255)</Capability>
  </Channel>
  <Channel Name="Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255"/>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Color Macro">
+ <Channel Name="Macro Colors">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="10">No Function</Capability>
-  <Capability Min="11" Max="30">Color 1</Capability>
-  <Capability Min="31" Max="50">Color 2</Capability>
-  <Capability Min="51" Max="70">Color 3</Capability>
-  <Capability Min="71" Max="90">Color 4</Capability>
-  <Capability Min="91" Max="110">Color 5</Capability>
-  <Capability Min="111" Max="130">Color 6</Capability>
-  <Capability Min="131" Max="150">Color 7</Capability>
-  <Capability Min="151" Max="170">Color 8</Capability>
-  <Capability Min="171" Max="200">RGB W 100</Capability>
-  <Capability Min="201" Max="205">White 1: 3200K</Capability>
-  <Capability Min="206" Max="210">White 2: 3400K</Capability>
-  <Capability Min="211" Max="215">White 3: 4200K</Capability>
-  <Capability Min="216" Max="220">White 4: 4900K</Capability>
-  <Capability Min="221" Max="225">White 5: 5600K</Capability>
-  <Capability Min="226" Max="230">White 6: 5900K</Capability>
-  <Capability Min="231" Max="235">White 7: 6500K</Capability>
-  <Capability Min="236" Max="240">White 8: 7200K</Capability>
-  <Capability Min="241" Max="245">White 9: 8000K</Capability>
-  <Capability Min="246" Max="250">White 10: 8500K</Capability>
-  <Capability Min="251" Max="255">White 11: 10000K</Capability>
+  <Capability Min="0" Max="10">No function</Capability>
+  <Capability Color2="#ffff00" Min="11" Color="#ff0000" Max="30">Red 100% / green up / blue 0%</Capability>
+  <Capability Color2="#00ff00" Min="31" Color="#ffff00" Max="50">Red down / green 100% / blue 0%</Capability>
+  <Capability Color2="#00ffff" Min="51" Color="#00ff00" Max="70">Red 0% / green 100% / blue up</Capability>
+  <Capability Color2="#0000ff" Min="71" Color="#00ffff" Max="90">Red 0% / green down / blue 100%</Capability>
+  <Capability Color2="#ff00ff" Min="91" Color="#0000ff" Max="110">Red up /green 0% / blue 100%</Capability>
+  <Capability Color2="#ff0000" Min="111" Color="#ff00ff" Max="130">Red 100% / green 0% / blue down</Capability>
+  <Capability Color2="#ffffff" Min="131" Color="#ff0000" Max="150">Red 100% / green up / blue up</Capability>
+  <Capability Color2="#0000ff" Min="151" Color="#ffffff" Max="170">Red down / green down / blue 100%</Capability>
+  <Capability Min="171" Color="#ffffff" Max="200">Red 100% / green 100% / blue 100%</Capability>
+  <Capability Min="201" Color="#ffbc76" Max="205">White 1: 3200K</Capability>
+  <Capability Min="206" Color="#ffc07f" Max="210">White 2: 3400K</Capability>
+  <Capability Min="211" Color="#ffd3a7" Max="215">White 3: 4200K</Capability>
+  <Capability Min="216" Color="#ffe5ce" Max="220">White 4: 4900K</Capability>
+  <Capability Min="221" Color="#fff1ea" Max="225">White 5: 5600K</Capability>
+  <Capability Min="226" Color="#fff1ea" Max="230">White 6: 5900K</Capability>
+  <Capability Min="231" Color="#fff9ff" Max="235">White 7: 6500K</Capability>
+  <Capability Min="236" Color="#e0e7ff" Max="240">White 8: 7200K</Capability>
+  <Capability Min="241" Color="#e0e7ff" Max="245">White 9: 8000K</Capability>
+  <Capability Min="246" Color="#e0e7ff" Max="250">White 10: 8500K</Capability>
+  <Capability Min="251" Color="#e0e7ff" Max="255">White 11: 10000K</Capability>
  </Channel>
  <Channel Name="Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="10">No Function</Capability>
+  <Capability Min="0" Max="10">No function</Capability>
   <Capability Min="11" Max="255">1 - 20 Hz</Capability>
  </Channel>
- <Channel Name="Auto - Prog - Controls">
+ <Channel Name="Auto + Custom">
   <Group Byte="0">Maintenance</Group>
-  <Capability Min="0" Max="10">No Function</Capability>
-  <Capability Min="11" Max="20">Fan OFF (3sec)</Capability>
-  <Capability Min="21" Max="30">Fan Low (3sec)</Capability>
-  <Capability Min="31" Max="40">Fan Normal (3sec)</Capability>
-  <Capability Min="41" Max="50">Fan High (3sec)</Capability>
-  <Capability Min="51" Max="60">Fan Auto (3sec)</Capability>
+  <Capability Min="0" Max="10">No function</Capability>
+  <Capability Min="11" Max="20">Fans off (after 3 seconds)</Capability>
+  <Capability Min="21" Max="30">Fans low (after 3 seconds)</Capability>
+  <Capability Min="31" Max="40">Fans normal (after 3 seconds)</Capability>
+  <Capability Min="41" Max="50">Fans high (after 3 seconds)</Capability>
+  <Capability Min="51" Max="60">Fan auto (after 3 seconds)</Capability>
   <Capability Min="61" Max="70">Auto 1</Capability>
   <Capability Min="71" Max="80">Auto 2</Capability>
   <Capability Min="81" Max="90">Auto 3</Capability>
@@ -208,193 +208,245 @@
  </Channel>
  <Channel Name="Auto Speed">
   <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="255">Only when CH7 Auto</Capability>
+  <Capability Min="0" Max="255">If ch7 is set to auto 1-auto 10 (only if ch7 061-160)</Capability>
  </Channel>
  <Channel Name="Dimmer Speed">
   <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="9">Preset Dimmer Speed (from menu)</Capability>
-  <Capability Min="10" Max="29">Linear Dimmer</Capability>
-  <Capability Min="30" Max="69">Non Linear 1 (fastest)</Capability>
-  <Capability Min="70" Max="129">Non Linear 2</Capability>
-  <Capability Min="130" Max="189">Non Linear 3</Capability>
-  <Capability Min="190" Max="255">Non Linear 4 (slowest)</Capability>
+  <Capability Min="0" Max="9">Preset dimmer speed from display menu</Capability>
+  <Capability Min="10" Max="29">Linear dimmer</Capability>
+  <Capability Min="30" Max="69">Non linear 1 (fastest)</Capability>
+  <Capability Min="70" Max="129">Non linear 2</Capability>
+  <Capability Min="130" Max="189">Non linear 3</Capability>
+  <Capability Min="190" Max="255">Non linear 4 (slowest)</Capability>
  </Channel>
  <Channel Name="Block">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="19">Block 1-8</Capability>
-  <Capability Min="20" Max="39">Block 1-2</Capability>
-  <Capability Min="40" Max="59">Block 3-4</Capability>
-  <Capability Min="60" Max="79">Block 5-6</Capability>
-  <Capability Min="80" Max="99">Block 7-8</Capability>
-  <Capability Min="100" Max="119">Block 1234</Capability>
-  <Capability Min="120" Max="139">Block 1256</Capability>
-  <Capability Min="140" Max="159">Block 1278</Capability>
-  <Capability Min="160" Max="179">Block 3456</Capability>
-  <Capability Min="180" Max="199">Block 3478</Capability>
-  <Capability Min="200" Max="219">Block 5678</Capability>
-  <Capability Min="220" Max="239">No Function</Capability>
-  <Capability Min="240" Max="255">Block 1-8</Capability>
+  <Capability Min="20" Max="39">Block 1, block 2</Capability>
+  <Capability Min="40" Max="59">Block 3, block 4</Capability>
+  <Capability Min="60" Max="79">Block 5, block 6</Capability>
+  <Capability Min="80" Max="99">Block 7, block 8</Capability>
+  <Capability Min="100" Max="119">Block 1, block 2, block 3, block 4</Capability>
+  <Capability Min="120" Max="139">Block 1, block 2, block 5, block 6</Capability>
+  <Capability Min="140" Max="159">Block 1, block 2, block 7, block 8</Capability>
+  <Capability Min="160" Max="179">Block 3, block 4, block 5, block 6</Capability>
+  <Capability Min="180" Max="199">Block 3, block 4, block 7, block 8</Capability>
+  <Capability Min="200" Max="219">Block 5, block 6, block 7, block 8</Capability>
+  <Capability Min="220" Max="239">No function</Capability>
+  <Capability Min="240" Max="255">Block 1, block 2, block 3, block 4</Capability>
  </Channel>
- <Channel Name="Hue">
-  <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255"/>
+ <Channel Name="ID Address Selection">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="9">All IDs</Capability>
+  <Capability Min="10" Max="19">ID 1</Capability>
+  <Capability Min="20" Max="29">ID 2</Capability>
+  <Capability Min="30" Max="39">ID 3</Capability>
+  <Capability Min="40" Max="49">ID 4</Capability>
+  <Capability Min="50" Max="59">ID 5</Capability>
+  <Capability Min="60" Max="69">ID 6</Capability>
+  <Capability Min="70" Max="79">ID 7</Capability>
+  <Capability Min="80" Max="89">ID 8</Capability>
+  <Capability Min="90" Max="99">ID 9</Capability>
+  <Capability Min="100" Max="109">ID 10</Capability>
+  <Capability Min="110" Max="119">ID 11</Capability>
+  <Capability Min="120" Max="129">ID 12</Capability>
+  <Capability Min="130" Max="139">ID 13</Capability>
+  <Capability Min="140" Max="149">ID 14</Capability>
+  <Capability Min="150" Max="159">ID 15</Capability>
+  <Capability Min="160" Max="169">ID 16</Capability>
+  <Capability Min="170" Max="179">ID 17</Capability>
+  <Capability Min="180" Max="189">ID 18</Capability>
+  <Capability Min="190" Max="199">ID 19</Capability>
+  <Capability Min="200" Max="209">ID 20</Capability>
+  <Capability Min="210" Max="210">ID 21</Capability>
+  <Capability Min="211" Max="211">ID 22</Capability>
+  <Capability Min="212" Max="212">ID 23</Capability>
+  <Capability Min="213" Max="213">ID 24</Capability>
+  <Capability Min="214" Max="214">ID 25</Capability>
+  <Capability Min="215" Max="215">ID 26</Capability>
+  <Capability Min="216" Max="216">ID 27</Capability>
+  <Capability Min="217" Max="217">ID 28</Capability>
+  <Capability Min="218" Max="218">ID 29</Capability>
+  <Capability Min="219" Max="219">ID 30</Capability>
+  <Capability Min="220" Max="220">ID 31</Capability>
+  <Capability Min="221" Max="221">ID 32</Capability>
+  <Capability Min="222" Max="222">ID 33</Capability>
+  <Capability Min="223" Max="223">ID 34</Capability>
+  <Capability Min="224" Max="224">ID 35</Capability>
+  <Capability Min="225" Max="225">ID 36</Capability>
+  <Capability Min="226" Max="226">ID 37</Capability>
+  <Capability Min="227" Max="227">ID 38</Capability>
+  <Capability Min="228" Max="228">ID 39</Capability>
+  <Capability Min="229" Max="229">ID 40</Capability>
+  <Capability Min="230" Max="230">ID 41</Capability>
+  <Capability Min="231" Max="231">ID 42</Capability>
+  <Capability Min="232" Max="232">ID 43</Capability>
+  <Capability Min="233" Max="233">ID 44</Capability>
+  <Capability Min="234" Max="234">ID 45</Capability>
+  <Capability Min="235" Max="235">ID 46</Capability>
+  <Capability Min="236" Max="236">ID 47</Capability>
+  <Capability Min="237" Max="237">ID 48</Capability>
+  <Capability Min="238" Max="238">ID 49</Capability>
+  <Capability Min="239" Max="239">ID 50</Capability>
+  <Capability Min="240" Max="240">ID 51</Capability>
+  <Capability Min="241" Max="241">ID 52</Capability>
+  <Capability Min="242" Max="242">ID 53</Capability>
+  <Capability Min="243" Max="243">ID 54</Capability>
+  <Capability Min="244" Max="244">ID 55</Capability>
+  <Capability Min="245" Max="245">ID 56</Capability>
+  <Capability Min="246" Max="246">ID 57</Capability>
+  <Capability Min="247" Max="247">ID 58</Capability>
+  <Capability Min="248" Max="248">ID 59</Capability>
+  <Capability Min="249" Max="249">ID 60</Capability>
+  <Capability Min="250" Max="250">ID 61</Capability>
+  <Capability Min="251" Max="251">ID 62</Capability>
+  <Capability Min="252" Max="252">ID 63</Capability>
+  <Capability Min="253" Max="253">ID 64</Capability>
+  <Capability Min="254" Max="254">ID 65</Capability>
+  <Capability Min="255" Max="255">ID 66</Capability>
  </Channel>
- <Channel Name="Saturation">
+ <Channel Name="Red">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255"/>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
- <Channel Name="Value">
+ <Channel Name="Green">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255"/>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
  </Channel>
  <Mode Name="Pixel">
   <Physical>
-   <Bulb Lumens="640" Type="LED" ColourTemperature="0"/>
-   <Dimensions Width="500" Height="80" Weight="3.2" Depth="190"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="65" DmxConnector="3-pin"/>
+   <Bulb Lumens="640" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="3.54" Height="88" Width="562" Depth="230"/>
+   <Lens Name="Other" DegreesMin="16" DegreesMax="16"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="82"/>
   </Physical>
-  <Channel Number="0">Pixel 1 Red</Channel>
-  <Channel Number="1">Pixel 1 Green</Channel>
-  <Channel Number="2">Pixel 1 Blue</Channel>
-  <Channel Number="3">Pixel 2 Red</Channel>
-  <Channel Number="4">Pixel 2 Green</Channel>
-  <Channel Number="5">Pixel 2 Blue</Channel>
-  <Channel Number="6">Pixel 3 Red</Channel>
-  <Channel Number="7">Pixel 3 Green</Channel>
-  <Channel Number="8">Pixel 3 Blue</Channel>
-  <Channel Number="9">Pixel 4 Red</Channel>
-  <Channel Number="10">Pixel 4 Green</Channel>
-  <Channel Number="11">Pixel 4 Blue</Channel>
-  <Channel Number="12">Pixel 5 Red</Channel>
-  <Channel Number="13">Pixel 5 Green</Channel>
-  <Channel Number="14">Pixel 5 Blue</Channel>
-  <Channel Number="15">Pixel 6 Red</Channel>
-  <Channel Number="16">Pixel 6 Green</Channel>
-  <Channel Number="17">Pixel 6 Blue</Channel>
-  <Channel Number="18">Pixel 7 Red</Channel>
-  <Channel Number="19">Pixel 7 Green</Channel>
-  <Channel Number="20">Pixel 7 Blue</Channel>
-  <Channel Number="21">Pixel 8 Red</Channel>
-  <Channel Number="22">Pixel 8 Green</Channel>
-  <Channel Number="23">Pixel 8 Blue</Channel>
+  <Channel Number="0">Block 1 Red</Channel>
+  <Channel Number="1">Block 1 Green</Channel>
+  <Channel Number="2">Block 1 Blue</Channel>
+  <Channel Number="3">Block 2 Red</Channel>
+  <Channel Number="4">Block 2 Green</Channel>
+  <Channel Number="5">Block 2 Blue</Channel>
+  <Channel Number="6">Block 3 Red</Channel>
+  <Channel Number="7">Block 3 Green</Channel>
+  <Channel Number="8">Block 3 Blue</Channel>
+  <Channel Number="9">Block 4 Red</Channel>
+  <Channel Number="10">Block 4 Green</Channel>
+  <Channel Number="11">Block 4 Blue</Channel>
+  <Channel Number="12">Block 5 Red</Channel>
+  <Channel Number="13">Block 5 Green</Channel>
+  <Channel Number="14">Block 5 Blue</Channel>
+  <Channel Number="15">Block 6 Red</Channel>
+  <Channel Number="16">Block 6 Green</Channel>
+  <Channel Number="17">Block 6 Blue</Channel>
+  <Channel Number="18">Block 7 Red</Channel>
+  <Channel Number="19">Block 7 Green</Channel>
+  <Channel Number="20">Block 7 Blue</Channel>
+  <Channel Number="21">Block 8 Red</Channel>
+  <Channel Number="22">Block 8 Green</Channel>
+  <Channel Number="23">Block 8 Blue</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
+   <Channel>0</Channel>
    <Channel>2</Channel>
   </Head>
   <Head>
-   <Channel>3</Channel>
-   <Channel>4</Channel>
    <Channel>5</Channel>
+   <Channel>4</Channel>
+   <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>6</Channel>
    <Channel>7</Channel>
+   <Channel>6</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
    <Channel>9</Channel>
-   <Channel>10</Channel>
    <Channel>11</Channel>
+   <Channel>10</Channel>
   </Head>
   <Head>
-   <Channel>12</Channel>
    <Channel>13</Channel>
+   <Channel>12</Channel>
    <Channel>14</Channel>
   </Head>
   <Head>
-   <Channel>17</Channel>
    <Channel>15</Channel>
+   <Channel>17</Channel>
    <Channel>16</Channel>
   </Head>
   <Head>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
    <Channel>20</Channel>
+   <Channel>19</Channel>
+   <Channel>18</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
    <Channel>23</Channel>
+   <Channel>22</Channel>
+   <Channel>21</Channel>
   </Head>
  </Mode>
  <Mode Name="Tour">
   <Physical>
-   <Bulb Lumens="0" Type="" ColourTemperature="0"/>
-   <Dimensions Width="0" Height="0" Weight="0" Depth="0"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="65" DmxConnector="3-pin"/>
+   <Bulb Lumens="640" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="3.54" Height="88" Width="562" Depth="230"/>
+   <Lens Name="Other" DegreesMin="16" DegreesMax="16"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="82"/>
   </Physical>
-  <Channel Number="0">Dimmer</Channel>
-  <Channel Number="1">Red</Channel>
-  <Channel Number="2">Green</Channel>
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">Red/Step Time</Channel>
+  <Channel Number="2">Green/Fade Time</Channel>
   <Channel Number="3">Blue</Channel>
-  <Channel Number="4">Color Macro</Channel>
+  <Channel Number="4">Macro Colors</Channel>
   <Channel Number="5">Strobe</Channel>
-  <Channel Number="6">Auto - Prog - Controls</Channel>
+  <Channel Number="6">Auto + Custom</Channel>
   <Channel Number="7">Auto Speed</Channel>
   <Channel Number="8">Dimmer Speed</Channel>
-  <Channel Number="9">Block</Channel>
+  <Channel Number="9">ID Address Selection</Channel>
+  <Channel Number="10">Block</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
-   <Channel>2</Channel>
+   <Channel>0</Channel>
    <Channel>3</Channel>
+   <Channel>2</Channel>
   </Head>
  </Mode>
  <Mode Name="ARC 1">
   <Physical>
-   <Bulb Lumens="0" Type="" ColourTemperature="0"/>
-   <Dimensions Width="0" Height="0" Weight="0" Depth="0"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="65" DmxConnector="3-pin"/>
+   <Bulb Lumens="640" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="3.54" Height="88" Width="562" Depth="230"/>
+   <Lens Name="Other" DegreesMin="16" DegreesMax="16"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="82"/>
   </Physical>
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
+   <Channel>0</Channel>
    <Channel>2</Channel>
   </Head>
  </Mode>
  <Mode Name="ARC 1+D">
   <Physical>
-   <Bulb Lumens="0" Type="" ColourTemperature="0"/>
-   <Dimensions Width="0" Height="0" Weight="0" Depth="0"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="65" DmxConnector="3-pin"/>
+   <Bulb Lumens="640" ColourTemperature="0" Type="LED"/>
+   <Dimensions Weight="3.54" Height="88" Width="562" Depth="230"/>
+   <Lens Name="Other" DegreesMin="16" DegreesMax="16"/>
+   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Technical DmxConnector="3-pin" PowerConsumption="82"/>
   </Physical>
-  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="0">Master Dimmer</Channel>
   <Channel Number="1">Red</Channel>
   <Channel Number="2">Green</Channel>
   <Channel Number="3">Blue</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
-   <Channel>2</Channel>
+   <Channel>0</Channel>
    <Channel>3</Channel>
-  </Head>
- </Mode>
- <Mode Name="HSV">
-  <Physical>
-   <Bulb Lumens="0" Type="" ColourTemperature="0"/>
-   <Dimensions Width="0" Height="0" Weight="0" Depth="0"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="65" DmxConnector="3-pin"/>
-  </Physical>
-  <Channel Number="0">Hue</Channel>
-  <Channel Number="1">Saturation</Channel>
-  <Channel Number="2">Value</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>2</Channel>
   </Head>
  </Mode>


### PR DESCRIPTION
Physical data added. Tour mode had a missing channel (ID address) so was incorrect in that mode.

Google for datasheet:

showtec spectral cyc650