### PR TITLE
(FIX): add a variable for the udev rules path

### DIFF
--- a/plugins/dmxusb/src/src.pro
+++ b/plugins/dmxusb/src/src.pro
@@ -122,7 +122,7 @@ CONFIG(libftdi) {
 
 unix:!macx {
     # Rules to make USB DMX devices readable & writable by normal users
-    udev.path  = /etc/udev/rules.d
+    udev.path  = $$UDEVRULESDIR
     udev.files = z65-dmxusb.rules
     INSTALLS  += udev
 }

--- a/plugins/hid/hid.pro
+++ b/plugins/hid/hid.pro
@@ -43,7 +43,7 @@ macx:SOURCES += macx/hidapi.cpp macx/hidosxjoystick.cpp
 
 unix:!macx {
     # Rules to make FX5 DMX devices readable & writable by normal users
-    udev.path  = /etc/udev/rules.d
+    udev.path  = $$UDEVRULESDIR
     udev.files = linux/z65-fx5-hid.rules
     INSTALLS  += udev
 }

--- a/plugins/peperoni/unix/unix.pro
+++ b/plugins/peperoni/unix/unix.pro
@@ -32,6 +32,6 @@ target.path = $$INSTALLROOT/$$PLUGINDIR
 INSTALLS   += target
 
 # UDEV rule to make Peperoni USB devices readable & writable for users in Linux
-udev.path  = /etc/udev/rules.d
+udev.path  = $$UDEVRULESDIR
 udev.files = z65-peperoni.rules
 !macx:INSTALLS  += udev

--- a/plugins/spi/spi.pro
+++ b/plugins/spi/spi.pro
@@ -11,7 +11,7 @@ INCLUDEPATH += $SYSROOT/usr/include
 CONFIG      += plugin
 
 # Rules to make SPI devices readable & writable by normal users
-udev.path  = /etc/udev/rules.d
+udev.path  = $$UDEVRULESDIR
 udev.files = z65-spi.rules
 INSTALLS  += udev
 

--- a/plugins/udmx/src/src.pro
+++ b/plugins/udmx/src/src.pro
@@ -50,7 +50,7 @@ INSTALLS   += target
 
 # UDEV rule to make uDMX USB device readable & writable for users in Linux
 unix:!macx {
-    udev.path  = /etc/udev/rules.d
+    udev.path  = $$UDEVRULESDIR
     udev.files = z65-anyma-udmx.rules
     INSTALLS  += udev
 }

--- a/variables.pri
+++ b/variables.pri
@@ -201,6 +201,9 @@ macx:WEBFILESDIR       = $$DATADIR/Web
 android:WEBFILESDIR    = $$DATADIR/web
 ios:WEBFILESDIR        = Web
 
+# udev rules
+unix:!macx:UDEVRULESDIR = /etc/udev/rules.d
+
 unix:!macx: {
   QTPREFIX = $$[QT_INSTALL_PREFIX]
   IN_USR = $$find(QTPREFIX, "/usr")


### PR DESCRIPTION
Add the UDEVRULESDIR variable to let packagers change the location of the udev rules directory in one place. Because some distributions of linux don't use "/etc/udev/rules.d" for the rules but something like "/usr/lib/udev/rules.d"