### PR TITLE
New fixture - American-DJ-WiFly-EXR-HEX5-IP

### DIFF
--- a/resources/fixtures/American-DJ-WiFly-EXR-HEX5-IP.qxf
+++ b/resources/fixtures/American-DJ-WiFly-EXR-HEX5-IP.qxf
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.10.2 GIT</Version>
+  <Author>Robert Box</Author>
+ </Creator>
+ <Manufacturer>American DJ</Manufacturer>
+ <Model>WiFly EXR HEX5 IP</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Red">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="Green">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="Blue">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="Color Macros/Programs/Auto Run">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="3" Color="#000000">Off/Color change/fade 1/Slow to fast</Capability>
+  <Capability Min="4" Max="7" Color="#ffce8f">/Color change/fade 1/Slow to fast</Capability>
+  <Capability Min="8" Max="11" Color="#00ff00">Green/Color change/fade 1/Slow to fast</Capability>
+  <Capability Min="12" Max="15" Color="#0000ff">Blue/Color change/fade 1/Slow to fast</Capability>
+  <Capability Min="16" Max="19" Color="#ffffff">White/Color change/fade 2/Slow to fast</Capability>
+  <Capability Min="20" Max="23" Color="#ffbf00">Amber/Color change/fade 2/Slow to fast</Capability>
+  <Capability Min="24" Max="27" Color="#9400d3">UV/Color change/fade 2/Slow to fast</Capability>
+  <Capability Min="28" Max="31" Color="#ffff00">R+G/Color change/fade 2/Slow to fast</Capability>
+  <Capability Min="32" Max="35" Color="#ff00ff">R+B/Color change/fade 3/Slow to fast</Capability>
+  <Capability Min="36" Max="39" Color="#ff8080">R+W/Color change/fade 3/Slow to fast</Capability>
+  <Capability Min="40" Max="43" Color="#ff6000">R+A/Color change/fade 3/Slow to fast</Capability>
+  <Capability Min="44" Max="47" Color="#ff0086">R+UV/Color change/fade 3/Slow to fast</Capability>
+  <Capability Min="48" Max="51" Color="#00ffff">G+B/Color change/fade 4/Slow to fast</Capability>
+  <Capability Min="52" Max="55" Color="#80ff80">G+W/Color change/fade 4/Slow to fast</Capability>
+  <Capability Min="56" Max="59" Color="#92ff00">G+A/Color change/fade 4/Slow to fast</Capability>
+  <Capability Min="60" Max="63" Color="#94ffd4">G+UV/Color change/fade 4/Slow to fast</Capability>
+  <Capability Min="64" Max="67" Color="#8080ff">B+W/Color change/fade 5/Slow to fast</Capability>
+  <Capability Min="68" Max="71" Color="#ffbfff">B+A/Color change/fade 5/Slow to fast</Capability>
+  <Capability Min="72" Max="75" Color="#5100ff">B+UV/Color change/fade 5/Slow to fast</Capability>
+  <Capability Min="76" Max="79" Color="#ffdf80">W+A/Color change/fade 5/Slow to fast</Capability>
+  <Capability Min="80" Max="83" Color="#dc8bff">W+UV/Color change/fade 6/Slow to fast</Capability>
+  <Capability Min="84" Max="87" Color="#ff7986">A+UV/Color change/fade 6/Slow to fast</Capability>
+  <Capability Min="88" Max="91" Color="#ffffff">R+G+B/Color change/fade 6/Slow to fast</Capability>
+  <Capability Min="92" Max="95" Color="#ffff80">R+G+W/Color change/fade 6/Slow to fast</Capability>
+  <Capability Min="96" Max="99" Color="#ffdf00">R+G+A/Color change/fade 7/Slow to fast</Capability>
+  <Capability Min="100" Max="103" Color="#ffa186">R+G+UV/Color change/fade 7/Slow to fast</Capability>
+  <Capability Min="104" Max="107" Color="#ff80ff">R+B+W/Color change/fade 7/Slow to fast</Capability>
+  <Capability Min="108" Max="111" Color="#ff6080">R+B+A/Color change/fade 7/Slow to fast</Capability>
+  <Capability Min="112" Max="115" Color="#dc00ff">R+B+UV/Color change/fade 8/Slow to fast</Capability>
+  <Capability Min="116" Max="119" Color="#ff9555">R+W+A/Color change/fade 8/Slow to fast</Capability>
+  <Capability Min="120" Max="123" Color="#ff63b5">R+W+UV/Color change/fade 8/Slow to fast</Capability>
+  <Capability Min="124" Max="127" Color="#ff4a52">R+A+UV/Color change/fade 8/Slow to fast</Capability>
+  <Capability Min="128" Max="131" Color="#80ffff">G+B+W/Color change/fade 9/Slow to fast</Capability>
+  <Capability Min="132" Max="135" Color="#92ff92">G+B+A/Color change/fade 9/Slow to fast</Capability>
+  <Capability Min="136" Max="139" Color="#518bff">G+B+UV/Color change/fade 9/Slow to fast</Capability>
+  <Capability Min="140" Max="143" Color="#b9ff5d">G+W+A/Color change/fade 9/Slow to fast</Capability>
+  <Capability Min="144" Max="147" Color="#c9ffe9">G+W+UV/Color change/fade 10/Slow to fast</Capability>
+  <Capability Min="148" Max="151" Color="#e6ff79">G+A+UV/Color change/fade 10/Slow to fast</Capability>
+  <Capability Min="152" Max="155" Color="#ffdfff">B+W+A/Color change/fade 10/Slow to fast</Capability>
+  <Capability Min="156" Max="159" Color="#8e5aff">B+W+UV/Color change/fade 10/Slow to fast</Capability>
+  <Capability Min="160" Max="163" Color="#dc69ff">B+A+UV/Color change/fade 11/Slow to fast</Capability>
+  <Capability Min="164" Max="167" Color="#ffadb5">W+A+UV/Color change/fade 11/Slow to fast</Capability>
+  <Capability Min="168" Max="171" Color="#ffffff">R+G+B+W/Color change/fade 11/Slow to fast</Capability>
+  <Capability Min="172" Max="175" Color="#ffdf80">R+G+B+A/Color change/fade 11/Slow to fast</Capability>
+  <Capability Min="176" Max="179" Color="#dc8bff">R+G+B+UV/Color change/fade 12/Slow to fast</Capability>
+  <Capability Min="180" Max="183" Color="#ffea55">R+G+W+A/Color change/fade 12/Slow to fast</Capability>
+  <Capability Min="184" Max="187" Color="#ffc6b5">R+G+W+UV/Color change/fade 12/Slow to fast</Capability>
+  <Capability Min="188" Max="191" Color="#ffad52">R+G+A+UV/Color change/fade 12/Slow to fast</Capability>
+  <Capability Min="192" Max="195" Color="#ff95aa">R+B+W+A/Color change/fade 13/Slow to fast</Capability>
+  <Capability Min="196" Max="199" Color="#e85aff">R+B+W+UV/Color change/fade 13/Slow to fast</Capability>
+  <Capability Min="200" Max="203" Color="#ff4ab5">R+B+A+UV/Color change/fade 13/Slow to fast</Capability>
+  <Capability Min="204" Max="207" Color="#ff7d82">R+W+A+UV/Color change/fade 13/Slow to fast</Capability>
+  <Capability Min="208" Max="211" Color="#b9ffb9">G+B+W+A/Color change/fade 14/Slow to fast</Capability>
+  <Capability Min="212" Max="215" Color="#8eb4ff">G+B+W+UV/Color change/fade 14/Slow to fast</Capability>
+  <Capability Min="216" Max="219" Color="#dcf4ff">G+B+A+UV/Color change/fade 14/Slow to fast</Capability>
+  <Capability Min="220" Max="223" Color="#efffaa">G+W+A+UV/Color change/fade 14/Slow to fast</Capability>
+  <Capability Min="224" Max="227" Color="#e89eff">B+W+A+UV/Color change/fade 15/Slow to fast</Capability>
+  <Capability Min="228" Max="231" Color="#ffeaaa">R+G+B+W+A/Color change/fade 15/Slow to fast</Capability>
+  <Capability Min="232" Max="235" Color="#e8b4ff">R+G+B+W+UV/Color change/fade 15/Slow to fast</Capability>
+  <Capability Min="236" Max="239" Color="#ffadb5">R+G+B+A+UV/Color change/fade 15/Slow to fast</Capability>
+  <Capability Min="240" Max="243" Color="#ffc482">R+G+W+A+UV/Color change/fade 16/Slow to fast</Capability>
+  <Capability Min="244" Max="247" Color="#ff7dca">R+B+W+A+UV/Color change/fade 16/Slow to fast</Capability>
+  <Capability Min="248" Max="251" Color="#e8f8ff">G+B+W+A+UV/Color change/fade 16/Slow to fast</Capability>
+  <Capability Min="252" Max="255" Color="#ffc4ca">R+G+B+W+A+UV/Color change/fade 16/Slow to fast</Capability>
+ </Channel>
+ <Channel Name="Strobing">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="31">LED off</Capability>
+  <Capability Min="32" Max="63">LED on</Capability>
+  <Capability Min="64" Max="95">Strobing slow - fast</Capability>
+  <Capability Min="96" Max="127">LED on</Capability>
+  <Capability Min="128" Max="159">Pulse strobing slow - fast</Capability>
+  <Capability Min="160" Max="191">LED on</Capability>
+  <Capability Min="192" Max="223">Random strobing slow - fast</Capability>
+  <Capability Min="224" Max="255">LED on</Capability>
+ </Channel>
+ <Channel Name="Master Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="Dimmer Curves">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="20">Standard</Capability>
+  <Capability Min="21" Max="40">Stage</Capability>
+  <Capability Min="41" Max="60">TV</Capability>
+  <Capability Min="61" Max="80">Architectural</Capability>
+  <Capability Min="81" Max="100">Theatre</Capability>
+  <Capability Min="101" Max="255">Default to unit setting</Capability>
+ </Channel>
+ <Channel Name="Program Selection Mode">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="51">Dimming mode</Capability>
+  <Capability Min="52" Max="102">Color macro mode</Capability>
+  <Capability Min="103" Max="153">Color change mode</Capability>
+  <Capability Min="154" Max="204">Color fade mode</Capability>
+  <Capability Min="205" Max="255">Auto run mode</Capability>
+ </Channel>
+ <Channel Name="Amber">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Amber</Colour>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="White">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="UV">
+  <Group Byte="0">Intensity</Group>
+  <Colour>UV</Colour>
+  <Capability Min="0" Max="255">0% - 100%</Capability>
+ </Channel>
+ <Channel Name="Program &amp; Auto Run Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Slow - fast</Capability>
+ </Channel>
+ <Mode Name="6 Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="1600" ColourTemperature="0"/>
+   <Dimensions Weight="5.4" Width="280" Height="194" Depth="310"/>
+   <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="56" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">UV</Channel>
+ </Mode>
+ <Mode Name="7 Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="1600" ColourTemperature="0"/>
+   <Dimensions Weight="5.4" Width="280" Height="194" Depth="310"/>
+   <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="56" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">UV</Channel>
+  <Channel Number="6">Master Dimmer</Channel>
+ </Mode>
+ <Mode Name="8 Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="1600" ColourTemperature="0"/>
+   <Dimensions Weight="5.4" Width="280" Height="194" Depth="310"/>
+   <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="56" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">UV</Channel>
+  <Channel Number="6">Master Dimmer</Channel>
+  <Channel Number="7">Strobing</Channel>
+ </Mode>
+ <Mode Name="11 Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="1600" ColourTemperature="0"/>
+   <Dimensions Weight="5.4" Width="280" Height="194" Depth="310"/>
+   <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="56" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">UV</Channel>
+  <Channel Number="6">Master Dimmer</Channel>
+  <Channel Number="7">Strobing</Channel>
+  <Channel Number="8">Program Selection Mode</Channel>
+  <Channel Number="9">Color Macros/Programs/Auto Run</Channel>
+  <Channel Number="10">Program &amp; Auto Run Speed</Channel>
+ </Mode>
+ <Mode Name="12 Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="1600" ColourTemperature="0"/>
+   <Dimensions Weight="5.4" Width="280" Height="194" Depth="310"/>
+   <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="56" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">UV</Channel>
+  <Channel Number="6">Master Dimmer</Channel>
+  <Channel Number="7">Strobing</Channel>
+  <Channel Number="8">Program Selection Mode</Channel>
+  <Channel Number="9">Color Macros/Programs/Auto Run</Channel>
+  <Channel Number="10">Program &amp; Auto Run Speed</Channel>
+  <Channel Number="11">Dimmer Curves</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Datasheet here:

http://www.adj.com/wifly-exr-hex5-ip

Click & Go colours are normalized to 255 accept black and UV. There is a deliberate mistake in [4-7] Color Macros where I missed out 'Red' 10 seconds after pushing the file. ;/