### PR TITLE
Fixture update - GLP-Junior-Scan-1

### DIFF
--- a/resources/fixtures/GLP-Junior-Scan-1.qxf
+++ b/resources/fixtures/GLP-Junior-Scan-1.qxf
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE FixtureDefinition>
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
-  <Name>Q Light Controller</Name>
-  <Version>2.6.1</Version>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.10.1</Version>
   <Author>Heikki Junnila</Author>
  </Creator>
  <Manufacturer>GLP</Manufacturer>
@@ -11,75 +11,75 @@
  <Type>Scanner</Type>
  <Channel Name="Pan">
   <Group Byte="0">Pan</Group>
-  <Capability Min="0" Max="255">Pan</Capability>
+  <Capability Min="0" Max="255">0° - 230°</Capability>
  </Channel>
  <Channel Name="Tilt">
   <Group Byte="0">Tilt</Group>
-  <Capability Min="0" Max="255">Tilt</Capability>
+  <Capability Min="0" Max="255">0° - 110°</Capability>
  </Channel>
  <Channel Name="Color">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="3">White</Capability>
-  <Capability Min="4" Max="7">Half-color 1</Capability>
-  <Capability Min="8" Max="11">Dark blue</Capability>
-  <Capability Min="12" Max="15">Half-color 2</Capability>
-  <Capability Min="16" Max="19">Dark green</Capability>
-  <Capability Min="20" Max="23">Half-color 3</Capability>
-  <Capability Min="24" Max="27">Light yellow</Capability>
-  <Capability Min="28" Max="31">Half-color 4</Capability>
-  <Capability Min="32" Max="35">Bright blue</Capability>
-  <Capability Min="36" Max="39">Half-color 5</Capability>
-  <Capability Min="40" Max="43">Lavender</Capability>
-  <Capability Min="44" Max="47">Half-color 6</Capability>
-  <Capability Min="48" Max="51">Magenta</Capability>
-  <Capability Min="52" Max="55">Half-color 7</Capability>
-  <Capability Min="56" Max="59">Light blue</Capability>
-  <Capability Min="60" Max="63">Half-color 8</Capability>
-  <Capability Min="64" Max="67">Fire</Capability>
-  <Capability Min="68" Max="71">Half-color 9</Capability>
-  <Capability Min="72" Max="75">Turquoise</Capability>
-  <Capability Min="76" Max="79">Half-color 10</Capability>
-  <Capability Min="80" Max="83">Pink</Capability>
-  <Capability Min="84" Max="87">Half-color 11</Capability>
-  <Capability Min="88" Max="91">Canary</Capability>
-  <Capability Min="92" Max="95">Half-color 12</Capability>
-  <Capability Min="96" Max="99">Golden amber</Capability>
-  <Capability Min="100" Max="103">Half-color 13</Capability>
-  <Capability Min="104" Max="107">Red</Capability>
-  <Capability Min="108" Max="111">Half-color 14</Capability>
-  <Capability Min="112" Max="115">Blue</Capability>
-  <Capability Min="116" Max="119">Half-color 15</Capability>
-  <Capability Min="120" Max="123">Green</Capability>
-  <Capability Min="124" Max="127">Half-color 16</Capability>
+  <Capability Min="0" Max="3" Color="#ffffff">White</Capability>
+  <Capability Min="4" Max="7" Color="#ffffff" Color2="#00007f">Half-color 1</Capability>
+  <Capability Min="8" Max="11" Color="#00007f">Dark blue</Capability>
+  <Capability Min="12" Max="15" Color="#00007f" Color2="#007f00">Half-color 2</Capability>
+  <Capability Min="16" Max="19" Color="#007f00">Dark green</Capability>
+  <Capability Min="20" Max="23" Color="#007f00" Color2="#ffff00">Half-color 3</Capability>
+  <Capability Min="24" Max="27" Color="#ffff00">Light yellow</Capability>
+  <Capability Min="28" Max="31" Color="#ffff00" Color2="#7f7fff">Half-color 4</Capability>
+  <Capability Min="32" Max="35" Color="#7f7fff">Bright blue</Capability>
+  <Capability Min="36" Max="39" Color="#7f7fff" Color2="#fad2ff">Half-color 5</Capability>
+  <Capability Min="40" Max="43" Color="#fad2ff">Lavender</Capability>
+  <Capability Min="44" Max="47" Color="#fad2ff" Color2="#ff00ff">Half-color 6</Capability>
+  <Capability Min="48" Max="51" Color="#ff00ff">Magenta</Capability>
+  <Capability Min="52" Max="55" Color="#ff00ff" Color2="#aaaaff">Half-color 7</Capability>
+  <Capability Min="56" Max="59" Color="#aaaaff">Light blue</Capability>
+  <Capability Min="60" Max="63" Color="#aaaaff" Color2="#ff3232">Half-color 8</Capability>
+  <Capability Min="64" Max="67" Color="#ff3232">Fire</Capability>
+  <Capability Min="68" Max="71" Color="#ff3232" Color2="#40e0d0">Half-color 9</Capability>
+  <Capability Min="72" Max="75" Color="#40e0d0" Color2="#40e0d0">Turquoise</Capability>
+  <Capability Min="76" Max="79" Color="#40e0d0" Color2="#ffaaff">Half-color 10</Capability>
+  <Capability Min="80" Max="83" Color="#ffaaff">Pink</Capability>
+  <Capability Min="84" Max="87" Color="#ffaaff" Color2="#eef66c">Half-color 11</Capability>
+  <Capability Min="88" Max="91" Color="#eef66c">Canary</Capability>
+  <Capability Min="92" Max="95" Color="#eef66c" Color2="#ffaf00">Half-color 12</Capability>
+  <Capability Min="96" Max="99" Color="#ffaf00">Golden amber</Capability>
+  <Capability Min="100" Max="103" Color="#ffaf00" Color2="#ff0000">Half-color 13</Capability>
+  <Capability Min="104" Max="107" Color="#ff0000">Red</Capability>
+  <Capability Min="108" Max="111" Color="#ff0000" Color2="#0000ff">Half-color 14</Capability>
+  <Capability Min="112" Max="115" Color="#0000ff">Blue</Capability>
+  <Capability Min="116" Max="119" Color="#0000ff" Color2="#00ff00">Half-color 15</Capability>
+  <Capability Min="120" Max="123" Color="#00ff00">Green</Capability>
+  <Capability Min="124" Max="127" Color="#00ff00">Half-color 16</Capability>
   <Capability Min="128" Max="131">Multicolor 1</Capability>
   <Capability Min="132" Max="135">Half-color 17</Capability>
   <Capability Min="136" Max="139">Multicolor 2</Capability>
-  <Capability Min="140" Max="253">Rainbow, slow -&gt; fast</Capability>
+  <Capability Min="140" Max="253">Rainbow, slow -> fast</Capability>
   <Capability Min="254" Max="254">Music color chaser slow</Capability>
   <Capability Min="255" Max="255">Music color chaser fast</Capability>
  </Channel>
  <Channel Name="Gobo">
   <Group Byte="0">Gobo</Group>
-  <Capability Min="0" Max="7">Open</Capability>
-  <Capability Min="8" Max="15">Gobo 1</Capability>
-  <Capability Min="16" Max="23">Gobo 2</Capability>
-  <Capability Min="24" Max="31">Gobo 3</Capability>
-  <Capability Min="32" Max="39">Gobo 4</Capability>
-  <Capability Min="40" Max="47">Gobo 5</Capability>
-  <Capability Min="48" Max="55">Gobo 6</Capability>
-  <Capability Min="56" Max="63">Gobo 7</Capability>
-  <Capability Min="64" Max="71">Gobo 8</Capability>
-  <Capability Min="72" Max="79">Gobo 9</Capability>
-  <Capability Min="80" Max="87">Gobo 10</Capability>
-  <Capability Min="88" Max="95">Gobo 11</Capability>
-  <Capability Min="96" Max="103">Gobo 12</Capability>
-  <Capability Min="104" Max="111">Gobo 13</Capability>
+  <Capability Min="0" Max="7" Res="Others/gobo00022.png">Open</Capability>
+  <Capability Min="8" Max="15" Res="GLP/gobo00006.png">Gobo 1</Capability>
+  <Capability Min="16" Max="23" Res="GLP/gobo00003.png">Gobo 2</Capability>
+  <Capability Min="24" Max="31" Res="GLP/gobo00008.png">Gobo 3</Capability>
+  <Capability Min="32" Max="39" Res="GLP/gobo00004.png">Gobo 4</Capability>
+  <Capability Min="40" Max="47" Res="Chauvet/gobo00036.png">Gobo 5</Capability>
+  <Capability Min="48" Max="55" Res="GLP/gobo00012.png">Gobo 6</Capability>
+  <Capability Min="56" Max="63" Res="Others/gobo00006.png">Gobo 7</Capability>
+  <Capability Min="64" Max="71" Res="Others/gobo00039.png">Gobo 8</Capability>
+  <Capability Min="72" Max="79" Res="SGM/gobo00028.png">Gobo 9</Capability>
+  <Capability Min="80" Max="87" Res="ClayPaky/gobo00049.png">Gobo 10</Capability>
+  <Capability Min="88" Max="95" Res="GLP/gobo00005.png">Gobo 11</Capability>
+  <Capability Min="96" Max="103" Res="Others/gobo00015.png">Gobo 12</Capability>
+  <Capability Min="104" Max="111" Res="Robe/gobo00070.png">Gobo 13</Capability>
   <Capability Min="112" Max="119">Gobo 14</Capability>
-  <Capability Min="120" Max="127">Gobo 15</Capability>
-  <Capability Min="128" Max="135">Gobo 16</Capability>
-  <Capability Min="136" Max="143">Gobo 17</Capability>
-  <Capability Min="144" Max="151">Gobo 18</Capability>
-  <Capability Min="152" Max="159">Gobo 19</Capability>
+  <Capability Min="120" Max="127" Res="Robe/gobo00041.png">Gobo 15</Capability>
+  <Capability Min="128" Max="135" Res="Others/gobo00029.png">Gobo 16</Capability>
+  <Capability Min="136" Max="143" Res="GLP/gobo00026.png">Gobo 17</Capability>
+  <Capability Min="144" Max="151" Res="SGM/gobo00063.png">Gobo 18</Capability>
+  <Capability Min="152" Max="159" Res="Robe/gobo00025.png">Gobo 19</Capability>
   <Capability Min="160" Max="253">No function</Capability>
   <Capability Min="254" Max="254">Music gobo chaser slow</Capability>
   <Capability Min="255" Max="255">Music gobo chaser fast</Capability>
@@ -90,13 +90,13 @@
   <Capability Min="9" Max="15">Shutter closed</Capability>
   <Capability Min="16" Max="31">Random shutter</Capability>
   <Capability Min="32" Max="47">Audio shutter</Capability>
-  <Capability Min="48" Max="239">Strobe, slow -&gt; fast</Capability>
+  <Capability Min="48" Max="239">Strobe, slow -> fast</Capability>
   <Capability Min="240" Max="255">Shutter open</Capability>
  </Channel>
  <Channel Name="Speed">
   <Group Byte="0">Speed</Group>
   <Capability Min="0" Max="1">Tracking mode</Capability>
-  <Capability Min="2" Max="255">Vector, slow -&gt; fast</Capability>
+  <Capability Min="2" Max="255">Vector, slow -> fast</Capability>
  </Channel>
  <Channel Name="Movement">
   <Group Byte="0">Effect</Group>
@@ -115,15 +115,15 @@
   <Capability Min="0" Max="15">Laser off</Capability>
   <Capability Min="16" Max="31">Random flashes</Capability>
   <Capability Min="32" Max="47">Audio trigger</Capability>
-  <Capability Min="48" Max="127">Laser strobe, slow -&gt; fast</Capability>
-  <Capability Min="128" Max="239">Laser strobe, slow -&gt; fast</Capability>
+  <Capability Min="48" Max="127">Laser strobe, slow -> fast</Capability>
+  <Capability Min="128" Max="239">Laser strobe, slow -> fast</Capability>
   <Capability Min="240" Max="255">Laser on</Capability>
  </Channel>
  <Channel Name="Special">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="63">No function</Capability>
-  <Capability Min="64" Max="79">Color chaser 1, slow -&gt; fast</Capability>
-  <Capability Min="80" Max="95">Color chaser 2, slow -&gt; fast</Capability>
+  <Capability Min="64" Max="79">Color chaser 1, slow -> fast</Capability>
+  <Capability Min="80" Max="95">Color chaser 2, slow -> fast</Capability>
   <Capability Min="96" Max="111">Pan/tilt audio trigger, slow</Capability>
   <Capability Min="112" Max="127">Pan/tilt audio trigger, fast</Capability>
   <Capability Min="128" Max="143">Pan/tilt random positions</Capability>
@@ -133,10 +133,11 @@
  </Channel>
  <Mode Name="Mode 1">
   <Physical>
-   <Bulb ColourTemperature="0" Lumens="0" Type=""/>
-   <Dimensions Width="0" Height="0" Weight="0" Depth="0"/>
-   <Lens DegreesMax="0" Name="Other" DegreesMin="0"/>
-   <Focus TiltMax="0" PanMax="0" Type="Fixed"/>
+   <Bulb Type="ELC 250W" ColourTemperature="0" Lumens="0"/>
+   <Dimensions Weight="7.5" Depth="210" Height="535" Width="305"/>
+   <Lens DegreesMin="16" Name="Other" DegreesMax="16"/>
+   <Focus TiltMax="110" PanMax="230" Type="Fixed"/>
+   <Technical PowerConsumption="350" DmxConnector="3-pin"/>
   </Physical>
   <Channel Number="0">Pan</Channel>
   <Channel Number="1">Tilt</Channel>


### PR DESCRIPTION
Updated physical data, colours and gobos. A lot of the gobos are approximate.

Found physical data for the '1' model here:

http://www.jenashop.nl/junior-scan1-silver-250w-p-392.html?osCsid=93feainc076io32r6hvlo38024