### PR TITLE
Allow for multiple LibFTDI devices with the same VID, PID, and serial.

### DIFF
--- a/plugins/dmxusb/src/dmxinterface.cpp
+++ b/plugins/dmxusb/src/dmxinterface.cpp
@@ -21,13 +21,15 @@
 #include "dmxinterface.h"
 
 DMXInterface::DMXInterface(const QString& serial, const QString& name, const QString &vendor,
-                           quint16 VID, quint16 PID, quint32 id)
+                           quint16 VID, quint16 PID, quint32 id, uint8_t usbBus, uint8_t usbAddr)
     : m_serial(serial)
     , m_name(name)
     , m_vendor(vendor)
     , m_vendorID(VID)
     , m_productID(PID)
     , m_id(id)
+    , m_usbBus(usbBus)
+    , m_usbAddr(usbAddr)
 {
 }
 
@@ -65,6 +67,16 @@ quint32 DMXInterface::id() const
     return m_id;
 }
 
+uint8_t DMXInterface::usbBus() const
+{
+    return m_usbBus;
+}
+
+uint8_t DMXInterface::usbAddr() const
+{
+    return m_usbAddr;
+}
+
 quint8 DMXInterface::busLocation()
 {
     return 0;
@@ -87,9 +99,9 @@ bool DMXInterface::validInterface(quint16 vendor, quint16 product)
     return true;
 }
 
-bool DMXInterface::checkInfo(QString &serial, QString &name, QString &vendor)
+bool DMXInterface::checkInfo(QString &serial, QString &name, QString &vendor, uint8_t &usbBus, uint8_t &usbAddr)
 {
-    if (m_serial == serial && m_name == name && m_vendor == vendor)
+    if (m_serial == serial && m_name == name && m_vendor == vendor && m_usbBus == usbBus && m_usbAddr == usbAddr)
         return true;
     return false;
 }
@@ -109,5 +121,4 @@ void DMXInterface::storeTypeMap(const QMap <QString,QVariant> map)
     QSettings settings;
     settings.setValue(SETTINGS_TYPE_MAP, map);
 }
-
 

--- a/plugins/dmxusb/src/dmxinterface.h
+++ b/plugins/dmxusb/src/dmxinterface.h
@@ -42,7 +42,7 @@ public:
      * @param id The ID of the device (used only when FTD2XX is the backend)
      */
     DMXInterface(const QString& serial, const QString& name, const QString &vendor,
-                 quint16 VID, quint16 PID, quint32 id = 0);
+                 quint16 VID, quint16 PID, quint32 id = 0, uint8_t usbBus = -1, uint8_t usbAddr = -1);
 
     /** Destructor */
     virtual ~DMXInterface();
@@ -67,6 +67,12 @@ public:
     /** Get the widget's FTD2XX ID number */
     quint32 id() const;
 
+    /** Get the widget's USB bus */
+    uint8_t usbBus() const;
+
+    /** Get the widget's USB device address */
+    uint8_t usbAddr() const;
+
     /** Virtual method to retrieve the original USB
      *  bus location of the device.
      *  Used only in Linux to perform a sysfs lookup */
@@ -79,6 +85,8 @@ private:
     quint16 m_vendorID;
     quint16 m_productID;
     quint32 m_id;
+    uint8_t m_usbBus;
+    uint8_t m_usbAddr;
 
     /************************************************************************
      * Widget enumeration
@@ -108,7 +116,7 @@ public:
      */
     static bool validInterface(quint16 vendor, quint16 product);
 
-    bool checkInfo(QString &serial, QString &name, QString &vendor);
+    bool checkInfo(QString &serial, QString &name, QString &vendor, uint8_t &usbBus, uint8_t &usbAddr);
 
     /**
      * Get a map of [serial = type] bindings that tells which serials should
@@ -170,3 +178,4 @@ public:
 };
 
 #endif
+

--- a/plugins/dmxusb/src/ftd2xx-interface.cpp
+++ b/plugins/dmxusb/src/ftd2xx-interface.cpp
@@ -193,7 +193,10 @@ QList<DMXInterface *> FTD2XXInterface::interfaces(QList<DMXInterface *> discover
             bool found = false;
             for (int c = 0; c < discoveredList.count(); c++)
             {
-                if (discoveredList.at(c)->checkInfo(serial, name, vendor, usbBus(), usbAddr()) == true)
+                // TODO: maybe these can be set to correct values?
+                uint8_t usbBus = -1;
+                uint8_t usbAddr = -1;
+                if (discoveredList.at(c)->checkInfo(serial, name, vendor, usbBus, usbAddr) == true)
                 {
                     found = true;
                     break;

--- a/plugins/dmxusb/src/ftd2xx-interface.cpp
+++ b/plugins/dmxusb/src/ftd2xx-interface.cpp
@@ -193,7 +193,7 @@ QList<DMXInterface *> FTD2XXInterface::interfaces(QList<DMXInterface *> discover
             bool found = false;
             for (int c = 0; c < discoveredList.count(); c++)
             {
-                if (discoveredList.at(c)->checkInfo(serial, name, vendor) == true)
+                if (discoveredList.at(c)->checkInfo(serial, name, vendor, -1, -1) == true)
                 {
                     found = true;
                     break;
@@ -436,6 +436,4 @@ uchar FTD2XXInterface::readByte(bool* ok)
 
     return 0;
 }
-
-
 

--- a/plugins/dmxusb/src/ftd2xx-interface.cpp
+++ b/plugins/dmxusb/src/ftd2xx-interface.cpp
@@ -193,7 +193,7 @@ QList<DMXInterface *> FTD2XXInterface::interfaces(QList<DMXInterface *> discover
             bool found = false;
             for (int c = 0; c < discoveredList.count(); c++)
             {
-                if (discoveredList.at(c)->checkInfo(serial, name, vendor, -1, -1) == true)
+                if (discoveredList.at(c)->checkInfo(serial, name, vendor, usbBus(), usbAddr()) == true)
                 {
                     found = true;
                     break;

--- a/plugins/dmxusb/src/libftdi-interface.h
+++ b/plugins/dmxusb/src/libftdi-interface.h
@@ -30,7 +30,7 @@ class LibFTDIInterface : public DMXInterface
 {
 public:
     LibFTDIInterface(const QString& serial, const QString& name, const QString& vendor,
-                     quint16 VID, quint16 PID, quint32 id);
+                     quint16 VID, quint16 PID, quint32 id, uint8_t usbBus = -1, uint8_t usbAddr = -1);
 
     /** Destructor */
     virtual ~LibFTDIInterface();
@@ -103,3 +103,4 @@ private:
 };
 
 #endif
+


### PR DESCRIPTION
I bought a few cheap China USB to RS485 bridges ([here](http://www.dx.com/p/usb-to-rs485-module-black-221402)) they use FTD2xx chips but the only thing is that they all have the same exact VID, PID, and serial numbers. This caused a problem when I had a few connected at once. QLC always tried to open the same one. This is obvious because these 3 identical fields are the ones that were used to open the device (using `ftdi_usb_open_desc`).
This fix may or may not seem like a dirty one. Basically, what it does is add another property to the `DMXInterface` class (and `LibFTDIInterface`). Then, that property is used in the `open()` function to loop through the available devices until a device with matching [USB Bus](http://libusb.sourceforge.net/api-1.0/group__dev.html#gaf2718609d50c8ded2704e4051b3d2925) and [USB Device Address](http://libusb.sourceforge.net/api-1.0/group__dev.html#gab6d4e39ac483ebaeb108f2954715305d). I didn't want to use [Port Number](http://libusb.sourceforge.net/api-1.0/group__dev.html#ga14879a0ea7daccdcddb68852d86c00c4), because it is not guaranteed to be unique.

Maxwell.