### PR TITLE
Fixed unexpected feedback from another page

### DIFF
--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -672,20 +672,23 @@ void VCWidget::sendFeedback(int value, QSharedPointer<QLCInputSource> src)
         if (src->needsUpdate())
             src->updateOuputValue(value);
 
-        QString chName = QString();
-
-        InputPatch* pat = m_doc->inputOutputMap()->inputPatch(src->universe());
-        if (pat != NULL)
+        if (acceptsInput())
         {
-            QLCInputProfile* profile = pat->profile();
-            if (profile != NULL)
+            QString chName = QString();
+
+            InputPatch* pat = m_doc->inputOutputMap()->inputPatch(src->universe());
+            if (pat != NULL)
             {
-                QLCInputChannel* ich = profile->channel(src->channel());
-                if (ich != NULL)
-                    chName = ich->name();
+                QLCInputProfile* profile = pat->profile();
+                if (profile != NULL)
+                {
+                    QLCInputChannel* ich = profile->channel(src->channel());
+                    if (ich != NULL)
+                        chName = ich->name();
+                }
             }
+            m_doc->inputOutputMap()->sendFeedBack(src->universe(), src->channel(), value, chName);
         }
-        m_doc->inputOutputMap()->sendFeedBack(src->universe(), src->channel(), value, chName);
     }
 }
 


### PR DESCRIPTION
Uses recently added acceptsInput() method since a disabled widget should not send any feedback from my point of view. If you care, it could be renamed or another sendsFeedback() could be added. Just let me know if you want something to change.
Fixes: #923 