### PR TITLE
VCSlider: ignore fade in and fade out times

### DIFF
--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -1008,6 +1008,8 @@ void VCSlider::writeDMXPlayback(MasterTimer* timer, QList<Universe *> ua)
     {
         if (value == 0)
         {
+            // Make sure we ignore the fade out time
+            function->adjustAttribute(0, Function::Intensity);
             if (function->stopped() == false)
                 function->stop();
         }
@@ -1015,7 +1017,12 @@ void VCSlider::writeDMXPlayback(MasterTimer* timer, QList<Universe *> ua)
         {
             if (function->stopped() == true)
             {
-                function->start(timer);
+                // Since this function is started by a fader, its fade in time
+                // is decided by the fader movement.
+                function->start(
+                        timer, false, 0,
+                        0, Function::defaultSpeed(), Function::defaultSpeed()
+                        );
             }
             emit functionStarting(m_playbackFunction, pIntensity);
             function->adjustAttribute(pIntensity * intensity(), Function::Intensity);


### PR DESCRIPTION
This way sliders in playback mode have the same behavior
as the sliders on a VCCueList.
Start a function with a slider -> manual fade in.
Stop a function with a slider -> manual fade out.


http://qlcplus.org/forum/viewtopic.php?f=12&t=9228