### PR TITLE
New fixture - OXO-LED-Funstrip-DMX

### DIFF
--- a/resources/fixtures/OXO-LED-Funstrip-DMX.qxf
+++ b/resources/fixtures/OXO-LED-Funstrip-DMX.qxf
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.10.2 GIT</Version>
+  <Author>Robert Box</Author>
+ </Creator>
+ <Manufacturer>OXO</Manufacturer>
+ <Model>LED Funstrip DMX</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="LED 1 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 2 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 3 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 4 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 5 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 6 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 7 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 8 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 9 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 10 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="Macro Program">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="7">Dimmer mode</Capability>
+  <Capability Min="8" Max="15">All full</Capability>
+  <Capability Min="16" Max="23">Program 1</Capability>
+  <Capability Min="24" Max="31">Program 2</Capability>
+  <Capability Min="32" Max="39">Program 3</Capability>
+  <Capability Min="40" Max="47">Program 4</Capability>
+  <Capability Min="48" Max="55">Program 5</Capability>
+  <Capability Min="56" Max="63">Program 6</Capability>
+  <Capability Min="64" Max="71">Program 7</Capability>
+  <Capability Min="72" Max="79">Program 8</Capability>
+  <Capability Min="80" Max="87">Program 9</Capability>
+  <Capability Min="88" Max="95">Program 10</Capability>
+  <Capability Min="96" Max="103">Program 11</Capability>
+  <Capability Min="104" Max="111">Program 12</Capability>
+  <Capability Min="112" Max="119">Program 13</Capability>
+  <Capability Min="120" Max="127">Program 14</Capability>
+  <Capability Min="128" Max="135">Program 15</Capability>
+  <Capability Min="136" Max="143">Program 16</Capability>
+  <Capability Min="144" Max="255">Auto</Capability>
+ </Channel>
+ <Channel Name="Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">From slow to fast</Capability>
+ </Channel>
+ <Channel Name="Fade Time">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="Lamp Mode">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="127">LED mode</Capability>
+  <Capability Min="128" Max="255">Tungsten mode</Capability>
+ </Channel>
+ <Channel Name="Play Mode">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="80">Stop</Capability>
+  <Capability Min="81" Max="160">Pause</Capability>
+  <Capability Min="161" Max="255">Play</Capability>
+ </Channel>
+ <Channel Name="Program Master">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">Dimmer 0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 1-10 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 1-5 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 6-10 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 1-2 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 3-4 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 5-6 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 7-8 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Channel Name="LED 9-10 Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0 - 100%</Capability>
+ </Channel>
+ <Mode Name="7-Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="6.3" Width="1040" Height="140" Depth="130"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">LED 1-10 Dimmer</Channel>
+  <Channel Number="1">Macro Program</Channel>
+  <Channel Number="2">Speed</Channel>
+  <Channel Number="3">Fade Time</Channel>
+  <Channel Number="4">Lamp Mode</Channel>
+  <Channel Number="5">Play Mode</Channel>
+  <Channel Number="6">Program Master</Channel>
+ </Mode>
+ <Mode Name="8-Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="6.3" Width="1040" Height="140" Depth="130"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">LED 1-5 Dimmer</Channel>
+  <Channel Number="1">LED 6-10 Dimmer</Channel>
+  <Channel Number="2">Macro Program</Channel>
+  <Channel Number="3">Speed</Channel>
+  <Channel Number="4">Fade Time</Channel>
+  <Channel Number="5">Lamp Mode</Channel>
+  <Channel Number="6">Play Mode</Channel>
+  <Channel Number="7">Program Master</Channel>
+  <Head>
+   <Channel>0</Channel>
+  </Head>
+  <Head>
+   <Channel>1</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="10-Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="6.3" Width="1040" Height="140" Depth="130"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">LED 1 Dimmer</Channel>
+  <Channel Number="1">LED 2 Dimmer</Channel>
+  <Channel Number="2">LED 3 Dimmer</Channel>
+  <Channel Number="3">LED 4 Dimmer</Channel>
+  <Channel Number="4">LED 5 Dimmer</Channel>
+  <Channel Number="5">LED 6 Dimmer</Channel>
+  <Channel Number="6">LED 7 Dimmer</Channel>
+  <Channel Number="7">LED 8 Dimmer</Channel>
+  <Channel Number="8">LED 9 Dimmer</Channel>
+  <Channel Number="9">LED 10 Dimmer</Channel>
+  <Head>
+   <Channel>0</Channel>
+  </Head>
+  <Head>
+   <Channel>1</Channel>
+  </Head>
+  <Head>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>3</Channel>
+  </Head>
+  <Head>
+   <Channel>4</Channel>
+  </Head>
+  <Head>
+   <Channel>5</Channel>
+  </Head>
+  <Head>
+   <Channel>6</Channel>
+  </Head>
+  <Head>
+   <Channel>7</Channel>
+  </Head>
+  <Head>
+   <Channel>8</Channel>
+  </Head>
+  <Head>
+   <Channel>9</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="11-Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="6.3" Width="1040" Height="140" Depth="130"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">LED 1-2 Dimmer</Channel>
+  <Channel Number="1">LED 3-4 Dimmer</Channel>
+  <Channel Number="2">LED 5-6 Dimmer</Channel>
+  <Channel Number="3">LED 7-8 Dimmer</Channel>
+  <Channel Number="4">LED 9-10 Dimmer</Channel>
+  <Channel Number="5">Macro Program</Channel>
+  <Channel Number="6">Speed</Channel>
+  <Channel Number="7">Fade Time</Channel>
+  <Channel Number="8">Lamp Mode</Channel>
+  <Channel Number="9">Play Mode</Channel>
+  <Channel Number="10">Program Master</Channel>
+  <Head>
+   <Channel>0</Channel>
+  </Head>
+  <Head>
+   <Channel>1</Channel>
+  </Head>
+  <Head>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>3</Channel>
+  </Head>
+  <Head>
+   <Channel>4</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="16-Channel">
+  <Physical>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="6.3" Width="1040" Height="140" Depth="130"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+   <Technical PowerConsumption="90" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">LED 1 Dimmer</Channel>
+  <Channel Number="1">LED 2 Dimmer</Channel>
+  <Channel Number="2">LED 3 Dimmer</Channel>
+  <Channel Number="3">LED 4 Dimmer</Channel>
+  <Channel Number="4">LED 5 Dimmer</Channel>
+  <Channel Number="5">LED 6 Dimmer</Channel>
+  <Channel Number="6">LED 7 Dimmer</Channel>
+  <Channel Number="7">LED 8 Dimmer</Channel>
+  <Channel Number="8">LED 9 Dimmer</Channel>
+  <Channel Number="9">LED 10 Dimmer</Channel>
+  <Channel Number="10">Macro Program</Channel>
+  <Channel Number="11">Speed</Channel>
+  <Channel Number="12">Fade Time</Channel>
+  <Channel Number="13">Lamp Mode</Channel>
+  <Channel Number="14">Play Mode</Channel>
+  <Channel Number="15">Program Master</Channel>
+  <Head>
+   <Channel>0</Channel>
+  </Head>
+  <Head>
+   <Channel>1</Channel>
+  </Head>
+  <Head>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>3</Channel>
+  </Head>
+  <Head>
+   <Channel>4</Channel>
+  </Head>
+  <Head>
+   <Channel>5</Channel>
+  </Head>
+  <Head>
+   <Channel>6</Channel>
+  </Head>
+  <Head>
+   <Channel>7</Channel>
+  </Head>
+  <Head>
+   <Channel>8</Channel>
+  </Head>
+  <Head>
+   <Channel>9</Channel>
+  </Head>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
For manual link see bottom post of this page:

http://www.qlcplus.org/forum/viewtopic.php?f=6&t=9540&p=41956#p41956

I have not included 'Program Master' (dimmer) as part of the heads. The manual suggests it is for the built in programs only but there is no proof. This is only a white fixture so I'm not sure if it matters much.