### PR TITLE
VC/Cue List Widget: Fixed sliders Mode not copied

### DIFF
--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -333,6 +333,9 @@ bool VCCueList::copyFrom(const VCWidget* widget)
     setPlaybackKeySequence(cuelist->playbackKeySequence());
     setStopKeySequence(cuelist->stopKeySequence());
 
+    /* Sliders mode */
+    setSlidersMode(cuelist->slidersMode());
+
     /* Common stuff */
     return VCWidget::copyFrom(widget);
 }


### PR DESCRIPTION
This fixes the issue that the sliders Mode status is not copied.
Reported here: http://www.qlcplus.org/forum/viewtopic.php?p=46703#p46703