### PR TITLE
Memory optimisation

### DIFF
--- a/engine/src/channelsgroup.cpp
+++ b/engine/src/channelsgroup.cpp
@@ -76,7 +76,7 @@ void ChannelsGroup::slotFixtureRemoved(quint32 fixtureId)
     while (channelsIt.hasNext())
     {
         SceneValue scv(channelsIt.next());
-        if (scv.fxi == fixtureId)
+        if (scv.fxi() == fixtureId)
         {
             channelsIt.remove();
             hasChanged = true;
@@ -170,20 +170,20 @@ QString ChannelsGroup::status(Doc *doc) const
 
     foreach (SceneValue value, m_channels)
     {
-        Fixture *fixture = doc->fixture(value.fxi);
+        Fixture *fixture = doc->fixture(value.fxi());
         if (fixture == NULL)
             return QString();
         const QLCFixtureMode *mode = fixture->fixtureMode();
         QString chInfo("<TR><TD>%1</TD><TD>%2</TD><TD>%3</TD></TR>");
         if (mode != NULL)
         {
-            info += chInfo.arg(fixture->name()).arg(value.channel + 1)
-                .arg(mode->channels().at(value.channel)->name());
+            info += chInfo.arg(fixture->name()).arg(value.channel() + 1)
+                .arg(mode->channels().at(value.channel())->name());
         }
         else
         {
-            info += chInfo.arg(fixture->name()).arg(value.channel + 1)
-                .arg(QString(tr("Channel %1")).arg(value.channel));
+            info += chInfo.arg(fixture->name()).arg(value.channel() + 1)
+                .arg(QString(tr("Channel %1")).arg(value.channel()));
         }
     }
 
@@ -267,7 +267,7 @@ bool ChannelsGroup::saveXML(QXmlStreamWriter *doc)
     {
         if (str.isEmpty() == false)
             str.append(",");
-        str.append(QString("%1,%2").arg(value.fxi).arg(value.channel));
+        str.append(QString("%1,%2").arg(value.fxi()).arg(value.channel()));
     }
 
     /* Channels Group entry */
@@ -323,16 +323,16 @@ bool ChannelsGroup::loadXML(QXmlStreamReader &xmlDoc)
         {
             SceneValue scv(QString(varray.at(i)).toUInt(),
                            QString(varray.at(i + 1)).toUInt(), 0);
-            Fixture* fxi = m_doc->fixture(scv.fxi);
+            Fixture* fxi = m_doc->fixture(scv.fxi());
             if (fxi == NULL)
             {
-                qWarning() << Q_FUNC_INFO << "Fixture not present:" << scv.fxi;
+                qWarning() << Q_FUNC_INFO << "Fixture not present:" << scv.fxi();
                 continue;
             }
-            const QLCChannel* ch = fxi->channel(scv.channel);
+            const QLCChannel* ch = fxi->channel(scv.channel());
             if (ch == NULL)
             {
-                qWarning() << Q_FUNC_INFO << "Fixture" << scv.fxi << "does not have channel" << scv.channel;
+                qWarning() << Q_FUNC_INFO << "Fixture" << scv.fxi() << "does not have channel" << scv.channel();
                 continue;
             }
             m_channels.append(scv);

--- a/engine/src/chaserstep.cpp
+++ b/engine/src/chaserstep.cpp
@@ -106,18 +106,18 @@ bool ChaserStep::loadXML(QXmlStreamReader &root, int& stepNumber)
     QXmlStreamAttributes attrs = root.attributes();
 
     if (attrs.hasAttribute(KXMLQLCFunctionSpeedFadeIn) == true)
-        fadeIn = attrs.value(KXMLQLCFunctionSpeedFadeIn).toString().toUInt();
+        fadeIn = attrs.value(KXMLQLCFunctionSpeedFadeIn).toUInt();
     if (attrs.hasAttribute(KXMLQLCFunctionSpeedHold) == true)
     {
-        hold = attrs.value(KXMLQLCFunctionSpeedHold).toString().toUInt();
+        hold = attrs.value(KXMLQLCFunctionSpeedHold).toUInt();
         holdFound = true;
     }
     if (attrs.hasAttribute(KXMLQLCFunctionSpeedFadeOut) == true)
-        fadeOut = attrs.value(KXMLQLCFunctionSpeedFadeOut).toString().toUInt();
+        fadeOut = attrs.value(KXMLQLCFunctionSpeedFadeOut).toUInt();
     if (attrs.hasAttribute(KXMLQLCFunctionSpeedDuration) == true)
-        duration = attrs.value(KXMLQLCFunctionSpeedDuration).toString().toUInt();
+        duration = attrs.value(KXMLQLCFunctionSpeedDuration).toUInt();
     if (attrs.hasAttribute(KXMLQLCFunctionNumber) == true)
-        stepNumber = attrs.value(KXMLQLCFunctionNumber).toString().toInt();
+        stepNumber = attrs.value(KXMLQLCFunctionNumber).toInt();
     if (attrs.hasAttribute(KXMLQLCStepNote) == true)
         note = attrs.value(KXMLQLCStepNote).toString();
 
@@ -126,12 +126,13 @@ bool ChaserStep::loadXML(QXmlStreamReader &root, int& stepNumber)
         QString stepValues = root.readElementText();
         if (stepValues.isEmpty() == false)
         {
-            QStringList varray = stepValues.split(",");
+            QVector<QStringRef> varray = stepValues.splitRef(",");
+            values.reserve(varray.count() / 3);
             for (int i = 0; i < varray.count(); i+=3)
             {
-                values.append(SceneValue(QString(varray.at(i)).toUInt(),
-                                         QString(varray.at(i + 1)).toUInt(),
-                                         uchar(QString(varray.at(i + 2)).toInt())));
+                values.append(SceneValue(varray.at(i).toUInt(),
+                                         varray.at(i + 1).toUInt(),
+                                         uchar(varray.at(i + 2).toInt())));
             }
             qSort(values.begin(), values.end());
         }

--- a/engine/src/chaserstep.cpp
+++ b/engine/src/chaserstep.cpp
@@ -189,7 +189,7 @@ bool ChaserStep::saveXML(QXmlStreamWriter *doc, int stepNumber, bool isSequence)
             {
                 if (stepValues.isEmpty() == false)
                     stepValues.append(QString(","));
-                stepValues.append(QString("%1,%2,%3").arg(scv.fxi).arg(scv.channel).arg(scv.value));
+                stepValues.append(QString("%1,%2,%3").arg(scv.fxi()).arg(scv.channel()).arg(scv.value));
             }
         }
         if (stepValues.isEmpty() == false)

--- a/engine/src/genericdmxsource.cpp
+++ b/engine/src/genericdmxsource.cpp
@@ -78,14 +78,13 @@ quint32 GenericDMXSource::channelsCount() const
 QList<SceneValue> GenericDMXSource::channels()
 {
     QList<SceneValue> chList;
+    chList.reserve( m_values.size());
+
     QMutableMapIterator <QPair<quint32,quint32>,uchar> it(m_values);
     while (it.hasNext() == true)
     {
         it.next();
-        SceneValue sv;
-        sv.fxi = it.key().first;
-        sv.channel = it.key().second;
-        sv.value = it.value();
+        SceneValue sv(it.key().first, it.key().second, it.value());
         chList.append(sv);
     }
     return chList;

--- a/engine/src/scenevalue.h
+++ b/engine/src/scenevalue.h
@@ -64,8 +64,14 @@ public:
     /** Copy constructor */
     SceneValue(const SceneValue& scv);
 
-    /** Destructor */
-    virtual ~SceneValue();
+    /** NON-virtual Destructor 
+     *
+     *  No class derives from this one and we need to keep the memory footprint
+     *  as low as possible.
+     *
+     *  TODO C++11: mark this as final
+     */
+    ~SceneValue();
 
     /** A SceneValue is not valid if .fxi == Fixture::invalidId() */
     bool isValid() const;

--- a/engine/src/scenevalue.h
+++ b/engine/src/scenevalue.h
@@ -73,6 +73,10 @@ public:
      */
     ~SceneValue();
 
+    void assign(quint32 fxi_id,
+               quint32 channel,
+               uchar value);
+
     /** A SceneValue is not valid if .fxi == Fixture::invalidId() */
     bool isValid() const;
 
@@ -88,11 +92,18 @@ public:
     /** Save this SceneValue to an XML document */
     bool saveXML(QXmlStreamWriter *doc) const;
 
-public:
+    quint32 channel() const;
     /** Fixture ID */
-    quint32 fxi;
-    quint32 channel;
+    quint32 fxi() const;
+    
+public:
     uchar value;
+
+private:
+    static quint32 compose(quint32 id, quint32 ch);
+
+private:
+    quint32 fixture_channel;
 };
 
 /** @} */

--- a/engine/test/scene/scene_test.cpp
+++ b/engine/test/scene/scene_test.cpp
@@ -84,29 +84,29 @@ void Scene_Test::values()
     /* Value 3 to fixture 1's channel number 2 */
     s.setValue(1, 2, 3);
     QVERIFY(s.values().size() == 1);
-    QVERIFY(s.values().at(0).fxi == 1);
-    QVERIFY(s.values().at(0).channel == 2);
+    QVERIFY(s.values().at(0).fxi() == 1);
+    QVERIFY(s.values().at(0).channel() == 2);
     QVERIFY(s.values().at(0).value == 3);
 
     /* Value 6 to fixture 4's channel number 5 */
     SceneValue scv(4, 5, 6);
     s.setValue(scv);
     QVERIFY(s.values().size() == 2);
-    QVERIFY(s.values().at(0).fxi == 1);
-    QVERIFY(s.values().at(0).channel == 2);
+    QVERIFY(s.values().at(0).fxi() == 1);
+    QVERIFY(s.values().at(0).channel() == 2);
     QVERIFY(s.values().at(0).value == 3);
-    QVERIFY(s.values().at(1).fxi == 4);
-    QVERIFY(s.values().at(1).channel == 5);
+    QVERIFY(s.values().at(1).fxi() == 4);
+    QVERIFY(s.values().at(1).channel() == 5);
     QVERIFY(s.values().at(1).value == 6);
 
     /* Replace previous value 3 with 15 for fixture 1's channel number 2 */
     s.setValue(1, 2, 15);
     QVERIFY(s.values().size() == 2);
-    QVERIFY(s.values().at(0).fxi == 1);
-    QVERIFY(s.values().at(0).channel == 2);
+    QVERIFY(s.values().at(0).fxi() == 1);
+    QVERIFY(s.values().at(0).channel() == 2);
     QVERIFY(s.values().at(0).value == 15);
-    QVERIFY(s.values().at(1).fxi == 4);
-    QVERIFY(s.values().at(1).channel == 5);
+    QVERIFY(s.values().at(1).fxi() == 4);
+    QVERIFY(s.values().at(1).channel() == 5);
     QVERIFY(s.values().at(1).value == 6);
 
     QVERIFY(s.value(1, 2) == 15);
@@ -116,25 +116,25 @@ void Scene_Test::values()
     /* No channel 5 for fixture 1 in the scene, unset shouldn't happen */
     s.unsetValue(1, 5);
     QVERIFY(s.values().size() == 2);
-    QVERIFY(s.values().at(0).fxi == 1);
-    QVERIFY(s.values().at(0).channel == 2);
+    QVERIFY(s.values().at(0).fxi() == 1);
+    QVERIFY(s.values().at(0).channel() == 2);
     QVERIFY(s.values().at(0).value == 15);
-    QVERIFY(s.values().at(1).fxi == 4);
-    QVERIFY(s.values().at(1).channel == 5);
+    QVERIFY(s.values().at(1).fxi() == 4);
+    QVERIFY(s.values().at(1).channel() == 5);
     QVERIFY(s.values().at(1).value == 6);
 
     /* Remove fixture 1's channel 2 from the scene */
     s.unsetValue(1, 2);
     QVERIFY(s.values().size() == 1);
-    QVERIFY(s.values().at(0).fxi == 4);
-    QVERIFY(s.values().at(0).channel == 5);
+    QVERIFY(s.values().at(0).fxi() == 4);
+    QVERIFY(s.values().at(0).channel() == 5);
     QVERIFY(s.values().at(0).value == 6);
 
     /* No fixture 1 anymore */
     s.unsetValue(1, 2);
     QVERIFY(s.values().size() == 1);
-    QVERIFY(s.values().at(0).fxi == 4);
-    QVERIFY(s.values().at(0).channel == 5);
+    QVERIFY(s.values().at(0).fxi() == 4);
+    QVERIFY(s.values().at(0).channel() == 5);
     QVERIFY(s.values().at(0).value == 6);
 
     /* Remove fixture 4's channel 5 from the scene */
@@ -167,15 +167,15 @@ void Scene_Test::fixtureRemoval()
     /* Simulate fixture removal signal with a fixture in the scene */
     s.slotFixtureRemoved(4);
     QVERIFY(s.values().size() == 1);
-    QVERIFY(s.values().at(0).fxi == 1);
-    QVERIFY(s.values().at(0).channel == 2);
+    QVERIFY(s.values().at(0).fxi() == 1);
+    QVERIFY(s.values().at(0).channel() == 2);
     QVERIFY(s.values().at(0).value == 3);
 
     /* Simulate fixture removal signal with an invalid fixture id */
     s.slotFixtureRemoved(Fixture::invalidId());
     QVERIFY(s.values().size() == 1);
-    QVERIFY(s.values().at(0).fxi == 1);
-    QVERIFY(s.values().at(0).channel == 2);
+    QVERIFY(s.values().at(0).fxi() == 1);
+    QVERIFY(s.values().at(0).channel() == 2);
     QVERIFY(s.values().at(0).value == 3);
 
     /* Simulate fixture removal signal with a fixture in the scene */

--- a/engine/test/scenevalue/scenevalue_test.cpp
+++ b/engine/test/scenevalue/scenevalue_test.cpp
@@ -29,14 +29,14 @@ void SceneValue_Test::initial()
 {
     SceneValue scv;
     QVERIFY(scv.isValid() == false);
-    QVERIFY(scv.fxi == Fixture::invalidId());
-    QVERIFY(scv.channel == QLCChannel::invalid());
+    QVERIFY(scv.fxi() == Fixture::invalidId());
+    QVERIFY(scv.channel() == QLCChannel::invalid());
     QVERIFY(scv.value == 0);
 
     SceneValue scv2(31337, 5150, 42);
     QVERIFY(scv2.isValid() == true);
-    QVERIFY(scv2.fxi == 31337);
-    QVERIFY(scv2.channel == 5150);
+    QVERIFY(scv2.fxi() == 31337);
+    QVERIFY(scv2.channel() == 5150);
     QVERIFY(scv2.value == 42);
 }
 
@@ -50,26 +50,26 @@ void SceneValue_Test::lessThan()
     QVERIFY((scv2 < scv1) == false);
 
     /* Both save same ID, invalid channel; same here */
-    scv1.fxi = 0;
-    scv2.fxi = 0;
+    scv1.assign(0, QLCChannel::invalid(), 0);
+    scv2.assign(0, QLCChannel::invalid(), 0);
     QVERIFY((scv1 < scv2) == false);
     QVERIFY((scv2 < scv1) == false);
 
     /* Same ID, different channel */
-    scv1.channel = 0;
-    scv2.channel = 1;
+    scv1.assign(0, 0, 0);
+    scv2.assign(0, 1, 0);
     QVERIFY((scv1 < scv2) == true);
     QVERIFY((scv2 < scv1) == false);
 
     /* Different ID, different channel */
-    scv1.fxi = 1;
-    scv2.fxi = 0;
+    scv1.assign(1, 0, 0);
+    scv2.assign(0, 1, 0);
     QVERIFY((scv1 < scv2) == false);
     QVERIFY((scv2 < scv1) == true);
 
     /* Different ID, same channel */
-    scv1.channel = 1;
-    scv2.channel = 1;
+    scv1.assign(1, 1, 0);
+    scv2.assign(0, 1, 0);
     QVERIFY((scv1 < scv2) == false);
     QVERIFY((scv2 < scv1) == true);
 }
@@ -95,8 +95,8 @@ void SceneValue_Test::loadSuccess()
 
     SceneValue scv;
     QVERIFY(scv.loadXML(xmlReader) == true);
-    QVERIFY(scv.fxi == 5);
-    QVERIFY(scv.channel == 60);
+    QVERIFY(scv.fxi() == 5);
+    QVERIFY(scv.channel() == 60);
     QVERIFY(scv.value == 100);
 }
 

--- a/ui/src/addchannelsgroup.cpp
+++ b/ui/src/addchannelsgroup.cpp
@@ -103,8 +103,8 @@ AddChannelsGroup::AddChannelsGroup(QWidget* parent, Doc* doc, ChannelsGroup *gro
 
             item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
             if (chans.count() > ch &&
-                chans.at(ch).fxi == fxi->id() &&
-                chans.at(ch).channel == c)
+                chans.at(ch).fxi() == fxi->id() &&
+                chans.at(ch).channel() == c)
             {
                 item->setCheckState(KColumnGroup, Qt::Checked);
                 m_checkedChannels++;

--- a/ui/src/audiobar.cpp
+++ b/ui/src/audiobar.cpp
@@ -113,10 +113,10 @@ void AudioBar::attachDmxChannels(Doc *doc, QList<SceneValue> list)
     m_absDmxChannels.clear();
     foreach(SceneValue scv, m_dmxChannels)
     {
-        Fixture *fx = doc->fixture(scv.fxi);
+        Fixture *fx = doc->fixture(scv.fxi());
         if (fx != NULL)
         {
-            quint32 absAddr = fx->universeAddress() + scv.channel;
+            quint32 absAddr = fx->universeAddress() + scv.channel();
             m_absDmxChannels.append(absAddr);
         }
     }
@@ -293,7 +293,7 @@ bool AudioBar::saveXML(QXmlStreamWriter *doc, QString tagName, int index)
         {
             if (chans.isEmpty() == false)
                 chans.append(",");
-            chans.append(QString("%1,%2").arg(scv.fxi).arg(scv.channel));
+            chans.append(QString("%1,%2").arg(scv.fxi()).arg(scv.channel()));
         }
         if (chans.isEmpty() == false)
         {

--- a/ui/src/dmxdumpfactory.cpp
+++ b/ui/src/dmxdumpfactory.cpp
@@ -141,10 +141,10 @@ void DmxDumpFactory::slotSelectSceneButtonClicked()
 
         foreach(SceneValue scv, scene->values())
         {
-            Fixture *fxi = m_doc->fixture(scv.fxi);
+            Fixture *fxi = m_doc->fixture(scv.fxi());
             if (fxi == NULL)
                 continue;
-            quint32 absAddress = fxi->universeAddress() + scv.channel;
+            quint32 absAddress = fxi->universeAddress() + scv.channel();
             if (chMask.length() > (int)absAddress)
                 chMask[absAddress] = 1;
         }

--- a/ui/src/fixtureconsole.cpp
+++ b/ui/src/fixtureconsole.cpp
@@ -166,14 +166,14 @@ void FixtureConsole::setOutputDMX(bool state)
 
 void FixtureConsole::setSceneValue(const SceneValue& scv)
 {
-    Q_ASSERT(scv.fxi == m_fixture);
+    Q_ASSERT(scv.fxi() == m_fixture);
 
     QListIterator <ConsoleChannel*> it(m_channels);
     while (it.hasNext() == true)
     {
         ConsoleChannel* cc = it.next();
         Q_ASSERT(cc != NULL);
-        if (cc->channel() == scv.channel)
+        if (cc->channel() == scv.channel())
         {
             cc->setChecked(true);
             cc->setValue(scv.value);
@@ -225,9 +225,9 @@ void FixtureConsole::setValues(const QList <SceneValue>& list, bool fromSelectio
     while (it.hasNext() == true)
     {
         SceneValue val(it.next());
-        if (val.channel < quint32(children().size()))
+        if (val.channel() < quint32(children().size()))
         {
-            ConsoleChannel* cc = channel(val.channel);
+            ConsoleChannel* cc = channel(val.channel());
             if (cc != NULL)
             {
                 cc->setChecked(true);

--- a/ui/src/fixturemanager.cpp
+++ b/ui/src/fixturemanager.cpp
@@ -464,11 +464,11 @@ void FixtureManager::updateChannelsGroupView()
         if (grp->getChannels().count() > 0)
         {
             SceneValue scv = grp->getChannels().at(0);
-            Fixture *fxi = m_doc->fixture(scv.fxi);
+            Fixture *fxi = m_doc->fixture(scv.fxi());
             if (fxi == NULL)
                 continue;
 
-            const QLCChannel* ch = fxi->channel(scv.channel);
+            const QLCChannel* ch = fxi->channel(scv.channel());
             if (ch != NULL)
                 grpItem->setIcon(KColumnName, ch->getIcon());
         }

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -608,8 +608,8 @@ QList<SceneValue> FixtureRemap::remapSceneValues(QList<SceneValue> funcList,
             if (val == srcList.at(v))
             {
                 SceneValue tgtVal = tgtList.at(v);
-                //qDebug() << "[Scene] Remapping" << val.fxi << val.channel << " to " << tgtVal.fxi << tgtVal.channel;
-                newValuesList.append(SceneValue(tgtVal.fxi, tgtVal.channel, val.value));
+                //qDebug() << "[Scene] Remapping" << val.fxi() << val.channel() << " to " << tgtVal.fxi << tgtVal.channel;
+                newValuesList.append(SceneValue(tgtVal.fxi(), tgtVal.channel(), val.value));
             }
         }
     }
@@ -692,9 +692,9 @@ void FixtureRemap::accept()
 
             for (int i = 0; i < sourceList.count(); i++)
             {
-                if (sourceList.at(i).fxi == head.fxi)
+                if (sourceList.at(i).fxi() == head.fxi)
                 {
-                    head.fxi = targetList.at(i).fxi;
+                    head.fxi = targetList.at(i).fxi();
                     group->resignHead(pt);
                     group->assignHead(pt, head);
                     break;
@@ -710,7 +710,7 @@ void FixtureRemap::accept()
         grp->resetChannels();
         QList <SceneValue> newList = remapSceneValues(grpChannels, sourceList, targetList);
         foreach (SceneValue val, newList)
-            grp->addChannel(val.fxi, val.channel);
+            grp->addChannel(val.fxi(), val.channel());
     }
 
     /* **********************************************************************
@@ -732,7 +732,7 @@ void FixtureRemap::accept()
 
                 for (int i = 0; i < newList.count(); i++)
                 {
-                    s->addFixture(newList.at(i).fxi);
+                    s->addFixture(newList.at(i).fxi());
                     s->setValue(newList.at(i));
                 }
             }
@@ -779,21 +779,21 @@ void FixtureRemap::accept()
                         SceneValue tgtVal = targetList.at(i);
                         // check for fixture ID match. EFX remapping must be performed
                         // just once for each target fixture
-                        if (srcVal.fxi == fxID && remappedFixtures.contains(tgtVal.fxi) == false)
+                        if (srcVal.fxi() == fxID && remappedFixtures.contains(tgtVal.fxi()) == false)
                         {
-                            Fixture *docFix = m_doc->fixture(tgtVal.fxi);
-                            quint32 fxCh = tgtVal.channel;
+                            Fixture *docFix = m_doc->fixture(tgtVal.fxi());
+                            quint32 fxCh = tgtVal.channel();
                             const QLCChannel *chan = docFix->channel(fxCh);
                             if (chan->group() == QLCChannel::Pan ||
                                 chan->group() == QLCChannel::Tilt)
                             {
                                 EFXFixture* ef = new EFXFixture(e);
                                 ef->copyFrom(efxFix);
-                                ef->setHead(GroupHead(tgtVal.fxi, 0)); // TODO!!! head!!!
+                                ef->setHead(GroupHead(tgtVal.fxi(), 0)); // TODO!!! head!!!
                                 if (e->addFixture(ef) == false)
                                     delete ef;
-                                qDebug() << "EFX remap" << srcVal.fxi << "to" << tgtVal.fxi;
-                                remappedFixtures.append(tgtVal.fxi);
+                                qDebug() << "EFX remap" << srcVal.fxi() << "to" << tgtVal.fxi();
+                                remappedFixtures.append(tgtVal.fxi());
                             }
                         }
                     }
@@ -833,17 +833,17 @@ void FixtureRemap::accept()
                     for (int v = 0; v < sourceList.count(); v++)
                     {
                         SceneValue val = sourceList.at(v);
-                        if (val.fxi == chan.fixture && val.channel == chan.channel)
+                        if (val.fxi() == chan.fixture && val.channel() == chan.channel)
                         {
-                            qDebug() << "Matching channel:" << chan.fixture << chan.channel << "to target:" << targetList.at(v).fxi << targetList.at(v).channel;
-                            newChannels.append(SceneValue(targetList.at(v).fxi, targetList.at(v).channel));
+                            qDebug() << "Matching channel:" << chan.fixture << chan.channel << "to target:" << targetList.at(v).fxi() << targetList.at(v).channel();
+                            newChannels.append(SceneValue(targetList.at(v).fxi(), targetList.at(v).channel()));
                         }
                     }
                 }
                 // this is crucial: here all the "unmapped" channels will be lost forever !
                 slider->clearLevelChannels();
                 foreach (SceneValue rmpChan, newChannels)
-                    slider->addLevelChannel(rmpChan.fxi, rmpChan.channel);
+                    slider->addLevelChannel(rmpChan.fxi(), rmpChan.channel());
             }
         }
         else if (widget->type() == VCWidget::AudioTriggersWidget)
@@ -869,17 +869,17 @@ void FixtureRemap::accept()
                 for (int i = 0; i < sourceList.count(); i++)
                 {
                     SceneValue val = sourceList.at(i);
-                    if (val.fxi == srxFxID)
+                    if (val.fxi() == srxFxID)
                     {
                         SceneValue tgtVal = targetList.at(i);
-                        Fixture *docFix = m_doc->fixture(tgtVal.fxi);
-                        quint32 fxCh = tgtVal.channel;
+                        Fixture *docFix = m_doc->fixture(tgtVal.fxi());
+                        quint32 fxCh = tgtVal.channel();
                         const QLCChannel *chan = docFix->channel(fxCh);
                         if (chan->group() == QLCChannel::Pan ||
                             chan->group() == QLCChannel::Tilt)
                         {
                             VCXYPadFixture tgtFix(m_doc);
-                            GroupHead head(tgtVal.fxi, 0);
+                            GroupHead head(tgtVal.fxi(), 0);
                             tgtFix.setHead(head);
                             copyFixtures.append(tgtFix);
                         }
@@ -906,10 +906,10 @@ void FixtureRemap::accept()
         {
             for( int v = 0; v < sourceList.count(); v++)
             {
-                if (sourceList.at(v).fxi == fxID)
+                if (sourceList.at(v).fxi() == fxID)
                 {
                     FixtureItemProperties rmpProp = props->fixtureProperties(fxID);
-                    remappedFixtureItems[targetList.at(v).fxi] = rmpProp;
+                    remappedFixtureItems[targetList.at(v).fxi()] = rmpProp;
                     break;
                 }
             }

--- a/ui/src/functionwizard.cpp
+++ b/ui/src/functionwizard.cpp
@@ -588,7 +588,7 @@ VCWidget *FunctionWizard::createWidget(int type, VCWidget *parent, int xpos, int
             {
                 Scene *scene = qobject_cast<Scene*> (func);
                 foreach (SceneValue scv, scene->values())
-                    slider->addLevelChannel(scv.fxi, scv.channel);
+                    slider->addLevelChannel(scv.fxi(), scv.channel());
 
                 if (pType == PaletteGenerator::PrimaryColors ||
                     pType == PaletteGenerator::SixteenColors)
@@ -622,11 +622,11 @@ VCWidget *FunctionWizard::createWidget(int type, VCWidget *parent, int xpos, int
             {
                 foreach(SceneValue scv, scene->values())
                 {
-                    Fixture *fixture = m_doc->fixture(scv.fxi);
+                    Fixture *fixture = m_doc->fixture(scv.fxi());
                     if (fixture == NULL)
                         continue;
 
-                    const QLCChannel* channel(fixture->channel(scv.channel));
+                    const QLCChannel* channel(fixture->channel(scv.channel()));
                     if (channel->group() == QLCChannel::Gobo)
                     {
                         QLCCapability *cap = channel->searchCapability(scv.value);

--- a/ui/src/groupsconsole.cpp
+++ b/ui/src/groupsconsole.cpp
@@ -67,7 +67,7 @@ void GroupsConsole::init()
         {
             SceneValue scv = grp->getChannels().at(0);
 
-            ConsoleChannel* cc = new ConsoleChannel(this, m_doc, scv.fxi, scv.channel, false);
+            ConsoleChannel* cc = new ConsoleChannel(this, m_doc, scv.fxi(), scv.channel(), false);
             cc->setLabel(grp->name());
             cc->setChannelsGroup(id);
             cc->setChannelStyleSheet(CNG_DEFAULT_STYLE);

--- a/ui/src/palettegenerator.cpp
+++ b/ui/src/palettegenerator.cpp
@@ -238,13 +238,13 @@ void PaletteGenerator::createColorScene(QList<SceneValue> chMap, QString name, P
     foreach(SceneValue scv, chMap)
     {
 
-        scene->setValue(scv.fxi, scv.channel, 255);
+        scene->setValue(scv.fxi(), scv.channel(), 255);
         if (subType == OddEven)
         {
             if (even)
-                evenScene->setValue(scv.fxi, scv.channel, 255);
+                evenScene->setValue(scv.fxi(), scv.channel(), 255);
             else
-                oddScene->setValue(scv.fxi, scv.channel, 255);
+                oddScene->setValue(scv.fxi(), scv.channel(), 255);
             even = !even;
         }
     }
@@ -307,13 +307,13 @@ void PaletteGenerator::createRGBCMYScene(QList<SceneValue> rcMap,
 
         foreach(SceneValue scv, rcMap)
         {
-            Fixture *fxi = m_doc->fixture(scv.fxi);
+            Fixture *fxi = m_doc->fixture(scv.fxi());
             int gmCh = -1, byCh = -1;
 
             for (int i = 0; i < fxi->heads(); i++)
             {
                 QLCFixtureHead head = fxi->head(i);
-                if(head.channels().contains(scv.channel))
+                if(head.channels().contains(scv.channel()))
                 {
                     if (head.rgbChannels().count() == 3)
                     {
@@ -334,23 +334,23 @@ void PaletteGenerator::createRGBCMYScene(QList<SceneValue> rcMap,
             if (gmCh == -1 || byCh == -1)
                 continue;
 
-            scene->setValue(scv.fxi, scv.channel, rc);
-            scene->setValue(scv.fxi, gmCh, gm);
-            scene->setValue(scv.fxi, byCh, by);
+            scene->setValue(scv.fxi(), scv.channel(), rc);
+            scene->setValue(scv.fxi(), gmCh, gm);
+            scene->setValue(scv.fxi(), byCh, by);
 
             if (subType == OddEven)
             {
                 if (even)
                 {
-                    evenScene->setValue(scv.fxi, scv.channel, rc);
-                    evenScene->setValue(scv.fxi, gmCh, gm);
-                    evenScene->setValue(scv.fxi, byCh, by);
+                    evenScene->setValue(scv.fxi(), scv.channel(), rc);
+                    evenScene->setValue(scv.fxi(), gmCh, gm);
+                    evenScene->setValue(scv.fxi(), byCh, by);
                 }
                 else
                 {
-                    oddScene->setValue(scv.fxi, scv.channel, rc);
-                    oddScene->setValue(scv.fxi, gmCh, gm);
-                    oddScene->setValue(scv.fxi, byCh, by);
+                    oddScene->setValue(scv.fxi(), scv.channel(), rc);
+                    oddScene->setValue(scv.fxi(), gmCh, gm);
+                    oddScene->setValue(scv.fxi(), byCh, by);
                 }
                 even = !even;
             }
@@ -439,7 +439,7 @@ void PaletteGenerator::createRGBMatrices(QList<SceneValue> rgbMap)
 
     foreach(SceneValue scv, rgbMap)
     {
-        m_fixtureGroup->assignFixture(scv.fxi);
+        m_fixtureGroup->assignFixture(scv.fxi());
         m_fixtureGroup->setName(m_model + tr(" - RGB Group"));
     }
     QStringList algoList = m_doc->rgbScriptsCache()->names();

--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -135,7 +135,7 @@ void SceneEditor::slotSetSceneValues(QList <SceneValue>&sceneValues)
     {
         SceneValue sv(it.next());
 
-        fixture = m_doc->fixture(sv.fxi);
+        fixture = m_doc->fixture(sv.fxi());
         Q_ASSERT(fixture != NULL);
 
         fc = fixtureConsole(fixture);
@@ -325,11 +325,11 @@ void SceneEditor::init(bool applyValues)
     {
         SceneValue scv(it.next());
 
-        if (fixtureItem(scv.fxi) == NULL)
+        if (fixtureItem(scv.fxi()) == NULL)
         {
             qWarning() << Q_FUNC_INFO
-                << "Fixture" << scv.fxi << "was not in the scene fixture list!";
-            Fixture* fixture = m_doc->fixture(scv.fxi);
+                << "Fixture" << scv.fxi() << "was not in the scene fixture list!";
+            Fixture* fixture = m_doc->fixture(scv.fxi());
             if (fixture == NULL)
                 continue;
 
@@ -346,7 +346,7 @@ void SceneEditor::setSceneValue(const SceneValue& scv)
     FixtureConsole* fc;
     Fixture* fixture;
 
-    fixture = m_doc->fixture(scv.fxi);
+    fixture = m_doc->fixture(scv.fxi());
     Q_ASSERT(fixture != NULL);
 
     fc = fixtureConsole(fixture);
@@ -512,7 +512,7 @@ void SceneEditor::slotPaste()
                 QList<SceneValue>thisFixtureVals;
                 foreach(SceneValue val, clipboard->getSceneValues())
                 {
-                    if (val.fxi == fxi)
+                    if (val.fxi() == fxi)
                         thisFixtureVals.append(val);
                 }
                 fc->setValues(thisFixtureVals, m_copyFromSelection);
@@ -832,7 +832,7 @@ void SceneEditor::slotBlindToggled(bool state)
         {
             m_source = new GenericDMXSource(m_doc);
             foreach(SceneValue scv, m_scene->values())
-                m_source->set(scv.fxi, scv.channel, scv.value);
+                m_source->set(scv.fxi(), scv.channel(), scv.value);
         }
     }
     else
@@ -917,7 +917,7 @@ void SceneEditor::slotViewModeChanged(bool toggled, bool applyValues)
                     SceneValue scv(it.next());
                     if (applyValues == false)
                         scv.value = 0;
-                    if (scv.fxi == fixture->id())
+                    if (scv.fxi() == fixture->id())
                         console->setSceneValue(scv);
                 }
 
@@ -945,7 +945,7 @@ void SceneEditor::slotViewModeChanged(bool toggled, bool applyValues)
                 SceneValue scv(it.next());
                 if (applyValues == false)
                     scv.value = 0;
-                if (scv.fxi == fixture->id())
+                if (scv.fxi() == fixture->id())
                     setSceneValue(scv);
             }
         }
@@ -1345,13 +1345,13 @@ void SceneEditor::slotChannelGroupsChanged(QTreeWidgetItem *item, int column)
         m_scene->addChannelGroup(grpID);
         foreach (SceneValue val, grp->getChannels())
         {
-            Fixture *fixture = m_doc->fixture(val.fxi);
+            Fixture *fixture = m_doc->fixture(val.fxi());
             if (fixture != NULL)
             {
                 if (addFixtureItem(fixture) == true)
-                    addFixtureTab(fixture, val.channel);
+                    addFixtureTab(fixture, val.channel());
                 else
-                    setTabChannelState(true, fixture, val.channel);
+                    setTabChannelState(true, fixture, val.channel());
             }
         }
     }
@@ -1360,9 +1360,9 @@ void SceneEditor::slotChannelGroupsChanged(QTreeWidgetItem *item, int column)
         m_scene->removeChannelGroup(grpID);
         foreach (SceneValue val, grp->getChannels())
         {
-            Fixture *fixture = m_doc->fixture(val.fxi);
+            Fixture *fixture = m_doc->fixture(val.fxi());
             if (fixture != NULL)
-                setTabChannelState(false, fixture, val.channel);
+                setTabChannelState(false, fixture, val.channel());
         }
     }
 
@@ -1446,13 +1446,13 @@ void SceneEditor::slotGroupValueChanged(quint32 groupID, uchar value)
             return;
         foreach (SceneValue scv, group->getChannels())
         {
-            Fixture *fixture = m_doc->fixture(scv.fxi);
+            Fixture *fixture = m_doc->fixture(scv.fxi());
             if (fixture == NULL)
                 continue;
             FixtureConsole *fc = fixtureConsole(fixture);
             if (fc == NULL)
                 continue;
-            fc->setValue(scv.channel, value);
+            fc->setValue(scv.channel(), value);
         }
         m_scene->setChannelGroupLevel(groupID, value);
     }

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -322,14 +322,14 @@ void ScriptEditor::slotAddSetFixture()
     QList<SceneValue> channelsList = cfg.channelsList();
     foreach(SceneValue sv, channelsList)
     {
-        Fixture* fxi = m_doc->fixture(sv.fxi);
+        Fixture* fxi = m_doc->fixture(sv.fxi());
         if (fxi != NULL)
         {
-            const QLCChannel* channel = fxi->channel(sv.channel);
+            const QLCChannel* channel = fxi->channel(sv.channel());
             m_editor->moveCursor(QTextCursor::StartOfLine);
             m_editor->textCursor().insertText(QString("%1:%2 ch:%3 val:0 // %4, %5\n")
                                                 .arg(Script::setFixtureCmd)
-                                                .arg(fxi->id()).arg(sv.channel)
+                                                .arg(fxi->id()).arg(sv.channel())
                                                 .arg(fxi->name()).arg(channel->name()));
             m_editor->moveCursor(QTextCursor::Down);
         }

--- a/ui/src/simpledesk.cpp
+++ b/ui/src/simpledesk.cpp
@@ -994,10 +994,10 @@ void SimpleDesk::slotGroupValueChanged(quint32 groupID, uchar value)
 
     foreach (SceneValue scv, group->getChannels())
     {
-        Fixture *fixture = m_doc->fixture(scv.fxi);
+        Fixture *fixture = m_doc->fixture(scv.fxi());
         if (fixture == NULL)
             continue;
-        quint32 absAddr = fixture->universeAddress() + scv.channel;
+        quint32 absAddr = fixture->universeAddress() + scv.channel();
         m_engine->setValue(absAddr, value);
 
         // Update sliders on screen
@@ -1022,7 +1022,7 @@ void SimpleDesk::slotGroupValueChanged(quint32 groupID, uchar value)
             if(fc != NULL)
             {
                 fc->blockSignals(true);
-                fc->setValue(scv.channel, value, false);
+                fc->setValue(scv.channel(), value, false);
                 fc->blockSignals(false);
             }
         }

--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -735,10 +735,10 @@ void VCXYPad::slotPresetClicked(bool checked)
 
         foreach(SceneValue scv, m_scene->values())
         {
-            Fixture *fixture = m_doc->fixture(scv.fxi);
+            Fixture *fixture = m_doc->fixture(scv.fxi());
             if (fixture == NULL)
                 continue;
-            const QLCChannel *ch = fixture->channel(scv.channel);
+            const QLCChannel *ch = fixture->channel(scv.channel());
             if (ch == NULL)
                 continue;
             if (ch->group() != QLCChannel::Pan && ch->group() != QLCChannel::Tilt)
@@ -747,7 +747,7 @@ void VCXYPad::slotPresetClicked(bool checked)
             SceneChannel sChan;
             sChan.m_universe = fixture->universe();
             sChan.m_fixture = fixture->id();
-            sChan.m_channel = fixture->address() + scv.channel;
+            sChan.m_channel = fixture->address() + scv.channel();
             sChan.m_group = ch->group();
             sChan.m_subType = ch->controlByte();
             m_sceneChannels.append(sChan);

--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -700,10 +700,10 @@ void VCXYPadProperties::slotAddSceneClicked()
         bool panTiltFound = false;
         foreach(SceneValue scv, scene->values())
         {
-            Fixture *fixture = m_doc->fixture(scv.fxi);
+            Fixture *fixture = m_doc->fixture(scv.fxi());
             if (fixture == NULL)
                 continue;
-            const QLCChannel *ch = fixture->channel(scv.channel);
+            const QLCChannel *ch = fixture->channel(scv.channel());
             if (ch == NULL)
                 continue;
             if (ch->group() == QLCChannel::Pan || ch->group() == QLCChannel::Tilt)

--- a/ui/test/palettegenerator/palettegenerator_test.cpp
+++ b/ui/test/palettegenerator/palettegenerator_test.cpp
@@ -126,10 +126,10 @@ void PaletteGenerator_Test::createColours()
         Scene* s = qobject_cast<Scene*> (doc.function(i));
         QVERIFY(s != NULL);
         QCOMPARE(s->values().size(), 2); // One colour for two fixtures
-        QCOMPARE(s->values().at(0).fxi, fxi1->id());
-        QCOMPARE(s->values().at(0).channel, quint32(2)); // DJScan colour channel
-        QCOMPARE(s->values().at(1).fxi, fxi2->id());
-        QCOMPARE(s->values().at(1).channel, quint32(2)); // DJScan colour channel
+        QCOMPARE(s->values().at(0).fxi(), fxi1->id());
+        QCOMPARE(s->values().at(0).channel(), quint32(2)); // DJScan colour channel
+        QCOMPARE(s->values().at(1).fxi(), fxi2->id());
+        QCOMPARE(s->values().at(1).channel(), quint32(2)); // DJScan colour channel
     }
 }
 
@@ -163,10 +163,10 @@ void PaletteGenerator_Test::createGobos()
         Scene* s = qobject_cast<Scene*> (doc.function(i));
         QVERIFY(s != NULL);
         QCOMPARE(s->values().size(), 2); // One gobo for two fixtures
-        QCOMPARE(s->values().at(0).fxi, fxi1->id());
-        QCOMPARE(s->values().at(0).channel, quint32(3)); // DJScan gobo channel
-        QCOMPARE(s->values().at(1).fxi, fxi2->id());
-        QCOMPARE(s->values().at(1).channel, quint32(3)); // DJScan gobo channel
+        QCOMPARE(s->values().at(0).fxi(), fxi1->id());
+        QCOMPARE(s->values().at(0).channel(), quint32(3)); // DJScan gobo channel
+        QCOMPARE(s->values().at(1).fxi(), fxi2->id());
+        QCOMPARE(s->values().at(1).channel(), quint32(3)); // DJScan gobo channel
     }
 }
 
@@ -201,10 +201,10 @@ void PaletteGenerator_Test::createShutters()
         Scene* s = qobject_cast<Scene*> (doc.function(i));
         QVERIFY(s != NULL);
         QCOMPARE(s->values().size(), 2); // One cap for two fixtures
-        QCOMPARE(s->values().at(0).fxi, fxi1->id());
-        QCOMPARE(s->values().at(0).channel, quint32(0)); // MAC300 shutter channel
-        QCOMPARE(s->values().at(1).fxi, fxi2->id());
-        QCOMPARE(s->values().at(1).channel, quint32(0)); // MAC300 shutter channel
+        QCOMPARE(s->values().at(0).fxi(), fxi1->id());
+        QCOMPARE(s->values().at(0).channel(), quint32(0)); // MAC300 shutter channel
+        QCOMPARE(s->values().at(1).fxi(), fxi2->id());
+        QCOMPARE(s->values().at(1).channel(), quint32(0)); // MAC300 shutter channel
     }
 }
 


### PR DESCRIPTION
This is a little experiment in decreasing memory footprint inspired by the "70 MB" showfile.
Since it's too much for my computer with 4GB to handle, I extracted one sequence with 9600 steps to separate file, and run valgrind --tool=massif on it (the file has no VC widgets and still it's 3 MB).
Baseline peak memory usage was 299 MB.

First commit makes SceneValue's destructor non-virtual which saves us size of virtual table (one pointer here).
Massif peak usage 199 MB. 30% down. Nice...

Second commit avoids some conversions and uses QString::splitRef instead of split to avoid creating QStrings and copying the data. It doesn't save memory, but may help with fragmentation. Massif says 194 MB. Not so big difference but still something. Note: splitRef is supported from QT 5.4.

Third commit combines fixture id and channel to one quint32. This saves one quint32 out of each SceneValue. It's a memory/time tradeoff. The time penaulty is decreased by the fact, that SceneValue comparison is simplified to quint32 comparison now. Massif says 159 MB (47% saved from the baseline).

Some memory could be saved by storing SceneValues in QVector instead of QList in ChaserStep (one pointer per SceneValue). Problem here is that Scene keeps SceneValues in QMap, and QMap::keys() provides the values as QList, so conversion to QVector must be provided in some place.