### PR TITLE
Fix language declaration of italian translation

### DIFF
--- a/etc/qlcplus.appdata.xml
+++ b/etc/qlcplus.appdata.xml
@@ -22,7 +22,7 @@
    richt op de verder ontwikkeling van QLC en om nieuwe functies te introduceren. Het primaire
    doel is om QLC+ op het niveau van andere commerciële lichtregeling software te brengen.
   </p>
-  <p xml:lang="nl">
+  <p xml:lang="it">
    QLC+ è un software gratuito e multi piattaforma per controllare sistemi di illuminazione 
    DMX o analogici come teste mobili, dimmer, scanner, ecc. Questo progetto è un fork
    del magnifico progetto QLC scritto da Heikki Junnila, che mira a continuare lo sviluppo di


### PR DESCRIPTION
Just saw that there were two "nl" entries. German translation will follow ...