### PR TITLE
Fixed no feedback from widgets in disabled frames

### DIFF
--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -673,7 +673,7 @@ void VCWidget::sendFeedback(int value, QSharedPointer<QLCInputSource> src)
     if (src->needsUpdate())
         src->updateOuputValue(value);
 
-    if (acceptsInput() == false)
+    if (acceptsInput() == false && isHidden())
         return;
 
     QString chName = QString();


### PR DESCRIPTION
This fixes the issue reported here: http://www.qlcplus.org/forum/viewtopic.php?f=33&t=10796
I'm still not sure if the use case is intended by QLC+, so if a disabled frame should send any feedback. But if it is considered as expected, we could simply use the visibility status of a widget in addition to the `acceptsInput` method (still needed for collapsed frames, in which the widgets are hidden).