### PR TITLE
VC: Fixed frame's keySequences not copied

### DIFF
--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -691,6 +691,10 @@ bool VCFrame::copyFrom(const VCWidget* widget)
 
     setPagesLoop(frame->m_pagesLoop);
 
+    setEnableKeySequence(frame->m_enableKeySequence);
+    setNextPageKeySequence(frame->m_nextPageKeySequence);
+    setPreviousPageKeySequence(frame->m_previousPageKeySequence);
+
     QListIterator <VCWidget*> it(widget->findChildren<VCWidget*>());
     while (it.hasNext() == true)
     {


### PR DESCRIPTION
This fixes the problem, that when copying a frame in vc, the keySequences for enabling and previous/next page are not copied.