### PR TITLE
Fixed Level Mode Sliders Return to zero

### DIFF
--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -232,8 +232,6 @@ void Universe::reset(int address, int range)
 
 
     memset(m_preGMValues->data() + address, 0, range * sizeof(*m_preGMValues->data()));
-    //memset(m_overrideActive->data() + address, 0, range * sizeof(*m_overrideActive->data()));
-    //memset(m_overrideValues->data() + address, 0, range * sizeof(*m_overrideValues->data()));
     memset(m_relativeValues.data() + address, 0, range * sizeof(*m_relativeValues.data()));
     memcpy(m_postGMValues->data() + address, m_modifiedZeroValues->data() + address, range * sizeof(*m_postGMValues->data()));
 
@@ -774,7 +772,7 @@ bool Universe::override(int channel, uchar value)
     if (channel >= m_usedChannels)
         m_usedChannels = channel + 1;
 
-//    if (forceLTP == false && (m_channelsMask->at(channel) & HTP) && value < (uchar)m_preGMValues->at(channel))
+//    if ((m_channelsMask->at(channel) & HTP) && value < (uchar)m_overrideValues->at(channel))
 //    {
 //        qDebug() << "[Universe] HTP check not passed" << channel << value;
 //        return false;

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -346,6 +346,7 @@ public:
      */
     const QByteArray preGMValues() const;
 
+
     /**
      * Get the current pre-Grand-Master value (used by functions and everyone
      * else INSIDE QLC+) at specified address.
@@ -353,6 +354,7 @@ public:
      * @return The current value at address
      */
     uchar preGMValue(int address) const;
+    uchar overrideValue(int address) const;
 
     /** Set all intensity channel values to zero */
     void zeroIntensityChannels();
@@ -401,6 +403,10 @@ protected:
     QVector<int> m_nonIntensityChannels;
     /** Array of values BEFORE the Grand Master changes */
     QScopedPointer<QByteArray> m_preGMValues;
+
+    QScopedPointer<QByteArray> m_overrideActive;
+    QScopedPointer<QByteArray> m_overrideValues;
+
     /** Array of values AFTER the Grand Master changes (applyGM) */
     QScopedPointer<QByteArray> m_postGMValues;
     /** Array of the last preGM values written before the zeroIntensityChannels call  */
@@ -445,6 +451,8 @@ public:
      * @return true if successful, otherwise false
      */
     bool write(int channel, uchar value, bool forceLTP = false);
+    bool override(int channel, uchar value);
+    bool enableOverride(int channel, bool enable);
 
     /**
      * Write a relative value to a DMX channel, taking Grand Master and HTP into

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -893,56 +893,6 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
         }
     }
 
-    if (m_monitorEnabled == true && m_levelValueChanged == false)
-    {
-        QListIterator <LevelChannel> it(m_levelChannels);
-        while (it.hasNext() == true)
-        {
-            LevelChannel lch(it.next());
-            Fixture* fxi = m_doc->fixture(lch.fixture);
-            if (fxi != NULL)
-            {
-                const QLCChannel* qlcch = fxi->channel(lch.channel);
-                if (qlcch == NULL)
-                    continue;
-
-                quint32 dmx_ch = fxi->address() + lch.channel;
-                int uni = fxi->universe();
-                if (uni < universes.count())
-                {
-                    uchar chValue = universes[uni]->preGMValue(dmx_ch);
-                    if (monitorSliderValue == -1)
-                    {
-                        monitorSliderValue = chValue;
-                        //qDebug() << "Monitor DMX value:" << monitorSliderValue << "level value:" << m_levelValue;
-                    }
-                    else
-                    {
-                        if (chValue != (uchar)monitorSliderValue)
-                        {
-                            mixedDMXlevels = true;
-                            // no need to proceed further as mixed values cannot
-                            // be represented by one single slider
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        // check if all the DMX channels controlled by this slider
-        // have the same value. If so, move the widget slider or knob
-        // to the detected position
-        if (mixedDMXlevels == false &&
-            monitorSliderValue != m_monitorValue)
-        {
-            emit monitorDMXValueChanged(monitorSliderValue);
-            // return here. At the next call of this method,
-            // the monitor level will kick in
-            return;
-        }
-    }
-
     QListIterator <LevelChannel> it(m_levelChannels);
     while (it.hasNext() == true)
     {
@@ -997,6 +947,58 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
                 universes[uni]->write(dmx_ch, modLevel * intensity());
         }
     }
+
+    if (m_monitorEnabled == true && m_levelValueChanged == false)
+    {
+        QListIterator <LevelChannel> it(m_levelChannels);
+        while (it.hasNext() == true)
+        {
+            LevelChannel lch(it.next());
+            Fixture* fxi = m_doc->fixture(lch.fixture);
+            if (fxi != NULL)
+            {
+                const QLCChannel* qlcch = fxi->channel(lch.channel);
+                if (qlcch == NULL)
+                    continue;
+
+                quint32 dmx_ch = fxi->address() + lch.channel;
+                int uni = fxi->universe();
+                if (uni < universes.count())
+                {
+                    uchar chValue = universes[uni]->preGMValue(dmx_ch);
+                    if (monitorSliderValue == -1)
+                    {
+                        monitorSliderValue = chValue;
+                        //qDebug() << "Monitor DMX value:" << monitorSliderValue << "level value:" << m_levelValue;
+                    }
+                    else
+                    {
+                        if (chValue != (uchar)monitorSliderValue)
+                        {
+                            mixedDMXlevels = true;
+                            // no need to proceed further as mixed values cannot
+                            // be represented by one single slider
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // check if all the DMX channels controlled by this slider
+        // have the same value. If so, move the widget slider or knob
+        // to the detected position
+        if (mixedDMXlevels == false &&
+            monitorSliderValue != m_monitorValue)
+        {
+            emit monitorDMXValueChanged(monitorSliderValue);
+            // return here. At the next call of this method,
+            // the monitor level will kick in
+            return;
+        }
+    }
+
+
     m_levelValueChanged = false;
 }
 

--- a/ui/src/virtualconsole/vcslider.h
+++ b/ui/src/virtualconsole/vcslider.h
@@ -454,12 +454,14 @@ public:
 
 private slots:
     void slotSliderMoved(int value);
+    void slotOverrideButtonClicked(bool checked);
 
 protected:
     QHBoxLayout* m_hbox;
     QAbstractSlider* m_slider; //!< either QClickAndGoSlider or KnobWidget
     bool m_externalMovement;
     SliderWidgetStyle m_widgetMode;
+    QToolButton *m_overrideButton;
 
     /*********************************************************************
      * Bottom label
@@ -547,6 +549,10 @@ public:
     bool loadXMLPlayback(QXmlStreamReader &pb_root);
 
     bool saveXML(QXmlStreamWriter *doc);
+
+
+    //new behaviour place in appropriate place
+    bool m_override;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcslider.h
+++ b/ui/src/virtualconsole/vcslider.h
@@ -338,6 +338,7 @@ protected:
 
     bool m_monitorEnabled;
     uchar m_monitorValue;
+    uchar m_previousSceneValue;
 
     /*********************************************************************
      * Playback
@@ -454,14 +455,16 @@ public:
 
 private slots:
     void slotSliderMoved(int value);
-    void slotOverrideButtonClicked(bool checked);
+    void slotResetButtonClicked();
+    void slotEnaAutoResetButtonClicked(bool checked);
 
 protected:
     QHBoxLayout* m_hbox;
     QAbstractSlider* m_slider; //!< either QClickAndGoSlider or KnobWidget
     bool m_externalMovement;
     SliderWidgetStyle m_widgetMode;
-    QToolButton *m_overrideButton;
+    QToolButton *m_resetButton;
+    QToolButton *m_enaAutoResetButton;
 
     /*********************************************************************
      * Bottom label
@@ -553,6 +556,8 @@ public:
 
     //new behaviour place in appropriate place
     bool m_override;
+    bool m_autoReset;
+    bool m_doReset;
 };
 
 /** @} */


### PR DESCRIPTION
Fixed
http://www.qlcplus.org/forum/viewtopic.php?f=29&p=45442#p45442

Problem was that slider in monitor modes first reads the value from the universe before appling its own value.
Now with first appling slider settings and monitoring afterwards everything works as expected