### PR TITLE
Fixed feedback not working with buttons on some controllers

### DIFF
--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -534,11 +534,19 @@ void VCButton::slotInputValueChanged(quint32 universe, quint32 channel, uchar va
             else if (isOn() == true && value == 0)
                 releaseFunction();
         }
-        else if (value > 0)
+        else
         {
-            // Only toggle when the external button is pressed.
-            // Releasing the button does nothing.
-            pressFunction();
+            if (value > 0)
+            {
+                // Only toggle when the external button is pressed.
+                pressFunction();
+            }
+            else
+            {
+                // Work around the "internal" feedback of some controllers
+                // by updating feedback state after button release.
+                updateFeedback();
+            }
         }
     }
 }


### PR DESCRIPTION
This happens for example at BCF 2000 and probably also APC40 mk2 due to some kind of internal feedback.
Only thing to do was to add updateFeedback() as soon as a button on external controller is released so that it has a proper LED state and not the one given by its "internal" feedback.
The change works great at my BCF 2000, since I have no other controllers at hand maybe someone could give it a try.

Bug has been reported here: http://www.qlcplus.org/forum/viewtopic.php?f=5&t=6900&p=29106
And I tried to describe it well here: http://www.qlcplus.org/forum/viewtopic.php?f=24&t=10158&p=45921#p45916