### PR TITLE
fix crash: select another input while rgbaudio is running

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 qlcplus (4.10.3) stable; urgency=low
 
+  * Audio Capture: Fix crash when selecting another audio input while a capture is running (David Garyga)
+  * Audio Capture: Fix crash when trying to use a wrongly configured audio input (David Garyga)
   * Scene Editor: Remember Channels Groups values when saving and loading a workspace (David Garyga)
   * Scene Editor: Remember fixtures even with no activated channel (David Garyga)
   * Show Manager: Fix crash when editing the total time of an empty chaser (David Garyga)

--- a/engine/src/audio/audiocapture.h
+++ b/engine/src/audio/audiocapture.h
@@ -43,11 +43,11 @@
  * @{
  */
 
-typedef struct
+struct BandsData
 {
     int m_registerCounter;
     QVector<double> m_fftMagnitudeBuffer;
-} BandsData;
+};
 
 class AudioCapture : public QThread
 {
@@ -75,10 +75,9 @@ public:
     void unregisterBandsNumber(int number);
     //int bandsNumber();
 
-    bool isInitialized();
-
     static int maxFrequency() { return SPECTRUM_MAX_FREQUENCY; }
 
+    protected:
     /*!
      * Prepares object for usage and setups required audio parameters.
      * Subclass should reimplement this function.
@@ -87,8 +86,11 @@ public:
      * @param bufferSize Audio dat buffer size\
      * @return initialization result (\b true - success, \b false - failure)
      */
-    virtual bool initialize();
+    virtual bool initialize() = 0;
 
+    virtual void uninitialize() = 0;
+
+    public:
     /*!
      * Returns input interface latency in milliseconds.
      */
@@ -142,7 +144,6 @@ protected:
     virtual bool readAudio(int maxSize) = 0;
 
     QMutex m_mutex;
-    bool m_isInitialized;
 
     unsigned int m_captureSize, m_sampleRate, m_channels;
 

--- a/engine/src/audio/audiocapture_alsa.cpp
+++ b/engine/src/audio/audiocapture_alsa.cpp
@@ -24,19 +24,19 @@
 
 AudioCaptureAlsa::AudioCaptureAlsa(QObject * parent)
     : AudioCapture(parent)
+    , m_captureHandle(NULL)
 {
-    m_captureHandle = NULL;
 }
 
 AudioCaptureAlsa::~AudioCaptureAlsa()
 {
-    if (m_captureHandle)
-        snd_pcm_close (m_captureHandle);
+    stop();
+    Q_ASSERT(m_captureHandle == NULL);
 }
 
 bool AudioCaptureAlsa::initialize()
 {
-    snd_pcm_hw_params_t *hw_params;
+    snd_pcm_hw_params_t *hw_params = NULL;
     QString dev_name = "default";
     int err;
 
@@ -45,67 +45,52 @@ bool AudioCaptureAlsa::initialize()
     if (var.isValid() == true)
         dev_name = var.toString();
 
-    AudioCapture::initialize();
-
     pcm_name = strdup(dev_name.toLatin1().data());
 
     qDebug() << "AudioCaptureAlsa: initializing device " << pcm_name;
 
-    if (m_captureHandle)
-    {
-        snd_pcm_close (m_captureHandle);
-        m_captureHandle = NULL;
-    }
+    Q_ASSERT(m_captureHandle == NULL);
 
     if ((err = snd_pcm_open (&m_captureHandle, pcm_name, SND_PCM_STREAM_CAPTURE, 0)) < 0)
-    {
         qWarning("cannot open audio device (%s)\n", snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params_malloc (&hw_params)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params_malloc (&hw_params)) < 0)
         qWarning("cannot allocate hardware parameter structure (%s)\n", snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params_any (m_captureHandle, hw_params)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params_any (m_captureHandle, hw_params)) < 0)
         qWarning("cannot initialize hardware parameter structure (%s)\n", snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params_set_access (m_captureHandle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params_set_access (m_captureHandle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0)
         qWarning("cannot set access type (%s)\n", snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params_set_format (m_captureHandle, hw_params, SND_PCM_FORMAT_S16_LE)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params_set_format (m_captureHandle, hw_params, SND_PCM_FORMAT_S16_LE)) < 0)
         qWarning("cannot set sample format (%s)\n", snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params_set_rate_near (m_captureHandle, hw_params, &m_sampleRate, 0)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params_set_rate_near (m_captureHandle, hw_params, &m_sampleRate, 0)) < 0)
         qWarning("cannot set sample rate (%s)\n", snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params_set_channels (m_captureHandle, hw_params, m_channels)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params_set_channels (m_captureHandle, hw_params, m_channels)) < 0)
         qWarning("cannot set channel count to %d (%s)\n", m_channels, snd_strerror (err));
-        return false;
-    }
-    if ((err = snd_pcm_hw_params (m_captureHandle, hw_params)) < 0)
-    {
+    else if ((err = snd_pcm_hw_params (m_captureHandle, hw_params)) < 0)
         qWarning("cannot set parameters (%s)\n", snd_strerror (err));
-        return false;
-    }
-    snd_pcm_hw_params_free (hw_params);
-
-    if ((err = snd_pcm_prepare (m_captureHandle)) < 0)
-    {
+    else if ((err = snd_pcm_prepare (m_captureHandle)) < 0)
         qWarning("cannot prepare audio interface for use (%s)\n", snd_strerror (err));
+
+    if (hw_params)
+        snd_pcm_hw_params_free (hw_params);
+
+    if (err < 0)
+    {
+        if (m_captureHandle != NULL)
+        {
+            snd_pcm_close(m_captureHandle);
+            m_captureHandle = NULL;
+        }
         return false;
     }
 
     return true;
+}
+
+void AudioCaptureAlsa::uninitialize()
+{
+    Q_ASSERT(m_captureHandle != NULL);
+    snd_pcm_close(m_captureHandle);
+    m_captureHandle = NULL;
 }
 
 qint64 AudioCaptureAlsa::latency()
@@ -123,10 +108,12 @@ void AudioCaptureAlsa::resume()
 
 bool AudioCaptureAlsa::readAudio(int maxSize)
 {
+    Q_ASSERT(m_captureHandle != NULL);
+
     int read;
     if ((read = snd_pcm_readi (m_captureHandle, m_audioBuffer, maxSize)) != maxSize)
     {
-        qWarning("read from audio interface failed (%s)\n", snd_strerror (read));
+        qWarning() << "[ALSA readAudio] read from audio interface failed (" << snd_strerror(read) << ")";
         return false;
     }
 

--- a/engine/src/audio/audiocapture_alsa.h
+++ b/engine/src/audio/audiocapture_alsa.h
@@ -39,12 +39,15 @@ public:
     ~AudioCaptureAlsa();
 
     /** @reimpl */
-    bool initialize();
-
-    /** @reimpl */
     qint64 latency();
 
 protected:
+    /** @reimpl */
+    bool initialize();
+
+    /** @reimpl */
+    virtual void uninitialize();
+
     /** @reimpl */
     void suspend();
 

--- a/engine/src/audio/audiocapture_portaudio.h
+++ b/engine/src/audio/audiocapture_portaudio.h
@@ -34,12 +34,15 @@ public:
     ~AudioCapturePortAudio();
 
     /** @reimpl */
-    bool initialize();
-
-    /** @reimpl */
     qint64 latency();
 
 protected:
+    /** @reimpl */
+    bool initialize();
+
+    /** @reimpl */
+    virtual void uninitialize();
+
     /** @reimpl */
     void suspend();
 

--- a/engine/src/audio/audiocapture_qt.h
+++ b/engine/src/audio/audiocapture_qt.h
@@ -36,15 +36,18 @@ public:
     ~AudioCaptureQt();
 
     /** @reimpl */
-    bool initialize();
-
-    /** @reimpl */
     qint64 latency();
 
     /** @reimpl */
     void setVolume(qreal volume);
 
 protected:
+    /** @reimpl */
+    bool initialize();
+
+    /** @reimpl */
+    virtual void uninitialize();
+
     /** @reimpl */
     void suspend();
 

--- a/engine/src/audio/audiocapture_wavein.h
+++ b/engine/src/audio/audiocapture_wavein.h
@@ -38,12 +38,15 @@ public:
     ~AudioCaptureWaveIn();
 
     /** @reimpl */
-    bool initialize();
-
-    /** @reimpl */
     qint64 latency();
 
 protected:
+    /** @reimpl */
+    bool initialize();
+
+    /** @reimpl */
+    virtual void uninitialize();
+
     /** @reimpl */
     void suspend();
 
@@ -54,8 +57,6 @@ protected:
     bool readAudio(int maxSize);
 
 private:
-    bool m_started;
-    QMutex m_mutex;
     int m_currentBufferIndex;
     char *m_internalBuffers[HEADERS_NUMBER];
 };

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -22,7 +22,6 @@
 #include <QXmlStreamWriter>
 #include <QStringList>
 #include <QString>
-#include <QCoreApplication>
 #include <QDebug>
 #include <QList>
 #include <QDir>

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -22,6 +22,7 @@
 #include <QXmlStreamWriter>
 #include <QStringList>
 #include <QString>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QList>
 #include <QDir>
@@ -242,6 +243,7 @@ QSharedPointer<AudioCapture> Doc::audioInputCapture()
 {
     if (!m_inputCapture)
     {
+        qDebug() << "Creating new audio capture";
         m_inputCapture = QSharedPointer<AudioCapture>(
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #if defined(__APPLE__) || defined(Q_OS_MAC)

--- a/engine/src/rgbaudio.cpp
+++ b/engine/src/rgbaudio.cpp
@@ -142,8 +142,6 @@ RGBMap RGBAudio::rgbMap(const QSize& size, uint rgb, int step)
     {
         m_bandsNumber = size.width();
         qDebug() << "[RGBAudio] set" << m_bandsNumber << "bars";
-        if (m_audioInput->isInitialized() == false)
-            m_audioInput->initialize();
         m_audioInput->registerBandsNumber(m_bandsNumber);
         return map;
     }

--- a/ui/src/inputoutputpatcheditor.cpp
+++ b/ui/src/inputoutputpatcheditor.cpp
@@ -1071,8 +1071,6 @@ void InputOutputPatchEditor::slotAudioInputPreview(bool enable)
 
     if (enable == true)
     {
-        if (m_inputCapture->isInitialized() == false)
-            m_inputCapture->initialize();
         connect(m_inputCapture, SIGNAL(dataProcessed(double*,int,double,quint32)),
                 this, SLOT(slotAudioUpdateLevel(double*,int,double,quint32)));
         m_inputCapture->registerBandsNumber(FREQ_SUBBANDS_DEFAULT_NUMBER);

--- a/ui/src/virtualconsole/vcaudiotriggers.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggers.cpp
@@ -187,8 +187,6 @@ void VCAudioTriggers::enableCapture(bool enable)
 
     if (enable == true)
     {
-        if (m_inputCapture->isInitialized() == false)
-            m_inputCapture->initialize();
         connect(m_inputCapture, SIGNAL(dataProcessed(double*,int,double,quint32)),
                 this, SLOT(slotDisplaySpectrum(double*,int,double,quint32)));
         m_inputCapture->registerBandsNumber(m_spectrum->barsNumber());


### PR DESCRIPTION
I made a little test for audio input stability:

- Create an RGB matrix in audio mode
- Create a chaser with just the matrix in it, with duration=0
- play the chaser
- go to the I/O tab, and mess with the audio input configuration

This makes QLC+ crash quite quickly.
With this patch, QLC+ does not crash.

What it does:
- AudioCapture::uninitialize() does the Audio uninitialization (instead of doing it in the destructor)
- AudioCapture::initialize() and AudioCapture::uninintialize() are called in the AudioCapture Thread. This way Qt objects (QAudioInput) are created and destroyed from the same thread. Qt likes this better.
- This allow AudioCapture::run() to know when initialization could not be achieved, and abandon reading.

Tested on Linux (Qt5 version, Qt4 version)
I will test on Windows (Qt5) soon. I can't test the windows Qt4 version. Is this still used ?
I can't test on OSX at all. Is the OSX Qt4 version still used ?