### PR TITLE
VC/Frame(PageShortcuts): Fixed pages not loaded properly when loading…

### DIFF
--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -1058,6 +1058,8 @@ bool VCFrame::loadXML(QXmlStreamReader &root)
         else if (root.name() == KXMLQLCVCFrameMultipage)
         {
             setMultipageMode(true);
+            // add initial shortcut
+            addShortcut();
             QXmlStreamAttributes attrs = root.attributes();
             if (attrs.hasAttribute(KXMLQLCVCFramePagesNumber))
                 setTotalPagesNumber(attrs.value(KXMLQLCVCFramePagesNumber).toString().toInt());


### PR DESCRIPTION
… workspace file that has been saved without shortcuts. This caused trouble in the number of pages available because there was no initial shortcut present.