### PR TITLE
RGB Matrix with generic dimmers

### DIFF
--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -99,7 +99,8 @@ void EFXFixture::setHead(GroupHead const & head)
             (fxi->tiltMsbChannel(head.head) != QLCChannel::invalid()))
         modes << PanTilt;
 
-    if((fxi->masterIntensityChannel(head.head) != QLCChannel::invalid()))
+    if((fxi->masterIntensityChannel() != QLCChannel::invalid()) ||
+            (fxi->intensityChannel(head.head) != QLCChannel::invalid()))
         modes << Dimmer;
 
     if((fxi->rgbChannels (head.head).size () >= 3))
@@ -159,7 +160,7 @@ bool EFXFixture::isValid() const
     else if (m_mode == PanTilt && fxi->panMsbChannel(head().head) == QLCChannel::invalid() && // Maybe a device can pan OR tilt
              fxi->tiltMsbChannel(head().head) == QLCChannel::invalid())   // but not both. Teh sux0r.
         return false;
-    else if (m_mode == Dimmer && fxi->masterIntensityChannel(head().head) == QLCChannel::invalid() )
+    else if (m_mode == Dimmer && fxi->masterIntensityChannel() == QLCChannel::invalid() && fxi->intensityChannel(head().head) == QLCChannel::invalid() )
         return false;
     else if (m_mode == RGB && fxi->rgbChannels(head().head).size () == 0)
         return false;
@@ -197,7 +198,7 @@ QStringList EFXFixture::modeList()
             (fxi->tiltMsbChannel(head().head) != QLCChannel::invalid()) )
         modes << KXMLQLCEFXFixtureModePanTilt;
 
-    if((fxi->masterIntensityChannel(head().head) != QLCChannel::invalid()))
+    if(fxi->masterIntensityChannel() != QLCChannel::invalid() || fxi->intensityChannel(head().head) != QLCChannel::invalid())
         modes << KXMLQLCEFXFixtureModeDimmer;
 
     if((fxi->rgbChannels (head().head).size () >= 3))
@@ -493,9 +494,13 @@ void EFXFixture::setPointDimmer(QList<Universe *> universes, float dimmer)
     Q_ASSERT(fxi != NULL);
 
     /* Don't write dimmer data directly to universes but use FadeChannel to avoid steps at EFX loop restart */
-    if (fxi->masterIntensityChannel(head().head) != QLCChannel::invalid())
+    if (fxi->intensityChannel(head().head) != QLCChannel::invalid())
     {
-        setFadeChannel(fxi->masterIntensityChannel(head().head),  dimmer);
+        setFadeChannel(fxi->intensityChannel(head().head), dimmer);
+    }
+    else if (fxi->masterIntensityChannel() != QLCChannel::invalid())
+    {
+        setFadeChannel(fxi->masterIntensityChannel(), dimmer);
     }
 }
 

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -340,27 +340,32 @@ quint32 Fixture::tiltLsbChannel(int head) const
     }
 }
 
-quint32 Fixture::masterIntensityChannel(int head) const
+quint32 Fixture::masterIntensityChannel() const
+{
+    if (m_fixtureMode == NULL)
+    {
+        return QLCChannel::invalid();
+    }
+
+    return m_fixtureMode->masterIntensityChannel();
+}
+
+quint32 Fixture::intensityChannel(int head) const
 {
     if (head == -1)
         return QLCChannel::invalid();
 
-    if (m_fixtureMode != NULL)
-    {
-        quint32 dimmerCh = QLCChannel::invalid();
-        if (head < m_fixtureMode->heads().size())
-            dimmerCh = m_fixtureMode->heads().at(head).masterIntensityChannel();
-
-        if (dimmerCh == QLCChannel::invalid())
-        {
-            dimmerCh = channel(QLCChannel::Intensity, QLCChannel::NoColour);
-        }
-        return dimmerCh;
-    }
-    else
+    if (m_fixtureMode == NULL)
     {
         return QLCChannel::invalid();
     }
+
+    if (head >= m_fixtureMode->heads().size())
+    {
+        return QLCChannel::invalid();
+    }
+
+    return m_fixtureMode->heads().at(head).intensityChannel();
 }
 
 QVector <quint32> Fixture::rgbChannels(int head) const

--- a/engine/src/fixture.h
+++ b/engine/src/fixture.h
@@ -266,8 +266,11 @@ public:
     /** @see QLCFixtureHead */
     quint32 tiltLsbChannel(int head = 0) const;
 
+    /** @see QLCFixtureMode */
+    quint32 masterIntensityChannel() const;
+
     /** @see QLCFixtureHead */
-    quint32 masterIntensityChannel(int head = 0) const;
+    quint32 intensityChannel(int head = 0) const;
 
     /** @see QLCFixtureHead */
     QVector <quint32> rgbChannels(int head = 0) const;

--- a/engine/src/qlcfixturehead.h
+++ b/engine/src/qlcfixturehead.h
@@ -97,10 +97,10 @@ public:
     quint32 tiltLsbChannel() const;
 
     /**
-     * Get the master intensity channel. For dimmers this is invalid.
-     * @return The master intensity channel or QLCChannel::invalid() if not applicable.
+     * Get the intensity (dimmer) channel. For dimmers this return the sole channel of the head.
+     * @return The intensity channel or QLCChannel::invalid() if not applicable.
      */
-    quint32 masterIntensityChannel() const;
+    quint32 intensityChannel() const;
 
     /**
      * Get a list of RGB channels. If the fixture doesn't support RGB mixing,
@@ -147,8 +147,8 @@ protected:
     /** The fine tilt channel */
     quint32 m_tiltLsbChannel;
 
-    /** The master intensity channel */
-    quint32 m_masterIntensityChannel;
+    /** The intensity (dimmer) channel */
+    quint32 m_intensityChannel;
 
     /** The RGB mix intensity channels */
     QVector <quint32> m_rgbChannels;

--- a/engine/src/qlcfixturemode.cpp
+++ b/engine/src/qlcfixturemode.cpp
@@ -32,12 +32,14 @@
 
 QLCFixtureMode::QLCFixtureMode(QLCFixtureDef* fixtureDef)
     : m_fixtureDef(fixtureDef)
+    , m_masterIntensityChannel(QLCChannel::invalid())
 {
     Q_ASSERT(fixtureDef != NULL);
 }
 
 QLCFixtureMode::QLCFixtureMode(QLCFixtureDef* fixtureDef, const QLCFixtureMode* mode)
     : m_fixtureDef(fixtureDef)
+    , m_masterIntensityChannel(QLCChannel::invalid())
 {
     Q_ASSERT(fixtureDef != NULL);
     Q_ASSERT(mode != NULL);
@@ -57,6 +59,7 @@ QLCFixtureMode& QLCFixtureMode::operator=(const QLCFixtureMode& mode)
         m_name = mode.m_name;
         m_physical = mode.m_physical;
         m_heads = mode.m_heads;
+        m_masterIntensityChannel = QLCChannel::invalid();
 
         /* Clear the existing list of channels */
         m_channels.clear();
@@ -224,6 +227,11 @@ quint32 QLCFixtureMode::channelNumber(QLCChannel::Group group, QLCChannel::Contr
     return QLCChannel::invalid();
 }
 
+quint32 QLCFixtureMode::masterIntensityChannel() const
+{
+    return m_masterIntensityChannel;
+}
+
 /*****************************************************************************
  * Heads
  *****************************************************************************/
@@ -270,6 +278,18 @@ void QLCFixtureMode::cacheHeads()
     {
         QLCFixtureHead& head(m_heads[i]);
         head.cacheChannels(this);
+    }
+
+    for (int i = 0; i < m_channels.size(); i++)
+    {
+        if (m_channels.at(i)->group() == QLCChannel::Intensity &&
+            m_channels.at(i)->controlByte() == QLCChannel::MSB &&
+            m_channels.at(i)->colour() == QLCChannel::NoColour &&
+            headForChannel(i) == -1)
+        {
+            m_masterIntensityChannel = i;
+            break;
+        }
     }
 }
 

--- a/engine/src/qlcfixturemode.h
+++ b/engine/src/qlcfixturemode.h
@@ -196,9 +196,13 @@ public:
      */
     quint32 channelNumber(QLCChannel::Group group, QLCChannel::ControlByte cByte = QLCChannel::MSB) const;
 
+    quint32 masterIntensityChannel() const;
+
 protected:
     /** List of channels (pointers are not owned) */
     QVector <QLCChannel*> m_channels;
+
+    quint32 m_masterIntensityChannel;
 
     /*********************************************************************
      * Heads

--- a/engine/test/qlcfixturehead/qlcfixturehead_test.cpp
+++ b/engine/test/qlcfixturehead/qlcfixturehead_test.cpp
@@ -189,7 +189,7 @@ void QLCFixtureHead_Test::cacheChannelsRgbMaster()
     QCOMPARE(head.tiltLsbChannel(), QLCChannel::invalid());
     QCOMPARE(head.rgbChannels(), QVector <quint32> () << 0 << 1 << 2);
     QCOMPARE(head.cmyChannels(), QVector <quint32> ());
-    QCOMPARE(head.masterIntensityChannel(), quint32(3));
+    QCOMPARE(head.intensityChannel(), quint32(3));
 }
 
 void QLCFixtureHead_Test::cacheChannelsCmyMaster()
@@ -226,7 +226,7 @@ void QLCFixtureHead_Test::cacheChannelsCmyMaster()
     QCOMPARE(head.tiltLsbChannel(), QLCChannel::invalid());
     QCOMPARE(head.rgbChannels(), QVector <quint32> ());
     QCOMPARE(head.cmyChannels(), QVector <quint32> () << 0 << 1 << 3);
-    QCOMPARE(head.masterIntensityChannel(), quint32(2));
+    QCOMPARE(head.intensityChannel(), quint32(2));
 }
 
 void QLCFixtureHead_Test::cacheChannelsPanTilt()
@@ -263,7 +263,7 @@ void QLCFixtureHead_Test::cacheChannelsPanTilt()
     QCOMPARE(head.tiltLsbChannel(), quint32(3));
     QCOMPARE(head.rgbChannels(), QVector <quint32> ());
     QCOMPARE(head.cmyChannels(), QVector <quint32> ());
-    QCOMPARE(head.masterIntensityChannel(), QLCChannel::invalid());
+    QCOMPARE(head.intensityChannel(), QLCChannel::invalid());
 
     head.cacheChannels((QLCFixtureMode*) 0xDEADBEEF);
     QCOMPARE(head.panMsbChannel(), quint32(0));
@@ -272,7 +272,7 @@ void QLCFixtureHead_Test::cacheChannelsPanTilt()
     QCOMPARE(head.tiltLsbChannel(), quint32(3));
     QCOMPARE(head.rgbChannels(), QVector <quint32> ());
     QCOMPARE(head.cmyChannels(), QVector <quint32> ());
-    QCOMPARE(head.masterIntensityChannel(), QLCChannel::invalid());
+    QCOMPARE(head.intensityChannel(), QLCChannel::invalid());
 }
 
 void QLCFixtureHead_Test::doublePanTilt()
@@ -348,7 +348,7 @@ void QLCFixtureHead_Test::cacheChannelsColor()
 void QLCFixtureHead_Test::dimmerHead()
 {
     QLCDimmerHead dh(5);
-    QCOMPARE(dh.masterIntensityChannel(), quint32(5));
+    QCOMPARE(dh.intensityChannel(), quint32(5));
     QCOMPARE(dh.m_channelsCached, true);
 }
 

--- a/engine/test/qlcfixturemode/qlcfixturemode_test.cpp
+++ b/engine/test/qlcfixturemode/qlcfixturemode_test.cpp
@@ -409,6 +409,48 @@ void QLCFixtureMode_Test::copy()
     delete anotherDef;
 }
 
+void QLCFixtureMode_Test::intensityChannels()
+{
+    QLCFixtureDef def;
+
+    QLCChannel * masterCh = new QLCChannel();
+    masterCh->setGroup(QLCChannel::Intensity);
+    masterCh->setControlByte(QLCChannel::MSB);
+    masterCh->setColour(QLCChannel::NoColour);
+    def.addChannel(masterCh);
+
+    QLCChannel * h1Ch = new QLCChannel();
+    h1Ch->setGroup(QLCChannel::Intensity);
+    h1Ch->setControlByte(QLCChannel::MSB);
+    h1Ch->setColour(QLCChannel::NoColour);
+    def.addChannel(h1Ch);
+
+    QLCChannel * h2Ch = new QLCChannel();
+    h2Ch->setGroup(QLCChannel::Intensity);
+    h2Ch->setControlByte(QLCChannel::MSB);
+    h2Ch->setColour(QLCChannel::NoColour);
+    def.addChannel(h2Ch);
+
+    QLCFixtureMode mode(&def);
+    mode.insertChannel(masterCh, 0);
+    mode.insertChannel(h1Ch, 1);
+    mode.insertChannel(h2Ch, 2);
+
+    QLCFixtureHead h1;
+    h1.addChannel(1);
+    mode.insertHead(0, h1);
+
+    QLCFixtureHead h2;
+    h2.addChannel(2);
+    mode.insertHead(1, h2);
+
+    mode.cacheHeads();
+
+    QCOMPARE(mode.masterIntensityChannel(), 0U);
+    QCOMPARE(mode.heads()[0].intensityChannel(), 1U);
+    QCOMPARE(mode.heads()[1].intensityChannel(), 2U);
+}
+
 void QLCFixtureMode_Test::load()
 {
     QBuffer buffer;

--- a/qmlui/mainview2d.cpp
+++ b/qmlui/mainview2d.cpp
@@ -289,7 +289,7 @@ void MainView2D::updateFixture(Fixture *fixture)
 
     for (int headIdx = 0; headIdx < fixture->heads(); headIdx++)
     {
-        quint32 mdIndex = fixture->masterIntensityChannel(headIdx);
+        quint32 mdIndex = fixture->intensityChannel(headIdx);
         //qDebug() << "Head" << headIdx << "dimmer channel:" << mdIndex;
         qreal intValue = 1.0;
         if (mdIndex != QLCChannel::invalid())

--- a/resources/fixtures/American-DJ-Chameleon-QBar-Pro.qxf
+++ b/resources/fixtures/American-DJ-Chameleon-QBar-Pro.qxf
@@ -357,17 +357,14 @@
    <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
-   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>12</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>12</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>

--- a/resources/fixtures/American-DJ-Dotz-TPar.qxf
+++ b/resources/fixtures/American-DJ-Dotz-TPar.qxf
@@ -258,24 +258,20 @@
   <Head>
    <Channel>4</Channel>
    <Channel>0</Channel>
-   <Channel>13</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
    <Channel>5</Channel>
    <Channel>1</Channel>
-   <Channel>13</Channel>
    <Channel>9</Channel>
   </Head>
   <Head>
    <Channel>2</Channel>
-   <Channel>13</Channel>
    <Channel>10</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
-   <Channel>13</Channel>
    <Channel>11</Channel>
    <Channel>7</Channel>
   </Head>

--- a/resources/fixtures/American-DJ-Event-Bar-Pro.qxf
+++ b/resources/fixtures/American-DJ-Event-Bar-Pro.qxf
@@ -159,7 +159,6 @@
   <Channel Number="21">Strobe</Channel>
   <Head>
    <Channel>4</Channel>
-   <Channel>20</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
@@ -169,7 +168,6 @@
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>5</Channel>
-   <Channel>20</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
@@ -179,12 +177,10 @@
    <Channel>14</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
-   <Channel>20</Channel>
   </Head>
   <Head>
    <Channel>19</Channel>
    <Channel>15</Channel>
-   <Channel>20</Channel>
    <Channel>16</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
@@ -225,7 +221,6 @@
   <Channel Number="24">Dimmer Curves</Channel>
   <Head>
    <Channel>4</Channel>
-   <Channel>20</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
@@ -235,7 +230,6 @@
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>5</Channel>
-   <Channel>20</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
@@ -245,12 +239,10 @@
    <Channel>14</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
-   <Channel>20</Channel>
   </Head>
   <Head>
    <Channel>19</Channel>
    <Channel>15</Channel>
-   <Channel>20</Channel>
    <Channel>16</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
@@ -295,7 +287,6 @@
   <Head>
    <Channel>0</Channel>
    <Channel>1</Channel>
-   <Channel>16</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
   </Head>
@@ -304,21 +295,18 @@
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
-   <Channel>16</Channel>
   </Head>
   <Head>
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
-   <Channel>16</Channel>
   </Head>
   <Head>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
-   <Channel>16</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/American-DJ-Event-Bar-Q4.qxf
+++ b/resources/fixtures/American-DJ-Event-Bar-Q4.qxf
@@ -327,7 +327,6 @@
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
-   <Channel>32</Channel>
    <Channel>7</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
@@ -335,7 +334,6 @@
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>32</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
@@ -347,7 +345,6 @@
   </Head>
   <Head>
    <Channel>20</Channel>
-   <Channel>32</Channel>
    <Channel>21</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
@@ -358,7 +355,6 @@
   </Head>
   <Head>
    <Channel>27</Channel>
-   <Channel>32</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
@@ -435,22 +431,18 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>3</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
-   <Channel>13</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
-   <Channel>13</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
@@ -584,14 +576,12 @@
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
-   <Channel>33</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>33</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
@@ -605,7 +595,6 @@
    <Channel>20</Channel>
    <Channel>21</Channel>
    <Channel>22</Channel>
-   <Channel>33</Channel>
    <Channel>23</Channel>
    <Channel>16</Channel>
    <Channel>17</Channel>
@@ -614,7 +603,6 @@
   </Head>
   <Head>
    <Channel>27</Channel>
-   <Channel>33</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>

--- a/resources/fixtures/American-DJ-Inno-Pocket-Z4.qxf
+++ b/resources/fixtures/American-DJ-Inno-Pocket-Z4.qxf
@@ -195,14 +195,12 @@
   <Channel Number="14">Master Dimmer</Channel>
   <Channel Number="15">Special Functions</Channel>
   <Head>
-   <Channel>14</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>14</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>8</Channel>
@@ -241,14 +239,12 @@
    <Channel>7</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>16</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
-   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="22 Channel">
@@ -286,14 +282,12 @@
    <Channel>7</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>18</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
-   <Channel>18</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/American-DJ-Mega-Bar-LED.qxf
+++ b/resources/fixtures/American-DJ-Mega-Bar-LED.qxf
@@ -157,19 +157,16 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>10</Channel>
   </Head>
  </Mode>
  <Mode Name="2 Channels">

--- a/resources/fixtures/American-DJ-Mega-Panel-LED.qxf
+++ b/resources/fixtures/American-DJ-Mega-Panel-LED.qxf
@@ -257,22 +257,18 @@
    <Channel>2</Channel>
    <Channel>1</Channel>
    <Channel>0</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>4</Channel>
    <Channel>3</Channel>
-   <Channel>13</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>13</Channel>
    <Channel>8</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>13</Channel>
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
@@ -316,17 +312,14 @@
    <Channel>2</Channel>
    <Channel>1</Channel>
    <Channel>0</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>4</Channel>
    <Channel>3</Channel>
-   <Channel>25</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
    <Channel>8</Channel>
-   <Channel>25</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
   </Head>
@@ -334,29 +327,24 @@
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>14</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>17</Channel>
    <Channel>15</Channel>
    <Channel>16</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>20</Channel>
    <Channel>19</Channel>
    <Channel>18</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>21</Channel>
-   <Channel>25</Channel>
    <Channel>23</Channel>
    <Channel>22</Channel>
   </Head>

--- a/resources/fixtures/American-DJ-Mega-Tri-Bar.qxf
+++ b/resources/fixtures/American-DJ-Mega-Tri-Bar.qxf
@@ -443,19 +443,16 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>11</Channel>
   </Head>
  </Mode>
  <Mode Name="54 Channel Mode">

--- a/resources/fixtures/American-DJ-On-X.qxf
+++ b/resources/fixtures/American-DJ-On-X.qxf
@@ -225,14 +225,12 @@
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
-   <Channel>13</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/American-DJ-Sweeper-Beam-Quad-LED.qxf
+++ b/resources/fixtures/American-DJ-Sweeper-Beam-Quad-LED.qxf
@@ -321,7 +321,6 @@
   <Channel Number="34">White (Lens 8)</Channel>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
@@ -329,7 +328,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
@@ -337,7 +335,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>11</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
@@ -345,7 +342,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>15</Channel>
@@ -353,7 +349,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
@@ -361,7 +356,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
@@ -369,7 +363,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>27</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
@@ -377,7 +370,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>1</Channel>
    <Channel>34</Channel>
    <Channel>31</Channel>
    <Channel>32</Channel>
@@ -433,7 +425,6 @@
   <Channel Number="38">White (Lens 8)</Channel>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
@@ -441,7 +432,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>11</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
@@ -449,7 +439,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>15</Channel>
@@ -457,7 +446,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
@@ -465,7 +453,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
@@ -473,7 +460,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>27</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
@@ -481,7 +467,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>34</Channel>
    <Channel>31</Channel>
    <Channel>32</Channel>
@@ -489,7 +474,6 @@
   </Head>
   <Head>
    <Channel>0</Channel>
-   <Channel>5</Channel>
    <Channel>35</Channel>
    <Channel>36</Channel>
    <Channel>37</Channel>

--- a/resources/fixtures/American-DJ-Ultra-Bar-12.qxf
+++ b/resources/fixtures/American-DJ-Ultra-Bar-12.qxf
@@ -404,19 +404,16 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>10</Channel>
   </Head>
  </Mode>
  <Mode Name="18 Channels mode">
@@ -508,37 +505,31 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>19</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>19</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>19</Channel>
   </Head>
   <Head>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
-   <Channel>19</Channel>
   </Head>
   <Head>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
-   <Channel>19</Channel>
   </Head>
   <Head>
    <Channel>17</Channel>
    <Channel>15</Channel>
    <Channel>16</Channel>
-   <Channel>19</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/American-DJ-Ultra-Bar-6.qxf
+++ b/resources/fixtures/American-DJ-Ultra-Bar-6.qxf
@@ -314,19 +314,16 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>10</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/American-DJ-Ultra-Bar-9.qxf
+++ b/resources/fixtures/American-DJ-Ultra-Bar-9.qxf
@@ -314,19 +314,16 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>10</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Beamz-LCB-252.qxf
+++ b/resources/fixtures/Beamz-LCB-252.qxf
@@ -292,14 +292,6 @@
   <Channel Number="3">Green</Channel>
   <Channel Number="4">Blue</Channel>
   <Channel Number="5">Auto Program</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
-   <Channel>3</Channel>
-   <Channel>4</Channel>
-   <Channel>5</Channel>
-  </Head>
  </Mode>
  <Mode Name="12 Ch.">
   <Physical>
@@ -330,7 +322,6 @@
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>

--- a/resources/fixtures/Blizzard-Lighting-Lo-Pro-CSI.qxf
+++ b/resources/fixtures/Blizzard-Lighting-Lo-Pro-CSI.qxf
@@ -46,11 +46,9 @@
   <Channel Number="4">Color Temperature</Channel>
   <Head>
    <Channel>2</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
-   <Channel>0</Channel>
   </Head>
  </Mode>
  <Mode Name="4 Channel">
@@ -67,11 +65,9 @@
   <Channel Number="3">Section 2 UV Intensity</Channel>
   <Head>
    <Channel>2</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
-   <Channel>0</Channel>
   </Head>
  </Mode>
  <Mode Name="3 Channel">
@@ -87,11 +83,9 @@
   <Channel Number="2">Section 2 UV Intensity</Channel>
   <Head>
    <Channel>1</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>2</Channel>
-   <Channel>0</Channel>
   </Head>
  </Mode>
  <Mode Name="2 Channel">

--- a/resources/fixtures/Blizzard-Lighting-Pixellicious.qxf
+++ b/resources/fixtures/Blizzard-Lighting-Pixellicious.qxf
@@ -222,17 +222,14 @@
   <Head>
    <Channel>3</Channel>
    <Channel>2</Channel>
-   <Channel>0</Channel>
    <Channel>4</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
    <Channel>8</Channel>
@@ -240,36 +237,30 @@
   <Head>
    <Channel>13</Channel>
    <Channel>12</Channel>
-   <Channel>0</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>15</Channel>
    <Channel>14</Channel>
-   <Channel>0</Channel>
    <Channel>16</Channel>
   </Head>
   <Head>
    <Channel>19</Channel>
    <Channel>18</Channel>
    <Channel>17</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>22</Channel>
    <Channel>21</Channel>
    <Channel>20</Channel>
   </Head>
   <Head>
    <Channel>24</Channel>
-   <Channel>0</Channel>
    <Channel>23</Channel>
    <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>28</Channel>
-   <Channel>0</Channel>
    <Channel>27</Channel>
    <Channel>26</Channel>
   </Head>
@@ -277,7 +268,6 @@
    <Channel>31</Channel>
    <Channel>30</Channel>
    <Channel>29</Channel>
-   <Channel>0</Channel>
   </Head>
  </Mode>
  <Mode Name="8 Channel Mode">
@@ -296,10 +286,5 @@
   <Channel Number="5">Auto Programs 1-15</Channel>
   <Channel Number="6">Auto Programs 16-29 + Mix Mode</Channel>
   <Channel Number="7">Auto Program Speed</Channel>
-  <Head>
-   <Channel>3</Channel>
-   <Channel>2</Channel>
-   <Channel>4</Channel>
-  </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Blizzard-Lighting-StormChaser.qxf
+++ b/resources/fixtures/Blizzard-Lighting-StormChaser.qxf
@@ -289,32 +289,25 @@
   <Channel Number="8">Pixel 6 Global Intensity</Channel>
   <Channel Number="9">Pixel 7 Global Intensity</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
    <Channel>4</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>5</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>7</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>8</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>9</Channel>
-   <Channel>1</Channel>
   </Head>
  </Mode>
  <Mode Name="31 Channel">
@@ -360,7 +353,6 @@
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>6</Channel>
-   <Channel>1</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
@@ -368,27 +360,23 @@
    <Channel>9</Channel>
    <Channel>8</Channel>
    <Channel>10</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>11</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
    <Channel>14</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>15</Channel>
    <Channel>17</Channel>
    <Channel>16</Channel>
-   <Channel>1</Channel>
    <Channel>18</Channel>
   </Head>
   <Head>
    <Channel>21</Channel>
    <Channel>20</Channel>
    <Channel>22</Channel>
-   <Channel>1</Channel>
    <Channel>19</Channel>
   </Head>
   <Head>
@@ -396,14 +384,12 @@
    <Channel>25</Channel>
    <Channel>24</Channel>
    <Channel>26</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>27</Channel>
    <Channel>29</Channel>
    <Channel>28</Channel>
    <Channel>30</Channel>
-   <Channel>1</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/BoomToneDJ-Quattro-Scan-LED.qxf
+++ b/resources/fixtures/BoomToneDJ-Quattro-Scan-LED.qxf
@@ -156,24 +156,20 @@
    <Channel>8</Channel>
    <Channel>7</Channel>
    <Channel>3</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>9</Channel>
    <Channel>4</Channel>
-   <Channel>1</Channel>
   </Head>
   <Head>
    <Channel>11</Channel>
    <Channel>5</Channel>
-   <Channel>1</Channel>
    <Channel>12</Channel>
   </Head>
   <Head>
    <Channel>13</Channel>
    <Channel>6</Channel>
-   <Channel>1</Channel>
    <Channel>14</Channel>
   </Head>
  </Mode>

--- a/resources/fixtures/BoomToneDJ-Sky-Bar-288-LED.qxf
+++ b/resources/fixtures/BoomToneDJ-Sky-Bar-288-LED.qxf
@@ -205,13 +205,11 @@
   <Channel Number="8">Strobe</Channel>
   <Channel Number="9">Master Dimmer</Channel>
   <Head>
-   <Channel>9</Channel>
    <Channel>2</Channel>
    <Channel>1</Channel>
    <Channel>0</Channel>
   </Head>
   <Head>
-   <Channel>9</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>3</Channel>
@@ -245,24 +243,20 @@
    <Channel>2</Channel>
    <Channel>1</Channel>
    <Channel>0</Channel>
-   <Channel>15</Channel>
   </Head>
   <Head>
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>3</Channel>
-   <Channel>15</Channel>
   </Head>
   <Head>
    <Channel>8</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
-   <Channel>15</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>9</Channel>
-   <Channel>15</Channel>
    <Channel>11</Channel>
   </Head>
  </Mode>
@@ -376,49 +370,41 @@
   <Channel Number="26">Strobe</Channel>
   <Channel Number="27">Master Dimmer</Channel>
   <Head>
-   <Channel>27</Channel>
    <Channel>2</Channel>
    <Channel>1</Channel>
    <Channel>0</Channel>
   </Head>
   <Head>
-   <Channel>27</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>27</Channel>
    <Channel>8</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
-   <Channel>27</Channel>
    <Channel>9</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>27</Channel>
    <Channel>14</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>27</Channel>
    <Channel>17</Channel>
    <Channel>16</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
-   <Channel>27</Channel>
    <Channel>20</Channel>
    <Channel>19</Channel>
    <Channel>18</Channel>
   </Head>
   <Head>
-   <Channel>27</Channel>
    <Channel>23</Channel>
    <Channel>22</Channel>
    <Channel>21</Channel>

--- a/resources/fixtures/Cameo-CLBARL10RGBA.qxf
+++ b/resources/fixtures/Cameo-CLBARL10RGBA.qxf
@@ -225,10 +225,6 @@
   </Physical>
   <Channel Number="0">Dimmer</Channel>
   <Channel Number="1">Colour-Macro</Channel>
-  <Head>
-   <Channel>1</Channel>
-   <Channel>0</Channel>
-  </Head>
  </Mode>
  <Mode Name="4-Channel">
   <Physical>
@@ -242,12 +238,6 @@
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
   <Channel Number="3">Amber</Channel>
-  <Head>
-   <Channel>1</Channel>
-   <Channel>0</Channel>
-   <Channel>3</Channel>
-   <Channel>2</Channel>
-  </Head>
  </Mode>
  <Mode Name="6-Channel">
   <Physical>
@@ -263,13 +253,6 @@
   <Channel Number="3">Amber</Channel>
   <Channel Number="4">Dimmer</Channel>
   <Channel Number="5">Mode</Channel>
-  <Head>
-   <Channel>1</Channel>
-   <Channel>0</Channel>
-   <Channel>3</Channel>
-   <Channel>2</Channel>
-   <Channel>4</Channel>
-  </Head>
  </Mode>
  <Mode Name="3-Channel">
   <Physical>
@@ -282,10 +265,6 @@
   <Channel Number="0">Colour Macros</Channel>
   <Channel Number="1">Dimmer/Speed</Channel>
   <Channel Number="2">Strobe speed</Channel>
-  <Head>
-   <Channel>1</Channel>
-   <Channel>0</Channel>
-  </Head>
  </Mode>
  <Mode Name="19-Channel">
   <Physical>
@@ -315,21 +294,18 @@
   <Channel Number="17">B4</Channel>
   <Channel Number="18">A4</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>3</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>7</Channel>
    <Channel>9</Channel>
    <Channel>8</Channel>
    <Channel>10</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>11</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
@@ -338,7 +314,6 @@
   <Head>
    <Channel>17</Channel>
    <Channel>16</Channel>
-   <Channel>1</Channel>
    <Channel>18</Channel>
    <Channel>15</Channel>
   </Head>

--- a/resources/fixtures/Cameo-CLHB400RGBW.qxf
+++ b/resources/fixtures/Cameo-CLHB400RGBW.qxf
@@ -379,14 +379,12 @@
   <Channel Number="17">Fourth Head - Dimmer</Channel>
   <Channel Number="18">Head Speed</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
    <Channel>11</Channel>
-   <Channel>0</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
   </Head>
@@ -394,11 +392,9 @@
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>15</Channel>
-   <Channel>0</Channel>
    <Channel>16</Channel>
    <Channel>17</Channel>
   </Head>
@@ -444,7 +440,6 @@
   <Channel Number="30">Master Colour Selection - Blue</Channel>
   <Channel Number="31">Master Colour Selection - White</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
@@ -456,7 +451,6 @@
    <Channel>11</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
-   <Channel>0</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
@@ -464,14 +458,12 @@
   <Head>
    <Channel>14</Channel>
    <Channel>15</Channel>
-   <Channel>0</Channel>
    <Channel>16</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>19</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
    <Channel>22</Channel>

--- a/resources/fixtures/Chauvet-4Bar-Tri.qxf
+++ b/resources/fixtures/Chauvet-4Bar-Tri.qxf
@@ -121,21 +121,15 @@
   <Channel Number="14">4Blue</Channel>
   <Head>
    <Channel>3</Channel>
-   <Channel>2</Channel>
-   <Channel>1</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
   </Head>
   <Head>
-   <Channel>2</Channel>
-   <Channel>1</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
-   <Channel>2</Channel>
-   <Channel>1</Channel>
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
@@ -144,8 +138,6 @@
    <Channel>14</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
-   <Channel>2</Channel>
-   <Channel>1</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Chauvet-Intimidator-Wash-Zoom-350-IRC.qxf
+++ b/resources/fixtures/Chauvet-Intimidator-Wash-Zoom-350-IRC.qxf
@@ -315,7 +315,6 @@
    <Channel>7</Channel>
    <Channel>6</Channel>
    <Channel>5</Channel>
-   <Channel>24</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
@@ -323,12 +322,10 @@
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
-   <Channel>24</Channel>
   </Head>
   <Head>
    <Channel>13</Channel>
    <Channel>16</Channel>
-   <Channel>24</Channel>
    <Channel>15</Channel>
    <Channel>14</Channel>
   </Head>
@@ -337,7 +334,6 @@
    <Channel>18</Channel>
    <Channel>17</Channel>
    <Channel>20</Channel>
-   <Channel>24</Channel>
   </Head>
  </Mode>
  <Mode Name="14-Ch">

--- a/resources/fixtures/Chauvet-Legend-412Z.qxf
+++ b/resources/fixtures/Chauvet-Legend-412Z.qxf
@@ -295,17 +295,14 @@
    <Channel>9</Channel>
    <Channel>8</Channel>
    <Channel>7</Channel>
-   <Channel>5</Channel>
   </Head>
   <Head>
    <Channel>14</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
    <Channel>11</Channel>
-   <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>5</Channel>
    <Channel>18</Channel>
    <Channel>17</Channel>
    <Channel>16</Channel>
@@ -314,7 +311,6 @@
   <Head>
    <Channel>22</Channel>
    <Channel>21</Channel>
-   <Channel>5</Channel>
    <Channel>20</Channel>
    <Channel>19</Channel>
   </Head>
@@ -435,6 +431,7 @@
    <Channel>8</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
+   <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>14</Channel>
@@ -442,6 +439,7 @@
    <Channel>12</Channel>
    <Channel>16</Channel>
    <Channel>15</Channel>
+   <Channel>17</Channel>
   </Head>
   <Head>
    <Channel>22</Channel>
@@ -449,6 +447,7 @@
    <Channel>20</Channel>
    <Channel>19</Channel>
    <Channel>18</Channel>
+   <Channel>23</Channel>
   </Head>
   <Head>
    <Channel>28</Channel>
@@ -456,6 +455,7 @@
    <Channel>26</Channel>
    <Channel>25</Channel>
    <Channel>24</Channel>
+   <Channel>29</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Chauvet-SlimBANK-TRI-18.qxf
+++ b/resources/fixtures/Chauvet-SlimBANK-TRI-18.qxf
@@ -199,20 +199,17 @@
   <Channel Number="11">Dimmer</Channel>
   <Channel Number="12">Shutter</Channel>
   <Head>
-   <Channel>11</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
    <Channel>8</Channel>
-   <Channel>11</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>

--- a/resources/fixtures/Clay-Paky-A.LEDA-Wash-K10.qxf
+++ b/resources/fixtures/Clay-Paky-A.LEDA-Wash-K10.qxf
@@ -859,29 +859,24 @@
    <Channel>19</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>23</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>26</Channel>
    <Channel>27</Channel>
-   <Channel>11</Channel>
    <Channel>28</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
    <Channel>31</Channel>
   </Head>
   <Head>
    <Channel>34</Channel>
-   <Channel>11</Channel>
    <Channel>32</Channel>
    <Channel>33</Channel>
   </Head>
@@ -889,28 +884,23 @@
    <Channel>35</Channel>
    <Channel>36</Channel>
    <Channel>37</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>38</Channel>
    <Channel>39</Channel>
    <Channel>40</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>41</Channel>
    <Channel>42</Channel>
    <Channel>43</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>44</Channel>
-   <Channel>11</Channel>
    <Channel>45</Channel>
    <Channel>46</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>47</Channel>
    <Channel>48</Channel>
    <Channel>49</Channel>
@@ -918,35 +908,29 @@
   <Head>
    <Channel>51</Channel>
    <Channel>52</Channel>
-   <Channel>11</Channel>
    <Channel>50</Channel>
   </Head>
   <Head>
    <Channel>53</Channel>
    <Channel>54</Channel>
    <Channel>55</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>56</Channel>
    <Channel>57</Channel>
    <Channel>58</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>59</Channel>
    <Channel>60</Channel>
    <Channel>61</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>62</Channel>
    <Channel>63</Channel>
    <Channel>64</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>65</Channel>
    <Channel>66</Channel>
    <Channel>67</Channel>
@@ -955,19 +939,16 @@
    <Channel>68</Channel>
    <Channel>69</Channel>
    <Channel>70</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>71</Channel>
    <Channel>72</Channel>
    <Channel>73</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>74</Channel>
    <Channel>75</Channel>
    <Channel>76</Channel>
-   <Channel>11</Channel>
   </Head>
  </Mode>
  <Mode Name="Extended RGBW">
@@ -1079,17 +1060,14 @@
    <Channel>21</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>24</Channel>
    <Channel>25</Channel>
    <Channel>26</Channel>
    <Channel>27</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
@@ -1098,7 +1076,6 @@
   <Head>
    <Channel>34</Channel>
    <Channel>35</Channel>
-   <Channel>11</Channel>
    <Channel>32</Channel>
    <Channel>33</Channel>
   </Head>
@@ -1107,25 +1084,21 @@
    <Channel>37</Channel>
    <Channel>38</Channel>
    <Channel>39</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>40</Channel>
    <Channel>41</Channel>
    <Channel>42</Channel>
    <Channel>43</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>44</Channel>
-   <Channel>11</Channel>
    <Channel>45</Channel>
    <Channel>46</Channel>
    <Channel>47</Channel>
   </Head>
   <Head>
    <Channel>51</Channel>
-   <Channel>11</Channel>
    <Channel>48</Channel>
    <Channel>49</Channel>
    <Channel>50</Channel>
@@ -1135,24 +1108,20 @@
    <Channel>53</Channel>
    <Channel>54</Channel>
    <Channel>55</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>56</Channel>
    <Channel>57</Channel>
    <Channel>58</Channel>
    <Channel>59</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>60</Channel>
    <Channel>61</Channel>
-   <Channel>11</Channel>
    <Channel>62</Channel>
    <Channel>63</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>64</Channel>
    <Channel>65</Channel>
    <Channel>66</Channel>
@@ -1163,24 +1132,20 @@
    <Channel>69</Channel>
    <Channel>70</Channel>
    <Channel>71</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>72</Channel>
    <Channel>73</Channel>
    <Channel>74</Channel>
    <Channel>75</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>76</Channel>
    <Channel>77</Channel>
    <Channel>78</Channel>
-   <Channel>11</Channel>
    <Channel>79</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>80</Channel>
    <Channel>81</Channel>
    <Channel>82</Channel>
@@ -1190,7 +1155,6 @@
    <Channel>85</Channel>
    <Channel>86</Channel>
    <Channel>87</Channel>
-   <Channel>11</Channel>
    <Channel>84</Channel>
   </Head>
   <Head>
@@ -1198,14 +1162,12 @@
    <Channel>89</Channel>
    <Channel>90</Channel>
    <Channel>91</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>92</Channel>
    <Channel>93</Channel>
    <Channel>94</Channel>
    <Channel>95</Channel>
-   <Channel>11</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Clay-Paky-A.LEDA-Wash-K20.qxf
+++ b/resources/fixtures/Clay-Paky-A.LEDA-Wash-K20.qxf
@@ -1273,29 +1273,24 @@
    <Channel>20</Channel>
    <Channel>21</Channel>
    <Channel>22</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>23</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>26</Channel>
    <Channel>27</Channel>
-   <Channel>11</Channel>
    <Channel>28</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
    <Channel>31</Channel>
   </Head>
   <Head>
    <Channel>34</Channel>
-   <Channel>11</Channel>
    <Channel>32</Channel>
    <Channel>33</Channel>
   </Head>
@@ -1303,28 +1298,23 @@
    <Channel>35</Channel>
    <Channel>36</Channel>
    <Channel>37</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>38</Channel>
    <Channel>39</Channel>
    <Channel>40</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>41</Channel>
    <Channel>42</Channel>
    <Channel>43</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>44</Channel>
-   <Channel>11</Channel>
    <Channel>45</Channel>
    <Channel>46</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>47</Channel>
    <Channel>48</Channel>
    <Channel>49</Channel>
@@ -1332,35 +1322,29 @@
   <Head>
    <Channel>51</Channel>
    <Channel>52</Channel>
-   <Channel>11</Channel>
    <Channel>50</Channel>
   </Head>
   <Head>
    <Channel>53</Channel>
    <Channel>54</Channel>
    <Channel>55</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>56</Channel>
    <Channel>57</Channel>
    <Channel>58</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>59</Channel>
    <Channel>60</Channel>
    <Channel>61</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>62</Channel>
    <Channel>63</Channel>
    <Channel>64</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>65</Channel>
    <Channel>66</Channel>
    <Channel>67</Channel>
@@ -1369,35 +1353,29 @@
    <Channel>68</Channel>
    <Channel>69</Channel>
    <Channel>70</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>71</Channel>
    <Channel>72</Channel>
    <Channel>73</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>74</Channel>
    <Channel>75</Channel>
    <Channel>76</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>77</Channel>
    <Channel>78</Channel>
-   <Channel>11</Channel>
    <Channel>79</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>80</Channel>
    <Channel>81</Channel>
    <Channel>82</Channel>
   </Head>
   <Head>
    <Channel>85</Channel>
-   <Channel>11</Channel>
    <Channel>83</Channel>
    <Channel>84</Channel>
   </Head>
@@ -1405,28 +1383,23 @@
    <Channel>86</Channel>
    <Channel>87</Channel>
    <Channel>88</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>89</Channel>
    <Channel>90</Channel>
    <Channel>91</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>92</Channel>
    <Channel>93</Channel>
    <Channel>94</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>95</Channel>
-   <Channel>11</Channel>
    <Channel>96</Channel>
    <Channel>97</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>98</Channel>
    <Channel>99</Channel>
    <Channel>100</Channel>
@@ -1434,35 +1407,29 @@
   <Head>
    <Channel>102</Channel>
    <Channel>103</Channel>
-   <Channel>11</Channel>
    <Channel>101</Channel>
   </Head>
   <Head>
    <Channel>104</Channel>
    <Channel>105</Channel>
    <Channel>106</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>107</Channel>
    <Channel>108</Channel>
    <Channel>109</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>110</Channel>
    <Channel>111</Channel>
    <Channel>112</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>113</Channel>
    <Channel>114</Channel>
    <Channel>115</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>116</Channel>
    <Channel>117</Channel>
    <Channel>118</Channel>
@@ -1471,24 +1438,20 @@
    <Channel>119</Channel>
    <Channel>120</Channel>
    <Channel>121</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>122</Channel>
    <Channel>123</Channel>
    <Channel>124</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>125</Channel>
    <Channel>126</Channel>
    <Channel>127</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>128</Channel>
    <Channel>129</Channel>
-   <Channel>11</Channel>
    <Channel>130</Channel>
   </Head>
  </Mode>
@@ -1673,17 +1636,14 @@
    <Channel>21</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>24</Channel>
    <Channel>25</Channel>
    <Channel>26</Channel>
    <Channel>27</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
@@ -1692,7 +1652,6 @@
   <Head>
    <Channel>34</Channel>
    <Channel>35</Channel>
-   <Channel>11</Channel>
    <Channel>32</Channel>
    <Channel>33</Channel>
   </Head>
@@ -1701,25 +1660,21 @@
    <Channel>37</Channel>
    <Channel>38</Channel>
    <Channel>39</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>40</Channel>
    <Channel>41</Channel>
    <Channel>42</Channel>
    <Channel>43</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>44</Channel>
-   <Channel>11</Channel>
    <Channel>45</Channel>
    <Channel>46</Channel>
    <Channel>47</Channel>
   </Head>
   <Head>
    <Channel>51</Channel>
-   <Channel>11</Channel>
    <Channel>48</Channel>
    <Channel>49</Channel>
    <Channel>50</Channel>
@@ -1729,24 +1684,20 @@
    <Channel>53</Channel>
    <Channel>54</Channel>
    <Channel>55</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>56</Channel>
    <Channel>57</Channel>
    <Channel>58</Channel>
    <Channel>59</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>60</Channel>
    <Channel>61</Channel>
-   <Channel>11</Channel>
    <Channel>62</Channel>
    <Channel>63</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>64</Channel>
    <Channel>65</Channel>
    <Channel>66</Channel>
@@ -1757,24 +1708,20 @@
    <Channel>69</Channel>
    <Channel>70</Channel>
    <Channel>71</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>72</Channel>
    <Channel>73</Channel>
    <Channel>74</Channel>
    <Channel>75</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>76</Channel>
    <Channel>77</Channel>
    <Channel>78</Channel>
-   <Channel>11</Channel>
    <Channel>79</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>80</Channel>
    <Channel>81</Channel>
    <Channel>82</Channel>
@@ -1784,7 +1731,6 @@
    <Channel>85</Channel>
    <Channel>86</Channel>
    <Channel>87</Channel>
-   <Channel>11</Channel>
    <Channel>84</Channel>
   </Head>
   <Head>
@@ -1792,17 +1738,14 @@
    <Channel>89</Channel>
    <Channel>90</Channel>
    <Channel>91</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>92</Channel>
    <Channel>93</Channel>
    <Channel>94</Channel>
    <Channel>95</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>96</Channel>
    <Channel>97</Channel>
    <Channel>98</Channel>
@@ -1811,7 +1754,6 @@
   <Head>
    <Channel>102</Channel>
    <Channel>103</Channel>
-   <Channel>11</Channel>
    <Channel>100</Channel>
    <Channel>101</Channel>
   </Head>
@@ -1820,25 +1762,21 @@
    <Channel>105</Channel>
    <Channel>106</Channel>
    <Channel>107</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>108</Channel>
    <Channel>109</Channel>
    <Channel>110</Channel>
    <Channel>111</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>112</Channel>
-   <Channel>11</Channel>
    <Channel>113</Channel>
    <Channel>114</Channel>
    <Channel>115</Channel>
   </Head>
   <Head>
    <Channel>119</Channel>
-   <Channel>11</Channel>
    <Channel>116</Channel>
    <Channel>117</Channel>
    <Channel>118</Channel>
@@ -1848,24 +1786,20 @@
    <Channel>121</Channel>
    <Channel>122</Channel>
    <Channel>123</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>124</Channel>
    <Channel>125</Channel>
    <Channel>126</Channel>
    <Channel>127</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>128</Channel>
    <Channel>129</Channel>
-   <Channel>11</Channel>
    <Channel>130</Channel>
    <Channel>131</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>132</Channel>
    <Channel>133</Channel>
    <Channel>134</Channel>
@@ -1876,24 +1810,20 @@
    <Channel>137</Channel>
    <Channel>138</Channel>
    <Channel>139</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>140</Channel>
    <Channel>141</Channel>
    <Channel>142</Channel>
    <Channel>143</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>144</Channel>
    <Channel>145</Channel>
    <Channel>146</Channel>
-   <Channel>11</Channel>
    <Channel>147</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>148</Channel>
    <Channel>149</Channel>
    <Channel>150</Channel>
@@ -1903,7 +1833,6 @@
    <Channel>153</Channel>
    <Channel>154</Channel>
    <Channel>155</Channel>
-   <Channel>11</Channel>
    <Channel>152</Channel>
   </Head>
   <Head>
@@ -1911,17 +1840,14 @@
    <Channel>157</Channel>
    <Channel>158</Channel>
    <Channel>159</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>160</Channel>
    <Channel>161</Channel>
    <Channel>162</Channel>
    <Channel>163</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>164</Channel>
    <Channel>165</Channel>
    <Channel>166</Channel>

--- a/resources/fixtures/Clay-Paky-A.LEDA-Wash-K5.qxf
+++ b/resources/fixtures/Clay-Paky-A.LEDA-Wash-K5.qxf
@@ -576,28 +576,23 @@
    <Channel>19</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>22</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>25</Channel>
    <Channel>26</Channel>
    <Channel>27</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>31</Channel>
    <Channel>32</Channel>
    <Channel>33</Channel>
@@ -606,13 +601,11 @@
    <Channel>34</Channel>
    <Channel>35</Channel>
    <Channel>36</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>37</Channel>
    <Channel>38</Channel>
    <Channel>39</Channel>
-   <Channel>11</Channel>
   </Head>
  </Mode>
  <Mode Name="Extended RGBW">
@@ -675,25 +668,21 @@
    <Channel>20</Channel>
    <Channel>21</Channel>
    <Channel>22</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>23</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
    <Channel>26</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>27</Channel>
-   <Channel>11</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
    <Channel>30</Channel>
   </Head>
   <Head>
    <Channel>34</Channel>
-   <Channel>11</Channel>
    <Channel>31</Channel>
    <Channel>32</Channel>
    <Channel>33</Channel>
@@ -703,19 +692,16 @@
    <Channel>36</Channel>
    <Channel>37</Channel>
    <Channel>38</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>39</Channel>
    <Channel>40</Channel>
    <Channel>41</Channel>
    <Channel>42</Channel>
-   <Channel>11</Channel>
   </Head>
   <Head>
    <Channel>43</Channel>
    <Channel>44</Channel>
-   <Channel>11</Channel>
    <Channel>45</Channel>
    <Channel>46</Channel>
   </Head>

--- a/resources/fixtures/Coemar-Stage-Lite-LED.qxf
+++ b/resources/fixtures/Coemar-Stage-Lite-LED.qxf
@@ -367,14 +367,12 @@
   <Channel Number="14">Effects movement</Channel>
   <Channel Number="15">Motors reset / special functions</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
@@ -411,7 +409,6 @@
   <Channel Number="19">Motors reset / special functions</Channel>
   <Head>
    <Channel>14</Channel>
-   <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
@@ -419,7 +416,6 @@
   </Head>
   <Head>
    <Channel>15</Channel>
-   <Channel>0</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
@@ -429,7 +425,6 @@
    <Channel>11</Channel>
    <Channel>12</Channel>
    <Channel>16</Channel>
-   <Channel>0</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
   </Head>

--- a/resources/fixtures/Electroconcept-SPC029.qxf
+++ b/resources/fixtures/Electroconcept-SPC029.qxf
@@ -275,25 +275,21 @@
   <Channel Number="11">Green 4/4</Channel>
   <Channel Number="12">Blue 4/4</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>3</Channel>
    <Channel>2</Channel>
    <Channel>1</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>7</Channel>
    <Channel>9</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>12</Channel>
@@ -334,48 +330,40 @@
   <Channel Number="24">Blue 8/8</Channel>
   <Head>
    <Channel>17</Channel>
-   <Channel>0</Channel>
    <Channel>9</Channel>
    <Channel>1</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>2</Channel>
    <Channel>18</Channel>
    <Channel>10</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>3</Channel>
    <Channel>19</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>4</Channel>
    <Channel>20</Channel>
    <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>5</Channel>
    <Channel>21</Channel>
    <Channel>13</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>6</Channel>
    <Channel>22</Channel>
    <Channel>14</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>7</Channel>
    <Channel>23</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>16</Channel>
    <Channel>8</Channel>
    <Channel>24</Channel>

--- a/resources/fixtures/Eurolite-LED-CBB-3-COB-RGB-3x15W-Bar.qxf
+++ b/resources/fixtures/Eurolite-LED-CBB-3-COB-RGB-3x15W-Bar.qxf
@@ -227,19 +227,16 @@
   <Channel Number="12">Strobe</Channel>
   <Channel Number="13">Dimmer Speed</Channel>
   <Head>
-   <Channel>11</Channel>
    <Channel>2</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>11</Channel>
    <Channel>8</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>

--- a/resources/fixtures/JB-Lighting-A12-Tunable-White.qxf
+++ b/resources/fixtures/JB-Lighting-A12-Tunable-White.qxf
@@ -425,33 +425,27 @@
   <Channel Number="35">Warm White - 4. Ring (Right Half Ring - F)</Channel>
   <Head>
    <Channel>14</Channel>
-   <Channel>6</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
    <Channel>19</Channel>
    <Channel>18</Channel>
-   <Channel>6</Channel>
   </Head>
   <Head>
    <Channel>23</Channel>
    <Channel>22</Channel>
-   <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>6</Channel>
    <Channel>27</Channel>
    <Channel>26</Channel>
   </Head>
   <Head>
-   <Channel>6</Channel>
    <Channel>31</Channel>
    <Channel>30</Channel>
   </Head>
   <Head>
    <Channel>35</Channel>
    <Channel>34</Channel>
-   <Channel>6</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Kam-LED-PartyBar.qxf
+++ b/resources/fixtures/Kam-LED-PartyBar.qxf
@@ -115,25 +115,21 @@
   <Channel Number="13">Spot4 - Green</Channel>
   <Channel Number="14">Spot4 - Blue</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>3</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>9</Channel>
    <Channel>11</Channel>
    <Channel>10</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
    <Channel>14</Channel>

--- a/resources/fixtures/Lanta-Orion-Link-V2.qxf
+++ b/resources/fixtures/Lanta-Orion-Link-V2.qxf
@@ -288,25 +288,21 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>13</Channel>
   </Head>
   <Head>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
-   <Channel>13</Channel>
   </Head>
  </Mode>
  <Mode Name="26 Channel">
@@ -347,35 +343,29 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
-   <Channel>25</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>25</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
   </Head>
   <Head>
    <Channel>17</Channel>
-   <Channel>25</Channel>
    <Channel>15</Channel>
    <Channel>16</Channel>
   </Head>
@@ -383,13 +373,11 @@
    <Channel>18</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>21</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
-   <Channel>25</Channel>
   </Head>
  </Mode>
 </FixtureDefinition>

--- a/resources/fixtures/Ledj-Stage-Color-24.qxf
+++ b/resources/fixtures/Ledj-Stage-Color-24.qxf
@@ -245,13 +245,11 @@
   <Channel Number="7">Green 2 Bottom Row</Channel>
   <Channel Number="8">Blue 2 Bottom Row</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>8</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
@@ -281,25 +279,21 @@
   <Channel Number="13">Green 4</Channel>
   <Channel Number="14">Blue 4</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>8</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
@@ -341,49 +335,41 @@
   <Channel Number="25">Green 8</Channel>
   <Channel Number="26">Blue 8</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>8</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
   </Head>
   <Head>
    <Channel>16</Channel>
-   <Channel>1</Channel>
    <Channel>17</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>18</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>21</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
    <Channel>26</Channel>

--- a/resources/fixtures/Ledj-Tri-LED-back-drop-controller.qxf
+++ b/resources/fixtures/Ledj-Tri-LED-back-drop-controller.qxf
@@ -236,49 +236,41 @@
   <Channel Number="26">Green 8</Channel>
   <Channel Number="27">Blue 8</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>16</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>25</Channel>
    <Channel>26</Channel>
    <Channel>27</Channel>

--- a/resources/fixtures/PR-Lighting-XLED-1037.qxf
+++ b/resources/fixtures/PR-Lighting-XLED-1037.qxf
@@ -221,24 +221,18 @@
   <Head>
    <Channel>12</Channel>
    <Channel>15</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
    <Channel>6</Channel>
    <Channel>9</Channel>
   </Head>
   <Head>
    <Channel>13</Channel>
-   <Channel>1</Channel>
    <Channel>16</Channel>
-   <Channel>2</Channel>
    <Channel>7</Channel>
    <Channel>10</Channel>
   </Head>
   <Head>
    <Channel>14</Channel>
    <Channel>17</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
    <Channel>8</Channel>
    <Channel>11</Channel>
   </Head>

--- a/resources/fixtures/PSL-Strip-Led-RGB-code-K2014.qxf
+++ b/resources/fixtures/PSL-Strip-Led-RGB-code-K2014.qxf
@@ -170,13 +170,11 @@
   <Channel Number="6">Green 2nd Half Bar</Channel>
   <Channel Number="7">Blue 2nd Half Bar</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
@@ -205,25 +203,21 @@
   <Channel Number="12">Green 4th Segment</Channel>
   <Channel Number="13">Blue 4th Segment</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
    <Channel>4</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>11</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>

--- a/resources/fixtures/Showtec-LED-Light-Bar-8.qxf
+++ b/resources/fixtures/Showtec-LED-Light-Bar-8.qxf
@@ -296,35 +296,29 @@
    <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>3</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>6</Channel>
    <Channel>7</Channel>
    <Channel>8</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
-   <Channel>25</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>25</Channel>
    <Channel>12</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
   </Head>
   <Head>
    <Channel>17</Channel>
-   <Channel>25</Channel>
    <Channel>15</Channel>
    <Channel>16</Channel>
   </Head>
@@ -332,13 +326,11 @@
    <Channel>18</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
-   <Channel>25</Channel>
   </Head>
   <Head>
    <Channel>21</Channel>
    <Channel>22</Channel>
    <Channel>23</Channel>
-   <Channel>25</Channel>
   </Head>
  </Mode>
  <Mode Name="d-P5">

--- a/resources/fixtures/Stairville-TRI-LED-Bundle-Complete.qxf
+++ b/resources/fixtures/Stairville-TRI-LED-Bundle-Complete.qxf
@@ -189,25 +189,21 @@
   <Channel Number="13">Green Spot 4</Channel>
   <Channel Number="14">Blue Spot 4</Channel>
   <Head>
-   <Channel>1</Channel>
    <Channel>5</Channel>
    <Channel>4</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>8</Channel>
    <Channel>7</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
   </Head>
   <Head>
-   <Channel>1</Channel>
    <Channel>14</Channel>
    <Channel>13</Channel>
    <Channel>12</Channel>
@@ -254,6 +250,16 @@
   <Channel Number="5">Blue Spot 3-4</Channel>
   <Channel Number="6">Flash</Channel>
   <Channel Number="7">Dimmer</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>3</Channel>
+   <Channel>4</Channel>
+   <Channel>5</Channel>
+  </Head>
  </Mode>
  <Mode Name="2 Channels">
   <Physical>

--- a/resources/fixtures/Stairville-xBrick-Full-Colour-16X3W.qxf
+++ b/resources/fixtures/Stairville-xBrick-Full-Colour-16X3W.qxf
@@ -128,25 +128,21 @@
   <Channel Number="11">Blue4</Channel>
   <Channel Number="12">Master Dimmer</Channel>
   <Head>
-   <Channel>12</Channel>
    <Channel>2</Channel>
    <Channel>0</Channel>
    <Channel>1</Channel>
   </Head>
   <Head>
-   <Channel>12</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>12</Channel>
    <Channel>8</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>12</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>9</Channel>

--- a/resources/fixtures/Starway-Servocolor-800.qxf
+++ b/resources/fixtures/Starway-Servocolor-800.qxf
@@ -246,11 +246,9 @@
    <Channel>5</Channel>
    <Channel>6</Channel>
    <Channel>7</Channel>
-   <Channel>17</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
-   <Channel>17</Channel>
    <Channel>12</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
@@ -258,7 +256,6 @@
   </Head>
   <Head>
    <Channel>16</Channel>
-   <Channel>17</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
@@ -311,21 +308,18 @@
   <Channel Number="19">Blue (Z3)</Channel>
   <Channel Number="20">White (Z3)</Channel>
   <Head>
-   <Channel>5</Channel>
    <Channel>12</Channel>
    <Channel>9</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>5</Channel>
    <Channel>16</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
-   <Channel>5</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>19</Channel>

--- a/resources/fixtures/Varytec-LED-Giga-bar-4-MKII.qxf
+++ b/resources/fixtures/Varytec-LED-Giga-bar-4-MKII.qxf
@@ -368,12 +368,6 @@
   <Channel Number="1">Green 1-16</Channel>
   <Channel Number="2">Blue 1-16</Channel>
   <Channel Number="3">White 1-16</Channel>
-  <Head>
-   <Channel>2</Channel>
-   <Channel>3</Channel>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-  </Head>
  </Mode>
  <Mode Name="Mode 2 - 8 Channels">
   <Physical>
@@ -391,13 +385,6 @@
   <Channel Number="5">Green 1-16</Channel>
   <Channel Number="6">Blue 1-16</Channel>
   <Channel Number="7">White 1-16</Channel>
-  <Head>
-   <Channel>6</Channel>
-   <Channel>7</Channel>
-   <Channel>4</Channel>
-   <Channel>5</Channel>
-   <Channel>0</Channel>
-  </Head>
  </Mode>
  <Mode Name="Mode 3 - 12 Channels">
   <Physical>
@@ -424,14 +411,12 @@
    <Channel>7</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
-   <Channel>0</Channel>
   </Head>
  </Mode>
  <Mode Name="Mode 4 - 20 Channels">
@@ -467,18 +452,15 @@
    <Channel>7</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>13</Channel>
-   <Channel>0</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
    <Channel>12</Channel>
@@ -487,7 +469,6 @@
    <Channel>18</Channel>
    <Channel>19</Channel>
    <Channel>16</Channel>
-   <Channel>0</Channel>
    <Channel>17</Channel>
   </Head>
  </Mode>
@@ -629,18 +610,15 @@
    <Channel>7</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>10</Channel>
    <Channel>11</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>13</Channel>
-   <Channel>0</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
    <Channel>12</Channel>
@@ -649,7 +627,6 @@
    <Channel>18</Channel>
    <Channel>19</Channel>
    <Channel>16</Channel>
-   <Channel>0</Channel>
    <Channel>17</Channel>
   </Head>
   <Head>
@@ -657,24 +634,20 @@
    <Channel>23</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
    <Channel>26</Channel>
    <Channel>27</Channel>
    <Channel>24</Channel>
    <Channel>25</Channel>
-   <Channel>0</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>30</Channel>
    <Channel>31</Channel>
    <Channel>28</Channel>
    <Channel>29</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>34</Channel>
    <Channel>35</Channel>
    <Channel>32</Channel>

--- a/resources/fixtures/XStatic-X-240Bar-RGB.qxf
+++ b/resources/fixtures/XStatic-X-240Bar-RGB.qxf
@@ -184,10 +184,6 @@
   </Physical>
   <Channel Number="0">Function</Channel>
   <Channel Number="1">Speed/Sensitivity</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-  </Head>
  </Mode>
  <Mode Name="3 Channel">
   <Physical>
@@ -200,11 +196,6 @@
   <Channel Number="0">Red 1</Channel>
   <Channel Number="1">Green 1</Channel>
   <Channel Number="2">Blue 1</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
-  </Head>
  </Mode>
  <Mode Name="4 Channel">
   <Physical>
@@ -218,12 +209,6 @@
   <Channel Number="1">Red 1</Channel>
   <Channel Number="2">Green 1</Channel>
   <Channel Number="3">Blue 1</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
-   <Channel>3</Channel>
-  </Head>
  </Mode>
  <Mode Name="7 Channel">
   <Physical>
@@ -240,15 +225,6 @@
   <Channel Number="4">Function</Channel>
   <Channel Number="5">Speed/Sensitivity</Channel>
   <Channel Number="6">Flash</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
-   <Channel>3</Channel>
-   <Channel>4</Channel>
-   <Channel>5</Channel>
-   <Channel>6</Channel>
-  </Head>
  </Mode>
  <Mode Name="14 Channel">
   <Physical>
@@ -273,25 +249,21 @@
   <Channel Number="12">Blue 4</Channel>
   <Channel Number="13">Flash</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>12</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
@@ -332,50 +304,42 @@
   <Channel Number="24">Blue 8</Channel>
   <Channel Number="25">Flash</Channel>
   <Head>
-   <Channel>0</Channel>
    <Channel>1</Channel>
    <Channel>2</Channel>
    <Channel>3</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>4</Channel>
    <Channel>5</Channel>
    <Channel>6</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>8</Channel>
    <Channel>9</Channel>
    <Channel>7</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>12</Channel>
    <Channel>10</Channel>
    <Channel>11</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>13</Channel>
    <Channel>14</Channel>
    <Channel>15</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>16</Channel>
    <Channel>17</Channel>
    <Channel>18</Channel>
   </Head>
   <Head>
-   <Channel>0</Channel>
    <Channel>19</Channel>
    <Channel>20</Channel>
    <Channel>21</Channel>
   </Head>
   <Head>
    <Channel>23</Channel>
-   <Channel>0</Channel>
    <Channel>24</Channel>
    <Channel>22</Channel>
   </Head>

--- a/resources/fixtures/update-fixture-map.rb
+++ b/resources/fixtures/update-fixture-map.rb
@@ -272,6 +272,13 @@ class Fixtures
     end
   end
 
+  def heads_have_common_channels(mode)
+    all_head_channels = mode.heads.inject([]) { |result, h| result + h.channels }.sort
+    unique_head_channels = all_head_channels.uniq.sort
+
+    all_head_channels != unique_head_channels
+  end
+
   def update_fixtures_map(filename = 'FixturesMap.xml')
     orig_data = File.read(filename)
     doc = LibXML::XML::Document.string(orig_data)
@@ -291,6 +298,7 @@ class Fixtures
       wrong_height = f.modes.find {|m| m.physical.dimensions.height == 0 }
       wrong_depth = f.modes.find {|m| m.physical.dimensions.depth == 0 }
       wrong_weight = f.modes.find {|m| m.physical.dimensions.weight == 0 }
+      wrong_heads = f.modes.find {|m| heads_have_common_channels(m) }
  
       problems = []
       problems << "PAN" if wrong_pan && has_pan
@@ -298,7 +306,8 @@ class Fixtures
       problems << "WIDTH" if wrong_width
       problems << "HEIGHT" if wrong_height
       problems << "DEPTH" if wrong_depth
-      problems << "WEIGHT" if wrong_weight 
+      problems << "WEIGHT" if wrong_weight
+      problems << "HEADS" if wrong_heads
       
       unless problems.empty?        
         puts "#{f.path}: #{problems.join ' '}"

--- a/ui/src/monitor/monitorfixtureitem.h
+++ b/ui/src/monitor/monitorfixtureitem.h
@@ -69,6 +69,7 @@ struct FixtureHead
     int m_strobePhase;
     QTimer* m_strobeTimer;
 
+    quint32 m_dimmer;
     quint32 m_masterDimmer;
     quint32 m_panChannel;
     int m_panMaxDegrees;
@@ -131,9 +132,10 @@ protected:
 private:
     void computeTiltPosition(FixtureHead *h, uchar value);
     void computePanPosition(FixtureHead *h, uchar value);
-    QColor computeColor(FixtureHead *head, const QByteArray & values);
-    uchar computeAlpha(FixtureHead *head, const QByteArray & values);
-    FixtureHead::ShutterState computeShutter(FixtureHead *head, const QByteArray & values);
+
+    QColor computeColor(const FixtureHead *head, const QByteArray & values);
+    uchar computeAlpha(const FixtureHead *head, const QByteArray & values);
+    FixtureHead::ShutterState computeShutter(const FixtureHead *head, const QByteArray & values);
 
 signals:
     void itemDropped(MonitorFixtureItem *);

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -995,7 +995,7 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
                 grpScene->setValue(head.fxi, rgbCh.at(2), 0);
             }
 
-            quint32 master = fxi->masterIntensityChannel(head.head);
+            quint32 master = fxi->intensityChannel(head.head);
             if (master != QLCChannel::invalid())
                 grpScene->setValue(head.fxi, master, 0);
         }
@@ -1063,7 +1063,7 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
                         step.values.append(SceneValue(head.fxi, rgbCh.at(2), rgb.blue()));
                     }
 
-                    quint32 master = fxi->masterIntensityChannel(head.head);
+                    quint32 master = fxi->intensityChannel(head.head);
                     if (master != QLCChannel::invalid())
                         step.values.append(SceneValue(head.fxi, master, 255));
                 }

--- a/ui/test/monitorfixtureitem/monitorfixtureitem.pro
+++ b/ui/test/monitorfixtureitem/monitorfixtureitem.pro
@@ -1,0 +1,21 @@
+include(../../../variables.pri)
+
+TEMPLATE = app
+LANGUAGE = C++
+TARGET   = monitorfixtureitem_test
+
+QT      += testlib gui script
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+INCLUDEPATH += ../../../plugins/interfaces
+INCLUDEPATH += ../../../engine/src
+INCLUDEPATH += ../../src ../../src/monitor
+DEPENDPATH  += ../../src
+
+QMAKE_LIBDIR += ../../../engine/src
+QMAKE_LIBDIR += ../../src
+LIBS        += -lqlcplusengine -lqlcplusui
+
+# Test sources
+SOURCES += monitorfixtureitem_test.cpp
+HEADERS += monitorfixtureitem_test.h

--- a/ui/test/monitorfixtureitem/monitorfixtureitem_test.cpp
+++ b/ui/test/monitorfixtureitem/monitorfixtureitem_test.cpp
@@ -1,0 +1,295 @@
+/*
+  Q Light Controller Plus
+  monitorfixtureitem_test.cpp
+
+  Copyright (C) Heikki Junnila
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QLabel>
+#include <QtTest>
+
+#define protected public
+#define private public
+#include "monitorfixtureitem.h"
+#undef protected
+#undef private
+
+#include "monitorfixtureitem_test.h"
+#include "qlcfixturedefcache.h"
+#include "qlcfixturedef.h"
+#include "qlcfile.h"
+#include "qlcmacros.h"
+#include "doc.h"
+
+#include "../../../engine/test/common/resource_paths.h"
+
+void MonitorFixtureItem_Test::initTestCase()
+{
+    m_doc = new Doc(this);
+
+    QDir dir(INTERNAL_FIXTUREDIR);
+    dir.setFilter(QDir::Files);
+    dir.setNameFilters(QStringList() << QString("*%1").arg(KExtFixture));
+    QVERIFY(m_doc->fixtureDefCache()->loadMap(dir) == true);  
+}
+
+void MonitorFixtureItem_Test::cleanupTestCase()
+{
+    delete m_doc;
+    m_doc = NULL;
+}
+
+void MonitorFixtureItem_Test::cleanup()
+{
+    m_doc->clearContents();
+}
+
+void MonitorFixtureItem_Test::computeAlpha()
+{
+    QFETCH(QString, manufacturer);
+    QFETCH(QString, model);
+    QFETCH(QString, mode);
+    QFETCH(quint32, masterDimmer);
+    QFETCH(quint32, head1Dimmer);
+    QFETCH(quint32, head2Dimmer);
+
+    Fixture* fxi = new Fixture(m_doc);
+    fxi->setName("Test Fixture");
+
+    QLCFixtureDef* def = m_doc->fixtureDefCache()->fixtureDef(manufacturer, model);
+    QVERIFY(def != NULL);
+    QVERIFY(def != NULL);
+    QVERIFY(def->channels().size() > 0);
+    QLCFixtureMode* m = def->mode(mode);
+    QVERIFY(m != NULL);
+
+    fxi->setFixtureDefinition(def, m);
+    fxi->setUniverse(0);
+    fxi->setAddress(0);
+    m_doc->addFixture(fxi);
+
+    MonitorFixtureItem* mfi = new MonitorFixtureItem(m_doc, fxi->id());
+    const FixtureHead* h1 = mfi->m_heads.at(0);
+    const FixtureHead* h2 = mfi->m_heads.at(1);
+
+    QVERIFY(h1 != NULL);
+    QVERIFY(h2 != NULL);
+
+    if (masterDimmer != QLCChannel::invalid())
+    {
+        QCOMPARE(h1->m_masterDimmer, masterDimmer);
+        QCOMPARE(h2->m_masterDimmer, masterDimmer);
+    }
+    else
+    {
+        QCOMPARE(h1->m_masterDimmer, QLCChannel::invalid());
+        QCOMPARE(h2->m_masterDimmer, QLCChannel::invalid());
+    }
+
+    if (head1Dimmer != QLCChannel::invalid())
+    {
+        QCOMPARE(h1->m_dimmer, head1Dimmer);
+    }
+    else
+    {
+        QCOMPARE(h1->m_dimmer, QLCChannel::invalid());
+    }
+
+    if (head2Dimmer != QLCChannel::invalid())
+    {
+        QCOMPARE(h2->m_dimmer, head2Dimmer);
+    }
+    else
+    {
+        QCOMPARE(h2->m_dimmer, QLCChannel::invalid());
+    }
+
+    if (masterDimmer == QLCChannel::invalid() && head1Dimmer == QLCChannel::invalid())
+    {
+       {
+           QByteArray values(fxi->channels(), 255);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)255u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)255u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 127);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)255u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)255u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 0);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)255u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)255u);
+       }
+    }
+    else if (masterDimmer != QLCChannel::invalid() && head1Dimmer == QLCChannel::invalid())
+    {
+       {
+           QByteArray values(fxi->channels(), 255);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)255u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)255u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 127);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)127u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)127u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 0);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)0u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)0u);
+       }
+    }
+    else if (masterDimmer == QLCChannel::invalid() && head1Dimmer != QLCChannel::invalid())
+    {
+       {
+           QByteArray values(fxi->channels(), 255);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)255u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)255u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 127);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)127u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)127u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 0);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)0u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)0u);
+       }
+    }
+    else // masterDimmer != QLCChannel::invalid() && head1Dimmer != QLCChannel::invalid()
+    {
+       // change both master & head dimmer
+
+       {
+           QByteArray values(fxi->channels(), 255);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)255u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)255u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 127);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)63u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)63u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 0);
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)0u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)0u);
+       }
+
+       // change only master dimmer
+
+       {
+           QByteArray values(fxi->channels(), 255);
+           values[masterDimmer] = 127;
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)127u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)127u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 255);
+           values[masterDimmer] = 0;
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)0u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)0u);
+       }
+
+       // change only head dimmer
+
+       {
+           QByteArray values(fxi->channels(), 255);
+           values[head1Dimmer] = 100;
+           values[head2Dimmer] = 200;
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)100u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)200u);
+       }
+
+       {
+           QByteArray values(fxi->channels(), 255);
+           values[head1Dimmer] = 0;
+           values[head2Dimmer] = 0;
+           QCOMPARE(mfi->computeAlpha(h1, values), (uchar)0u);
+           QCOMPARE(mfi->computeAlpha(h2, values), (uchar)0u);
+       }
+    }
+}
+
+void MonitorFixtureItem_Test::computeAlpha_data()
+{
+    QTest::addColumn<QString>("manufacturer");
+    QTest::addColumn<QString>("model");
+    QTest::addColumn<QString>("mode");
+    QTest::addColumn<quint32>("masterDimmer");
+    QTest::addColumn<quint32>("head1Dimmer");
+    QTest::addColumn<quint32>("head2Dimmer");
+
+    QTest::newRow("5 heads with dimmer")
+        << "Showtec"
+        << "Sunstrip Active"
+        << "5 Channels Mode"
+        << QLCChannel::invalid()
+        << 0u
+        << 1u;
+
+    QTest::newRow("4 heads with dimmer and RGB")
+        << "American DJ"
+        << "Quad Scan LED"
+        << "28 Channels mode"
+        << QLCChannel::invalid()
+        << 5u
+        << 12u;
+ 
+    QTest::newRow("Master dimmer and 4 heads with dimmer")
+        << "American DJ"
+        << "Event Bar LED"
+        << "25 Channel Mode"
+        << 24u
+        << 4u
+        << 9u;
+        
+    QTest::newRow("Master dimmer and 3 heads with RGB")
+        << "American DJ"
+        << "Mega Bar LED"
+        << "11 Channels"
+        << 10u
+        << QLCChannel::invalid()
+        << QLCChannel::invalid();
+
+    QTest::newRow("Master dimmer and 4 heads with dimmer and RGB")
+        << "ADB"
+        << "ALC4"
+        << "Extended 21 Channels (CT Linear)"
+        << 0u
+        << 1u
+        << 6u;
+
+     QTest::newRow("4 RGB heads")
+        << "American DJ"
+        << "Dotz Bar 1.4"
+        << "12 Channel"
+        << QLCChannel::invalid()
+        << QLCChannel::invalid()
+        << QLCChannel::invalid();
+}
+
+QTEST_MAIN(MonitorFixtureItem_Test)

--- a/ui/test/monitorfixtureitem/monitorfixtureitem_test.h
+++ b/ui/test/monitorfixtureitem/monitorfixtureitem_test.h
@@ -1,6 +1,6 @@
 /*
-  Q Light Controller - Unit tests
-  qlcfixturemode_test.h
+  Q Light Controller Plus
+  monitorfixtureitem_test.h
 
   Copyright (C) Heikki Junnila
 
@@ -17,47 +17,26 @@
   limitations under the License.
 */
 
-#ifndef QLCFIXTUREMODE_TEST_H
-#define QLCFIXTUREMODE_TEST_H
+#ifndef MONITORFIXTUREITEM_TEST_H
+#define MONITORFIXTUREITEM_TEST_H
 
 #include <QObject>
 
-class QLCFixtureDef;
-class QLCChannel;
-
-class QLCFixtureMode_Test : public QObject
+class Doc;
+class MonitorFixtureItem_Test : public QObject
 {
     Q_OBJECT
 
 private slots:
     void initTestCase();
-
-    void fixtureDef();
-    void name();
-    void physical();
-    void insertChannel();
-    void removeChannel();
-    void channelByName();
-    void channelByIndex();
-    void channels();
-    void channelNumber();
-    void heads();
-    void copy();
-    void intensityChannels();
-
-    void load();
-    void loadWrongRoot();
-    void loadNoName();
-    void save();
-
     void cleanupTestCase();
+    void cleanup();
+
+    void computeAlpha();
+    void computeAlpha_data();
 
 private:
-    QLCFixtureDef* m_fixtureDef;
-    QLCChannel* m_ch1;
-    QLCChannel* m_ch2;
-    QLCChannel* m_ch3;
-    QLCChannel* m_ch4;
+    Doc* m_doc;
 };
 
 #endif

--- a/ui/test/monitorfixtureitem/test.sh
+++ b/ui/test/monitorfixtureitem/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+LD_LIBRARY_PATH=../../src:../../../engine/src \
+    DYLD_FALLBACK_LIBRARY_PATH=../../src:../../../engine/src \
+    ./monitorfixtureitem_test

--- a/ui/test/test.pro
+++ b/ui/test/test.pro
@@ -5,6 +5,7 @@ SUBDIRS += addfixture
 SUBDIRS += efxpreviewarea
 SUBDIRS += functionselection
 SUBDIRS += monitorfixture
+SUBDIRS += monitorfixtureitem
 SUBDIRS += palettegenerator
 SUBDIRS += vcbutton
 SUBDIRS += vccuelist


### PR DESCRIPTION
This should fix #827. First commit adjusts fixture definitions, the other code.