### PR TITLE
Cameo led rgbw par64 18x8 w

### DIFF
--- a/resources/fixtures/Cameo-LED-RGBW-PAR64-18x8W.qxf
+++ b/resources/fixtures/Cameo-LED-RGBW-PAR64-18x8W.qxf
@@ -3,61 +3,39 @@
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
   <Name>Q Light Controller Plus</Name>
-  <Version>4.8.4</Version>
-  <Author>VagSag</Author>
+  <Version>4.10.2 GIT</Version>
+  <Author>VagSag, siegmund</Author>
  </Creator>
  <Manufacturer>Cameo</Manufacturer>
  <Model>LED RGBW PAR64 18x8W</Model>
  <Type>Color Changer</Type>
  <Channel Name="Master Dimmer">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Master dimmer</Capability>
+  <Capability Min="0" Max="255">0-100%</Capability>
  </Channel>
  <Channel Name="Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="255">Strobing (Slow--&gt;Fast)</Capability>
+  <Capability Min="0" Max="255">0-100%</Capability>
  </Channel>
- <Channel Name="RED">
+ <Channel Name="Red">
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
-  <Capability Min="0" Max="255" Color="#ff0000">Red</Capability>
+  <Capability Min="0" Max="255" Color="#ff0000">0-100%</Capability>
  </Channel>
- <Channel Name="GREEN">
+ <Channel Name="Green">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="255">Green</Capability>
+  <Capability Min="0" Max="255">0-100%</Capability>
  </Channel>
- <Channel Name="BLUE">
+ <Channel Name="Blue">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
-  <Capability Min="0" Max="255">Blue</Capability>
+  <Capability Min="0" Max="255">0-100%</Capability>
  </Channel>
- <Channel Name="WHITE">
+ <Channel Name="White">
   <Group Byte="0">Intensity</Group>
   <Colour>White</Colour>
-  <Capability Min="0" Max="255">White</Capability>
- </Channel>
- <Channel Name="Effects-Programs (7ch)">
-  <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="4">BL / ColorMix Ch3 - Ch6</Capability>
-  <Capability Min="5" Max="10" Color="#ff0000">Red</Capability>
-  <Capability Min="11" Max="15" Color="#00ff00">Green</Capability>
-  <Capability Min="16" Max="20" Color="#0800ff">Blue</Capability>
-  <Capability Min="21" Max="25" Color="#ffffff">White</Capability>
-  <Capability Min="26" Max="30" Color="#ffff00">Yellow</Capability>
-  <Capability Min="31" Max="35" Color="#00ffff">Cyan</Capability>
-  <Capability Min="36" Max="40" Color="#ff007f">Magenta</Capability>
-  <Capability Min="41" Max="45" Color="#ff8fe7">Pink</Capability>
-  <Capability Min="46" Max="50" Color="#aaff00">Bright Green</Capability>
-  <Capability Min="51" Max="55" Color="#aa55ff">Lavender</Capability>
-  <Capability Min="56" Max="60" Color="#ffb2ff">Pale Pink</Capability>
-  <Capability Min="61" Max="65" Color="#ffaa00">Amber</Capability>
-  <Capability Min="66" Max="70" Color="#ff55ff">Bright Magenta</Capability>
-  <Capability Min="71" Max="75" Color="#aaffff">Pale Cyan</Capability>
-  <Capability Min="76" Max="80" Color="#ffec9c">Warm White</Capability>
-  <Capability Min="81" Max="150">Color Jumping Speed: slow(081) - fast(150)</Capability>
-  <Capability Min="151" Max="220">Color Fading Speed: slow(151) - fast(220)</Capability>
-  <Capability Min="221" Max="255">Sound Control (Mic Sensitivity)</Capability>
+  <Capability Min="0" Max="255">0-100%</Capability>
  </Channel>
  <Channel Name="Color Macros">
   <Group Byte="0">Colour</Group>
@@ -65,102 +43,102 @@
   <Capability Min="17" Max="33" Color="#00ff00">Green</Capability>
   <Capability Min="34" Max="50" Color="#0000ff">Blue</Capability>
   <Capability Min="51" Max="67" Color="#ffffff">White</Capability>
-  <Capability Min="68" Max="84" Color="#ff8800">Orange</Capability>
+  <Capability Min="68" Max="84" Color="#ffff00">Yellow</Capability>
   <Capability Min="85" Max="101" Color="#00ffff">Cyan</Capability>
-  <Capability Min="102" Max="118" Color="#aa55ff">Lavender</Capability>
-  <Capability Min="119" Max="135" Color="#ff85d1">Pink</Capability>
-  <Capability Min="136" Max="152" Color="#55ff7f">Bright Green</Capability>
-  <Capability Min="153" Max="169" Color="#ff00ff">Magenta</Capability>
-  <Capability Min="170" Max="186" Color="#ffaaff">Pale Pink</Capability>
-  <Capability Min="187" Max="203" Color="#ffaa00">Amber</Capability>
-  <Capability Min="204" Max="220" Color="#ff55ff">Bright Magenta</Capability>
-  <Capability Min="221" Max="237" Color="#aaffff">Pale Cyan</Capability>
-  <Capability Min="238" Max="255" Color="#ffe1b7">Warm White</Capability>
+  <Capability Min="102" Max="118" Color="#ff00ff">Magenta</Capability>
+  <Capability Min="119" Max="135" Color="#ff69b4">Pink</Capability>
+  <Capability Min="136" Max="152" Color="#90ee90">Bright green</Capability>
+  <Capability Min="153" Max="169" Color="#e6e6fa">Lavender</Capability>
+  <Capability Min="170" Max="186" Color="#ffc0cb">Pale pink</Capability>
+  <Capability Min="187" Max="203" Color="#ffffe0">Bright Yellow</Capability>
+  <Capability Min="204" Max="220" Color="#ff55ff">Bright magenta</Capability>
+  <Capability Min="221" Max="237" Color="#e0ffff">Pale Cyan</Capability>
+  <Capability Min="238" Max="255" Color="#faebd7">Warm white</Capability>
  </Channel>
- <Channel Name="Effects-Programs (3ch)">
-  <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="4">Black Out</Capability>
+ <Channel Name="Color Macros/Effects">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="4">Blackout</Capability>
   <Capability Min="5" Max="10" Color="#ff0000">Red</Capability>
   <Capability Min="11" Max="15" Color="#00ff00">Green</Capability>
-  <Capability Min="16" Max="20" Color="#0800ff">Blue</Capability>
+  <Capability Min="16" Max="20" Color="#0000ff">Blue</Capability>
   <Capability Min="21" Max="25" Color="#ffffff">White</Capability>
   <Capability Min="26" Max="30" Color="#ffff00">Yellow</Capability>
   <Capability Min="31" Max="35" Color="#00ffff">Cyan</Capability>
-  <Capability Min="36" Max="40" Color="#ff007f">Magenta</Capability>
-  <Capability Min="41" Max="45" Color="#ff8fe7">Pink</Capability>
-  <Capability Min="46" Max="50" Color="#aaff00">Bright Green</Capability>
-  <Capability Min="51" Max="55" Color="#aa55ff">Lavender</Capability>
-  <Capability Min="56" Max="60" Color="#ffb2ff">Pale Pink</Capability>
-  <Capability Min="61" Max="65" Color="#ffaa00">Amber</Capability>
-  <Capability Min="66" Max="70" Color="#ff55ff">Bright Magenta</Capability>
-  <Capability Min="71" Max="75" Color="#aaffff">Pale Cyan</Capability>
-  <Capability Min="76" Max="80" Color="#ffec9c">Warm White</Capability>
-  <Capability Min="81" Max="150">Color Jumping Speed: slow(081) - fast(150)</Capability>
-  <Capability Min="151" Max="220">Color Fading Speed: slow(151) - fast(220)</Capability>
-  <Capability Min="221" Max="255">Sound Control (Mic Sensitivity)</Capability>
+  <Capability Min="36" Max="40" Color="#ff00ff">Magenta</Capability>
+  <Capability Min="41" Max="45" Color="#ff69b4">Pink</Capability>
+  <Capability Min="46" Max="50" Color="#90ee90">Bright green</Capability>
+  <Capability Min="51" Max="55" Color="#e6e6fa">Lavender</Capability>
+  <Capability Min="56" Max="60" Color="#ffc0cb">Pale Pink</Capability>
+  <Capability Min="61" Max="65" Color="#ffffe0">Bright yellow</Capability>
+  <Capability Min="66" Max="70" Color="#ff55ff">Bright magenta</Capability>
+  <Capability Min="71" Max="75" Color="#e0ffff">Pale cyan</Capability>
+  <Capability Min="76" Max="80" Color="#faebd7">Warm white</Capability>
+  <Capability Min="81" Max="150" Res="Others/rainbow.png">Color jumping speed: slow(081) - fast(150)</Capability>
+  <Capability Min="151" Max="220" Res="Others/rainbow.png">Color fading speed: slow(151) - fast(220)</Capability>
+  <Capability Min="221" Max="255">Sound control (mic sensitivity)</Capability>
  </Channel>
  <Mode Name="2-Channel Mode">
   <Physical>
-   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
-   <Dimensions Depth="305" Height="270" Weight="3.2" Width="260"/>
-   <Lens DegreesMin="25" DegreesMax="25" Name="Other"/>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="4.5" Width="230" Height="220" Depth="255"/>
+   <Lens Name="Other" DegreesMin="25" DegreesMax="25"/>
    <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
-   <Technical DmxConnector="3-pin" PowerConsumption="170"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
   </Physical>
   <Channel Number="0">Master Dimmer</Channel>
   <Channel Number="1">Color Macros</Channel>
  </Mode>
- <Mode Name="3-Channel Mode1">
+ <Mode Name="3-Channel Mode 1">
   <Physical>
-   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
-   <Dimensions Depth="305" Height="270" Weight="3.2" Width="260"/>
-   <Lens DegreesMin="25" DegreesMax="25" Name="Other"/>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="4.5" Width="230" Height="220" Depth="255"/>
+   <Lens Name="Other" DegreesMin="25" DegreesMax="25"/>
    <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
-   <Technical DmxConnector="3-pin" PowerConsumption="170"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
   </Physical>
   <Channel Number="0">Master Dimmer</Channel>
   <Channel Number="1">Strobe</Channel>
-  <Channel Number="2">Effects-Programs (3ch)</Channel>
+  <Channel Number="2">Color Macros/Effects</Channel>
  </Mode>
- <Mode Name="3-Channel Mode2">
+ <Mode Name="3-Channel Mode 2">
   <Physical>
-   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
-   <Dimensions Depth="305" Height="270" Weight="3.2" Width="260"/>
-   <Lens DegreesMin="25" DegreesMax="25" Name="Other"/>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="4.5" Width="230" Height="220" Depth="255"/>
+   <Lens Name="Other" DegreesMin="25" DegreesMax="25"/>
    <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
-   <Technical DmxConnector="3-pin" PowerConsumption="170"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
   </Physical>
-  <Channel Number="0">RED</Channel>
-  <Channel Number="1">GREEN</Channel>
-  <Channel Number="2">BLUE</Channel>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
  </Mode>
  <Mode Name="4-Channel Mode">
   <Physical>
-   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
-   <Dimensions Depth="305" Height="270" Weight="3.2" Width="260"/>
-   <Lens DegreesMin="25" DegreesMax="25" Name="Other"/>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="4.5" Width="230" Height="220" Depth="255"/>
+   <Lens Name="Other" DegreesMin="25" DegreesMax="25"/>
    <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
-   <Technical DmxConnector="3-pin" PowerConsumption="170"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
   </Physical>
-  <Channel Number="0">RED</Channel>
-  <Channel Number="1">GREEN</Channel>
-  <Channel Number="2">BLUE</Channel>
-  <Channel Number="3">WHITE</Channel>
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
  </Mode>
  <Mode Name="7-Channel Mode">
   <Physical>
-   <Bulb ColourTemperature="0" Type="LED" Lumens="0"/>
-   <Dimensions Depth="305" Height="270" Weight="3.2" Width="260"/>
-   <Lens DegreesMin="25" DegreesMax="25" Name="Other"/>
+   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+   <Dimensions Weight="4.5" Width="230" Height="220" Depth="255"/>
+   <Lens Name="Other" DegreesMin="25" DegreesMax="25"/>
    <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
-   <Technical DmxConnector="3-pin" PowerConsumption="170"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
   </Physical>
   <Channel Number="0">Master Dimmer</Channel>
   <Channel Number="1">Strobe</Channel>
-  <Channel Number="2">RED</Channel>
-  <Channel Number="3">GREEN</Channel>
-  <Channel Number="4">BLUE</Channel>
-  <Channel Number="5">WHITE</Channel>
-  <Channel Number="6">Color Macros</Channel>
+  <Channel Number="2">Red</Channel>
+  <Channel Number="3">Green</Channel>
+  <Channel Number="4">Blue</Channel>
+  <Channel Number="5">White</Channel>
+  <Channel Number="6">Color Macros/Effects</Channel>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Stairville-MH-X60th-LED-Spot.qxf
+++ b/resources/fixtures/Stairville-MH-X60th-LED-Spot.qxf
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.10.2 GIT</Version>
+  <Author>Jasper Zevering</Author>
+ </Creator>
+ <Manufacturer>Stairville</Manufacturer>
+ <Model>MH-X60th LED Spot</Model>
+ <Type>Moving Head</Type>
+ <Channel Name="Rotation">
+  <Group Byte="0">Pan</Group>
+  <Capability Min="0" Max="255">0° up to the maximum value of the pan area: 180°, 270° or 540°</Capability>
+ </Channel>
+ <Channel Name="Fine Adjustment Rotation">
+  <Group Byte="1">Pan</Group>
+  <Capability Min="0" Max="255">Pan</Capability>
+ </Channel>
+ <Channel Name="Inclination">
+  <Group Byte="0">Tilt</Group>
+  <Capability Min="0" Max="255">0° up to the maximum value of the tilt area: 90°, 180° or 270°</Capability>
+ </Channel>
+ <Channel Name="Fine Adjustment Inclination">
+  <Group Byte="1">Tilt</Group>
+  <Capability Min="0" Max="255">Tilt</Capability>
+ </Channel>
+ <Channel Name="Response Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Response speed</Capability>
+ </Channel>
+ <Channel Name="Colour Wheel">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="6" Color="#ffffff">White</Capability>
+  <Capability Min="7" Max="13" Color="#ffff00">Yellow</Capability>
+  <Capability Min="14" Max="20" Color="#ff00ff">Pink</Capability>
+  <Capability Min="21" Max="27" Color="#00ff00">Green</Capability>
+  <Capability Min="28" Max="34" Color="#d76aed">Peachblow</Capability>
+  <Capability Min="35" Max="41" Color="#0000ff">Blue</Capability>
+  <Capability Min="42" Max="48" Color="#4cbb17">Kelly-green</Capability>
+  <Capability Min="49" Max="55" Color="#ff0000">Red</Capability>
+  <Capability Min="56" Max="63" Color="#00008b">Dark blue</Capability>
+  <Capability Min="64" Max="70" Color="#ffffff" Color2="#ffff00">White + yellow</Capability>
+  <Capability Min="71" Max="77" Color="#ffff00" Color2="#ff00ff">Yellow + pink</Capability>
+  <Capability Min="78" Max="84" Color="#ff00ff" Color2="#00ff00">Pink + green</Capability>
+  <Capability Min="85" Max="91" Color="#00ff00" Color2="#d76aed">Green + peachblow</Capability>
+  <Capability Min="92" Max="98" Color="#d76aed" Color2="#0000ff">Peachblow + blue</Capability>
+  <Capability Min="99" Max="105" Color="#0000ff" Color2="#4cbb17">Blue + kelly-green</Capability>
+  <Capability Min="106" Max="112" Color="#4cbb17" Color2="#ff0000">Kelly-green + red</Capability>
+  <Capability Min="113" Max="119" Color="#ff0000" Color2="#00008b">Red + dark blue</Capability>
+  <Capability Min="120" Max="127" Color="#00008b" Color2="#ffffff">Dark blue + white</Capability>
+  <Capability Min="128" Max="191" Res="Others/rainbow.png">Rainbow effect in positive sense of direction, increasing speed</Capability>
+  <Capability Min="192" Max="255" Res="Others/rainbow.png">Rainbow effect in negative sense direction, increasing speed</Capability>
+ </Channel>
+ <Channel Name="Shutter">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="3">Closed (black out)</Capability>
+  <Capability Min="4" Max="7">Open</Capability>
+  <Capability Min="8" Max="76">Strobe light, increasing speed</Capability>
+  <Capability Min="77" Max="145">Triple strobe, increasing speed</Capability>
+  <Capability Min="146" Max="215">Random strobe light, incresing speed</Capability>
+  <Capability Min="216" Max="255">Open</Capability>
+ </Channel>
+ <Channel Name="Electronic Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">0% to 100%</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="7" Res="Others/open.png">Open</Capability>
+  <Capability Min="8" Max="15" Res="ClayPaky/gobo00067.png">Gobo 2</Capability>
+  <Capability Min="16" Max="23" Res="Chauvet/gobo00015.png">Gobo 3</Capability>
+  <Capability Min="24" Max="31" Res="Chauvet/gobo00001.png">Gobo 4</Capability>
+  <Capability Min="32" Max="39" Res="Chauvet/gobo00016.png">Gobo 5</Capability>
+  <Capability Min="40" Max="47" Res="Chauvet/gobo00017.png">Gobo 6</Capability>
+  <Capability Min="48" Max="55" Res="Chauvet/gobo00018.png">Gobo 7</Capability>
+  <Capability Min="56" Max="63" Res="Chauvet/gobo00019.png">Gobo 8</Capability>
+  <Capability Min="64" Max="71" Res="Chauvet/gobo00019.png">Gobo 8 shake, increasing speed</Capability>
+  <Capability Min="72" Max="79" Res="Chauvet/gobo00018.png">Gobo 7 shake, increasing speed</Capability>
+  <Capability Min="80" Max="87" Res="Chauvet/gobo00017.png">Gobo 6 shake, increasing speed</Capability>
+  <Capability Min="88" Max="95" Res="Chauvet/gobo00016.png">Gobo 5 shake, increasing speed</Capability>
+  <Capability Min="96" Max="103" Res="Chauvet/gobo00001.png">Gobo 4 shake, increasing speed</Capability>
+  <Capability Min="104" Max="111" Res="Chauvet/gobo00015.png">Gobo 3 shake, increasing speed</Capability>
+  <Capability Min="112" Max="119" Res="ClayPaky/gobo00067.png">Gobo 2 shake, increasing speed</Capability>
+  <Capability Min="120" Max="127" Res="Others/open.png">Open</Capability>
+  <Capability Min="128" Max="191">Rotation of the gobo wheel counterclockwise, increasing speed</Capability>
+  <Capability Min="192" Max="255">Rotation of the gobo wheel clockwise, increasing speed</Capability>
+ </Channel>
+ <Channel Name="Gobo Rotation">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="63">Fixed</Capability>
+  <Capability Min="64" Max="147">Rotation clockwise, increasing speed</Capability>
+  <Capability Min="148" Max="231">Rotation counterclockwise, increasing speed</Capability>
+  <Capability Min="232" Max="255">Bouncing</Capability>
+ </Channel>
+ <Channel Name="Special Functions">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="7">Unused</Capability>
+  <Capability Min="8" Max="15">Blackout during pan or tilt movement</Capability>
+  <Capability Min="16" Max="23">Blackout during colour wheel movement</Capability>
+  <Capability Min="24" Max="31">Blackout during Gobo wheel movement</Capability>
+  <Capability Min="32" Max="39">No blackout during pan or tilt movement and colour wheel movement</Capability>
+  <Capability Min="40" Max="47">No blackout during pan or tilt movement and gobo wheel movement</Capability>
+  <Capability Min="48" Max="55">No blackout during pan or tilt movement, colour wheel movement and Gobo wheel movement</Capability>
+  <Capability Min="56" Max="95">Unused</Capability>
+  <Capability Min="96" Max="103">Pan reset</Capability>
+  <Capability Min="104" Max="111">Tilt reset</Capability>
+  <Capability Min="112" Max="119">Colour wheel reset</Capability>
+  <Capability Min="120" Max="127">Gobo wheel reset</Capability>
+  <Capability Min="128" Max="135">Gobo rotation reset</Capability>
+  <Capability Min="136" Max="143">Prism reset</Capability>
+  <Capability Min="144" Max="151">Sharpness reset</Capability>
+  <Capability Min="152" Max="159">All channels reset</Capability>
+  <Capability Min="160" Max="255">Unused</Capability>
+ </Channel>
+ <Channel Name="Built in Programmes">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="7">Unused</Capability>
+  <Capability Min="8" Max="23">Programme 1</Capability>
+  <Capability Min="24" Max="39">Programme 2</Capability>
+  <Capability Min="40" Max="55">Programme 3</Capability>
+  <Capability Min="56" Max="71">Programme 4</Capability>
+  <Capability Min="72" Max="87">Programme 5</Capability>
+  <Capability Min="88" Max="103">Programme 6</Capability>
+  <Capability Min="104" Max="119">Programme 7</Capability>
+  <Capability Min="120" Max="135">Programme 8</Capability>
+  <Capability Min="136" Max="151">Sound-control 1</Capability>
+  <Capability Min="152" Max="167">Sound-control 2</Capability>
+  <Capability Min="168" Max="183">Sound-control 3</Capability>
+  <Capability Min="184" Max="199">Sound-control 4</Capability>
+  <Capability Min="200" Max="215">Sound-control 5</Capability>
+  <Capability Min="216" Max="231">Sound-control 6</Capability>
+  <Capability Min="232" Max="247">Sound-control 7</Capability>
+  <Capability Min="248" Max="255">Sound-control 8</Capability>
+ </Channel>
+ <Channel Name="Prism">
+  <Group Byte="0">Prism</Group>
+  <Capability Min="0" Max="7">White</Capability>
+  <Capability Min="8" Max="12">Static</Capability>
+  <Capability Min="13" Max="130">Clockwise rotating, increasing speed</Capability>
+  <Capability Min="131" Max="247">Counterclockwise rotating, increasing speed</Capability>
+  <Capability Min="248" Max="255">Static</Capability>
+ </Channel>
+ <Channel Name="Sharpness">
+  <Group Byte="0">Beam</Group>
+  <Capability Min="0" Max="255">Sharpness</Capability>
+ </Channel>
+ <Mode Name="14 ch mode">
+  <Physical>
+   <Bulb Type="LED" Lumens="1019" ColourTemperature="0"/>
+   <Dimensions Weight="10.4" Width="325" Height="435" Depth="290"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="540" TiltMax="270"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Rotation</Channel>
+  <Channel Number="1">Inclination</Channel>
+  <Channel Number="2">Fine Adjustment Rotation</Channel>
+  <Channel Number="3">Fine Adjustment Inclination</Channel>
+  <Channel Number="4">Response Speed</Channel>
+  <Channel Number="5">Colour Wheel</Channel>
+  <Channel Number="6">Shutter</Channel>
+  <Channel Number="7">Electronic Dimmer</Channel>
+  <Channel Number="8">Gobo Wheel</Channel>
+  <Channel Number="9">Gobo Rotation</Channel>
+  <Channel Number="10">Special Functions</Channel>
+  <Channel Number="11">Built in Programmes</Channel>
+  <Channel Number="12">Prism</Channel>
+  <Channel Number="13">Sharpness</Channel>
+ </Mode>
+ <Mode Name="8 ch mode">
+  <Physical>
+   <Bulb Type="LED" Lumens="1019" ColourTemperature="0"/>
+   <Dimensions Weight="10.4" Width="325" Height="435" Depth="290"/>
+   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+   <Focus Type="Fixed" PanMax="540" TiltMax="270"/>
+   <Technical PowerConsumption="170" DmxConnector="3-pin"/>
+  </Physical>
+  <Channel Number="0">Rotation</Channel>
+  <Channel Number="1">Inclination</Channel>
+  <Channel Number="2">Colour Wheel</Channel>
+  <Channel Number="3">Shutter</Channel>
+  <Channel Number="4">Gobo Wheel</Channel>
+  <Channel Number="5">Gobo Rotation</Channel>
+  <Channel Number="6">Prism</Channel>
+  <Channel Number="7">Sharpness</Channel>
+ </Mode>
+</FixtureDefinition>


### PR DESCRIPTION
Updated fixture:

New version has fixed the macro channels which differ between the operating modes.

Mode 2 is colours only. Modes 3 (1) and 7 have colours and macros.

http://www.qlcplus.org/forum/viewtopic.php?f=3&t=9620