### PR TITLE
Force universe ID and Index to be the same

### DIFF
--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -247,9 +247,6 @@ signals:
     void universesWritten(int index, const QByteArray& universesCount);
 
 private:
-    /** Keep track of the lastest asigned universe ID */
-    quint32 m_latestUniverseId;
-
     /** The values of all universes */
     QList<Universe *> m_universeArray;
 

--- a/engine/test/inputoutputmap/inputoutputmap_test.cpp
+++ b/engine/test/inputoutputmap/inputoutputmap_test.cpp
@@ -207,8 +207,15 @@ void InputOutputMap_Test::removeUniverse()
 {
     InputOutputMap im(m_doc, 4);
     QVERIFY(im.universesCount() == 4);
-    im.removeUniverse(1);
+
+    // Creating a gap in the universe list is forbidden
+    QVERIFY(im.removeUniverse(1) == false);
+    QVERIFY(im.universesCount() == 4);
+
+    // Removing the last universe is OK
+    QVERIFY(im.removeUniverse(3) == true);
     QVERIFY(im.universesCount() == 3);
+
     QVERIFY(im.removeUniverse(7) == false);
     im.removeAllUniverses();
     QVERIFY(im.universesCount() == 0);

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -208,7 +208,6 @@ void InputOutputManager::updateList()
     }
     else
     {
-        m_deleteUniverseAction->setEnabled(true);
         m_list->setCurrentItem(m_list->item(0));
         m_uniNameEdit->setEnabled(true);
         m_uniNameEdit->setText(m_ioMap->getUniverseNameByIndex(0));
@@ -301,6 +300,11 @@ void InputOutputManager::slotCurrentItemChanged()
     quint32 universe = item->data(Qt::UserRole).toInt();
     if (m_editorUniverse == universe)
         return;
+
+    if ((universe + 1) != m_ioMap->universesCount())
+        m_deleteUniverseAction->setEnabled(false);
+    else
+        m_deleteUniverseAction->setEnabled(true);
 
     if (m_editor != NULL)
     {

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -351,13 +351,7 @@ void InputOutputManager::slotDeleteUniverse()
 {
     int uniIdx = m_list->currentRow();
 
-    if ((uniIdx + 1) != (int)(m_ioMap->universesCount()))
-    {
-        QMessageBox::information(this,
-                tr("Unable to remove universe"),
-                tr("You can only remove universes starting from the last one"));
-        return;
-    }
+    Q_ASSERT((uniIdx + 1) == (int)(m_ioMap->universesCount()));
 
     // Check if the universe is patched
     if (m_ioMap->isUniversePatched(uniIdx) == true)

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -347,6 +347,14 @@ void InputOutputManager::slotDeleteUniverse()
 {
     int uniIdx = m_list->currentRow();
 
+    if ((uniIdx + 1) != (int)(m_ioMap->universesCount()))
+    {
+        QMessageBox::information(this,
+                tr("Unable to remove universe"),
+                tr("You can only remove universes starting from the last one"));
+        return;
+    }
+
     // Check if the universe is patched
     if (m_ioMap->isUniversePatched(uniIdx) == true)
     {


### PR DESCRIPTION
Forbid creating gaps in the universe list
by deleting a universe that is not the last one.

When loading a workspace that contains gaps in
the universe list, fill the gaps.

This fixes various issues and crashes that happen
when a gap is present in the universe list.




Related thread in the forum: http://qlcplus.org/forum/viewtopic.php?f=5&t=9303
This is open for discussion.

After struggling with the 'only use universe ID' solution (that touches a lot of files and can be seen here https://github.com/plugz/qlcplus/tree/universeindex-fix-2), and realising that the qmlui code uses universes indexes everywhere, and that I don't know shit about qml... I gave up and came up with a way more simple solution to this issue:
Force universeID==universeIndex

Pros of this solution: no more id/index confusion.
Bad with this solution: it forbids deleting a universe in the middle of the universe list.