### PR TITLE
Added support for RBG pixel panels

### DIFF
--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -661,6 +661,12 @@ QLCFixtureDef *Fixture::genericRGBPanelDef(int columns, Components components)
             def->addChannel(red);
             def->addChannel(blue);
         }
+        else if (components == RBG)
+        {
+            def->addChannel(red);
+            def->addChannel(blue);
+            def->addChannel(green);
+        }
         else if (components == RGBW)
         {
             QLCChannel* white = new QLCChannel();
@@ -697,6 +703,8 @@ QLCFixtureMode *Fixture::genericRGBPanelMode(QLCFixtureDef *def, Components comp
         mode->setName("GBR");
     else if (components == GRB)
         mode->setName("GRB");
+    else if (components == RBG)
+        mode->setName("RBG");
     else if (components == RGBW)
     {
         mode->setName("RGBW");
@@ -947,6 +955,7 @@ bool Fixture::loadXML(QXmlStreamReader &xmlDoc, Doc *doc,
         else if (modeName == "BRG") components = BRG;
         else if (modeName == "GBR") components = GBR;
         else if (modeName == "GRB") components = GRB;
+        else if (modeName == "RBG") components = RBG;
         else if (modeName == "RGBW")
         {
             components = RGBW;

--- a/engine/src/fixture.h
+++ b/engine/src/fixture.h
@@ -426,7 +426,8 @@ public:
         BRG,
         GBR,
         GRB,
-        RGBW
+        RGBW,
+        RBG
     };
 #if QT_VERSION >= 0x050500
     Q_ENUM(Components)

--- a/qmlui/qml/fixturesfunctions/RGBPanelProperties.qml
+++ b/qmlui/qml/fixturesfunctions/RGBPanelProperties.qml
@@ -154,6 +154,7 @@ Rectangle
                     ListElement { mLabel: "BRG"; mValue: Fixture.BRG }
                     ListElement { mLabel: "GBR"; mValue: Fixture.GBR }
                     ListElement { mLabel: "GRB"; mValue: Fixture.GRB }
+                    ListElement { mLabel: "RBG"; mValue: Fixture.RBG }
                     ListElement { mLabel: "RGBW"; mValue: Fixture.RGBW }
                 }
             }

--- a/ui/src/addrgbpanel.cpp
+++ b/ui/src/addrgbpanel.cpp
@@ -40,6 +40,7 @@ AddRGBPanel::AddRGBPanel(QWidget *parent, const Doc *doc)
     m_compCombo->addItem("BRG");
     m_compCombo->addItem("GBR");
     m_compCombo->addItem("GRB");
+    m_compCombo->addItem("RBG");
     m_compCombo->addItem("RGBW");
 
     checkAddressAvailability();
@@ -171,6 +172,8 @@ Fixture::Components AddRGBPanel::components()
     else if (m_compCombo->currentIndex() == 4)
         return Fixture::GRB;
     else if (m_compCombo->currentIndex() == 5)
+        return Fixture::RBG;
+    else if (m_compCombo->currentIndex() == 6)
         return Fixture::RGBW;
 
     return Fixture::RGB;


### PR DESCRIPTION
This is my first pull request on GitHub, so please advise if I'm not doing something right.

I have a chain of LED pixels using WS2811 chips. For some reason they are wired in RBG channel order. I've added support for RBG in pixel panels following the examples of other channel orderings. This change seems to work in my setup, so I thought others might find it useful.


Peter 