### PR TITLE
VC/Clock: Added external inputs for controlling countdown/stopwatch

### DIFF
--- a/ui/src/virtualconsole/vcaudiotriggersproperties.ui
+++ b/ui/src/virtualconsole/vcaudiotriggersproperties.ui
@@ -7,14 +7,14 @@
 
   Copyright (c) 2015 Massimo Callegari
 
-  Licensed under the Apache License, Version 2.0 (the "License");
+  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0.txt
 
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
+  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
@@ -146,31 +146,7 @@
         </spacer>
        </item>
        <item row="0" column="0">
-        <widget class="QFrame" name="frame">
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <layout class="QVBoxLayout" name="m_extControlLayout"/>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QVBoxLayout" name="m_extControlLayout"/>
        </item>
       </layout>
      </widget>

--- a/ui/src/virtualconsole/vcclock.h
+++ b/ui/src/virtualconsole/vcclock.h
@@ -21,6 +21,7 @@
 #define VCCLOCK_H
 
 #include <QDateTime>
+#include <QKeySequence>
 
 #include "vcwidget.h"
 
@@ -88,7 +89,7 @@ public:
     };
 
     void setClockType(ClockType type);
-    ClockType clockType();
+    ClockType clockType() const;
 
     QString typeToString(ClockType type);
     ClockType stringToType(QString str);
@@ -118,13 +119,14 @@ private:
 public:
     void setCountdown(int h, int m, int s);
     long currentTime() { return m_currentTime; }
-    void resetTime();
     int getHours() { return m_hh; }
     int getMinutes() { return m_mm; }
     int getSeconds() { return m_ss; }
 
 protected slots:
     void slotUpdateTime();
+    void slotPlayPauseTimer();
+    void slotResetTimer();
 
 private:
     int m_hh, m_mm, m_ss;
@@ -132,23 +134,58 @@ private:
     quint32 m_currentTime;
     bool m_isPaused;
 
+public:
+    static const quint8 playInputSourceId;
+    static const quint8 resetInputSourceId;
+
+    /*************************************************************************
+     * Key sequences
+     *************************************************************************/
+public:
+    /** Set the keyboard key combination for playing/pausing the timer */
+    void setPlayKeySequence(const QKeySequence& keySequence);
+
+    /** Get the keyboard key combination for playing/pausing the timer */
+    QKeySequence playKeySequence() const;
+
+    /** Set the keyboard key combination for resetting the timer */
+    void setResetKeySequence(const QKeySequence& keySequence);
+
+    /** Get the keyboard key combination for resetting the timer */
+    QKeySequence resetKeySequence() const;
+
+private:
+    QKeySequence m_playKeySequence;
+    QKeySequence m_resetKeySequence;
+
+protected slots:
+    void slotKeyPressed(const QKeySequence& keySequence);
+
+    /*************************************************************************
+     * External Input
+     *************************************************************************/
+public:
+    void updateFeedback();
+
+protected slots:
+    void slotInputValueChanged(quint32 universe, quint32 channel, uchar value);
+
+private:
+    quint32 m_playLatestValue;
+    quint32 m_resetLatestValue;
+
     /*********************************************************************
      * Clipboard
      *********************************************************************/
 public:
     VCWidget* createCopy(VCWidget* parent);
+    bool copyFrom(const VCWidget *widget);
 
     /*********************************************************************
      * Properties
      *********************************************************************/
 public:
     void editProperties();
-
-    /*****************************************************************************
-     * External input
-     *****************************************************************************/
-    /** @reimp */
-    void updateFeedback() { }
 
     /*********************************************************************
      * Load & Save

--- a/ui/src/virtualconsole/vcclockproperties.cpp
+++ b/ui/src/virtualconsole/vcclockproperties.cpp
@@ -21,6 +21,7 @@
 
 #include "vcclockproperties.h"
 #include "functionselection.h"
+#include "inputselectionwidget.h"
 
 #define KColumnName     0
 #define KColumnTime     1
@@ -33,6 +34,24 @@ VCClockProperties::VCClockProperties(VCClock *clock, Doc *doc)
     Q_ASSERT(clock != NULL);
 
     setupUi(this);
+
+    m_playInputWidget = new InputSelectionWidget(m_doc, this);
+    m_playInputWidget->setTitle(tr("Play/Pause control"));
+    m_playInputWidget->setCustomFeedbackVisibility(true);
+    m_playInputWidget->setKeySequence(m_clock->playKeySequence());
+    m_playInputWidget->setInputSource(m_clock->inputSource(VCClock::playInputSourceId));
+    m_playInputWidget->setWidgetPage(m_clock->page());
+    m_playInputWidget->show();
+    m_externalInputLayout->addWidget(m_playInputWidget);
+
+    m_resetInputWidget = new InputSelectionWidget(m_doc, this);
+    m_resetInputWidget->setTitle(tr("Reset control"));
+    m_resetInputWidget->setCustomFeedbackVisibility(true);
+    m_resetInputWidget->setKeySequence(m_clock->resetKeySequence());
+    m_resetInputWidget->setInputSource(m_clock->inputSource(VCClock::resetInputSourceId));
+    m_resetInputWidget->setWidgetPage(m_clock->page());
+    m_resetInputWidget->show();
+    m_externalInputLayout->addWidget(m_resetInputWidget);
 
     switch(m_clock->clockType())
     {
@@ -48,6 +67,12 @@ VCClockProperties::VCClockProperties(VCClock *clock, Doc *doc)
         }
         break;
         case VCClock::Clock:
+        {
+            m_clockRadio->setChecked(true);
+            m_playInputWidget->hide();
+            m_resetInputWidget->hide();
+        }
+        break;
         default:
             m_clockRadio->setChecked(true);
         break;
@@ -56,6 +81,12 @@ VCClockProperties::VCClockProperties(VCClock *clock, Doc *doc)
     foreach(VCClockSchedule sch, m_clock->schedules())
         addScheduleItem(sch);
 
+    connect(m_clockRadio, SIGNAL(clicked()),
+            this, SLOT(slotTypeSelectChanged()));
+    connect(m_countdownRadio, SIGNAL(clicked()),
+            this, SLOT(slotTypeSelectChanged()));
+    connect(m_stopWatchRadio, SIGNAL(clicked()),
+            this, SLOT(slotTypeSelectChanged()));
     connect(m_addScheduleBtn, SIGNAL(clicked()),
             this, SLOT(slotAddSchedule()));
     connect(m_removeScheduleBtn, SIGNAL(clicked()),
@@ -116,7 +147,29 @@ void VCClockProperties::accept()
         m_clock->addSchedule(sch);
     }
 
+    /* Key sequences */
+    m_clock->setPlayKeySequence(m_playInputWidget->keySequence());
+    m_clock->setResetKeySequence(m_resetInputWidget->keySequence());
+
+    /* Input sources */
+    m_clock->setInputSource(m_playInputWidget->inputSource(), VCClock::playInputSourceId);
+    m_clock->setInputSource(m_resetInputWidget->inputSource(), VCClock::resetInputSourceId);
+
     QDialog::accept();
+}
+
+void VCClockProperties::slotTypeSelectChanged()
+{
+    if (m_clockRadio->isChecked())
+    {
+        m_resetInputWidget->hide();
+        m_playInputWidget->hide();
+    }
+    else
+    {
+        m_resetInputWidget->show();
+        m_playInputWidget->show();
+    }
 }
 
 void VCClockProperties::slotAddSchedule()

--- a/ui/src/virtualconsole/vcclockproperties.h
+++ b/ui/src/virtualconsole/vcclockproperties.h
@@ -25,6 +25,8 @@
 #include "ui_vcclockproperties.h"
 #include "vcclock.h"
 
+class InputSelectionWidget;
+
 /** @addtogroup ui_vc_props
  * @{
  */
@@ -44,12 +46,17 @@ public slots:
     void accept();
 
 protected slots:
+    void slotTypeSelectChanged();
     void slotAddSchedule();
     void slotRemoveSchedule();
 
 private:
     VCClock *m_clock;
     Doc* m_doc;
+
+protected:
+    InputSelectionWidget *m_playInputWidget;
+    InputSelectionWidget *m_resetInputWidget;
 };
 
 /** @} */

--- a/ui/src/virtualconsole/vcclockproperties.ui
+++ b/ui/src/virtualconsole/vcclockproperties.ui
@@ -7,14 +7,14 @@
 
   Copyright (c) 2015 Massimo Callegari
 
-  Licensed under the Apache License, Version 2.0 (the "License");
+  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0.txt
 
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
+  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
@@ -36,9 +36,16 @@
    <iconset resource="../qlcui.qrc">
     <normaloff>:/clock.png</normaloff>:/clock.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox">
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="m_clockTypeGroup">
      <property name="title">
       <string>Clock type</string>
      </property>
@@ -106,7 +113,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Schedule</string>
@@ -188,12 +195,8 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+   <item row="1" column="0">
+    <layout class="QGridLayout" name="m_externalInputLayout"/>
    </item>
   </layout>
  </widget>

--- a/ui/src/virtualconsole/vcclockproperties.ui
+++ b/ui/src/virtualconsole/vcclockproperties.ui
@@ -25,8 +25,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>380</height>
+    <width>520</width>
+    <height>460</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,166 +37,187 @@
     <normaloff>:/clock.png</normaloff>:/clock.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="3" column="0">
+   <item row="0" column="0">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="general_tab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QGroupBox" name="m_clockTypeGroup">
+         <property name="title">
+          <string>Clock type</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="m_stopWatchRadio">
+            <property name="text">
+             <string>Stopwatch</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="m_hoursSpin">
+            <property name="suffix">
+             <string>h</string>
+            </property>
+            <property name="maximum">
+             <number>23</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="m_countdownRadio">
+            <property name="text">
+             <string>Countdown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QSpinBox" name="m_minutesSpin">
+            <property name="suffix">
+             <string>m</string>
+            </property>
+            <property name="maximum">
+             <number>59</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QSpinBox" name="m_secondsSpin">
+            <property name="suffix">
+             <string>s</string>
+            </property>
+            <property name="maximum">
+             <number>59</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="m_clockRadio">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Clock</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Schedule</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="leftMargin">
+           <number>5</number>
+          </property>
+          <property name="topMargin">
+           <number>5</number>
+          </property>
+          <property name="rightMargin">
+           <number>5</number>
+          </property>
+          <property name="bottomMargin">
+           <number>5</number>
+          </property>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="m_addScheduleBtn">
+            <property name="icon">
+             <iconset resource="../qlcui.qrc">
+              <normaloff>:/edit_add.png</normaloff>:/edit_add.png</iconset>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>24</width>
+              <height>24</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QToolButton" name="m_removeScheduleBtn">
+            <property name="icon">
+             <iconset resource="../qlcui.qrc">
+              <normaloff>:/edit_remove.png</normaloff>:/edit_remove.png</iconset>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>24</width>
+              <height>24</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="0" rowspan="3">
+           <widget class="QTreeWidget" name="m_scheduleTree">
+            <property name="rootIsDecorated">
+             <bool>false</bool>
+            </property>
+            <property name="itemsExpandable">
+             <bool>false</bool>
+            </property>
+            <column>
+             <property name="text">
+              <string>Function</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Time</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="input_tab">
+      <attribute name="title">
+       <string>Input</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="m_externalInputLayout"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="m_clockTypeGroup">
-     <property name="title">
-      <string>Clock type</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="m_stopWatchRadio">
-        <property name="text">
-         <string>Stopwatch</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="m_hoursSpin">
-        <property name="suffix">
-         <string>h</string>
-        </property>
-        <property name="maximum">
-         <number>23</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="m_countdownRadio">
-        <property name="text">
-         <string>Countdown</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="m_minutesSpin">
-        <property name="suffix">
-         <string>m</string>
-        </property>
-        <property name="maximum">
-         <number>59</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="QSpinBox" name="m_secondsSpin">
-        <property name="suffix">
-         <string>s</string>
-        </property>
-        <property name="maximum">
-         <number>59</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="m_clockRadio">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Clock</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Schedule</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>5</number>
-      </property>
-      <property name="topMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>5</number>
-      </property>
-      <item row="0" column="1">
-       <widget class="QToolButton" name="m_addScheduleBtn">
-        <property name="icon">
-         <iconset resource="../qlcui.qrc">
-          <normaloff>:/edit_add.png</normaloff>:/edit_add.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QToolButton" name="m_removeScheduleBtn">
-        <property name="icon">
-         <iconset resource="../qlcui.qrc">
-          <normaloff>:/edit_remove.png</normaloff>:/edit_remove.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="0" rowspan="3">
-       <widget class="QTreeWidget" name="m_scheduleTree">
-        <property name="rootIsDecorated">
-         <bool>false</bool>
-        </property>
-        <property name="itemsExpandable">
-         <bool>false</bool>
-        </property>
-        <column>
-         <property name="text">
-          <string>Function</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Time</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QGridLayout" name="m_externalInputLayout"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
As requested [here](http://www.qlcplus.org/forum/viewtopic.php?f=18&t=10923&p=47289) I added external input support for the clock widget in countdown and stopwatch mode.
I was not yet able to test feedback, but will this weekend.
I'm not completely sure about the order in the properties dialog but think as it is now is sufficient.