### PR TITLE
Enable Alt-key shortcuts on Mac OS

### DIFF
--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -64,6 +64,10 @@
 #   include "hotplugmonitor.h"
 #endif
 
+#if defined(__APPLE__) || defined(Q_OS_MAC)
+extern void qt_set_sequence_auto_mnemonic(bool b);
+#endif
+
 //#define DEBUG_SPEED
 
 #ifdef DEBUG_SPEED
@@ -209,6 +213,10 @@ void App::init()
     m_tab->setTabPosition(QTabWidget::South);
     setCentralWidget(m_tab);
 
+#if defined(__APPLE__) || defined(Q_OS_MAC)
+    qt_set_sequence_auto_mnemonic(true);
+#endif
+    
     QLCFile::checkRaspberry();
 
     QVariant var = settings.value(SETTINGS_GEOMETRY);


### PR DESCRIPTION
By default, Qt does not enable standard Alt-key mnemonics on MacOS. This commit lets QLC+ on MacOS respond to Alt-key shortcuts the same as on other platforms.

This change also allows MacOS users to type the first letter of a dialog box button, the same as on Windows and Linux - for example, Y for "Yes" to "There are still running functions. Stop them?".