### PR TITLE
osc rework: fix receiving packets on wrong interface

### DIFF
--- a/plugins/E1.31/e131controller.cpp
+++ b/plugins/E1.31/e131controller.cpp
@@ -436,5 +436,4 @@ void E131Controller::processPendingPackets()
                 << ", that does not look like E1.31";
         }
     }
-// TODO? use this test?                if (senderAddress != m_ipAddr || info.inputMulticast == false)
 }

--- a/plugins/osc/osccontroller.cpp
+++ b/plugins/osc/osccontroller.cpp
@@ -25,32 +25,22 @@
 
 OSCController::OSCController(QString ipaddr, Type type, quint32 line, QObject *parent)
     : QObject(parent)
+    , m_ipAddr(ipaddr)
+    , m_packetSent(0)
+    , m_packetReceived(0)
+    , m_line(line)
+    , m_outputSocket(new QUdpSocket(this))
+    , m_packetizer(new OSCPacketizer())
 {
-    m_ipAddr = QHostAddress(ipaddr);
-    m_line = line;
-
     qDebug() << "[OSCController] type: " << type;
-    m_packetizer.reset(new OSCPacketizer());
-    m_packetSent = 0;
-    m_packetReceived = 0;
-
-    m_outputSocket = new QUdpSocket(this);
+    // Ensure packets will be sent from the correct interface
+    m_outputSocket->bind(m_ipAddr, 0);
 }
 
 OSCController::~OSCController()
 {
     qDebug() << Q_FUNC_INFO;
-    //disconnect(m_outputSocket, SIGNAL(readyRead()), this, SLOT(processPendingPackets()));
-    if (m_outputSocket->isOpen())
-        m_outputSocket->close();
-    QMapIterator<quint32, QByteArray *> it(m_dmxValuesMap);
-    while(it.hasNext())
-    {
-        it.next();
-        QByteArray *ba = it.value();
-        delete ba;
-    }
-    m_dmxValuesMap.clear();
+    qDeleteAll(m_dmxValuesMap);
 }
 
 QHostAddress OSCController::getNetworkIP() const
@@ -68,7 +58,7 @@ void OSCController::addUniverse(quint32 universe, OSCController::Type type)
     else
     {
         UniverseInfo info;
-        info.inputSocket = NULL;
+        info.inputSocket.clear();
         info.inputPort = 7700 + universe;
         if (m_ipAddr == QHostAddress::LocalHost)
         {
@@ -84,45 +74,29 @@ void OSCController::addUniverse(quint32 universe, OSCController::Type type)
         info.outputPort = 9000 + universe;
         info.type = type;
         m_universeMap[universe] = info;
-        m_portsMap[info.inputPort] = universe;
     }
 
-    QUdpSocket *socket = m_universeMap[universe].inputSocket;
-    if (type == Input && socket == NULL)
+    if (type == Input)
     {
-        quint16 inPort = m_universeMap[universe].inputPort;
-        socket = new QUdpSocket(this);
-        if (socket->bind(inPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint) == false)
-        {
-            qDebug() << "[OSCController] failed to bind socket to port" << inPort;
-            delete m_universeMap[universe].inputSocket;
-            m_universeMap[universe].inputSocket = NULL;
-        }
-        else
-            connect(socket, SIGNAL(readyRead()),
-                    this, SLOT(processPendingPackets()));
+        UniverseInfo& info = m_universeMap[universe];
+        info.inputSocket.clear();
+        info.inputSocket = getInputSocket(info.inputPort);
     }
 }
 
 void OSCController::removeUniverse(quint32 universe, OSCController::Type type)
 {
-    qDebug() << "### OSCController::removeUniverse";
+    qDebug() << "[OSC] removeUniverse - universe" << universe << ", type" << type;
     if (m_universeMap.contains(universe))
     {
+        UniverseInfo& info = m_universeMap[universe];
         if (type == Input)
-        {
-            m_portsMap.take(m_universeMap[universe].inputPort);
-            if (m_universeMap[universe].inputSocket != NULL)
-            {
-                disconnect(m_universeMap[universe].inputSocket, SIGNAL(readyRead()),
-                           this, SLOT(processPendingPackets()));
-                delete m_universeMap[universe].inputSocket;
-            }
-        }
-        if (m_universeMap[universe].type == type)
+            info.inputSocket.clear();
+
+        if (info.type == type)
             m_universeMap.take(universe);
         else
-            m_universeMap[universe].type &= ~type;
+            info.type &= ~type;
     }
 }
 
@@ -131,38 +105,32 @@ bool OSCController::setInputPort(quint32 universe, quint16 port)
     if (!m_universeMap.contains(universe))
         return false;
 
-    qDebug() << "### OSCController::setInputPort";
     QMutexLocker locker(&m_dataMutex);
-    if (m_portsMap.contains(m_universeMap[universe].inputPort))
-        m_portsMap.take(m_universeMap[universe].inputPort);
-    m_universeMap[universe].inputPort = port;
-    m_portsMap[port] = universe;
+    UniverseInfo& info = m_universeMap[universe];
 
-    QUdpSocket *socket = m_universeMap[universe].inputSocket;
-    if (socket == NULL)
-    {
-        socket = new QUdpSocket(this);
-        qDebug() << "[OSC] new input socket created on universe" << universe;
-    }
-    else
-    {
-        disconnect(socket, SIGNAL(readyRead()),
-                this, SLOT(processPendingPackets()));
-        qDebug() << "[OSC] socket disconnected from universe" << universe;
-    }
+    if (info.inputPort == port)
+        return port == 7700 + universe;
+    info.inputPort = port;
 
-    if (socket->bind(port, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint) == false)
-    {
-        qDebug() << "[OSCController] failed to bind socket to port" << port;
-        return false;
-    }
-
-    qDebug() << "[OSC] socket connected for universe" << universe;
-    connect(socket, SIGNAL(readyRead()),
-            this, SLOT(processPendingPackets()));
-    m_universeMap[universe].inputSocket = socket;
+    info.inputSocket.clear();
+    info.inputSocket = getInputSocket(port);
 
     return port == 7700 + universe;
+}
+
+QSharedPointer<QUdpSocket> OSCController::getInputSocket(quint16 port)
+{
+    foreach(UniverseInfo const& info, m_universeMap)
+    {
+        if (info.inputSocket && info.inputPort == port)
+            return info.inputSocket;
+    }
+
+    QSharedPointer<QUdpSocket> inputSocket(new QUdpSocket(this));
+    inputSocket->bind(m_ipAddr, port, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+    connect(inputSocket.data(), SIGNAL(readyRead()),
+            this, SLOT(processPendingPackets()));
+    return inputSocket;
 }
 
 bool OSCController::setFeedbackIPAddress(quint32 universe, QString address)
@@ -367,55 +335,60 @@ void OSCController::sendFeedback(const quint32 universe, quint32 channel, uchar 
         m_packetSent++;
 }
 
+void OSCController::handlePacket(QUdpSocket* socket, QByteArray const& datagram, QHostAddress const& senderAddress)
+{
+#if _DEBUG_RECEIVED_PACKETS
+    qDebug() << "Received packet with size: " << datagram.size() << ", host: " << senderAddress.toString();
+#else
+    Q_UNUSED(senderAddress);
+#endif
+
+    QList< QPair<QString, QByteArray> > messages = m_packetizer->parsePacket(datagram);
+
+    QListIterator <QPair<QString,QByteArray> > it(messages);
+    while (it.hasNext() == true)
+    {
+        QPair <QString,QByteArray> msg(it.next());
+
+        QString path = msg.first;
+        QByteArray values = msg.second;
+
+        qDebug() << "[OSC] message has path:" << path << "values:" << values.count();
+        if (values.isEmpty())
+            continue;
+
+        for (QMap<quint32, UniverseInfo>::iterator it = m_universeMap.begin(); it != m_universeMap.end(); ++it)
+        {
+            quint32 universe = it.key();
+            UniverseInfo& info = it.value();
+            if (info.inputSocket == socket)
+            {
+                if (values.count() > 1)
+                {
+                    info.multipartCache[path] = values;
+                    for(int i = 0; i < values.count(); i++)
+                    {
+                        QString modPath = QString("%1_%2").arg(path).arg(i);
+                        emit valueChanged(universe, m_line, getHash(modPath), (uchar)values.at(i), modPath);
+                    }
+                }
+                else
+                    emit valueChanged(universe, m_line, getHash(path), (uchar)values.at(0), path);
+            }
+        }
+    }
+    m_packetReceived++;
+}
+
 void OSCController::processPendingPackets()
 {
     QUdpSocket *socket = qobject_cast<QUdpSocket *>(sender());
+    QByteArray datagram;
+    QHostAddress senderAddress;
     while (socket->hasPendingDatagrams())
     {
-        QByteArray datagram;
-        QHostAddress senderAddress;
         datagram.resize(socket->pendingDatagramSize());
         socket->readDatagram(datagram.data(), datagram.size(), &senderAddress);
-        //if (senderAddress != m_ipAddr)
-        {
-            //qDebug() << "Received packet with size: " << datagram.size() << ", host: " << senderAddress.toString();
-            QList< QPair<QString, QByteArray> > messages = m_packetizer->parsePacket(datagram);
-
-            QListIterator <QPair<QString,QByteArray> > it(messages);
-            while (it.hasNext() == true)
-            {
-                QPair <QString,QByteArray> msg(it.next());
-
-                QString path = msg.first;
-                QByteArray values = msg.second;
-
-                qDebug() << "[OSC] message has path:" << path << "values:" << values.count();
-                if (values.isEmpty())
-                    continue;
-
-                quint16 port = socket->localPort();
-                if (m_portsMap.contains(port))
-                {
-                    qDebug() << "here -- 1";
-                    if (values.count() > 1)
-                    {
-                        quint32 uni = m_portsMap[port];
-                        if (m_universeMap.contains(uni))
-                        {
-                            //m_universeMap[uni].multipartCache[path].resize(values.count());
-                            m_universeMap[uni].multipartCache[path] = values;
-                        }
-                        for(int i = 0; i < values.count(); i++)
-                        {
-                            QString modPath = QString("%1_%2").arg(path).arg(i);
-                            emit valueChanged(m_portsMap[port], m_line, getHash(modPath), (uchar)values.at(i), modPath);
-                        }
-                    }
-                    else
-                        emit valueChanged(m_portsMap[port], m_line, getHash(path), (uchar)values.at(0), path);
-                }
-            }
-            m_packetReceived++;
-        }
+        handlePacket(socket, datagram, senderAddress);
     }
 }

--- a/plugins/osc/osccontroller.h
+++ b/plugins/osc/osccontroller.h
@@ -30,7 +30,7 @@
 
 typedef struct
 {
-    QUdpSocket *inputSocket;
+    QSharedPointer<QUdpSocket> inputSocket;
 
     quint16 inputPort;
 
@@ -118,10 +118,16 @@ public:
     /** Send a feedback using the specified path and value */
     void sendFeedback(const quint32 universe, quint32 channel, uchar value, const QString &key);
 
+private:
+    QSharedPointer<QUdpSocket> getInputSocket(quint16 port);
+
 protected:
     /** Calculate a 16bit unsigned hash as a unique representation
      *  of a OSC path. If new, the hash is added to the hash map (m_hashMap) */
     quint16 getHash(QString path);
+
+private:
+    void handlePacket(QUdpSocket* socket, QByteArray const& datagram, QHostAddress const& senderAddress);
 
 private slots:
     /** Async event raised when new packets have been received */
@@ -141,7 +147,7 @@ private:
     quint32 m_line;
 
     /** The UDP socket used to output OSC packets */
-    QUdpSocket *m_outputSocket;
+    QSharedPointer<QUdpSocket> m_outputSocket;
 
     /** Helper class used to create or parse OSC packets */
     QScopedPointer<OSCPacketizer> m_packetizer;
@@ -153,10 +159,6 @@ private:
     /** Map of the QLC+ universes transmitted/received by this
      *  controller, with the related, specific parameters */
     QMap<quint32, UniverseInfo> m_universeMap;
-
-    /** Map of the relation between input ports and QLC+ universes,
-     *  since a single controller can handle input for several universes */
-    QMap<quint16, quint32>m_portsMap;
 
     /** Mutex to handle the change of output IP address or in general
      *  variables that could be used to transmit/receive data */

--- a/plugins/osc/oscpacketizer.cpp
+++ b/plugins/osc/oscpacketizer.cpp
@@ -95,7 +95,7 @@ void OSCPacketizer::setupOSCGeneric(QByteArray &data, QString &path, QString typ
 /*********************************************************************
  * Receiver functions
  *********************************************************************/
-bool OSCPacketizer::parseMessage(QByteArray &data, QString &path, QByteArray &values)
+bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArray& values)
 {
     path.clear();
     values.clear();
@@ -201,7 +201,7 @@ bool OSCPacketizer::parseMessage(QByteArray &data, QString &path, QByteArray &va
     return true;
 }
 
-QList<QPair<QString, QByteArray> > OSCPacketizer::parsePacket(QByteArray &data)
+QList<QPair<QString, QByteArray> > OSCPacketizer::parsePacket(QByteArray const& data)
 {
     int bufPos = 0;
     QList<QPair<QString, QByteArray> > messages;

--- a/plugins/osc/oscpacketizer.h
+++ b/plugins/osc/oscpacketizer.h
@@ -82,7 +82,7 @@ private:
      * @param values the array of values extracted from the buffer
      * @return true on successful parsing, otherwise false
      */
-    bool parseMessage(QByteArray &data, QString &path, QByteArray &values);
+    bool parseMessage(QByteArray const& data, QString& path, QByteArray& values);
 public:
     /**
      * Parse a OSC packet received from the network.
@@ -90,7 +90,7 @@ public:
      * @param data the payload of a UDP packet received from the network
      * @return a list of couples of OSC path/values
      */
-    QList< QPair<QString, QByteArray> > parsePacket(QByteArray& data);
+    QList<QPair<QString, QByteArray> > parsePacket(QByteArray const& data);
 
 };
 


### PR DESCRIPTION
Also use safer pointers


Fix #833

I also tested #832
Without this patch, QLC+ crashes when unchecking/checking 2 times the input of a line with feedback enabled.
With this patch, no crash, and the input still works.
So maybe it fixes #832 too, or maybe my test procedure was wrong.