### PR TITLE
New feature: Split out a tab to a separate window on double-click

### DIFF
--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -1288,6 +1288,7 @@ void App::slotMoveTabToSeparateWindow(int index)
         /* 3. make it a separate window (that cannot be closed) */
         wid->setWindowFlags((wid->windowFlags() | Qt::Window) & (~Qt::WindowCloseButtonHint));
         wid->setWindowTitle(APPNAME + QString(" - ") + m_tab->tabText(index).replace("&", ""));
+        wid->setWindowIcon(m_tab->tabIcon(index));
 
         /* 4. show it in the foreground */
         wid->show();

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -1271,8 +1271,9 @@ void App::slotMoveTabToSeparateWindow(int index)
     {
         /* Make the widget a separate window */
 
-        /* 1. create a new dummy-widget that keeps the tab in place and store
-         * the original QWidget* in a custom property*/
+        /* 1. create a new dummy-widget that keeps the tab in place and informs
+         * the user. Store the original QWidget* in a custom property so we
+         * can re-integrate it into the tab again later */
         QLabel* dummyWidget = new QLabel(tr("This tab has been moved to a " \
                                             "separate window. Double-click the " \
                                             "tab again to re-integrate it."),

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -1314,6 +1314,7 @@ void App::slotMoveTabToSeparateWindow(int index)
         /* 4. remove the dummyTab, using indexOf since index might
          * have changed due to our insert above */
         m_tab->removeTab(m_tab->indexOf(wid));
+        delete wid;
 
         /* 5. Select the just re-integrated tab */
         m_tab->setCurrentWidget(realWidget);

--- a/ui/src/app.h
+++ b/ui/src/app.h
@@ -160,7 +160,7 @@ public slots:
 
     void slotRecentFileClicked(QAction *recent);
 
-    void slotMoveTabToSeparateWindow(int index);
+    void slotDetachTabWidget(int index);
 
 private:
     QAction* m_fileNewAction;

--- a/ui/src/app.h
+++ b/ui/src/app.h
@@ -160,6 +160,8 @@ public slots:
 
     void slotRecentFileClicked(QAction *recent);
 
+    void slotMoveTabToSeparateWindow(int index);
+
 private:
     QAction* m_fileNewAction;
     QAction* m_fileOpenAction;

--- a/ui/src/fixturemanager.cpp
+++ b/ui/src/fixturemanager.cpp
@@ -76,7 +76,7 @@ FixtureManager* FixtureManager::s_instance = NULL;
  *****************************************************************************/
 
 FixtureManager::FixtureManager(QWidget* parent, Doc* doc)
-    : QWidget(parent)
+    : NonClosableWidget(parent)
     , m_doc(doc)
     , m_splitter(NULL)
     , m_fixtures_tree(NULL)
@@ -1113,10 +1113,10 @@ void FixtureManager::slotAddRGBPanel()
         int transpose = 0;
         if (rgb.direction() == AddRGBPanel::Vertical)
         {
-        	int tmp = columns;
-        	columns = rows;
-        	rows = tmp;
-        	transpose = 1;
+            int tmp = columns;
+            columns = rows;
+            rows = tmp;
+            transpose = 1;
         }
 
         QLCFixtureDef *rowDef = NULL;
@@ -1134,35 +1134,35 @@ void FixtureManager::slotAddRGBPanel()
 
         if (transpose)
         {
-			if (rgb.orientation() == AddRGBPanel::TopRight ||
-				rgb.orientation() == AddRGBPanel::BottomRight)
-			{
-				currRow = rows -1;
-				rowInc = -1;
-			}
-			if (rgb.orientation() == AddRGBPanel::BottomRight ||
-				rgb.orientation() == AddRGBPanel::BottomLeft)
-			{
-				xPosStart = columns - 1;
-				xPosEnd = 0;
-				xPosInc = -1;
-			}
+            if (rgb.orientation() == AddRGBPanel::TopRight ||
+                rgb.orientation() == AddRGBPanel::BottomRight)
+            {
+                currRow = rows -1;
+                rowInc = -1;
+            }
+            if (rgb.orientation() == AddRGBPanel::BottomRight ||
+                rgb.orientation() == AddRGBPanel::BottomLeft)
+            {
+                xPosStart = columns - 1;
+                xPosEnd = 0;
+                xPosInc = -1;
+            }
         }
         else
         {
-			if (rgb.orientation() == AddRGBPanel::BottomLeft ||
-				rgb.orientation() == AddRGBPanel::BottomRight)
-			{
-				currRow = rows -1;
-				rowInc = -1;
-			}
-			if (rgb.orientation() == AddRGBPanel::TopRight ||
-				rgb.orientation() == AddRGBPanel::BottomRight)
-			{
-				xPosStart = columns - 1;
-				xPosEnd = 0;
-				xPosInc = -1;
-			}
+            if (rgb.orientation() == AddRGBPanel::BottomLeft ||
+                rgb.orientation() == AddRGBPanel::BottomRight)
+            {
+                currRow = rows -1;
+                rowInc = -1;
+            }
+            if (rgb.orientation() == AddRGBPanel::TopRight ||
+                rgb.orientation() == AddRGBPanel::BottomRight)
+            {
+                xPosStart = columns - 1;
+                xPosEnd = 0;
+                xPosInc = -1;
+            }
         }
 
         for (int i = 0; i < rows; i++)
@@ -1195,10 +1195,10 @@ void FixtureManager::slotAddRGBPanel()
                 int xPos = xPosStart;
                 for (int h = 0; h < fxi->heads(); h++)
                 {
-                	if (transpose)
-                		grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
-                	else
-                		grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
+                    if (transpose)
+                        grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
+                    else
+                        grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
                     xPos += xPosInc;
                 }
             }
@@ -1209,10 +1209,10 @@ void FixtureManager::slotAddRGBPanel()
                     int xPos = xPosStart;
                     for (int h = 0; h < fxi->heads(); h++)
                     {
-                    	if (transpose)
-                    		grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
-                    	else
-                    		grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
+                        if (transpose)
+                            grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
+                        else
+                            grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
                         xPos += xPosInc;
                     }
                 }
@@ -1221,10 +1221,10 @@ void FixtureManager::slotAddRGBPanel()
                     int xPos = xPosEnd;
                     for (int h = 0; h < fxi->heads(); h++)
                     {
-                    	if (transpose)
-                    		grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
-                    	else
-                    		grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
+                        if (transpose)
+                            grp->assignHead(QLCPoint(currRow, xPos), GroupHead(fxi->id(), h));
+                        else
+                            grp->assignHead(QLCPoint(xPos, currRow), GroupHead(fxi->id(), h));
                         xPos += (-xPosInc);
                     }
                 }

--- a/ui/src/fixturemanager.h
+++ b/ui/src/fixturemanager.h
@@ -22,6 +22,7 @@
 
 #include <QWidget>
 
+#include "nonclosablewidget.h"
 #include "function.h"
 #include "fixture.h"
 #include "doc.h"
@@ -45,7 +46,7 @@ class QMenu;
 #define KXMLQLCFixtureManager "FixtureManager"
 #define KXMLQLCFixtureManagerSplitterSize "SplitterSize"
 
-class FixtureManager : public QWidget
+class FixtureManager : public NonClosableWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(FixtureManager)

--- a/ui/src/functionmanager.cpp
+++ b/ui/src/functionmanager.cpp
@@ -81,7 +81,7 @@ FunctionManager* FunctionManager::s_instance = NULL;
  *****************************************************************************/
 
 FunctionManager::FunctionManager(QWidget* parent, Doc* doc)
-    : QWidget(parent)
+    : NonClosableWidget(parent)
     , m_doc(doc)
     , m_hsplitter(NULL)
     , m_vsplitter(NULL)

--- a/ui/src/functionmanager.h
+++ b/ui/src/functionmanager.h
@@ -23,6 +23,7 @@
 #include <QWidget>
 #include <QList>
 
+#include "nonclosablewidget.h"
 #include "function.h"
 #include "doc.h"
 
@@ -39,7 +40,7 @@ class Doc;
  * @{
  */
 
-class FunctionManager : public QWidget
+class FunctionManager : public NonClosableWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(FunctionManager)

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -56,7 +56,7 @@
 InputOutputManager* InputOutputManager::s_instance = NULL;
 
 InputOutputManager::InputOutputManager(QWidget* parent, Doc* doc)
-    : QWidget(parent)
+    : NonClosableWidget(parent)
     , m_doc(doc)
     , m_toolbar(NULL)
     , m_addUniverseAction(NULL)
@@ -70,7 +70,7 @@ InputOutputManager::InputOutputManager(QWidget* parent, Doc* doc)
     s_instance = this;
 
     Q_ASSERT(doc != NULL);
-    
+
     m_ioMap = doc->inputOutputMap();
 
     /* Create a new layout for this widget */

--- a/ui/src/inputoutputmanager.h
+++ b/ui/src/inputoutputmanager.h
@@ -23,6 +23,8 @@
 #include <QWidget>
 #include <QIcon>
 
+#include "nonclosablewidget.h"
+
 class InputOutputPatchEditor;
 class QListWidgetItem;
 class QListWidget;
@@ -42,7 +44,7 @@ class Doc;
  * @{
  */
 
-class InputOutputManager : public QWidget
+class InputOutputManager : public NonClosableWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(InputOutputManager)

--- a/ui/src/nonclosablewidget.cpp
+++ b/ui/src/nonclosablewidget.cpp
@@ -1,0 +1,11 @@
+#include "nonclosablewidget.h"
+
+NonClosableWidget::NonClosableWidget(QWidget *parent) : QWidget(parent)
+{
+
+}
+
+void NonClosableWidget::closeEvent(QCloseEvent *event)
+{
+    event->ignore();
+}

--- a/ui/src/nonclosablewidget.h
+++ b/ui/src/nonclosablewidget.h
@@ -1,0 +1,21 @@
+#ifndef NONCLOSABLEWIDGET_H
+#define NONCLOSABLEWIDGET_H
+
+#include <QWidget>
+#include <QCloseEvent>
+
+class NonClosableWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit NonClosableWidget(QWidget *parent = nullptr);
+
+protected:
+    void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+
+signals:
+
+public slots:
+};
+
+#endif // NONCLOSABLEWIDGET_H

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -56,7 +56,7 @@
 ShowManager* ShowManager::s_instance = NULL;
 
 ShowManager::ShowManager(QWidget* parent, Doc* doc)
-    : QWidget(parent)
+    : NonClosableWidget(parent)
     , m_doc(doc)
     , m_show(NULL)
     , m_currentTrack(NULL)
@@ -149,7 +149,7 @@ ShowManager::ShowManager(QWidget* parent, Doc* doc)
     container->setLayout(new QVBoxLayout);
     container->layout()->setContentsMargins(0, 0, 0, 0);
     m_splitter->widget(1)->hide();
-    
+
     connect(m_doc, SIGNAL(clearing()), this, SLOT(slotDocClearing()));
     connect(m_doc, SIGNAL(functionRemoved(quint32)), this, SLOT(slotFunctionRemoved(quint32)));
     connect(m_doc, SIGNAL(loaded()), this, SLOT(slotDocLoaded()));

--- a/ui/src/showmanager/showmanager.h
+++ b/ui/src/showmanager/showmanager.h
@@ -24,6 +24,7 @@
 #include <QWidget>
 #include <QList>
 
+#include "nonclosablewidget.h"
 #include "multitrackview.h"
 #include "sequenceitem.h"
 #include "trackitem.h"
@@ -44,7 +45,7 @@ class Doc;
  * @{
  */
 
-class ShowManager : public QWidget
+class ShowManager : public NonClosableWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(ShowManager)
@@ -55,13 +56,13 @@ class ShowManager : public QWidget
 public:
     ShowManager(QWidget* parent, Doc* doc);
     ~ShowManager();
-    
+
     /** Get the singleton instance */
     static ShowManager* instance();
 
     /** Start from scratch; clear everything */
     void clearContents();
-    
+
 signals:
     /** Emitted when the FunctionManager's tab is de/activated */
     void functionManagerActive(bool active);
@@ -75,7 +76,7 @@ protected:
 
 protected:
     static ShowManager* s_instance;
-    
+
     Doc* m_doc;
     /** Currently selected show */
     Show* m_show;

--- a/ui/src/simpledesk.cpp
+++ b/ui/src/simpledesk.cpp
@@ -76,7 +76,7 @@ QString ssOverride = "QGroupBox { background-color: qlineargradient(x1: 0, y1: 0
  *****************************************************************************/
 
 SimpleDesk::SimpleDesk(QWidget* parent, Doc* doc)
-    : QWidget(parent)
+    : NonClosableWidget(parent)
     , m_engine(new SimpleDeskEngine(doc))
     , m_doc(doc)
     , m_docChanged(false)

--- a/ui/src/simpledesk.h
+++ b/ui/src/simpledesk.h
@@ -27,6 +27,8 @@
 #include <QList>
 #include <QHash>
 
+#include "nonclosablewidget.h"
+
 class GrandMasterSlider;
 class SimpleDeskEngine;
 class QXmlStreamReader;
@@ -53,7 +55,7 @@ class Cue;
 
 #define KXMLQLCSimpleDesk "SimpleDesk"
 
-class SimpleDesk : public QWidget
+class SimpleDesk : public NonClosableWidget
 {
     Q_OBJECT
 

--- a/ui/src/src.pro
+++ b/ui/src/src.pro
@@ -97,7 +97,8 @@ HEADERS += aboutbox.h \
            simpledeskengine.h \
            speeddial.h \
            speeddialwidget.h \
-           universeitemwidget.h
+           universeitemwidget.h \
+    nonclosablewidget.h
 
 # Monitor headers
 HEADERS += monitor/monitor.h \
@@ -272,7 +273,8 @@ SOURCES += aboutbox.cpp \
            simpledeskengine.cpp \
            speeddial.cpp \
            speeddialwidget.cpp \
-           universeitemwidget.cpp
+           universeitemwidget.cpp \
+    nonclosablewidget.cpp
 
 # Monitor sources
 SOURCES += monitor/monitor.cpp \

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -70,7 +70,7 @@ VirtualConsole* VirtualConsole::s_instance = NULL;
  ****************************************************************************/
 
 VirtualConsole::VirtualConsole(QWidget* parent, Doc* doc)
-    : QWidget(parent)
+    : NonClosableWidget(parent)
     , m_doc(doc)
     , m_latestWidgetId(0)
 

--- a/ui/src/virtualconsole/virtualconsole.h
+++ b/ui/src/virtualconsole/virtualconsole.h
@@ -26,6 +26,7 @@
 #include <QFrame>
 #include <QList>
 
+#include "nonclosablewidget.h"
 #include "vcproperties.h"
 #include "doc.h"
 
@@ -48,7 +49,7 @@ class QMenu;
  * @{
  */
 
-class VirtualConsole : public QWidget
+class VirtualConsole : public NonClosableWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(VirtualConsole)


### PR DESCRIPTION
Hi, I had this request from a colleague of mine. He wanted to be able to have the different tabs of the main window (Fixtures, Functions, Shows, Simple Desk, Virtual Console) on different screens. Since they currently are all in the main window, you can make the window span multiple screens but you can only display one tab at a time.

This PR make it possible (for Qt5.6+ only since Qt4 is missing the "tabBarDoubleClicked" SIGNAL) to double-click a tab to make it a separate window. If it shall be re-integrated again, just double-click the tab again. Closing the window has been prevented.
If a tab has been split out, it can be moved to another screen than the one displaying the main window.

Comments welcome!

P.S.: Oh and it would be awesome if someone could please make me new windows build of this branch (or of master after it has been merged) since I'm on Linux and he is on Windows and he cannot use the feature until next release or someone builds this for me. He is not experienced enough to set up the build system on his machine and I don't have Windows at all. Thanks!