### PR TITLE
Implemented catching sliders feature

### DIFF
--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -946,8 +946,6 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
     QMutexLocker locker(&m_levelValueMutex);
 
     uchar modLevel = m_levelValue;
-    bool mixedDMXlevels = false;
-    int monitorSliderValue = -1;
 
     int r = 0, g = 0, b = 0, c = 0, m = 0, y = 0;
 
@@ -983,6 +981,9 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
 
     if (m_monitorEnabled == true && m_levelValueChanged == false)
     {
+        bool mixedDMXlevels = false;
+        int monitorSliderValue = -1;
+
         QListIterator <LevelChannel> it(m_levelChannels);
         while (it.hasNext() == true)
         {

--- a/ui/src/virtualconsole/vcslider.h
+++ b/ui/src/virtualconsole/vcslider.h
@@ -557,6 +557,21 @@ protected slots:
     void slotInputValueChanged(quint32 universe, quint32 channel, uchar value);
 
     /*********************************************************************
+     * Catching status
+     *********************************************************************/
+private:
+    /** Indicates whether the external control matches the actual slider value **/
+    bool m_isCatched;
+
+public:
+    /** Set the catching status of the slider **/
+    void setCatched(bool catched);
+
+    /** @reimp */
+    /** Used to notice disable events to reset the catch state **/
+    void changeEvent(QEvent * event);
+
+    /*********************************************************************
      * Intensity
      *********************************************************************/
 public:

--- a/ui/src/virtualconsole/vcslider.h
+++ b/ui/src/virtualconsole/vcslider.h
@@ -562,10 +562,16 @@ protected slots:
 private:
     /** Indicates whether the external control matches the actual slider value **/
     bool m_isCaught;
+    /** Store last value of external input to determine if it is caught **/
+    int m_lastInput;
+    /** Indicates whether the value of m_lastInput is valid **/
+    bool m_lastInputValid;
 
 public:
     /** Set the catching status of the slider **/
     void setCaught(bool caught);
+    /** Checks if the slider was caught with the last value val from external input **/
+    bool checkIfCaught(float val);
 
     /** @reimp */
     /** Used to notice disable events to reset the catch state **/

--- a/ui/src/virtualconsole/vcslider.h
+++ b/ui/src/virtualconsole/vcslider.h
@@ -561,11 +561,11 @@ protected slots:
      *********************************************************************/
 private:
     /** Indicates whether the external control matches the actual slider value **/
-    bool m_isCatched;
+    bool m_isCaught;
 
 public:
     /** Set the catching status of the slider **/
-    void setCatched(bool catched);
+    void setCaught(bool caught);
 
     /** @reimp */
     /** Used to notice disable events to reset the catch state **/


### PR DESCRIPTION
As requested here: http://www.qlcplus.org/forum/viewtopic.php?f=18&t=10814&p=46597#p46597
It would be great if sliders could be "caught" by external controls, if they have no motor faders.

I tried to implement this. It depends on if there is a feedback patched to the universe - if not, the new behavior is applied.
To catch the slider, simply move the external control to the current level of the slider and the slider will follow your external control as soon as you reached a certain area around the current level with your external control.

There is one drawback: If you move very fast across the current value, the slider might not be caught, but I wouldn't consider this is a big problem.