### PR TITLE
Save in temp file before replacing destination file

### DIFF
--- a/engine/src/qlcfixturedef.cpp
+++ b/engine/src/qlcfixturedef.cpp
@@ -301,7 +301,9 @@ QFile::FileError QLCFixtureDef::saveXML(const QString& fileName)
     if (fileName.isEmpty() == true)
         return QFile::OpenError;
 
-    QFile file(fileName);
+    QString tempFileName(fileName);
+    tempFileName += ".temp";
+    QFile file(tempFileName);
     if (file.open(QIODevice::WriteOnly) == false)
         return file.error();
 
@@ -329,6 +331,19 @@ QFile::FileError QLCFixtureDef::saveXML(const QString& fileName)
     error = QFile::NoError;
     doc.writeEndDocument();
     file.close();
+
+    // Save to actual requested file name
+    QFile currFile(fileName);
+    if (currFile.exists() && !currFile.remove())
+    {
+        qWarning() << "Could not erase" << fileName;
+        return currFile.error();
+    }
+    if (!file.rename(fileName))
+    {
+        qWarning() << "Could not rename" << tempFileName << "to" << fileName;
+        return file.error();
+    }
 
     return error;
 }

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -1378,7 +1378,9 @@ bool App::loadXML(QXmlStreamReader& doc, bool goToConsole, bool fromMemory)
 
 QFile::FileError App::saveXML(const QString& fileName)
 {
-    QFile file(fileName);
+    QString tempFileName(fileName);
+    tempFileName += ".temp";
+    QFile file(tempFileName);
     if (file.open(QIODevice::WriteOnly) == false)
         return file.error();
 
@@ -1417,6 +1419,19 @@ QFile::FileError App::saveXML(const QString& fileName)
     /* End the document and close all the open elements */
     doc.writeEndDocument();
     file.close();
+
+    // Save to actual requested file name
+    QFile currFile(fileName);
+    if (currFile.exists() && !currFile.remove())
+    {
+        qWarning() << "Could not erase" << fileName;
+        return currFile.error();
+    }
+    if (!file.rename(fileName))
+    {
+        qWarning() << "Could not rename" << tempFileName << "to" << fileName;
+        return file.error();
+    }
 
     /* Set the file name for the current Doc instance and
        set it also in an unmodified state. */


### PR DESCRIPTION
This way, in case of a crash during saving,
the current destination file will not become blank or corrupt.

Idea here:
http://qlcplus.org/forum/viewtopic.php?f=5&t=9227&p=40548&hilit=crash+while+saving#p40548