### PR TITLE
Script: fix load/save cycle

### DIFF
--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -184,7 +184,15 @@ QString Script::data() const
 
 QStringList Script::dataLines() const
 {
-    return m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+
+    // http://www.qlcplus.org/forum/viewtopic.php?f=21&t=11467
+    // m_data after appendData (i.e. after loadXML) has trailing LF
+    // that the split above turns into excess element
+    if (!result.isEmpty())
+        result.takeLast();
+
+    return result;
 }
 
 QList<quint32> Script::functionList() const

--- a/engine/test/script/script_test.cpp
+++ b/engine/test/script/script_test.cpp
@@ -62,4 +62,19 @@ void Script_Test::initial()
         scr.executeCommand(i, doc.masterTimer(), ua);
 }
 
+void Script_Test::loadSave()
+{
+    Doc doc(this);
+    GrandMaster *gm = new GrandMaster();
+    QList<Universe*> ua;
+    ua.append(new Universe(0, gm));
+    ua.append(new Universe(1, gm));
+    ua.append(new Universe(2, gm));
+    ua.append(new Universe(3, gm));
+
+    Script scr(&doc);
+    scr.setData(script0);
+    QCOMPARE(scr.dataLines().size(), 9);
+}
+
 QTEST_APPLESS_MAIN(Script_Test)

--- a/engine/test/script/script_test.h
+++ b/engine/test/script/script_test.h
@@ -29,6 +29,8 @@ class Script_Test : public QObject
 private slots:
     void initTestCase();
     void initial();
+
+    void loadSave();
 };
 
 #endif


### PR DESCRIPTION
Excess empty line was created after each cycle.
Reported by benste at http://www.qlcplus.org/forum/viewtopic.php?f=21&t=11467