### PR TITLE
Rgbmatrix preview fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ qlcplus (4.10.3) stable; urgency=low
   * Audio Capture: Fix crash when trying to use a wrongly configured audio input (David Garyga)
   * Scene Editor: Remember Channels Groups values when saving and loading a workspace (David Garyga)
   * Scene Editor: Remember fixtures even with no activated channel (David Garyga)
+  * RGBMatrix Editor: Fix preview now working when fadein > 0 (David Garyga)
+  * RGBMatrix Editor: Fix lenght of fadeout on the preview (David Garyga)
   * Show Manager: Fix crash when editing the total time of an empty chaser (David Garyga)
   * Show Manager/Function Selection: Fix sequences always displayed even with Chasers and Scenes both filtered out (David Garyga)
   * Input/Output Manager: Forbid deleting universes in the middle of the list, this prevents a lot of bugs and crashes (David Garyga)

--- a/ui/src/rgbitem.cpp
+++ b/ui/src/rgbitem.cpp
@@ -25,91 +25,65 @@
 #include "qlcmacros.h"
 #include "rgbitem.h"
 
-static QColor getColor(QColor oldColor, QColor color, uint ms, uint elapsed)
+template<typename T_QGraphicsItem>
+RGBItem<T_QGraphicsItem>::RGBItem(QGraphicsItem* parent)
+    : T_QGraphicsItem(parent)
+    , m_elapsed(0)
 {
-    if (ms == 0)
+}
+
+template<typename T_QGraphicsItem>
+void RGBItem<T_QGraphicsItem>::setColor(QRgb rgb)
+{
+    m_oldColor = this->brush().color();
+    m_color = QColor(rgb);
+    m_elapsed = 0;
+}
+
+template<typename T_QGraphicsItem>
+QRgb RGBItem<T_QGraphicsItem>::color() const
+{
+    return m_color.rgb();
+}
+
+template<typename T_QGraphicsItem>
+void RGBItem<T_QGraphicsItem>::draw(uint elapsedMs, uint targetMs)
+{
+    m_elapsed += elapsedMs;
+
+    if (targetMs == 0)
     {
-        return color;
+        this->setBrush(m_color);
     }
-    else if (elapsed <= ms)
+    else if (m_elapsed <= targetMs)
     {
         int red, green, blue;
-        if (oldColor.red() < color.red())
-            red = SCALE(qreal(elapsed), qreal(0), qreal(ms), qreal(oldColor.red()), qreal(color.red()));
+        if (m_oldColor.red() < m_color.red())
+            red = SCALE(qreal(m_elapsed), qreal(0), qreal(targetMs), qreal(m_oldColor.red()), qreal(m_color.red()));
         else
-            red = SCALE(qreal(elapsed), qreal(ms), qreal(0), qreal(color.red()), qreal(oldColor.red()));
+            red = SCALE(qreal(m_elapsed), qreal(targetMs), qreal(0), qreal(m_color.red()), qreal(m_oldColor.red()));
         red = CLAMP(red, 0, 255);
 
-        if (oldColor.green() < color.green())
-            green = SCALE(qreal(elapsed), qreal(0), qreal(ms), qreal(oldColor.green()), qreal(color.green()));
+        if (m_oldColor.green() < m_color.green())
+            green = SCALE(qreal(m_elapsed), qreal(0), qreal(targetMs), qreal(m_oldColor.green()), qreal(m_color.green()));
         else
-            green = SCALE(qreal(elapsed), qreal(ms), qreal(0), qreal(color.green()), qreal(oldColor.green()));
+            green = SCALE(qreal(m_elapsed), qreal(targetMs), qreal(0), qreal(m_color.green()), qreal(m_oldColor.green()));
         green = CLAMP(green, 0, 255);
 
-        if (oldColor.blue() < color.blue())
-            blue = SCALE(qreal(elapsed), qreal(0), qreal(ms), qreal(oldColor.blue()), qreal(color.blue()));
+        if (m_oldColor.blue() < m_color.blue())
+            blue = SCALE(qreal(m_elapsed), qreal(0), qreal(targetMs), qreal(m_oldColor.blue()), qreal(m_color.blue()));
         else
-            blue = SCALE(qreal(elapsed), qreal(ms), qreal(0), qreal(color.blue()), qreal(oldColor.blue()));
+            blue = SCALE(qreal(m_elapsed), qreal(targetMs), qreal(0), qreal(m_color.blue()), qreal(m_oldColor.blue()));
         blue = CLAMP(blue, 0, 255);
 
-        return QColor(red, green, blue);
+        this->setBrush(QColor(red, green, blue));
     }
-    return QColor();
+    else
+        this->setBrush(m_color);
+
+//    qDebug() << Q_FUNC_INFO << m_elapsed << this->brush().color().red() << this->brush().color().green() << this->brush().color().blue();
 }
 
-/************************************************************************
- * RGB Circle Item
- ************************************************************************/
-
-RGBCircleItem::RGBCircleItem(QGraphicsItem* parent)
-    : QGraphicsEllipseItem(parent)
-    , m_elapsed(0)
-{
-}
-
-void RGBCircleItem::setColor(QRgb rgb)
-{
-    m_oldColor = brush().color();
-    m_color = QColor(rgb);
-    m_elapsed = 0;
-}
-
-QRgb RGBCircleItem::color() const
-{
-    return m_color.rgb();
-}
-
-void RGBCircleItem::draw(uint ms)
-{
-    setBrush(getColor(m_oldColor, m_color, ms, m_elapsed));
-    m_elapsed += MasterTimer::tick();
-}
-
-/************************************************************************
- * RGB Rect Item
- ************************************************************************/
-
-RGBRectItem::RGBRectItem(QGraphicsItem* parent)
-    : QGraphicsRectItem(parent)
-    , m_elapsed(0)
-{
-}
-
-void RGBRectItem::setColor(QRgb rgb)
-{
-    m_oldColor = brush().color();
-    m_color = QColor(rgb);
-    m_elapsed = 0;
-}
-
-QRgb RGBRectItem::color() const
-{
-    return m_color.rgb();
-}
-
-void RGBRectItem::draw(uint ms)
-{
-    setBrush(getColor(m_oldColor, m_color, ms, m_elapsed));
-    m_elapsed += MasterTimer::tick();
-}
-
+// Force instantiation of templates
+template class RGBItem<QGraphicsEllipseItem>;
+template class RGBItem<QGraphicsRectItem>;

--- a/ui/src/rgbitem.cpp
+++ b/ui/src/rgbitem.cpp
@@ -25,35 +25,31 @@
 #include "qlcmacros.h"
 #include "rgbitem.h"
 
-template<typename T_QGraphicsItem>
-RGBItem<T_QGraphicsItem>::RGBItem(QGraphicsItem* parent)
-    : T_QGraphicsItem(parent)
-    , m_elapsed(0)
+RGBItem::RGBItem(QAbstractGraphicsShapeItem* graphicsItem)
+    : m_elapsed(0)
+    , m_graphicsItem(graphicsItem)
 {
 }
 
-template<typename T_QGraphicsItem>
-void RGBItem<T_QGraphicsItem>::setColor(QRgb rgb)
+void RGBItem::setColor(QRgb rgb)
 {
-    m_oldColor = this->brush().color();
+    m_oldColor = m_graphicsItem->brush().color();
     m_color = QColor(rgb);
     m_elapsed = 0;
 }
 
-template<typename T_QGraphicsItem>
-QRgb RGBItem<T_QGraphicsItem>::color() const
+QRgb RGBItem::color() const
 {
     return m_color.rgb();
 }
 
-template<typename T_QGraphicsItem>
-void RGBItem<T_QGraphicsItem>::draw(uint elapsedMs, uint targetMs)
+void RGBItem::draw(uint elapsedMs, uint targetMs)
 {
     m_elapsed += elapsedMs;
 
     if (targetMs == 0)
     {
-        this->setBrush(m_color);
+        m_graphicsItem->setBrush(m_color);
     }
     else if (m_elapsed <= targetMs)
     {
@@ -76,14 +72,13 @@ void RGBItem<T_QGraphicsItem>::draw(uint elapsedMs, uint targetMs)
             blue = SCALE(qreal(m_elapsed), qreal(targetMs), qreal(0), qreal(m_color.blue()), qreal(m_oldColor.blue()));
         blue = CLAMP(blue, 0, 255);
 
-        this->setBrush(QColor(red, green, blue));
+        m_graphicsItem->setBrush(QColor(red, green, blue));
     }
     else
-        this->setBrush(m_color);
-
-//    qDebug() << Q_FUNC_INFO << m_elapsed << this->brush().color().red() << this->brush().color().green() << this->brush().color().blue();
+        m_graphicsItem->setBrush(m_color);
 }
 
-// Force instantiation of templates
-template class RGBItem<QGraphicsEllipseItem>;
-template class RGBItem<QGraphicsRectItem>;
+QAbstractGraphicsShapeItem* RGBItem::graphicsItem() const
+{
+    return m_graphicsItem.data();
+}

--- a/ui/src/rgbitem.h
+++ b/ui/src/rgbitem.h
@@ -20,33 +20,31 @@
 #ifndef RGBITEM_H
 #define RGBITEM_H
 
-#include <QGraphicsEllipseItem>
+#include <QAbstractGraphicsShapeItem>
 #include <QColor>
 
 /** @addtogroup ui_functions
  * @{
  */
 
-template<typename T_QGraphicsItem>
-class RGBItem: public T_QGraphicsItem
+class RGBItem
 {
 public:
-    RGBItem(QGraphicsItem* parent = 0);
-    ~RGBItem() { }
+    RGBItem(QAbstractGraphicsShapeItem* graphicsItem);
 
     void setColor(QRgb rgb);
     QRgb color() const;
 
     void draw(uint elapsedMs, uint targetMs);
 
+    QAbstractGraphicsShapeItem* graphicsItem() const;
+
 private:
     QColor m_color;
     QColor m_oldColor;
     uint m_elapsed;
+    QScopedPointer<QAbstractGraphicsShapeItem> m_graphicsItem;
 };
-
-typedef RGBItem<QGraphicsEllipseItem> RGBCircleItem;
-typedef RGBItem<QGraphicsRectItem> RGBRectItem;
 
 /** @} */
 

--- a/ui/src/rgbitem.h
+++ b/ui/src/rgbitem.h
@@ -27,20 +27,17 @@
  * @{
  */
 
-/************************************************************************
- * RGB Circle Item
- ************************************************************************/
-
-class RGBCircleItem : public QGraphicsEllipseItem
+template<typename T_QGraphicsItem>
+class RGBItem: public T_QGraphicsItem
 {
 public:
-    RGBCircleItem(QGraphicsItem* parent = 0);
-    ~RGBCircleItem() { }
+    RGBItem(QGraphicsItem* parent = 0);
+    ~RGBItem() { }
 
     void setColor(QRgb rgb);
     QRgb color() const;
 
-    void draw(uint ms);
+    void draw(uint elapsedMs, uint targetMs);
 
 private:
     QColor m_color;
@@ -48,26 +45,8 @@ private:
     uint m_elapsed;
 };
 
-/************************************************************************
- * RGB Rect Item
- ************************************************************************/
-
-class RGBRectItem : public QGraphicsRectItem
-{
-public:
-    RGBRectItem(QGraphicsItem* parent = 0);
-    ~RGBRectItem() { }
-
-    void setColor(QRgb rgb);
-    QRgb color() const;
-
-    void draw(uint ms);
-
-private:
-    QColor m_color;
-    QColor m_oldColor;
-    uint m_elapsed;
-};
+typedef RGBItem<QGraphicsEllipseItem> RGBCircleItem;
+typedef RGBItem<QGraphicsRectItem> RGBRectItem;
 
 /** @} */
 

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -40,6 +40,7 @@
 #include "rgbimage.h"
 #include "rgbitem.h"
 #include "rgbtext.h"
+#include "qlcmacros.h"
 #include "apputil.h"
 #include "chaser.h"
 #include "scene.h"
@@ -539,7 +540,7 @@ bool RGBMatrixEditor::createPreviewItems()
                                   ITEM_SIZE - (2 * ITEM_PADDING),
                                   ITEM_SIZE - (2 * ITEM_PADDING));
                     item->setColor(map[y][x]);
-                    item->draw(0);
+                    item->draw(0, 0);
                     m_scene->addItem(item);
                     m_previewHash[pt] = item;
                 }
@@ -551,7 +552,7 @@ bool RGBMatrixEditor::createPreviewItems()
                                   ITEM_SIZE - 1,
                                   ITEM_SIZE - 1);
                     item->setColor(map[y][x]);
-                    item->draw(0);
+                    item->draw(0, 0);
                     m_scene->addItem(item);
                     m_previewHash[pt] = item;
                 }
@@ -563,15 +564,14 @@ bool RGBMatrixEditor::createPreviewItems()
 
 void RGBMatrixEditor::slotPreviewTimeout()
 {
-    RGBCircleItem* shape = NULL;
-
     if (m_matrix->duration() <= 0)
         return;
 
     RGBMap map;
 
     m_previewIterator += MasterTimer::tick();
-    if (m_previewIterator >= m_matrix->duration())
+    uint elapsed = 0;
+    while (m_previewIterator > 0 && m_previewIterator >= m_matrix->duration())
     {
         int stepsCount = m_matrix->stepsCount();
         //qDebug() << "previewTimeout. Step:" << m_previewStep;
@@ -609,7 +609,9 @@ void RGBMatrixEditor::slotPreviewTimeout()
                 m_matrix->updateStepColor(m_previewStep);
         }
         map = m_matrix->previewMap(m_previewStep);
-        m_previewIterator = 0;
+
+        m_previewIterator -= MAX(m_matrix->duration(), MasterTimer::tick());
+        elapsed += MAX(m_matrix->duration(), MasterTimer::tick());
     }
     for (int y = 0; y < map.size(); y++)
     {
@@ -618,14 +620,17 @@ void RGBMatrixEditor::slotPreviewTimeout()
             QLCPoint pt(x, y);
             if (m_previewHash.contains(pt) == true)
             {
-                shape = static_cast<RGBCircleItem*>(m_previewHash[pt]);
+                // TODO
+                // this is plain wrong. An RGBRectItem should not be
+                // accessed through an RGBCircleItem pointer.
+                RGBCircleItem* shape = static_cast<RGBCircleItem*>(m_previewHash[pt]);
                 if (shape->color() != QColor(map[y][x]).rgb())
                     shape->setColor(map[y][x]);
 
                 if (shape->color() == QColor(Qt::black).rgb())
-                    shape->draw(m_matrix->fadeOutSpeed());
+                    shape->draw(elapsed, m_matrix->fadeOutSpeed());
                 else
-                    shape->draw(m_matrix->fadeInSpeed());
+                    shape->draw(elapsed, m_matrix->fadeInSpeed());
             }
         }
     }

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -532,30 +532,32 @@ bool RGBMatrixEditor::createPreviewItems()
 
             if (grp->headHash().contains(pt) == true)
             {
+                RGBItem* item;
                 if (m_shapeButton->isChecked() == false)
                 {
-                    RGBCircleItem* item = new RGBCircleItem;
-                    item->setRect(x * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
-                                  y * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
-                                  ITEM_SIZE - (2 * ITEM_PADDING),
-                                  ITEM_SIZE - (2 * ITEM_PADDING));
-                    item->setColor(map[y][x]);
-                    item->draw(0, 0);
-                    m_scene->addItem(item);
-                    m_previewHash[pt] = item;
+                    QGraphicsEllipseItem* circleItem = new QGraphicsEllipseItem();
+                    circleItem->setRect(
+                            x * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
+                            y * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
+                            ITEM_SIZE - (2 * ITEM_PADDING),
+                            ITEM_SIZE - (2 * ITEM_PADDING));
+                    item = new RGBItem(circleItem);
                 }
                 else
                 {
-                    RGBRectItem* item = new RGBRectItem;
-                    item->setRect(x * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
-                                  y * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
-                                  ITEM_SIZE - 1,
-                                  ITEM_SIZE - 1);
-                    item->setColor(map[y][x]);
-                    item->draw(0, 0);
-                    m_scene->addItem(item);
-                    m_previewHash[pt] = item;
+                    QGraphicsRectItem* rectItem = new QGraphicsRectItem();
+                    rectItem->setRect(
+                            x * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
+                            y * RECT_SIZE + RECT_PADDING + ITEM_PADDING,
+                            ITEM_SIZE - (2 * ITEM_PADDING),
+                            ITEM_SIZE - (2 * ITEM_PADDING));
+                    item = new RGBItem(rectItem);
                 }
+
+                item->setColor(map[y][x]);
+                item->draw(0, 0);
+                m_scene->addItem(item->graphicsItem());
+                m_previewHash[pt] = item;
             }
         }
     }
@@ -620,10 +622,7 @@ void RGBMatrixEditor::slotPreviewTimeout()
             QLCPoint pt(x, y);
             if (m_previewHash.contains(pt) == true)
             {
-                // TODO
-                // this is plain wrong. An RGBRectItem should not be
-                // accessed through an RGBCircleItem pointer.
-                RGBCircleItem* shape = static_cast<RGBCircleItem*>(m_previewHash[pt]);
+                RGBItem* shape = m_previewHash[pt];
                 if (shape->color() != QColor(map[y][x]).rgb())
                     shape->setColor(map[y][x]);
 

--- a/ui/src/rgbmatrixeditor.h
+++ b/ui/src/rgbmatrixeditor.h
@@ -30,6 +30,7 @@
 
 class SpeedDialWidget;
 class QGraphicsScene;
+class RGBItem;
 class QTimer;
 
 /** @addtogroup ui_functions
@@ -128,7 +129,7 @@ private:
     QTimer* m_previewTimer;
     uint m_previewIterator;
     int m_previewStep;
-    QHash <QLCPoint,QGraphicsItem*> m_previewHash;
+    QHash<QLCPoint, RGBItem*> m_previewHash;
 };
 
 /** @} */


### PR DESCRIPTION
Fix #749 

Also fix a bug that was here from the beginning of times: fadeout "tail" size way too big and sometimes stucked




Issue not fixed: the fadein "tail" is never seen because the tick of the preview is based on the duration of the rgbmatrix. As the duration of the rgbmatrix is FadeIn+Hold, the fadein is never seen.
I propose 3 solutions:
- Calculate a better tick for the rgbmatrix preview (based on greatest common divisor of fadein and hold ?)
- Go back to previewTick == MasterTimerTick
- Not care about this