### PR TITLE
Require capabilities in fixture.xsd

### DIFF
--- a/resources/schemas/fixture.xsd
+++ b/resources/schemas/fixture.xsd
@@ -74,7 +74,7 @@ elementFormDefault="qualified"
     <xs:sequence>
         <xs:element name="Group" type="groupType"/>
         <xs:element name="Colour" type="colorType" minOccurs="0"/>
-        <xs:element name="Capability" type="capabilityType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="Capability" type="capabilityType" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="Name" type="xs:string" use="required"/>
 </xs:complexType>

--- a/resources/schemas/fixture.xsd
+++ b/resources/schemas/fixture.xsd
@@ -74,7 +74,7 @@ elementFormDefault="qualified"
     <xs:sequence>
         <xs:element name="Group" type="groupType"/>
         <xs:element name="Colour" type="colorType" minOccurs="0"/>
-        <xs:element name="Capability" type="capabilityType" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element name="Capability" type="capabilityType" minOccurs="1" maxOccurs="256"/>
     </xs:sequence>
     <xs:attribute name="Name" type="xs:string" use="required"/>
 </xs:complexType>


### PR DESCRIPTION
The php fixture validator (L129) checks if there are capabilities present:
```php
if (!isset($channel->Capability))
{
    print "ERROR: channel &lt;".$origName."&gt; has no capabilities. Please define at least one, with a meaningful description<br>";
    $error++;
}
```
If this check is right, I guess the schema can also demand a minimum of 1 capability.