### PR TITLE
Add support for Retina displays on MacOSX (Fix #733)

### DIFF
--- a/etc/Info.plist
+++ b/etc/Info.plist
@@ -20,6 +20,12 @@
 	<key>CFBundleName</key>
 	<string>Q Light Controller Plus</string>
 
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Change Info.Plist according to http://blog.qt.io/blog/2013/04/25/retina-display-support-for-mac-os-ios-and-x11/