### PR TITLE
Add appdata files and install them

### DIFF
--- a/etc/etc.pro
+++ b/etc/etc.pro
@@ -17,6 +17,10 @@ unix:!macx {
     mime.files += qlcplus.xml
     INSTALLS   += mime
 
+    appdata.path   = $$INSTALLROOT/share/appdata/
+    appdata.files += qlcplus-fixtureeditor.appdata.xml qlcplus.appdata.xml
+    INSTALLS      += appdata
+
     # This is nowadays run by dpkg (TODO: rpm)
     #MIMEUPDATE    = $$system("which update-mime-database")
     #mimeupdate.commands = $$MIMEUPDATE /usr/share/mime

--- a/etc/qlcplus-fixtureeditor.appdata.xml
+++ b/etc/qlcplus-fixtureeditor.appdata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Dave Olsthoorn <dave.olsthoorn@gmail.com> -->
+<component type="desktop">
+ <id>qlcplus-fixtureeditor.desktop</id>
+ <metadata_license>CC-BY-SA-3.0</metadata_license>
+ <project_license>Apache-2.0</project_license>
+ <name>QLC+ Fixture Editor</name>
+ <summary>Fixture Editor for QLC+</summary>
+ <summary xml:lang="nl">Armatuur Editor voor QLC+</summary>
+ <description>
+  <p>
+   This is the Fixture Editor for QLC+.
+   <!-- TODO: make a better description -->
+  </p>
+  <p xml:lang="nl">
+   Dit is de Armatuur Editor voor QLC+
+   <!-- TODO: make a better description -->
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image>http://www.qlcplus.org/shots/qlcplus_fixtureeditor.png</image>
+   <caption>Fixture Editor</caption>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.qlcplus.org/</url>
+ <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues</url>
+</component>

--- a/etc/qlcplus.appdata.xml
+++ b/etc/qlcplus.appdata.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Dave Olsthoorn <dave.olsthoorn@gmail.com> -->
+<component type="desktop">
+ <id>qlcplus.desktop</id>
+ <metadata_license>CC-BY-SA-3.0</metadata_license>
+ <project_license>Apache-2.0</project_license>
+ <name>QLC+</name>
+ <summary>Control lights using DMX or analog systems</summary>
+ <summary xml:lang="nl">Bestuur verlichting met DMX of analoge systemen</summary>
+ <description>
+  <p>
+   QLC+ is free and cross-platform software to control DMX or analog lighting
+   systems like moving heads, dimmers, scanners etc. This project is a fork of
+   the great QLC project written by Heikki Junnila that aims to continue the
+   development of QLC and to introduce new features. The primary goal is to
+   bring QLC+ at the level of other commercial lighting control software.
+  </p>
+  <p xml:lang="nl">
+   QLC+ is gratis en cross-platform software voor het besturen van DMX of analoge
+   verlichting systemen zoals moving heads, dimmers, scanners etc. Dit project is
+   een verbetering van het grote QLC project geschreven door Heikki Junnila dat zich
+   richt op de verder ontwikkeling van QLC en om nieuwe functies te introduceren. Het primaire
+   doel is om QLC+ op het niveau van andere commerciële lichtregeling software te brengen.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image>http://www.qlcplus.org/shots/qlcplus_fixtures.png</image>
+   <caption>Fixtures panel</caption>
+  </screenshot>
+  <screenshot>
+   <image>http://www.qlcplus.org/shots/qlcplus_chgroups.png</image>
+   <caption>Channel groups</caption>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.qlcplus.org/</url>
+ <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues</url>
+</component>

--- a/plugins/E1.31/E1.31.pro
+++ b/plugins/E1.31/E1.31.pro
@@ -44,3 +44,9 @@ SOURCES += e131packetizer.cpp \
            e131controller.cpp \
            e131plugin.cpp \
            configuree131.cpp
+
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-e131.metainfo.xml
+   INSTALLS       += metainfo 
+}

--- a/plugins/E1.31/qlcplus-e131.metainfo.xml
+++ b/plugins/E1.31/qlcplus-e131.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-e131</id>
+  <extends>qlcplus.desktop</extends>
+  <name>E1.31</name>
+  <summary>Use E1.31 with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[e1.31]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/artnet/src/qlcplus-artnet.metainfo.xml
+++ b/plugins/artnet/src/qlcplus-artnet.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-artnet</id>
+  <extends>qlcplus.desktop</extends>
+  <name>Artnet</name>
+  <summary>Use artnet with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[artnet]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/artnet/src/src.pro
+++ b/plugins/artnet/src/src.pro
@@ -44,3 +44,9 @@ SOURCES += artnetpacketizer.cpp \
            artnetcontroller.cpp \
            artnetplugin.cpp \
            configureartnet.cpp
+
+unix:!macx {
+    metainfo.path   = $$INSTALLROOT/share/appdata/
+    metainfo.files += qlcplus-artnet.metainfo.xml 
+    INSTALLS       += metainfo
+}

--- a/plugins/dmx4linux/dmx4linux.pro
+++ b/plugins/dmx4linux/dmx4linux.pro
@@ -26,3 +26,7 @@ HEADERS += dmx4linux.h
 
 SOURCES += ../interfaces/qlcioplugin.cpp
 SOURCES += dmx4linux.cpp
+
+metainfo.path   = $$INSTALLROOT/share/appdata/ 
+metainfo.files += qlcplus-dmx4linux.metainfo.xml
+INSTALLS       += metainfo

--- a/plugins/dmx4linux/qlcplus-dmx4linux.metainfo.xml
+++ b/plugins/dmx4linux/qlcplus-dmx4linux.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-dmx4linux</id>
+  <extends>qlcplus.desktop</extends>
+  <name>DMX4Linux</name>
+  <summary>Use DMX4Linux with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[DMX4Linux]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/dmxusb/src/qlcplus-dmxusb.metainfo.xml
+++ b/plugins/dmxusb/src/qlcplus-dmxusb.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-dmxusb</id>
+  <extends>qlcplus.desktop</extends>
+  <name>DMXUSB</name>
+  <summary>Use USB enabled DMX devices with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[DMXUSB]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/dmxusb/src/src.pro
+++ b/plugins/dmxusb/src/src.pro
@@ -125,6 +125,10 @@ unix:!macx {
     udev.path  = $$UDEVRULESDIR
     udev.files = z65-dmxusb.rules
     INSTALLS  += udev
+    
+    metainfo.path   = $$INSTALLROOT/share/appdata/
+    metainfo.files += qlcplus-dmxusb.metainfo.xml
+    INSTALLS       += metainfo
 }
 
 TRANSLATIONS += DMX_USB_de_DE.ts

--- a/plugins/enttecwing/src/qlcplus-enttecwing.metainfo.xml
+++ b/plugins/enttecwing/src/qlcplus-enttecwing.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-enttecwing</id>
+  <extends>qlcplus.desktop</extends>
+  <name>Enttec Wing</name>
+  <summary>Use your Enttec Wing with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[enttecwing]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/enttecwing/src/src.pro
+++ b/plugins/enttecwing/src/src.pro
@@ -56,3 +56,10 @@ macx {
 # Installation
 target.path = $$INSTALLROOT/$$PLUGINDIR
 INSTALLS   += target
+
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-enttecwing.metainfo.xml
+   INSTALLS       += metainfo 
+}
+

--- a/plugins/hid/hid.pro
+++ b/plugins/hid/hid.pro
@@ -46,6 +46,10 @@ unix:!macx {
     udev.path  = $$UDEVRULESDIR
     udev.files = linux/z65-fx5-hid.rules
     INSTALLS  += udev
+
+    metainfo.path   = $$INSTALLROOT/share/appdata/
+    metainfo.files += linux/qlcplus-hid.metainfo.xml
+    INSTALLS       += metainfo
 }
 
 TRANSLATIONS += HID_fi_FI.ts

--- a/plugins/hid/linux/qlcplus-hid.metainfo.xml
+++ b/plugins/hid/linux/qlcplus-hid.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-hid</id>
+  <extends>qlcplus.desktop</extends>
+  <name>Hid</name>
+  <summary>Use hid devices with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[hid]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/loopback/src/qlcplus-loopback.metainfo.xml
+++ b/plugins/loopback/src/qlcplus-loopback.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-loopback</id>
+  <extends>qlcplus.desktop</extends>
+  <name>Loopback</name>
+  <summary>DMX loopback for QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[e1.31]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/loopback/src/src.pro
+++ b/plugins/loopback/src/src.pro
@@ -32,3 +32,9 @@ macx:include(../../../macx/nametool.pri)
 
 target.path = $$INSTALLROOT/$$PLUGINDIR
 INSTALLS   += target
+
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-loopback.metainfo.xml
+   INSTALLS       += metainfo 
+}

--- a/plugins/midi/midi.pro
+++ b/plugins/midi/midi.pro
@@ -14,3 +14,9 @@ TRANSLATIONS += MIDI_cz_CZ.ts
 TRANSLATIONS += MIDI_pt_BR.ts
 TRANSLATIONS += MIDI_ca_ES.ts
 TRANSLATIONS += MIDI_ja_JP.ts
+
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-midi.metainfo.xml
+   INSTALLS       += metainfo 
+}

--- a/plugins/midi/qlcplus-midi.metainfo.xml
+++ b/plugins/midi/qlcplus-midi.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-midi</id>
+  <extends>qlcplus.desktop</extends>
+  <name>Midi</name>
+  <summary>Use Midi for controlling QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[Midi]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/ola/ola.pro
+++ b/plugins/ola/ola.pro
@@ -23,6 +23,13 @@ macx: {
     LIBS      += -L/usr/local/lib -lolaserver -lola -lolacommon -lprotobuf
 }
 
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-ola.metainfo.xml
+   INSTALLS       += metainfo 
+}
+
+
 # Forms
 FORMS += configureolaio.ui
 

--- a/plugins/ola/qlcplus-ola.metainfo.xml
+++ b/plugins/ola/qlcplus-ola.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-ola</id>
+  <extends>qlcplus.desktop</extends>
+  <name>OLA</name>
+  <summary>OLA connector for QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[OLA]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/osc/osc.pro
+++ b/plugins/osc/osc.pro
@@ -44,3 +44,9 @@ SOURCES += oscpacketizer.cpp \
            osccontroller.cpp \
            oscplugin.cpp \
            configureosc.cpp
+
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-osc.metainfo.xml
+   INSTALLS       += metainfo 
+}

--- a/plugins/osc/qlcplus-osc.metainfo.xml
+++ b/plugins/osc/qlcplus-osc.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-osc</id>
+  <extends>qlcplus.desktop</extends>
+  <name>OSC</name>
+  <summary>Use OSC with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[OSC]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/peperoni/unix/qlcplus-peperoni.metainfo.xml
+++ b/plugins/peperoni/unix/qlcplus-peperoni.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-peperoni</id>
+  <extends>qlcplus.desktop</extends>
+  <name>Peperoni</name>
+  <summary>Use peperoni devices with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[peperoni]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/peperoni/unix/unix.pro
+++ b/plugins/peperoni/unix/unix.pro
@@ -35,3 +35,10 @@ INSTALLS   += target
 udev.path  = $$UDEVRULESDIR
 udev.files = z65-peperoni.rules
 !macx:INSTALLS  += udev
+
+unix:!macx {
+   metainfo.path   = $$INSTALLROOT/share/appdata/
+   metainfo.files += qlcplus-peperoni.metainfo.xml
+   INSTALLS       += metainfo 
+}
+

--- a/plugins/spi/qlcplus-spi.metainfo.xml
+++ b/plugins/spi/qlcplus-spi.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-spi</id>
+  <extends>qlcplus.desktop</extends>
+  <name>SPI</name>
+  <summary>Use SPI controlled lights with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[SPI]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/spi/spi.pro
+++ b/plugins/spi/spi.pro
@@ -15,6 +15,10 @@ udev.path  = $$UDEVRULESDIR
 udev.files = z65-spi.rules
 INSTALLS  += udev
 
+metainfo.path   = $$INSTALLROOT/share/appdata/
+metainfo.files += qlcplus-spi.metainfo.xml
+INSTALLS       += metainfo
+
 target.path = $$INSTALLROOT/$$PLUGINDIR
 INSTALLS   += target
 

--- a/plugins/udmx/src/qlcplus-udmx.metainfo.xml
+++ b/plugins/udmx/src/qlcplus-udmx.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>qlcplus-udmx</id>
+  <extends>qlcplus.desktop</extends>
+  <name>uDMX</name>
+  <summary>Use uDMX devices with QLC+</summary>
+  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[uDMX]:</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/plugins/udmx/src/src.pro
+++ b/plugins/udmx/src/src.pro
@@ -53,4 +53,8 @@ unix:!macx {
     udev.path  = $$UDEVRULESDIR
     udev.files = z65-anyma-udmx.rules
     INSTALLS  += udev
+
+    metainfo.path   = $$INSTALLROOT/share/appdata/
+    metainfo.files += qlcplus-udmx.metainfo.xml
+    INSTALLS       += metainfo
 }


### PR DESCRIPTION
Appdata files get used by software-center on ubuntu, gnome-software-centre on fedora and other software centers. This also gives room for seperate icons and info for plugins if we implement a ".metainfo.xml" file for them. The plugins most likely also get listed underneath the package they extend.

For more info on appdata go [here](http://www.freedesktop.org/software/appstream/docs/chap-Metadata.html) and for more info on metainfo go [here](http://www.freedesktop.org/software/appstream/docs/sect-Quickstart-Addons.html).