### PR TITLE
focus video player

### DIFF
--- a/qmlui/videoprovider.cpp
+++ b/qmlui/videoprovider.cpp
@@ -192,6 +192,8 @@ void VideoContent::playVideo()
                                   Q_ARG(QVariant, QVariant::fromValue(m_video)));
     }
 
+    m_viewContext->setFlags(m_viewContext->flags() | Qt::WindowStaysOnTopHint);
+
     if (m_video->fullscreen())
     {
         m_provider->setFullscreenContext(m_viewContext);

--- a/ui/src/videoprovider.cpp
+++ b/ui/src/videoprovider.cpp
@@ -223,6 +223,7 @@ void VideoWidget::slotPlaybackVideo()
         m_videoPlayer->setPosition(0);
 
     m_videoWidget->show();
+    m_videoWidget->setWindowFlags(m_videoWidget->windowFlags() | Qt::WindowStaysOnTopHint);
     m_videoPlayer->play();
 }
 


### PR DESCRIPTION
As of now, the video player shows up behind other Applications (like Powerpoint) if QLC+ is not focused. I suggesst this solution, however I wasn't able to compile and test it under windows.
Cheers