### PR TITLE
fix audiocapture_qt

### DIFF
--- a/engine/audio/src/audiocapture.h
+++ b/engine/audio/src/audiocapture.h
@@ -137,7 +137,7 @@ signals:
 
 protected:
     /*!
-     * Reads up to \b maxSize bytes from \b the input interface device.
+     * Reads up to \b maxSize uint16 from \b the input interface device.
      * Returns an array of the bytes read, or an empty array if an error occurred.
      * Subclass should reimplement this function.
      */

--- a/engine/audio/src/audiocapture_qt.h
+++ b/engine/audio/src/audiocapture_qt.h
@@ -62,6 +62,7 @@ private:
     QIODevice *m_input;
     QAudioFormat m_format;
     qreal m_volume;
+    unsigned int m_currentBufferPosition;
 };
 
 /** @} */


### PR DESCRIPTION
fix #795 

The issue is that neither QAudioInput::bytesReady()
nor QIODevice::bytesAvailable() are reliable here.

The only solution is to simply call QIODevice::read()
and use its return value.