### PR TITLE
Add copy & paste buttons to speed dial functions page

### DIFF
--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -270,12 +270,12 @@ void VCSpeedDialProperties::slotRemoveClicked()
         delete it.next();
 }
 
-void VCSpeedDialProperties::applySelectedFactorsToAllClicked()
+void VCSpeedDialProperties::copySelectedFactorsClicked()
 {
-    QList <QTreeWidgetItem*> selectedItems = m_tree->selectedItems();
-    if (selectedItems.isEmpty())
+    QList <QTreeWidgetItem*> allSelected = m_tree->selectedItems();
+    if (allSelected.isEmpty())
         return;
-    QTreeWidgetItem* selected = m_tree->selectedItems().first();
+    QTreeWidgetItem* selected = allSelected.first();
 
     // clear focus on the combobox to apply the selected value
     QApplication* app = static_cast<QApplication*>(QApplication::instance());
@@ -283,26 +283,30 @@ void VCSpeedDialProperties::applySelectedFactorsToAllClicked()
     if (focusedWidget) focusWidget()->clearFocus();
     m_tree->focusWidget();
 
-    VCSpeedDialFunction::SpeedMultiplier fadeInMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEIN, PROP_ID).toUInt());
-    VCSpeedDialFunction::SpeedMultiplier fadeOutMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEOUT, PROP_ID).toUInt());
-    VCSpeedDialFunction::SpeedMultiplier durationMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_DURATION, PROP_ID).toUInt());
+    copiedFactorValues.fadeInMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEIN, PROP_ID).toUInt());
+    copiedFactorValues.fadeOutMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEOUT, PROP_ID).toUInt());
+    copiedFactorValues.durationMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_DURATION, PROP_ID).toUInt());
 
+    m_pasteFactorsButton->setEnabled(true);
+}
+
+void VCSpeedDialProperties::pasteFactorsToSelectedClicked()
+{
+    // is only called after the paste button has been enabled and copiedFactorValues is filled with data
     const QStringList &multiplierNames = VCSpeedDialFunction::speedMultiplierNames();
 
-    for (int i = 0; i < m_tree->topLevelItemCount(); i++)
-    {
-        QTreeWidgetItem* item = m_tree->topLevelItem(i);
+    foreach (QTreeWidgetItem* item, m_tree->selectedItems()) {
         Q_ASSERT(item != NULL);
 
         QVariant id = item->data(COL_NAME, PROP_ID);
         if (id.isValid() == true)
         {
-            item->setText(COL_FADEIN, multiplierNames[fadeInMultiplier]);
-            item->setData(COL_FADEIN, PROP_ID, fadeInMultiplier);
-            item->setText(COL_FADEOUT, multiplierNames[fadeOutMultiplier]);
-            item->setData(COL_FADEOUT, PROP_ID, fadeOutMultiplier);
-            item->setText(COL_DURATION, multiplierNames[durationMultiplier]);
-            item->setData(COL_DURATION, PROP_ID, durationMultiplier);
+            item->setText(COL_FADEIN, multiplierNames[copiedFactorValues.fadeInMultiplier]);
+            item->setData(COL_FADEIN, PROP_ID, copiedFactorValues.fadeInMultiplier);
+            item->setText(COL_FADEOUT, multiplierNames[copiedFactorValues.fadeOutMultiplier]);
+            item->setData(COL_FADEOUT, PROP_ID, copiedFactorValues.fadeOutMultiplier);
+            item->setText(COL_DURATION, multiplierNames[copiedFactorValues.durationMultiplier]);
+            item->setData(COL_DURATION, PROP_ID, copiedFactorValues.durationMultiplier);
         }
     }
 }

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -277,6 +277,12 @@ void VCSpeedDialProperties::applySelectedFactorsToAllClicked()
         return;
     QTreeWidgetItem* selected = m_tree->selectedItems().first();
 
+    // clear focus on the combobox to apply the selected value
+    QApplication* app = static_cast<QApplication*>(QApplication::instance());
+    QWidget* focusedWidget = app->focusWidget();
+    if (focusedWidget) focusWidget()->clearFocus();
+    m_tree->focusWidget();
+
     VCSpeedDialFunction::SpeedMultiplier fadeInMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEIN, PROP_ID).toUInt());
     VCSpeedDialFunction::SpeedMultiplier fadeOutMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEOUT, PROP_ID).toUInt());
     VCSpeedDialFunction::SpeedMultiplier durationMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_DURATION, PROP_ID).toUInt());

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -270,6 +270,45 @@ void VCSpeedDialProperties::slotRemoveClicked()
         delete it.next();
 }
 
+void VCSpeedDialProperties::applySlotFactorsToAllClicked()
+{
+    QList <QTreeWidgetItem*> selectedItems = m_tree->selectedItems();
+    if (selectedItems.isEmpty())
+        return;
+
+    QTreeWidgetItem* selected = m_tree->selectedItems().first();
+
+    VCSpeedDialFunction::SpeedMultiplier fadeInMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEIN, PROP_ID).toUInt());
+    VCSpeedDialFunction::SpeedMultiplier fadeOutMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEOUT, PROP_ID).toUInt());
+    VCSpeedDialFunction::SpeedMultiplier durationMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_DURATION, PROP_ID).toUInt());
+
+    const QStringList &multiplierNames = VCSpeedDialFunction::speedMultiplierNames();
+
+    for (int i = 0; i < m_tree->topLevelItemCount(); i++)
+    {
+        QTreeWidgetItem* item = m_tree->topLevelItem(i);
+        Q_ASSERT(item != NULL);
+
+        QVariant id = item->data(COL_NAME, PROP_ID);
+        if (id.isValid() == true)
+        {
+            VCSpeedDialFunction speeddialfunction(id.toUInt());
+
+            speeddialfunction.fadeInMultiplier = fadeInMultiplier;
+            speeddialfunction.fadeOutMultiplier = fadeOutMultiplier;
+            speeddialfunction.durationMultiplier = durationMultiplier;
+
+            item->setText(COL_FADEIN, multiplierNames[speeddialfunction.fadeInMultiplier]);
+            item->setData(COL_FADEIN, PROP_ID, speeddialfunction.fadeInMultiplier);
+            item->setText(COL_FADEOUT, multiplierNames[speeddialfunction.fadeOutMultiplier]);
+            item->setData(COL_FADEOUT, PROP_ID, speeddialfunction.fadeOutMultiplier);
+            item->setText(COL_DURATION, multiplierNames[speeddialfunction.durationMultiplier]);
+            item->setData(COL_DURATION, PROP_ID, speeddialfunction.durationMultiplier);
+        }
+    }
+
+}
+
 QList <VCSpeedDialFunction> VCSpeedDialProperties::functions() const
 {
     QList <VCSpeedDialFunction> list;

--- a/ui/src/virtualconsole/vcspeeddialproperties.cpp
+++ b/ui/src/virtualconsole/vcspeeddialproperties.cpp
@@ -270,12 +270,11 @@ void VCSpeedDialProperties::slotRemoveClicked()
         delete it.next();
 }
 
-void VCSpeedDialProperties::applySlotFactorsToAllClicked()
+void VCSpeedDialProperties::applySelectedFactorsToAllClicked()
 {
     QList <QTreeWidgetItem*> selectedItems = m_tree->selectedItems();
     if (selectedItems.isEmpty())
         return;
-
     QTreeWidgetItem* selected = m_tree->selectedItems().first();
 
     VCSpeedDialFunction::SpeedMultiplier fadeInMultiplier = static_cast<VCSpeedDialFunction::SpeedMultiplier>(selected->data(COL_FADEIN, PROP_ID).toUInt());
@@ -292,21 +291,14 @@ void VCSpeedDialProperties::applySlotFactorsToAllClicked()
         QVariant id = item->data(COL_NAME, PROP_ID);
         if (id.isValid() == true)
         {
-            VCSpeedDialFunction speeddialfunction(id.toUInt());
-
-            speeddialfunction.fadeInMultiplier = fadeInMultiplier;
-            speeddialfunction.fadeOutMultiplier = fadeOutMultiplier;
-            speeddialfunction.durationMultiplier = durationMultiplier;
-
-            item->setText(COL_FADEIN, multiplierNames[speeddialfunction.fadeInMultiplier]);
-            item->setData(COL_FADEIN, PROP_ID, speeddialfunction.fadeInMultiplier);
-            item->setText(COL_FADEOUT, multiplierNames[speeddialfunction.fadeOutMultiplier]);
-            item->setData(COL_FADEOUT, PROP_ID, speeddialfunction.fadeOutMultiplier);
-            item->setText(COL_DURATION, multiplierNames[speeddialfunction.durationMultiplier]);
-            item->setData(COL_DURATION, PROP_ID, speeddialfunction.durationMultiplier);
+            item->setText(COL_FADEIN, multiplierNames[fadeInMultiplier]);
+            item->setData(COL_FADEIN, PROP_ID, fadeInMultiplier);
+            item->setText(COL_FADEOUT, multiplierNames[fadeOutMultiplier]);
+            item->setData(COL_FADEOUT, PROP_ID, fadeOutMultiplier);
+            item->setText(COL_DURATION, multiplierNames[durationMultiplier]);
+            item->setData(COL_DURATION, PROP_ID, durationMultiplier);
         }
     }
-
 }
 
 QList <VCSpeedDialFunction> VCSpeedDialProperties::functions() const

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -59,7 +59,7 @@ private:
 private slots:
     void slotAddClicked();
     void slotRemoveClicked();
-    void applySlotFactorsToAllClicked();
+    void applySelectedFactorsToAllClicked();
 
 private:
     /** Generate a QList of functions currently in the tree widget */

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -24,10 +24,10 @@
 
 #include "ui_vcspeeddialproperties.h"
 #include "qlcinputsource.h"
+#include "vcspeeddialfunction.h"
 
 class InputSelectionWidget;
 class VCSpeedDial;
-class VCSpeedDialFunction;
 class VCSpeedDialPreset;
 class SpeedDialWidget;
 class Doc;
@@ -59,7 +59,8 @@ private:
 private slots:
     void slotAddClicked();
     void slotRemoveClicked();
-    void applySelectedFactorsToAllClicked();
+    void copySelectedFactorsClicked();
+    void pasteFactorsToSelectedClicked();
 
 private:
     /** Generate a QList of functions currently in the tree widget */
@@ -67,6 +68,12 @@ private:
 
     /** Create a tree item for the given function $id */
     void createFunctionItem(const VCSpeedDialFunction &speeddialfunction);
+
+    struct {
+        VCSpeedDialFunction::SpeedMultiplier fadeInMultiplier;
+        VCSpeedDialFunction::SpeedMultiplier fadeOutMultiplier;
+        VCSpeedDialFunction::SpeedMultiplier durationMultiplier;
+    } copiedFactorValues;
 
     /************************************************************************
      * Input page

--- a/ui/src/virtualconsole/vcspeeddialproperties.h
+++ b/ui/src/virtualconsole/vcspeeddialproperties.h
@@ -59,6 +59,7 @@ private:
 private slots:
     void slotAddClicked();
     void slotRemoveClicked();
+    void applySlotFactorsToAllClicked();
 
 private:
     /** Generate a QList of functions currently in the tree widget */

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -96,13 +96,13 @@
         </widget>
        </item>
        <item row="2" column="2">
-        <widget class="QToolButton" name="m_applyToAllButton">
+        <widget class="QToolButton" name="m_copyFactorsButton">
          <property name="toolTip">
-          <string>Apply factors from selected function to all</string>
+          <string>Copy the factors of the selected function</string>
          </property>
          <property name="icon">
           <iconset resource="../qlcui.qrc">
-           <normaloff>:/editcopyall.png</normaloff>:/editcopyall.png</iconset>
+           <normaloff>:/editcopy.png</normaloff>:/editcopy.png</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -113,6 +113,26 @@
         </widget>
        </item>
        <item row="3" column="2">
+        <widget class="QToolButton" name="m_pasteFactorsButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="toolTip">
+          <string>Paste copied factors to all selected functions</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../qlcui.qrc">
+           <normaloff>:/editpaste.png</normaloff>:/editpaste.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -125,7 +145,7 @@
          </property>
         </spacer>
        </item>
-       <item row="0" column="0" rowspan="4" colspan="2">
+       <item row="0" column="0" rowspan="5" colspan="2">
         <widget class="QTreeWidget" name="m_tree">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -547,10 +567,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>m_applyToAllButton</sender>
+   <sender>m_copyFactorsButton</sender>
    <signal>clicked()</signal>
    <receiver>VCSpeedDialProperties</receiver>
-   <slot>applySelectedFactorsToAllClicked()</slot>
+   <slot>copySelectedFactorsClicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>376</x>
@@ -559,6 +579,22 @@
     <hint type="destinationlabel">
      <x>396</x>
      <y>223</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>m_pasteFactorsButton</sender>
+   <signal>clicked()</signal>
+   <receiver>VCSpeedDialProperties</receiver>
+   <slot>pasteFactorsToSelectedClicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>376</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>396</x>
+     <y>283</y>
     </hint>
    </hints>
   </connection>

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -61,7 +61,71 @@
        <string>Functions</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0" rowspan="3" colspan="2">
+       <item row="0" column="2">
+        <widget class="QToolButton" name="m_addButton">
+         <property name="toolTip">
+          <string>Add functions to be controlled</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../qlcui.qrc">
+           <normaloff>:/edit_add.png</normaloff>:/edit_add.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QToolButton" name="m_removeButton">
+         <property name="toolTip">
+          <string>Remove selected functions</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../qlcui.qrc">
+           <normaloff>:/edit_remove.png</normaloff>:/edit_remove.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QToolButton" name="m_applyToAllButton">
+         <property name="toolTip">
+          <string>Apply factors from selected function to all</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../qlcui.qrc">
+           <normaloff>:/editcopyall.png</normaloff>:/editcopyall.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>18</width>
+           <height>198</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0" rowspan="4" colspan="2">
         <widget class="QTreeWidget" name="m_tree">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -123,53 +187,6 @@
           </property>
          </column>
         </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QToolButton" name="m_addButton">
-         <property name="toolTip">
-          <string>Add functions to be controlled</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../qlcui.qrc">
-           <normaloff>:/edit_add.png</normaloff>:/edit_add.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>32</width>
-           <height>32</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QToolButton" name="m_removeButton">
-         <property name="toolTip">
-          <string>Remove selected functions</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../qlcui.qrc">
-           <normaloff>:/edit_remove.png</normaloff>:/edit_remove.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>32</width>
-           <height>32</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>18</width>
-           <height>198</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
@@ -526,6 +543,22 @@
     <hint type="destinationlabel">
      <x>396</x>
      <y>163</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>m_applyToAllButton</sender>
+   <signal>clicked()</signal>
+   <receiver>VCSpeedDialProperties</receiver>
+   <slot>applySlotFactorsToAllClicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>376</x>
+     <y>213</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>396</x>
+     <y>223</y>
     </hint>
    </hints>
   </connection>

--- a/ui/src/virtualconsole/vcspeeddialproperties.ui
+++ b/ui/src/virtualconsole/vcspeeddialproperties.ui
@@ -550,7 +550,7 @@
    <sender>m_applyToAllButton</sender>
    <signal>clicked()</signal>
    <receiver>VCSpeedDialProperties</receiver>
-   <slot>applySlotFactorsToAllClicked()</slot>
+   <slot>applySelectedFactorsToAllClicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>376</x>


### PR DESCRIPTION
I often have lots of functions connected to a speed dial in the virtual console where i want to control the fade times in the same way. To save a lot of clicking in the dropdown boxes I added a button to apply the factors from the selected function to the others (see screenshots).

<img width="942" alt="bildschirmfoto 2017-06-13 um 11 11 54" src="https://user-images.githubusercontent.com/10384363/27075238-da9beff0-5029-11e7-899b-7c6d65fb2c0d.png">

results in 

<img width="798" alt="bildschirmfoto 2017-06-13 um 11 17 57" src="https://user-images.githubusercontent.com/10384363/27075302-01b5874a-502a-11e7-8534-020c5ca13652.png">
