### PR TITLE
Hysteresis

### DIFF
--- a/plugins/gpio/gpioplugin.cpp
+++ b/plugins/gpio/gpioplugin.cpp
@@ -48,6 +48,7 @@ void GPIOPlugin::init()
         gpio->m_number = i;
         gpio->m_usage = NoUsage;
         gpio->m_value = 1;
+        gpio->m_count = 0;
 
         QString pinPath = QString("/sys/class/gpio/gpio%1/value").arg(i);
         gpio->m_file = new QFile(pinPath);

--- a/plugins/gpio/gpioplugin.h
+++ b/plugins/gpio/gpioplugin.h
@@ -33,6 +33,7 @@ typedef struct
     int m_usage;
     QFile *m_file;
     uchar m_value;
+    uchar m_count;
 } GPIOPinInfo;
 
 class ReadThread;

--- a/plugins/gpio/gpioreaderthread.cpp
+++ b/plugins/gpio/gpioreaderthread.cpp
@@ -22,6 +22,8 @@
 #include "gpioreaderthread.h"
 #include "gpioplugin.h"
 
+#define HYSTERESIS_THRESHOLD  3
+
 ReadThread::ReadThread(GPIOPlugin *plugin, QObject *parent)
     : QThread(parent)
     , m_plugin(plugin)
@@ -110,14 +112,17 @@ void ReadThread::run()
             uchar newVal = dataRead.toUInt();
             if (newVal != gpio->m_value)
             {
-                gpio->m_count += 1;
-                if (gpio->m_count > 3) {
+                gpio->m_count++;
+                if (gpio->m_count > HYSTERESIS_THRESHOLD) 
+                {
                     qDebug() << "Value read: GPIO:" << gpio->m_number << "val:" <<  newVal;
                     gpio->m_value = newVal;
                     gpio->m_count = 0;
                     emit valueChanged(gpio->m_number, gpio->m_value);
                 }
-            } else {
+            } 
+            else 
+            {
                 gpio->m_count = 0;
             }
         }

--- a/plugins/gpio/gpioreaderthread.cpp
+++ b/plugins/gpio/gpioreaderthread.cpp
@@ -110,9 +110,15 @@ void ReadThread::run()
             uchar newVal = dataRead.toUInt();
             if (newVal != gpio->m_value)
             {
-                qDebug() << "Value read: GPIO:" << gpio->m_number << "val:" <<  newVal;
-                gpio->m_value = newVal;
-                emit valueChanged(gpio->m_number, gpio->m_value);
+                gpio->m_counter += 1;
+                if (gpio->m_counter > 3) {
+                    qDebug() << "Value read: GPIO:" << gpio->m_number << "val:" <<  newVal;
+                    gpio->m_value = newVal;
+                    gpio->m_counter = 0;
+                    emit valueChanged(gpio->m_number, gpio->m_value);
+                }
+            } else {
+                gpio->m_counter = 0;
             }
         }
         locker.unlock();

--- a/plugins/gpio/gpioreaderthread.cpp
+++ b/plugins/gpio/gpioreaderthread.cpp
@@ -110,15 +110,15 @@ void ReadThread::run()
             uchar newVal = dataRead.toUInt();
             if (newVal != gpio->m_value)
             {
-                gpio->m_counter += 1;
-                if (gpio->m_counter > 3) {
+                gpio->m_count += 1;
+                if (gpio->m_count > 3) {
                     qDebug() << "Value read: GPIO:" << gpio->m_number << "val:" <<  newVal;
                     gpio->m_value = newVal;
-                    gpio->m_counter = 0;
+                    gpio->m_count = 0;
                     emit valueChanged(gpio->m_number, gpio->m_value);
                 }
             } else {
-                gpio->m_counter = 0;
+                gpio->m_count = 0;
             }
         }
         locker.unlock();


### PR DESCRIPTION
GPIO inputs are noisy. Even with good power supplies and proper electronics in the front you get occasional false triggers (I had 2 last summer. One by itself before the show and one when someone stepped on some cables). This patch requires the value to be stable for 200ms before we accept the trigger as real. The hysteresis work both ways so you also check for release of the button.

It does slow down the response from a button press by 200ms. But on the other hand you can also use internal pull-ups and cheap power supplies without problems with your buttons.

The best thing is that you get no false triggers. And that is quite important for the end user.