### PR TITLE
Increase maximum fixture group dimensions that UI accepts as valid.

### DIFF
--- a/ui/src/createfixturegroup.ui
+++ b/ui/src/createfixturegroup.ui
@@ -7,14 +7,14 @@
 
   Copyright (c) 2015 Massimo Callegari
 
-  Licensed under the Apache License, Version 2.0 (the "License");
+  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0.txt
 
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
+  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
@@ -63,6 +63,9 @@
         <property name="minimum">
          <number>1</number>
         </property>
+        <property name="maximum">
+         <number>999</number>
+        </property>
        </widget>
       </item>
       <item>
@@ -76,6 +79,9 @@
        <widget class="QSpinBox" name="m_heightSpin">
         <property name="minimum">
          <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>999</number>
         </property>
        </widget>
       </item>

--- a/ui/src/fixturegroupeditor.ui
+++ b/ui/src/fixturegroupeditor.ui
@@ -7,14 +7,14 @@
 
   Copyright (c) 2015 Massimo Callegari
 
-  Licensed under the Apache License, Version 2.0 (the "License");
+  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0.txt
 
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
+  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
@@ -25,8 +25,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
-    <height>432</height>
+    <width>599</width>
+    <height>539</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,6 +97,9 @@
      <property name="minimum">
       <number>1</number>
      </property>
+     <property name="maximum">
+      <number>999</number>
+     </property>
     </widget>
    </item>
    <item row="8" column="4">
@@ -126,6 +129,9 @@
      </property>
      <property name="minimum">
       <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>999</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Fixture group maximum dimensions are limited in UI. One can easily create fixture group larger than 99px by 99px by adding RGB panel, but can not enter dimensions larger than 99px by 99px in fixture group editor or create dialog.
I increased limit to 999, which should suit most of us for time being.