### PR TITLE
Webaccess improvements

### DIFF
--- a/webaccess/res/websocket.js
+++ b/webaccess/res/websocket.js
@@ -52,9 +52,10 @@ window.onload = function() {
     }
   }
   else if (msgParams[1] == "SLIDER") {
+    // Slider message is <ID>|SLIDER|<SLIDER VALUE>|<DISPLAY VALUE>
     obj.value = msgParams[2];
     var labelObj = document.getElementById("slv" + msgParams[0]);
-    labelObj.innerHTML = msgParams[2];
+    labelObj.innerHTML = msgParams[3];
   }
   else if (msgParams[1] == "CUE") {
     setCueIndex(msgParams[0], msgParams[2]);

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -796,9 +796,11 @@ QString WebAccess::getButtonHTML(VCButton *btn)
 void WebAccess::slotSliderValueChanged(QString val)
 {
     VCSlider *slider = (VCSlider *)sender();
+    int sliderVal = slider->sliderValue();
 
-    QString wsMessage = QString("%1|SLIDER|%2").arg(slider->id()).arg(val);
-
+    // <ID>|SLIDER|<SLIDER VALUE>|<DISPLAY VALUE>
+    QString wsMessage = QString("%1|SLIDER|%2|%3").arg(slider->id()).arg(sliderVal).arg(val);
+    
     sendWebSocketMessage(wsMessage.toUtf8());
 }
 
@@ -815,8 +817,9 @@ QString WebAccess::getSliderHTML(VCSlider *slider)
 
     str += "<div id=\"slv" + slID + "\" "
             "class=\"vcslLabel\" style=\"top:0px;\">" +
-            QString::number(slider->sliderValue()) + "</div>\n";
+            slider->topLabelText() + "</div>\n";
 
+    //TODO: Take into account slider's min and max values
     str +=  "<input type=\"range\" class=\"vVertical\" "
             "id=\"" + slID + "\" "
             "oninput=\"slVchange(" + slID + ");\" ontouchmove=\"slVchange(" + slID + ");\" "


### PR DESCRIPTION
I'm opening this PR to start a discussion about web console.
It is a great idea, but still requires a lot of improvements.

I'm starting this with fix for sliders in inverted and percentage modes.
Test console for this one: http://pastebin.com/effRheTr

As stated in the commit I see these possible improvements for sliders:
- Properly using min/max values to span the whole slider
  range from min to max, not 0 to 255.
- Sliders in 'knob' mode - they should use some other input
  method, maybe a simple numeric up/down (or textbox) ?
  That might be useful for someone.
- It would be nice to have horizontal sliders, but that also
  means implementing them in VC, so probably won't be done.

I'll also work on #933
What other things should be prioritized as far as webaccess is concerned?
Personally I would love to have speeddial implemented, at least in some way. I would see it as just the presets + display of current value. Maybe add multipliers, though I don't think they fit usecases for web console.

What are your thoughts?