### PR TITLE
E1.31: fix crash on wrong packet format

### DIFF
--- a/plugins/E1.31/e131packetizer.cpp
+++ b/plugins/E1.31/e131packetizer.cpp
@@ -211,7 +211,6 @@ bool E131Packetizer::fillDMXdata(QByteArray& data, QByteArray &dmx, quint32 &uni
 {
     if (data.isNull())
         return false;
-    dmx.clear();
 
     universe = (data[113] << 8) + data[114];
 
@@ -220,7 +219,8 @@ bool E131Packetizer::fillDMXdata(QByteArray& data, QByteArray &dmx, quint32 &uni
     int length = (msb << 8) | lsb;
 
     qDebug() << "[E1.31 fillDMXdata] length: " << length - 1;
-    for (int i = 126; i < 126 + length - 1; i++)
-        dmx.append(data.at(i));
+
+    dmx.clear();
+    dmx.append(data.mid(126, length - 1));
     return true;
 }


### PR DESCRIPTION
Hello!

When receiving bad/strange/incompatible packets on E1.31 port, QLC crashes because it tries to read more bytes in the packet than the packet contains.

This PR fixes the crash by rewriting the length contained in the packet data.

Another solution would be to make this check in checkPacket(), and discard the packet on wrong length.

cheers
  