### PR TITLE
Fix some warnings in the german translations

### DIFF
--- a/fixtureeditor/fixtureeditor_de_DE.ts
+++ b/fixtureeditor/fixtureeditor_de_DE.ts
@@ -69,7 +69,7 @@
     <message>
         <location filename="app.cpp" line="148"/>
         <source>Unable to load fixture definition: </source>
-        <translation>Gerätedefinition konnte nicht geladen werden:</translation>
+        <translation>Gerätedefinition konnte nicht geladen werden: </translation>
     </message>
     <message>
         <location filename="app.cpp" line="242"/>

--- a/plugins/E1.31/E131_de_DE.ts
+++ b/plugins/E1.31/E131_de_DE.ts
@@ -118,7 +118,7 @@ Bitte vor Bestätigung korrigieren.</translation>
     <message>
         <location filename="e131plugin.cpp" line="142"/>
         <source>Packets sent: </source>
-        <translation>Gesendete Pakete:</translation>
+        <translation>Gesendete Pakete: </translation>
     </message>
     <message>
         <location filename="e131plugin.cpp" line="273"/>
@@ -128,7 +128,7 @@ Bitte vor Bestätigung korrigieren.</translation>
     <message>
         <location filename="e131plugin.cpp" line="282"/>
         <source>Packets received: </source>
-        <translation>Empfangene Pakete:</translation>
+        <translation>Empfangene Pakete: </translation>
     </message>
 </context>
 </TS>

--- a/plugins/artnet/src/ArtNet_de_DE.ts
+++ b/plugins/artnet/src/ArtNet_de_DE.ts
@@ -49,7 +49,7 @@
     <message>
         <location filename="artnetplugin.cpp" line="153"/>
         <source>Packets sent: </source>
-        <translation>Gesendete Pakete:</translation>
+        <translation>Gesendete Pakete: </translation>
     </message>
     <message>
         <location filename="artnetplugin.cpp" line="283"/>
@@ -74,7 +74,7 @@
     <message>
         <location filename="artnetplugin.cpp" line="298"/>
         <source>Packets received: </source>
-        <translation>Empfangene Pakete:</translation>
+        <translation>Empfangene Pakete: </translation>
     </message>
 </context>
 <context>

--- a/plugins/midi/src/MIDI_de_DE.ts
+++ b/plugins/midi/src/MIDI_de_DE.ts
@@ -145,7 +145,7 @@
     <message>
         <location filename="../../engine/src/qlcfile.cpp" line="210"/>
         <source>A timeout occurred.</source>
-        <translation>Es ist eine Zeitüberschreitung aufgetreten. </translation>
+        <translation>Es ist eine Zeitüberschreitung aufgetreten.</translation>
     </message>
     <message>
         <location filename="../../engine/src/qlcfile.cpp" line="212"/>

--- a/plugins/osc/OSC_de_DE.ts
+++ b/plugins/osc/OSC_de_DE.ts
@@ -84,12 +84,12 @@ Bitte vor Bestätigung korrigieren.</translation>
     <message>
         <location filename="oscplugin.cpp" line="141"/>
         <source>Packets sent: </source>
-        <translation>Pakete gesendet:</translation>
+        <translation>Pakete gesendet: </translation>
     </message>
     <message>
         <location filename="oscplugin.cpp" line="275"/>
         <source>Packets received: </source>
-        <translation>Pakete empfangen:</translation>
+        <translation>Pakete empfangen: </translation>
     </message>
     <message>
         <location filename="oscplugin.cpp" line="132"/>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -679,7 +679,7 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
     <message>
         <location filename="app.cpp" line="731"/>
         <source>Quit QLC+</source>
-        <translation>QLC+ beenden </translation>
+        <translation>QLC+ beenden</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1207"/>
@@ -2425,7 +2425,7 @@ Changes will be lost if you don&apos;t save them.</source>
         <location filename="fixtureremap.cpp" line="130"/>
         <location filename="fixtureremap.cpp" line="132"/>
         <source> (remapped)</source>
-        <translation>-(neu zugewiesen)</translation>
+        <translation> (neu zugewiesen)</translation>
     </message>
     <message>
         <location filename="fixtureremap.cpp" line="161"/>
@@ -4787,6 +4787,7 @@ Der Assistent kennt keinen Unterschied zwischen einem Schalter und einem Regler,
 </source>
         <translation>Syntaxfehler bei Zeile %1:
 %2
+
 </translation>
     </message>
     <message>
@@ -6146,12 +6147,12 @@ Dauer: %3
     <message>
         <location filename="virtualconsole/vcmatrixproperties.ui" line="370"/>
         <source> Add start color knobs</source>
-        <translation>Schalter für Anfangsfarbe hinzufügen</translation>
+        <translation> Schalter für Anfangsfarbe hinzufügen</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcmatrixproperties.ui" line="281"/>
         <source> Add end color knobs</source>
-        <translation>Schalter für Endfarbe hinzufügen</translation>
+        <translation> Schalter für Endfarbe hinzufügen</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcmatrixproperties.ui" line="348"/>

--- a/webaccess/src/webaccess_de_DE.ts
+++ b/webaccess/src/webaccess_de_DE.ts
@@ -230,17 +230,17 @@
     <message>
         <location filename="webaccessnetwork.cpp" line="101"/>
         <source>Network interface: </source>
-        <translation>Netzwerk Schnittstelle:</translation>
+        <translation>Netzwerk Schnittstelle: </translation>
     </message>
     <message>
         <location filename="webaccessnetwork.cpp" line="106"/>
         <source>Access point name (SSID): </source>
-        <translation>Name des AccessPoints (SSID):</translation>
+        <translation>Name des AccessPoints (SSID): </translation>
     </message>
     <message>
         <location filename="webaccessnetwork.cpp" line="108"/>
         <source>WPA-PSK Password: </source>
-        <translation>WPA-PSK Passwort:</translation>
+        <translation>WPA-PSK Passwort: </translation>
     </message>
     <message>
         <location filename="webaccessnetwork.cpp" line="113"/>
@@ -255,17 +255,17 @@
     <message>
         <location filename="webaccessnetwork.cpp" line="119"/>
         <source>IP Address: </source>
-        <translation>IP Addresse:</translation>
+        <translation>IP Addresse: </translation>
     </message>
     <message>
         <location filename="webaccessnetwork.cpp" line="121"/>
         <source>Netmask: </source>
-        <translation>Netzmaske:</translation>
+        <translation>Netzmaske: </translation>
     </message>
     <message>
         <location filename="webaccessnetwork.cpp" line="123"/>
         <source>Gateway: </source>
-        <translation>Gateway:</translation>
+        <translation>Gateway: </translation>
     </message>
     <message>
         <location filename="webaccessnetwork.cpp" line="126"/>


### PR DESCRIPTION
Modified whitespaces to align with source strings. No news strings to be translated.