### PR TITLE
Fix slider not returning to 0 on stopping of playback function

### DIFF
--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -898,6 +898,7 @@ void VCSlider::slotPlaybackFunctionStopped(quint32 fid)
             m_slider->setValue(0);
         resetIntensityOverrideAttribute();
     }
+    updateFeedback();
     m_externalMovement = false;
 }
 


### PR DESCRIPTION
This fixes a problem, that an external slider does not return to 0 after a playback function is stopped.