### PR TITLE
Remove color from Off value in Color Macro channel.

### DIFF
--- a/resources/fixtures/American-DJ-12P-Hex.qxf
+++ b/resources/fixtures/American-DJ-12P-Hex.qxf
@@ -55,7 +55,7 @@
  </Channel>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="3" Color="#000000">Off</Capability>
+  <Capability Min="0" Max="3">Off</Capability>
   <Capability Min="4" Max="7" Color="#ff0000">Red</Capability>
   <Capability Min="8" Max="11" Color="#00ff00">Green</Capability>
   <Capability Min="12" Max="15" Color="#0000ff">Blue</Capability>

--- a/resources/fixtures/American-DJ-5P-Hex.qxf
+++ b/resources/fixtures/American-DJ-5P-Hex.qxf
@@ -55,7 +55,7 @@
  </Channel>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="3" Color="#000000">Off</Capability>
+  <Capability Min="0" Max="3">Off</Capability>
   <Capability Min="4" Max="7" Color="#ff0000">Red</Capability>
   <Capability Min="8" Max="11" Color="#00ff00">Green</Capability>
   <Capability Min="12" Max="15" Color="#0000ff">Blue</Capability>


### PR DESCRIPTION
Otherwise the black color will override R/G/B values in 2d monitor.

I suspect other fixtures may have similar problem.
Maybe new test for fixture validator: Color channel must have value without color attached.