### PR TITLE
Add support for the AVLdiy.cn UDMX clone with non-standard VID/PID

### DIFF
--- a/plugins/udmx/src/udmxdevice.cpp
+++ b/plugins/udmx/src/udmxdevice.cpp
@@ -35,6 +35,23 @@
 
 #define UDMX_SHARED_VENDOR     0x16C0 /* VOTI */
 #define UDMX_SHARED_PRODUCT    0x05DC /* Obdev's free shared PID */
+
+#define UDMX_AVLDIY_D512_CLONE_VENDOR     0x03EB /* Atmel Corp. (Clone VID)*/
+#define UDMX_AVLDIY_D512_CLONE_PRODUCT    0x8888 /* Clone PID */
+
+#define UDMX_USB_SIGNATURES_COUNT  2
+
+/* List of UDMX and clones VID/PID */
+const uint16_t UDMX_USB_SIGNATURES[UDMX_USB_SIGNATURES_COUNT][2] = 
+{
+    {
+      UDMX_SHARED_VENDOR, UDMX_SHARED_PRODUCT
+    },
+    {
+      UDMX_AVLDIY_D512_CLONE_VENDOR, UDMX_AVLDIY_D512_CLONE_PRODUCT
+    }
+};
+
 #define UDMX_SET_CHANNEL_RANGE 0x0002 /* Command to set n channel values */
 
 #define SETTINGS_FREQUENCY "udmx/frequency"
@@ -73,18 +90,21 @@ UDMXDevice::~UDMXDevice()
 
 bool UDMXDevice::isUDMXDevice(const struct usb_device* device)
 {
+    int signatureNum;
+
     if (device == NULL)
         return false;
 
-    if ((device->descriptor.idVendor == UDMX_SHARED_VENDOR) &&
-        (device->descriptor.idProduct == UDMX_SHARED_PRODUCT))
-    {
-        return true;
+    for (signatureNum = 0; signatureNum < UDMX_USB_SIGNATURES_COUNT; signatureNum++) 
+    { 
+        if ((device->descriptor.idVendor == UDMX_USB_SIGNATURES[signatureNum][0]) &&
+            (device->descriptor.idProduct == UDMX_USB_SIGNATURES[signatureNum][1]))
+        {
+             return true;
+        }
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 void UDMXDevice::extractName()

--- a/plugins/udmx/src/z65-anyma-udmx.rules
+++ b/plugins/udmx/src/z65-anyma-udmx.rules
@@ -1,7 +1,10 @@
 # These rules should work on newer udev architecture as well as the older one.
 # Basically they watch for all "usb" subsystem add/change events, that occur
-# for devices with VID==16C0 and PID==05DC (meaning Anyma's uDMX devices), and
+# for Anyma's uDMX devices and clones, and
 # set their device nodes' permissions so that ALL users can read and write to
 # them. The devices nodes are found under /dev/bus/usb/xxx/yyy.
 SUBSYSTEM=="usb*", ACTION=="add|change", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", MODE="0666"
 SUBSYSTEM=="usb*", ACTION=="add|change", SYSFS{idVendor}=="16c0", SYSFS{idProduct}=="05dc", MODE="0666"
+
+SUBSYSTEM=="usb*", ACTION=="add|change", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="8888", MODE="0666"
+SUBSYSTEM=="usb*", ACTION=="add|change", SYSFS{idVendor}=="03eb", SYSFS{idProduct}=="8888", MODE="0666"


### PR DESCRIPTION
Propose to add support for the UDMX clone from AVLdiy.cn with non-standard VID/PID 03eb:8888.

I bought this cable from DealExtreme and found out, that it doesn't work with QLC+ because of different USB vid/pid. Device is tested and works with changes, proposed in my commit.

Detects as:
[39684.701431] usb 3-1.3: New USB device found, idVendor=03eb, idProduct=8888
[39684.701437] usb 3-1.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[39684.701440] usb 3-1.3: Product: D512
[39684.701442] usb 3-1.3: Manufacturer: AVLdiy.cn
[39684.701445] usb 3-1.3: SerialNumber: AVLdiy.cn0001

PS: It's my first contribution to the open source project, so please point out any mistakes.