### PR TITLE
Fix translate

### DIFF
--- a/qlc.pro
+++ b/qlc.pro
@@ -45,9 +45,9 @@ win32:coverage.commands = @echo Get a better OS.
 translations.target = translate
 QMAKE_EXTRA_TARGETS += translations
 translations.commands += ./translate.sh
-translations.files += qlcplus_de_DE.qm qlcplus_es_ES.qm qlcplus_fr_FR.qm
-translations.files += qlcplus_it_IT.qm qlcplus_nl_NL.qm qlcplus_cz_CZ.qm
-translations.files += qlcplus_pt_BR.qm qlcplus_ca_ES.qm qlcplus_ja_JP.qm
+translations.files = ./qlcplus_de_DE.qm ./qlcplus_es_ES.qm ./qlcplus_fr_FR.qm
+translations.files += ./qlcplus_it_IT.qm ./qlcplus_nl_NL.qm ./qlcplus_cz_CZ.qm
+translations.files += ./qlcplus_pt_BR.qm ./qlcplus_ca_ES.qm ./qlcplus_ja_JP.qm
 translations.path   = $$INSTALLROOT/$$TRANSLATIONDIR
 INSTALLS           += translations
 

--- a/translate.sh
+++ b/translate.sh
@@ -34,7 +34,7 @@ function compile {
     echo Processing $1
     INPUT_NAME="*_${1}.ts"
     OUTPUT_NAME="qlcplus_${1}.qm"
-    $LRELEASE_BIN $(find . -name $INPUT_NAME) -qm $OUTPUT_NAME
+    $LRELEASE_BIN -silent $(find . -name $INPUT_NAME) -qm $OUTPUT_NAME
 }
 
 # Compile all translated languages present in $languages

--- a/translate.sh
+++ b/translate.sh
@@ -32,7 +32,9 @@ fi
 # Compile all files for the given language into one common qlcplus_<lang>.qm file
 function compile {
     echo Processing $1
-    $LRELEASE_BIN -silent `find . -name *_$1.ts` -qm qlcplus_$1.qm
+    INPUT_NAME="*_${1}.ts"
+    OUTPUT_NAME="qlcplus_${1}.qm"
+    $LRELEASE_BIN $(find . -name $INPUT_NAME) -qm $OUTPUT_NAME
 }
 
 # Compile all translated languages present in $languages


### PR DESCRIPTION
This fix
- removes the "-silent" parameter from the call to lrelease since that is not a real parameter
- makes use of bash variables to specify the names of files in translate.sh
- makes the translate files install by putting "./" in front of the file names