### PR TITLE
Added direction to RGB panel creation dialog.

### DIFF
--- a/resources/docs/addrgbpanel.html
+++ b/resources/docs/addrgbpanel.html
@@ -109,6 +109,18 @@ Let's have a look at every option in this panel:
   of the end of a row is on the first column of the next row.</TD>
  </TR>
 
+ <TR>
+  <TD COLSPAN=2 style="text-align:center;"><B>Direction</B></TD>
+ </TR>
+ <TR>
+  <TD><B>Horizontal</B></TD>
+  <TD>Pixel addresses are incremented horizontally.</TD>
+ </TR>
+ <TR>
+  <TD><B>Vertical</B></TD>
+  <TD>Pixel addresses are incremented vertically.</TD>
+ </TR>
+
 </TABLE>
 
 </BODY>

--- a/ui/src/addrgbpanel.cpp
+++ b/ui/src/addrgbpanel.cpp
@@ -150,6 +150,16 @@ AddRGBPanel::Type AddRGBPanel::type()
     return Unknown;
 }
 
+AddRGBPanel::Direction AddRGBPanel::direction()
+{
+	if (m_verticalRadio->isChecked())
+		return Vertical;
+	else if (m_horizontalRadio->isChecked())
+		return Horizontal;
+
+	return Undefined;
+}
+
 Fixture::Components AddRGBPanel::components()
 {
     if (m_compCombo->currentIndex() == 1)

--- a/ui/src/addrgbpanel.h
+++ b/ui/src/addrgbpanel.h
@@ -51,6 +51,12 @@ public:
         ZigZag
     };
 
+    enum Direction {
+    	Undefined,
+		Horizontal,
+		Vertical
+    };
+
     QString name();
     int universeIndex();
     int address();
@@ -60,6 +66,7 @@ public:
     quint32 physicalHeight();
     Orientation orientation();
     Type type();
+    Direction direction();
     Fixture::Components components();
 
 private:

--- a/ui/src/addrgbpanel.ui
+++ b/ui/src/addrgbpanel.ui
@@ -7,14 +7,14 @@
 
   Copyright (c) 2015 Massimo Callegari
 
-  Licensed under the Apache License, Version 2.0 (the "License");
+  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0.txt
 
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
+  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
@@ -25,8 +25,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>464</width>
-    <height>448</height>
+    <width>477</width>
+    <height>485</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,187 +37,6 @@
     <normaloff>:/rgbpanel.png</normaloff>:/rgbpanel.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Size</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Columns</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Rows</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Total pixels</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QSpinBox" name="m_columnSpin">
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>170</number>
-          </property>
-          <property name="value">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="m_rowSpin">
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>999</number>
-          </property>
-          <property name="value">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="m_totalLabel">
-          <property name="text">
-           <string notr="true">100</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="title">
-      <string>Orientation</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="m_oriTopRightRadio">
-        <property name="text">
-         <string>Top-Right</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="m_oriTopLeftRadio">
-        <property name="text">
-         <string>Top-Left</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="m_oriBottomLeftRadio">
-        <property name="text">
-         <string>Bottom-Left</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QRadioButton" name="m_oriBottomRightRadio">
-        <property name="text">
-         <string>Bottom-Right</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QGroupBox" name="groupBox_5">
-     <property name="title">
-      <string>Physical</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <layout class="QGridLayout" name="gridLayout_5">
-        <property name="verticalSpacing">
-         <number>0</number>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Width</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QSpinBox" name="m_phyWidthSpin">
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>99999</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Height</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="m_phyHeightSpin">
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>99999</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -295,6 +114,124 @@
      </layout>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="groupBox_5">
+     <property name="title">
+      <string>Physical</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_5">
+        <property name="verticalSpacing">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Width</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="m_phyWidthSpin">
+          <property name="suffix">
+           <string>mm</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Height</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="m_phyHeightSpin">
+          <property name="suffix">
+           <string>mm</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Orientation</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="m_oriTopRightRadio">
+        <property name="text">
+         <string>Top-Right</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="m_oriTopLeftRadio">
+        <property name="text">
+         <string>Top-Left</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="m_oriBottomLeftRadio">
+        <property name="text">
+         <string>Bottom-Left</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QRadioButton" name="m_oriBottomRightRadio">
+        <property name="text">
+         <string>Bottom-Right</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="2" column="1">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
@@ -321,14 +258,103 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Size</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Columns</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Rows</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Total pixels</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="m_columnSpin">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>170</number>
+          </property>
+          <property name="value">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="m_rowSpin">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>999</number>
+          </property>
+          <property name="value">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="m_totalLabel">
+          <property name="text">
+           <string notr="true">100</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_6">
+     <property name="title">
+      <string>Direction</string>
      </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="m_horizontalRadio">
+        <property name="text">
+         <string>Horizontal</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="m_verticalRadio">
+        <property name="text">
+         <string>Vertical</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/ui/src/fixturemanager.cpp
+++ b/ui/src/fixturemanager.cpp
@@ -1052,8 +1052,6 @@ void FixtureManager::slotAddRGBPanel()
     {
         int rows = rgb.rows();
         int columns = rgb.columns();
-        quint32 phyWidth = rgb.physicalWidth();
-        quint32 phyHeight = rgb.physicalHeight() / rows;
         Fixture::Components components = rgb.components();
 
         FixtureGroup *grp = new FixtureGroup(m_doc);
@@ -1063,6 +1061,15 @@ void FixtureManager::slotAddRGBPanel()
         grp->setSize(panelSize);
         m_doc->addFixtureGroup(grp);
         updateGroupMenu();
+
+        int transpose = 0;
+        if (rgb.direction() == AddRGBPanel::Vertical)
+        {
+        	int tmp = columns;
+        	columns = rows;
+        	rows = tmp;
+        	transpose = 1;
+        }
 
         QLCFixtureDef *rowDef = NULL;
         QLCFixtureMode *rowMode = NULL;
@@ -1074,18 +1081,40 @@ void FixtureManager::slotAddRGBPanel()
         int xPosEnd = columns - 1;
         int xPosInc = 1;
 
-        if (rgb.orientation() == AddRGBPanel::BottomLeft ||
-            rgb.orientation() == AddRGBPanel::BottomRight)
+        quint32 phyWidth = rgb.physicalWidth();
+        quint32 phyHeight = rgb.physicalHeight() / rows;
+
+        if (transpose)
         {
-            currRow = rows -1;
-            rowInc = -1;
+			if (rgb.orientation() == AddRGBPanel::TopRight ||
+				rgb.orientation() == AddRGBPanel::BottomRight)
+			{
+				currRow = rows -1;
+				rowInc = -1;
+			}
+			if (rgb.orientation() == AddRGBPanel::BottomRight ||
+				rgb.orientation() == AddRGBPanel::BottomLeft)
+			{
+				xPosStart = columns - 1;
+				xPosEnd = 0;
+				xPosInc = -1;
+			}
         }
-        if (rgb.orientation() == AddRGBPanel::TopRight ||
-            rgb.orientation() == AddRGBPanel::BottomRight)
+        else
         {
-            xPosStart = columns - 1;
-            xPosEnd = 0;
-            xPosInc = -1;
+			if (rgb.orientation() == AddRGBPanel::BottomLeft ||
+				rgb.orientation() == AddRGBPanel::BottomRight)
+			{
+				currRow = rows -1;
+				rowInc = -1;
+			}
+			if (rgb.orientation() == AddRGBPanel::TopRight ||
+				rgb.orientation() == AddRGBPanel::BottomRight)
+			{
+				xPosStart = columns - 1;
+				xPosEnd = 0;
+				xPosInc = -1;
+			}
         }
 
         for (int i = 0; i < rows; i++)
@@ -1118,7 +1147,10 @@ void FixtureManager::slotAddRGBPanel()
                 int xPos = xPosStart;
                 for (int h = 0; h < fxi->heads(); h++)
                 {
-                    grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
+                	if (transpose)
+                		grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
+                	else
+                		grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
                     xPos += xPosInc;
                 }
             }
@@ -1129,7 +1161,10 @@ void FixtureManager::slotAddRGBPanel()
                     int xPos = xPosStart;
                     for (int h = 0; h < fxi->heads(); h++)
                     {
-                        grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
+                    	if (transpose)
+                    		grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
+                    	else
+                    		grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
                         xPos += xPosInc;
                     }
                 }
@@ -1138,7 +1173,10 @@ void FixtureManager::slotAddRGBPanel()
                     int xPos = xPosEnd;
                     for (int h = 0; h < fxi->heads(); h++)
                     {
-                        grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
+                    	if (transpose)
+                    		grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
+                    	else
+                    		grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
                         xPos += (-xPosInc);
                     }
                 }


### PR DESCRIPTION
Had to work with panels where LED pixels were interconnected top to bottom instead of side to side and it was easier for me to add this feature to code than to figure how to transpose matrices myself. Hopefully others will find this feature useful as well.
If any code release forms have to be signed by me, I will gladly do that.