### PR TITLE
Channel editor: allow temporary invalid cap ranges

### DIFF
--- a/engine/src/qlccapability.cpp
+++ b/engine/src/qlccapability.cpp
@@ -52,16 +52,7 @@ QLCCapability *QLCCapability::createCopy()
                                             m_resourceColor1, m_resourceColor2);
     return copy;
 }
-/*
-QLCCapability::QLCCapability(const QLCCapability* capability)
-{
-    m_min = 0;
-    m_max = UCHAR_MAX;
 
-    if (capability != NULL)
-        *this = *capability;
-}
-*/
 QLCCapability::~QLCCapability()
 {
 }

--- a/engine/src/qlccapability.h
+++ b/engine/src/qlccapability.h
@@ -72,8 +72,6 @@ public:
                   const QColor &color1 = QColor(), const QColor &color2 = QColor(),
                   QObject *parent = 0);
 
-    /** Copy constructor */
-    //QLCCapability(const QLCCapability* cap);
     QLCCapability *createCopy();
 
     /** Destructor */

--- a/engine/src/qlcchannel.cpp
+++ b/engine/src/qlcchannel.cpp
@@ -468,6 +468,32 @@ bool QLCChannel::addCapability(QLCCapability* cap)
     return true;
 }
 
+bool QLCChannel::setCapabilityRange(QLCCapability* cap, uchar min, uchar max)
+{
+    Q_ASSERT(cap != NULL);
+
+    uchar prevMin = cap->min();
+    cap->setMin(min);
+    uchar prevMax = cap->max();
+    cap->setMax(max);
+
+    /* Check for overlapping values */
+    foreach (QLCCapability* another, m_capabilities)
+    {
+        if (another == cap)
+            continue;
+
+        if (another->overlaps(cap) == true)
+        {
+            cap->setMin(prevMin);
+            cap->setMax(prevMax);
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool QLCChannel::removeCapability(QLCCapability* cap)
 {
     Q_ASSERT(cap != NULL);

--- a/engine/src/qlcchannel.h
+++ b/engine/src/qlcchannel.h
@@ -233,6 +233,9 @@ public:
     /** Remove a capability from the channel */
     bool removeCapability(QLCCapability* cap);
 
+    /** Change a current cap range, checking for feasibility */
+    bool setCapabilityRange(QLCCapability* cap, uchar min, uchar max);
+
     /** Sort capabilities to ascending order by their values */
     void sortCapabilities();
 

--- a/fixtureeditor/editchannel.ui
+++ b/fixtureeditor/editchannel.ui
@@ -256,7 +256,14 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="3" column="0" colspan="3">
+         <widget class="QLabel" name="m_invalidMinMax">
+          <property name="text">
+           <string>Invalid Range: overlapping with another capability.</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>


### PR DESCRIPTION
A message is displayed as long as the range is invalid, and the values are not applied.

http://qlcplus.org/forum/viewtopic.php?f=5&t=9167&start=10