### PR TITLE
Fix .sh codacy issues

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -10,7 +10,7 @@
 # Human-readable HTML results are written under coverage/html.
 #
 
-ARCH=`uname`
+ARCH=$(uname)
 
 #############################################################################
 # Test directories to find coverage measurements from
@@ -50,7 +50,7 @@ function gather_data {
 #############################################################################
 
 # Check if lcov is installed
-if [ -z `which lcov` ]; then
+if [ -z $(which lcov) ]; then
     echo "Unable to produce coverage results; can't find lcov."
 fi
 
@@ -66,7 +66,7 @@ mkdir -p coverage/html
 # Preparation
 #############################################################################
 
-for ((i = 0; i < ${tlen}; i++))
+for ((i = 0; i < tlen; i++))
 do
     prepare ${test[i]} $i
 done

--- a/create-dmg.sh
+++ b/create-dmg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#VERSION=`head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/'`
-VERSION=`grep -m 1 APPVERSION variables.pri | cut -d '=' -f 2 | sed -e 's/^[[:space:]]*//' | tr ' ' _ | tr -d '\r\n'`
+#VERSION=$(head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/')
+VERSION=$(grep -m 1 APPVERSION variables.pri | cut -d '=' -f 2 | sed -e 's/^[[:space:]]*//' | tr ' ' _ | tr -d '\r\n')
 
 # Compile translations
 ./translate.sh

--- a/create-rpm.sh
+++ b/create-rpm.sh
@@ -12,8 +12,7 @@ if [ ! -d rpm ]; then
 	exit 1;
 fi
 
-VERSION=`head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/'`
-SOURCES=qlcplus
+VERSION=$(head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/')
 RPMBUILD=~/rpmbuild
 
 # Prepare RPM build directory hierarchy

--- a/translate.sh
+++ b/translate.sh
@@ -5,9 +5,9 @@ languages="de_DE es_ES fr_FR it_IT nl_NL cz_CZ pt_BR ca_ES ja_JP"
 
 if [ -n "$1" ]; then
     echo "Forcing the use of lrelease-$1"
-    LRELEASE_BIN=`which lrelease-$1`
+    LRELEASE_BIN=$(which lrelease-$1)
 else
-    LRELEASE_BIN=`which lrelease`
+    LRELEASE_BIN=$(which lrelease)
 fi
 
 # if QTDIR has been defined, use those tools right away
@@ -16,11 +16,11 @@ if [ -n "$QTDIR" ]; then
 else
     # if lrelease is not available, try with lrelease-qt4
     if [ -z "$LRELEASE_BIN" ]; then
-        LRELEASE_BIN=`which lrelease-qt4`
+        LRELEASE_BIN=$(which lrelease-qt4)
 
         # if lrelease-qt4 is not available, try with lrelease-qt5
         if [ -z "$LRELEASE_BIN" ]; then
-	    LRELEASE_BIN=`which lrelease-qt5`
+	    LRELEASE_BIN=$(which lrelease-qt5)
 	    if [ -z "$LRELEASE_BIN" ]; then
 		echo "lrelease, lrelease-qt4 and lrelease-qt5 are not present in this system ! Aborting."
 		exit

--- a/unittest.sh
+++ b/unittest.sh
@@ -4,14 +4,14 @@
 # Engine tests
 #############################################################################
 
-CURRUSER=`whoami`
+CURRUSER=$(whoami)
 TESTPREFIX=""
 SLEEPCMD=""
 HAS_XSERVER="0"
 
 if [ "$CURRUSER" == "buildbot" ] || [ "$CURRUSER" == "abuild" ]; then
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    if [ `which xvfb-run` == "" ]; then
+    if [ $(which xvfb-run) == "" ]; then
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
@@ -26,9 +26,9 @@ if [ "$CURRUSER" == "buildbot" ] || [ "$CURRUSER" == "abuild" ]; then
 else
 
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    XPID=`pidof X`
+    XPID=$(pidof X)
     if [ ! ${#XPID} -gt 0 ]; then
-      XPID=`pidof Xorg`
+      XPID=$(pidof Xorg)
     fi
     if [ ${#XPID} -gt 0 ]; then
       HAS_XSERVER="1"
@@ -42,16 +42,16 @@ else
 fi
 
 TESTDIR=engine/test
-TESTS=`find ${TESTDIR} -maxdepth 1 -mindepth 1 -type d`
+TESTS=$(find ${TESTDIR} -maxdepth 1 -mindepth 1 -type d)
 for test in ${TESTS}
 do
     # Ignore .git
-    if [ `echo ${test} | grep ".git"` ]; then
+    if [ $(echo ${test} | grep ".git") ]; then
         continue
     fi
 
     # Isolate just the test name
-    test=`echo ${test} | sed 's/engine\/test\///'`
+    test=$(echo ${test} | sed 's/engine\/test\///')
 
     $SLEEPCMD
     # Execute the test
@@ -77,12 +77,12 @@ TESTS=`find ${TESTDIR} -maxdepth 1 -mindepth 1 -type d`
 for test in ${TESTS}
 do
     # Ignore .git
-    if [ `echo ${test} | grep ".git"` ]; then
+    if [ $(echo ${test} | grep ".git") ]; then
         continue
     fi
 
     # Isolate just the test name
-    test=`echo ${test} | sed 's/ui\/test\///'`
+    test=$(echo ${test} | sed 's/ui\/test\///')
 
     $SLEEPCMD
     # Execute the test


### PR DESCRIPTION
- replace backticks with $() (see https://mywiki.wooledge.org/BashFAQ/082)
- remove SOURCES from create_rpm.sh (unused since 2.6.2010)