### PR TITLE
Channel modifiers for blackout

### DIFF
--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -97,12 +97,12 @@ void InputOutputMap::setBlackout(bool blackout)
     for (quint32 i = 0; i < universesCount(); i++)
     {
         Universe *universe = m_universeArray.at(i);
-        if (universe->outputPatch() != NULL)
+        if (blackout == true)
         {
-            if (blackout == true)
-                universe->outputPatch()->dump(universe->id(), zeros);
+            universe->dumpOutput(zeros);
             // notify the universe listeners that some channels have changed
         }
+
         locker.unlock();
         if (blackout == true)
             emit universesWritten(i, zeros);

--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -93,24 +93,24 @@ void InputOutputMap::setBlackout(bool blackout)
     QMutexLocker locker(&m_universeMutex);
     m_blackout = blackout;
 
-    QByteArray zeros(512, 0);
     for (quint32 i = 0; i < universesCount(); i++)
     {
         Universe *universe = m_universeArray.at(i);
+        QByteArray data;
+
         if (blackout == true)
         {
-            universe->dumpOutput(zeros);
-            // notify the universe listeners that some channels have changed
+            universe->dumpBlackout();
+            data = universe->blackoutData();
         }
-
-        locker.unlock();
-        if (blackout == true)
-            emit universesWritten(i, zeros);
         else
         {
-            const QByteArray postGM = universe->postGMValues()->mid(0, universe->usedChannels());
-            emit universesWritten(i, postGM);
+            data = universe->postGMValues()->mid(0, universe->usedChannels());
         }
+
+        // notify the universe listeners that some channels have changed
+        locker.unlock();
+        emit universesWritten(i, data);
         locker.relock();
     }
 

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -684,6 +684,20 @@ void Universe::setChannelModifier(ushort channel, ChannelModifier *modifier)
 
     (*m_modifiedZeroValues)[channel] =
         (modifier == NULL ? uchar(0) : modifier->getValue(0));
+
+    if (modifier != NULL)
+    {
+        if (channel >= m_totalChannels)
+        {
+            m_totalChannels = channel + 1;
+            m_totalChannelsChanged = true;
+        }
+
+        if (channel >= m_usedChannels)
+            m_usedChannels = channel + 1;
+    }
+
+    updatePostGMValue(channel);
 }
 
 ChannelModifier *Universe::channelModifier(ushort channel)

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -540,6 +540,16 @@ void Universe::dumpOutput(const QByteArray &data)
     m_totalChannelsChanged = false;
 }
 
+void Universe::dumpBlackout()
+{
+    dumpOutput(*m_modifiedZeroValues);
+}
+
+const QByteArray& Universe::blackoutData()
+{
+    return *m_modifiedZeroValues;
+}
+
 void Universe::flushInput()
 {
     if (m_inputPatch == NULL)

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -228,6 +228,17 @@ public:
      */
     void dumpOutput(const QByteArray& data);
 
+    /**
+     * @brief dumpBlackout
+     */
+    void dumpBlackout();
+
+    /**
+     * @brief blackoutData
+     * @return
+     */
+    const QByteArray& blackoutData();
+
     void flushInput();
 
 protected slots:


### PR DESCRIPTION
- first commit is a simplification of code (reusing Universe::dumpOutput). This has the advantage, that blackout data are sent to all patched outputs, not just the first one (relevant only for QLC+5)
- second commit 1) changes what data is output on blackout: now instead of plain zeroes, channel modifiers are applied; 2) simplifies code structure 3) calls postGMValues() under lock (this is the change that needs the most thorough review)
- third commit updates m_usedChannels, m_totalChannels and post GM data so that data is affected immediately after CM is applied
