### PR TITLE
Chauvet q spot 260 led

### DIFF
--- a/resources/fixtures/Chauvet-Q-Spot-260-LED.qxf
+++ b/resources/fixtures/Chauvet-Q-Spot-260-LED.qxf
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE FixtureDefinition>
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
-  <Name>Q Light Controller</Name>
-  <Version>3.2.0-3-r2623</Version>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.10.1</Version>
   <Author>Christopher Enoch</Author>
  </Creator>
  <Manufacturer>Chauvet</Manufacturer>
@@ -11,92 +11,92 @@
  <Type>Moving Head</Type>
  <Channel Name="Pan">
   <Group Byte="0">Pan</Group>
-  <Capability Min="0" Max="255">Pan 0-540 degrees</Capability>
+  <Capability Min="0" Max="255">0~540°</Capability>
  </Channel>
  <Channel Name="Pan Fine">
   <Group Byte="1">Pan</Group>
-  <Capability Min="0" Max="255">Pan Fine</Capability>
+  <Capability Min="0" Max="255">Fine movement control</Capability>
  </Channel>
  <Channel Name="Tilt">
   <Group Byte="0">Tilt</Group>
-  <Capability Min="0" Max="255">Fine 0-270 degrees</Capability>
+  <Capability Min="0" Max="255">0~270°</Capability>
  </Channel>
  <Channel Name="Pan/Tilt Speed">
   <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="255">Pan/Tilt Speed Fast-Slow</Capability>
+  <Capability Min="0" Max="255">Fast~slow</Capability>
  </Channel>
  <Channel Name="Color Wheel">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="16">White</Capability>
-  <Capability Min="17" Max="33">Red</Capability>
-  <Capability Min="34" Max="50">Yellow</Capability>
-  <Capability Min="51" Max="67">Magenta</Capability>
-  <Capability Min="68" Max="84">Green</Capability>
-  <Capability Min="85" Max="101">Orange</Capability>
-  <Capability Min="102" Max="118">Blue</Capability>
-  <Capability Min="119" Max="135">Light Blue</Capability>
-  <Capability Min="136" Max="152">Light Green</Capability>
-  <Capability Min="153" Max="255">Rainbow/Linear</Capability>
+  <Capability Min="0" Color="#ffffff" Max="16">White</Capability>
+  <Capability Min="17" Color="#ff0000" Max="33">Red</Capability>
+  <Capability Min="34" Color="#ffff00" Max="50">Yellow</Capability>
+  <Capability Min="51" Color="#ff00ff" Max="67">Magenta</Capability>
+  <Capability Min="68" Color="#00ff00" Max="84">Green</Capability>
+  <Capability Min="85" Color="#ff7f00" Max="101">Orange</Capability>
+  <Capability Min="102" Color="#0000ff" Max="118">Blue</Capability>
+  <Capability Min="119" Color="#7f7fff" Max="135">Light blue</Capability>
+  <Capability Min="136" Color="#7fff7f" Max="152">Light green</Capability>
+  <Capability Min="153" Max="255" Res="Others/rainbow.png">Rainbow or linear effect</Capability>
  </Channel>
- <Channel Name="Fixed Gobo">
+ <Channel Name="Fixed Gobo Wheel">
   <Group Byte="0">Gobo</Group>
-  <Capability Min="0" Max="9">No Gobo</Capability>
-  <Capability Min="10" Max="19">Gobo 1</Capability>
-  <Capability Min="20" Max="29">Gobo 2</Capability>
-  <Capability Min="30" Max="39">Gobo 3</Capability>
-  <Capability Min="40" Max="49">Gobo 4</Capability>
-  <Capability Min="50" Max="59">Gobo 5</Capability>
-  <Capability Min="60" Max="69">Gobo 6</Capability>
-  <Capability Min="70" Max="79">Gobo 7</Capability>
-  <Capability Min="80" Max="89">Gobo 8</Capability>
-  <Capability Min="90" Max="99">Gobo 9</Capability>
-  <Capability Min="100" Max="114">Shaking Gobo 9</Capability>
-  <Capability Min="115" Max="129">Shaking Gobo 8</Capability>
-  <Capability Min="130" Max="144">Shaking Gobo 7</Capability>
-  <Capability Min="145" Max="159">Shaking Gobo 6</Capability>
-  <Capability Min="160" Max="174">Shaking Gobo 5</Capability>
-  <Capability Min="175" Max="189">Shaking Gobo 4</Capability>
-  <Capability Min="190" Max="204">Shaking Gobo 3</Capability>
-  <Capability Min="205" Max="219">Shaking Gobo 2</Capability>
-  <Capability Min="220" Max="234">Shaking Gobo 1</Capability>
+  <Capability Min="0" Max="9">No</Capability>
+  <Capability Min="10" Max="19">1</Capability>
+  <Capability Min="20" Max="29">2</Capability>
+  <Capability Min="30" Max="39">3</Capability>
+  <Capability Min="40" Max="49">4</Capability>
+  <Capability Min="50" Max="59">5</Capability>
+  <Capability Min="60" Max="69">6</Capability>
+  <Capability Min="70" Max="79">7</Capability>
+  <Capability Min="80" Max="89">8</Capability>
+  <Capability Min="90" Max="99">9</Capability>
+  <Capability Min="100" Max="114">Shaking 9</Capability>
+  <Capability Min="115" Max="129">Shaking 8</Capability>
+  <Capability Min="130" Max="144">Shaking 7</Capability>
+  <Capability Min="145" Max="159">Shaking 6</Capability>
+  <Capability Min="160" Max="174">Shaking 5</Capability>
+  <Capability Min="175" Max="189">Shaking 4</Capability>
+  <Capability Min="190" Max="204">Shaking 3</Capability>
+  <Capability Min="205" Max="219">Shaking 2</Capability>
+  <Capability Min="220" Max="234">Shaking 1</Capability>
   <Capability Min="235" Max="255">Flow effect</Capability>
  </Channel>
- <Channel Name="Rotating Gobo">
+ <Channel Name="Rotating Gobo wheel">
   <Group Byte="0">Gobo</Group>
-  <Capability Min="0" Max="9">No Gobo</Capability>
-  <Capability Min="10" Max="19">Gobo 1</Capability>
-  <Capability Min="20" Max="29">Gobo 2</Capability>
-  <Capability Min="30" Max="39">Gobo 3</Capability>
-  <Capability Min="40" Max="49">Gobo 4</Capability>
-  <Capability Min="50" Max="59">Gobo 5</Capability>
-  <Capability Min="60" Max="69">Gobo 6</Capability>
-  <Capability Min="70" Max="79">Gobo 7</Capability>
-  <Capability Min="80" Max="99">Shaking Gobo 7</Capability>
-  <Capability Min="100" Max="119">Shaking Gobo 6</Capability>
-  <Capability Min="120" Max="139">Shaking Gobo 5</Capability>
-  <Capability Min="140" Max="159">Shaking Gobo 4</Capability>
-  <Capability Min="160" Max="179">Shaking Gobo 3</Capability>
-  <Capability Min="180" Max="199">Shaking Gobo 2</Capability>
-  <Capability Min="200" Max="219">Shaking Gobo 1</Capability>
+  <Capability Min="0" Max="9">No</Capability>
+  <Capability Min="10" Max="19">1</Capability>
+  <Capability Min="20" Max="29">2</Capability>
+  <Capability Min="30" Max="39">3</Capability>
+  <Capability Min="40" Max="49">4</Capability>
+  <Capability Min="50" Max="59">5</Capability>
+  <Capability Min="60" Max="69">6</Capability>
+  <Capability Min="70" Max="79">7</Capability>
+  <Capability Min="80" Max="99">Shaking 7</Capability>
+  <Capability Min="100" Max="119">Shaking 6</Capability>
+  <Capability Min="120" Max="139">Shaking 5</Capability>
+  <Capability Min="140" Max="159">Shaking 4</Capability>
+  <Capability Min="160" Max="179">Shaking 3</Capability>
+  <Capability Min="180" Max="199">Shaking 2</Capability>
+  <Capability Min="200" Max="219">Shaking 1</Capability>
   <Capability Min="220" Max="255">Flow effect</Capability>
  </Channel>
  <Channel Name="Gobo Rotation">
   <Group Byte="0">Gobo</Group>
   <Capability Min="0" Max="60">Gobo Indexing</Capability>
-  <Capability Min="61" Max="158">CW rotation (slow-fast)</Capability>
-  <Capability Min="159" Max="255">CCW rotation (slow-fast)</Capability>
+  <Capability Min="61" Max="158">Clockwise rotation from slow to fast</Capability>
+  <Capability Min="159" Max="255">Anticlockwise rotation from slow to fast</Capability>
  </Channel>
  <Channel Name="Tilt Fine">
   <Group Byte="1">Tilt</Group>
-  <Capability Min="0" Max="255"/>
+  <Capability Min="0" Max="255">Fine movement control</Capability>
  </Channel>
  <Channel Name="Rotating Prism">
   <Group Byte="0">Prism</Group>
-  <Capability Min="0" Max="0">No Function</Capability>
+  <Capability Min="0" Max="0">No function</Capability>
   <Capability Min="1" Max="4">Prism engaged (no rotation)</Capability>
-  <Capability Min="5" Max="127">CCW rotation (slow-fast)</Capability>
-  <Capability Min="128" Max="132">No Function</Capability>
-  <Capability Min="133" Max="255">CW rotation (slow-fast)</Capability>
+  <Capability Min="5" Max="127">CCW rotation (slow~fast)</Capability>
+  <Capability Min="128" Max="132">No function</Capability>
+  <Capability Min="133" Max="255">CW rotation (slow~fast)</Capability>
  </Channel>
  <Channel Name="Focus">
   <Group Byte="0">Effect</Group>
@@ -104,40 +104,40 @@
  </Channel>
  <Channel Name="Dimmer">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Dark-Bright</Capability>
+  <Capability Min="0" Max="255">Dark~bright</Capability>
  </Channel>
  <Channel Name="Strobe">
   <Group Byte="0">Shutter</Group>
   <Capability Min="0" Max="31">Close</Capability>
   <Capability Min="32" Max="63">Open</Capability>
-  <Capability Min="64" Max="95">Strobe (slow-fast)</Capability>
+  <Capability Min="64" Max="95">Slow~fast</Capability>
   <Capability Min="96" Max="127">Open</Capability>
-  <Capability Min="128" Max="159">Pulse Strobe Effect (slow-fast)</Capability>
+  <Capability Min="128" Max="159">Pulse strobe effect: slow~fast</Capability>
   <Capability Min="160" Max="191">Open</Capability>
-  <Capability Min="192" Max="223">Random Strobe Effect (slow-fast)</Capability>
+  <Capability Min="192" Max="223">Random strobe effect: slow~fast</Capability>
   <Capability Min="224" Max="255">Open</Capability>
  </Channel>
  <Channel Name="Control">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="19">No function</Capability>
-  <Capability Min="20" Max="39">Pan/tilt black activation (3s delay)</Capability>
-  <Capability Min="40" Max="59">Pan/tilt black deactivation (3s delay)</Capability>
-  <Capability Min="60" Max="79">Auto 1 (3s delay)</Capability>
-  <Capability Min="80" Max="99">Auto 2 (3s delay)</Capability>
-  <Capability Min="100" Max="119">Sound 1 (3s delay)</Capability>
-  <Capability Min="120" Max="139">Sound 2 (3s delay)</Capability>
+  <Capability Min="20" Max="39">Pan/tilt black activation (activated after 3s)</Capability>
+  <Capability Min="40" Max="59">Pan/tilt black deactivation (activated after 3s)</Capability>
+  <Capability Min="60" Max="79">Auto 1 (activated after 3s)</Capability>
+  <Capability Min="80" Max="99">Auto 2 (activated after 3s)</Capability>
+  <Capability Min="100" Max="119">Sound 1 (activated after 3s)</Capability>
+  <Capability Min="120" Max="139">Sound 2 (activated after 3s)</Capability>
   <Capability Min="140" Max="159">Custom</Capability>
-  <Capability Min="160" Max="179">Test (3s delay)</Capability>
+  <Capability Min="160" Max="179">Test (activated after 3s)</Capability>
   <Capability Min="180" Max="199">No function</Capability>
-  <Capability Min="200" Max="219">Reset (3s delay)</Capability>
+  <Capability Min="200" Max="219">Reset (activated after 3s)</Capability>
   <Capability Min="220" Max="255">No function</Capability>
  </Channel>
  <Mode Name="Advanced">
   <Physical>
-   <Bulb Lumens="5400" Type="LED" ColourTemperature="0"/>
-   <Dimensions Width="295" Height="485" Weight="13.6" Depth="290"/>
-   <Lens DegreesMax="15" Name="Other" DegreesMin="15"/>
-   <Focus PanMax="0" Type="Head" TiltMax="0"/>
+   <Bulb Lumens="5400" ColourTemperature="0" Type="LED"/>
+   <Dimensions Height="485" Depth="290" Weight="13.6" Width="295"/>
+   <Lens DegreesMin="15" Name="Other" DegreesMax="15"/>
+   <Focus PanMax="540" Type="Head" TiltMax="270"/>
    <Technical PowerConsumption="150" DmxConnector="3-pin"/>
   </Physical>
   <Channel Number="0">Pan</Channel>
@@ -146,8 +146,8 @@
   <Channel Number="3">Tilt Fine</Channel>
   <Channel Number="4">Pan/Tilt Speed</Channel>
   <Channel Number="5">Color Wheel</Channel>
-  <Channel Number="6">Fixed Gobo</Channel>
-  <Channel Number="7">Rotating Gobo</Channel>
+  <Channel Number="6">Fixed Gobo Wheel</Channel>
+  <Channel Number="7">Rotating Gobo wheel</Channel>
   <Channel Number="8">Gobo Rotation</Channel>
   <Channel Number="9">Rotating Prism</Channel>
   <Channel Number="10">Focus</Channel>
@@ -157,17 +157,17 @@
  </Mode>
  <Mode Name="Basic">
   <Physical>
-   <Bulb Lumens="5400" Type="LED" ColourTemperature="0"/>
-   <Dimensions Width="295" Height="485" Weight="13.6" Depth="290"/>
-   <Lens DegreesMax="15" Name="Other" DegreesMin="15"/>
-   <Focus PanMax="0" Type="Head" TiltMax="0"/>
+   <Bulb Lumens="5400" ColourTemperature="0" Type="LED"/>
+   <Dimensions Height="485" Depth="290" Weight="13.6" Width="295"/>
+   <Lens DegreesMin="15" Name="Other" DegreesMax="15"/>
+   <Focus PanMax="540" Type="Head" TiltMax="270"/>
    <Technical PowerConsumption="150" DmxConnector="3-pin"/>
   </Physical>
   <Channel Number="0">Pan</Channel>
   <Channel Number="1">Tilt</Channel>
   <Channel Number="2">Color Wheel</Channel>
-  <Channel Number="3">Fixed Gobo</Channel>
-  <Channel Number="4">Rotating Gobo</Channel>
+  <Channel Number="3">Fixed Gobo Wheel</Channel>
+  <Channel Number="4">Rotating Gobo wheel</Channel>
   <Channel Number="5">Gobo Rotation</Channel>
   <Channel Number="6">Rotating Prism</Channel>
   <Channel Number="7">Focus</Channel>

--- a/resources/fixtures/Eurolite-KLS200.qxf
+++ b/resources/fixtures/Eurolite-KLS200.qxf
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE FixtureDefinition>
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
-  <Name>Q Light Controller</Name>
-  <Version>3.1.0</Version>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.10.1</Version>
   <Author>Heikki Junnila</Author>
  </Creator>
  <Manufacturer>Eurolite</Manufacturer>
  <Model>KLS200</Model>
  <Type>Color Changer</Type>
- <Channel Name="Internal programs">
+ <Channel Name="Internal Programs, Auto Mode, Sound Countrolled Mode">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="9">Manual Control</Capability>
+  <Capability Min="0" Max="9">Off</Capability>
   <Capability Min="10" Max="29">Program 1</Capability>
   <Capability Min="30" Max="49">Program 2</Capability>
   <Capability Min="50" Max="69">Program 3</Capability>
@@ -23,86 +23,87 @@
   <Capability Min="170" Max="189">Program 9</Capability>
   <Capability Min="190" Max="209">Program 10</Capability>
   <Capability Min="210" Max="229">Program 11</Capability>
-  <Capability Min="230" Max="249">Automatic Control</Capability>
-  <Capability Min="250" Max="255">Music Control</Capability>
+  <Capability Min="230" Max="249">Automatic control</Capability>
+  <Capability Min="250" Max="255">Music control</Capability>
  </Channel>
  <Channel Name="Master Dimmer">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Dimmer</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="255">Strobe Speed</Capability>
+  <Capability Min="0" Max="9">Off</Capability>
+  <Capability Min="10" Max="255">Flash, with increasing speed</Capability>
  </Channel>
  <Channel Name="Spot 1: Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Spot 1: Red</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 1: Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Spot 1: Green</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 1: Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Spot 1: Green</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 2: Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Spot 2: Red</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 2: Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Spot 2: Green</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 2: Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Spot 2: Blue</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 3: Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Spot 3: Red</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 3: Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Spot 3: Green</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 3: Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Spot 3: Blue</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 4: Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255">Spot 4: Red</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 4: Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Spot 4: Green</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Channel Name="Spot 4: Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Spot 4: Blue</Capability>
+  <Capability Min="0" Max="255">Dimming from 0 - 100%</Capability>
  </Channel>
  <Mode Name="Mode 1">
   <Physical>
    <Bulb Lumens="0" Type="LED" ColourTemperature="0"/>
-   <Dimensions Width="0" Height="0" Weight="3" Depth="0"/>
-   <Lens DegreesMax="0" Name="PC" DegreesMin="0"/>
-   <Focus PanMax="0" Type="Fixed" TiltMax="0"/>
-   <Technical PowerConsumption="70" DmxConnector="3-pin"/>
+   <Dimensions Width="1110" Depth="59" Weight="3" Height="295"/>
+   <Lens DegreesMin="25" DegreesMax="25" Name="Other"/>
+   <Focus Type="25" TiltMax="0" PanMax="0"/>
+   <Technical PowerConsumption="55" DmxConnector="3-pin"/>
   </Physical>
-  <Channel Number="0">Internal programs</Channel>
+  <Channel Number="0">Internal Programs, Auto Mode, Sound Countrolled Mode</Channel>
   <Channel Number="1">Master Dimmer</Channel>
   <Channel Number="2">Strobe</Channel>
   <Channel Number="3">Spot 1: Red</Channel>


### PR DESCRIPTION
Updated physical data and click and go colours. No gobo images found on the web.

https://www.google.co.uk/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&cad=rja&uact=8&ved=0CCIQFjABahUKEwikqIrBofnIAhWH6xoKHf59BjE&url=http%3A%2F%2Fwww.chauvetprofessional.com%2Fwp-content%2Fuploads%2F2015%2F07%2FQ-Spot_260-LED_UM_Rev-02-1-30-12DEC.pdf&usg=AFQjCNGOQgseHRuWEgdTfERNEkqNCCv3Lw&sig2=EYBiGyutT8xJYi3ZVV9cMg