### PR TITLE
litte fix for the launcher

### DIFF
--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -89,7 +89,11 @@ void Launcher::launchQLC(const QStringList& arguments)
     QString path(QApplication::applicationDirPath());
     if (path.endsWith(QString("/")) == false)
         path += QString("/");
+#ifndef QMLUI
     path += QString("qlcplus");
+#else
+    path += QString("qlcplus-qml");
+#endif /* QMLUI */
     QProcess::startDetached(path, arguments);
     QApplication::exit();
 }


### PR DESCRIPTION
When building on OSX with the new qmlui, this fix enables the launcher to run the binary "qmlplus-qml" instead of "qlcplus"