### PR TITLE
Fixed choose external input does not consider page number

### DIFF
--- a/ui/src/inputselectionwidget.cpp
+++ b/ui/src/inputselectionwidget.cpp
@@ -175,9 +175,9 @@ void InputSelectionWidget::slotChooseInputClicked()
     SelectInputChannel sic(this, m_doc->inputOutputMap());
     if (sic.exec() == QDialog::Accepted)
     {
-        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), sic.channel()));
+        m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(sic.universe(), (m_widgetPage << 16) | sic.channel()));
         updateInputSource();
-        emit inputValueChanged(sic.universe(), sic.channel());
+        emit inputValueChanged(sic.universe(), (m_widgetPage << 16) | sic.channel());
     }
 }
 


### PR DESCRIPTION
This fixes the problem that the "Choose external input" dialog does not consider page numbers if it's executed in a multipage frame.

Reported here: http://www.qlcplus.org/forum/viewtopic.php?f=33&t=10612&p=46219