### PR TITLE
Fixes and enhancements in WebAccess

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -16,6 +16,9 @@ qlcplus (4.11.2) stable; urgency=low
   * Virtual Console/Cue List: allow to select a step with next/previous buttons during pause
   * Virtual Console/Cue List: go to the right chaser step after a pause (thanks to Krzysztof Walo)
   * Virtual Console/Frame: fix regression preventing to send the disable feedback
+  * Web Access/VirtualConsole: possibility to use Buttons in Flash mode (Sylvain Laugié)
+  * Web Access/VirtualConsole: possibility to use circular scrolling of pages on Frames (Sylvain Laugié)
+  * Web Access/VirtualConsole: AudioTriggers state is updated in Web UI when changed from QLC+ (Sylvain Laugié)
   * plugins/udmx: added 'channels' configuration parameter (see documentation)
   * plugins/E1.31: fix crash on wrong packet length (David Garyga)
   * New fixture: DTS XR7 Spot (thanks to Nicolò Zanon)

--- a/ui/src/virtualconsole/vcaudiotriggers.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggers.cpp
@@ -195,6 +195,8 @@ void VCAudioTriggers::enableCapture(bool enable)
         m_button->setChecked(true);
         m_button->blockSignals(false);
 
+        emit captureEnabled(true);
+
         // Invalid ID: Stop every other widget
         emit functionStarting(Function::invalidId());
     }
@@ -210,6 +212,8 @@ void VCAudioTriggers::enableCapture(bool enable)
         m_button->blockSignals(true);
         m_button->setChecked(false);
         m_button->blockSignals(false);
+
+        emit captureEnabled(false);
     }
 }
 

--- a/ui/src/virtualconsole/vcaudiotriggers.h
+++ b/ui/src/virtualconsole/vcaudiotriggers.h
@@ -79,6 +79,9 @@ public:
 public slots:
     void slotEnableButtonToggled(bool toggle);
 
+signals:
+    void captureEnabled(bool enabled);
+
 protected slots:
     void slotDisplaySpectrum(double *spectrumBands, int size, double maxMagnitude, quint32 power);
 #if QT_VERSION >= 0x050000

--- a/webaccess/res/Test_Web_API.html
+++ b/webaccess/res/Test_Web_API.html
@@ -452,8 +452,9 @@ Load a project:
   </td>
   <td colspan="2">
     This API is the direct way to set a Virtual Console widget value. It can be used for Buttons, Sliders and
-    Audio Triggers. The value to set depends on the widget type itself. Buttons and Audio triggers will only
-    support values 0 (= off) and 255 (= on) while Sliders will accept all the values in the 0-255 range.
+    Audio Triggers. The value to set depends on the widget type itself. Buttons will only support values 255
+    (= button is pressed) and 0 (= button is released), Audio triggers will support values 0 (= off) and 255 (= on)
+    and Sliders will accept all the values in the 0-255 range.
   </td>
  </tr>
  

--- a/webaccess/res/virtualconsole.js
+++ b/webaccess/res/virtualconsole.js
@@ -18,16 +18,26 @@
 */
 
 /* VCButton */
-function buttonClick(id) {
+function buttonPress(id) {
+ websocket.send(id + "|255");
+}
+
+function buttonRelease(id) {
+ websocket.send(id + "|0");
+}
+
+function wsSetButtonState(id, state) {
  var obj = document.getElementById(id);
- if (obj.value === undefined || obj.value === "0" || obj.value === "127") {
+ if (state === "255") {
   obj.value = "255";
   obj.style.border = "3px solid #00E600";
+ } else if (state === "127") {
+  obj.value = "127";
+  obj.style.border = "3px solid #FFAA00";
  } else {
   obj.value = "0";
   obj.style.border = "3px solid #A0A0A0";
  }
- websocket.send(id + "|" + obj.value);
 }
 
 /* VCCueList */
@@ -35,13 +45,13 @@ var cueListsIndices = new Array();
 
 function setCueIndex(id, idx) {
  var oldIdx = cueListsIndices[id];
- if (oldIdx != undefined && oldIdx !== -1) {
+ if (oldIdx != undefined && oldIdx !== "-1") {
    var oldCueObj = document.getElementById(id + "_" + oldIdx);
    oldCueObj.style.backgroundColor="#FFFFFF";
  }
  cueListsIndices[id] = idx;
  var currCueObj = document.getElementById(id + "_" + idx);
- if (idx != "-1") {
+ if (idx !== "-1") {
    currCueObj.style.backgroundColor="#5E7FDF";
  }
 }
@@ -49,9 +59,9 @@ function setCueIndex(id, idx) {
 function sendCueCmd(id, cmd) {
  if (cmd === "PLAY") {
    var obj = document.getElementById("play" + id);
-   if (cueListsIndices[id] === -1) {
+   if (cueListsIndices[id] === "-1") {
      obj.innerHTML = "<img src=\"player_pause.png\" width=\"27\">";
-     setCueIndex(id, 0);
+     setCueIndex(id, "0");
    }
    else {
      obj.innerHTML = "<img src=\"player_play.png\" width=\"27\">";
@@ -75,6 +85,17 @@ function enableCue(id, idx) {
  btnObj.innerHTML = "<img src=\"player_pause.png\" width=\"27\">";
  setCueIndex(id, idx);
  websocket.send(id + "|STEP|" + idx);
+}
+
+function wsSetCueIndex(id, idx) {
+ setCueIndex(id, idx);
+ var playObj = document.getElementById("play" + id);
+ if (idx === "-1") {
+    playObj.innerHTML = "<img src=\"player_play.png\" width=\"27\">";
+ }
+ else {
+    playObj.innerHTML = "<img src=\"player_pause.png\" width=\"27\">";
+ }
 }
 
 /* VCFrame */
@@ -119,30 +140,11 @@ function frameToggleCollapse(id) {
 }
 
 function frameNextPage(id) {
- var currPage = framesCurrentPage[id];
- var pagesNum = framesTotalPages[id];
- if (currPage + 1 < pagesNum) {
-  var framePageObj = document.getElementById("fp" + id + "_" + currPage);
-  framePageObj.style.visibility = "hidden";
-  framesCurrentPage[id]++;
-  var frameNextPageObj = document.getElementById("fp" + id + "_" + framesCurrentPage[id]);
-  frameNextPageObj.style.visibility = "visible";
-  updateFrameLabel(id);
-  websocket.send(id + "|NEXT_PG");
- }
+ websocket.send(id + "|NEXT_PG");
 }
 
 function framePreviousPage(id) {
- var currPage = framesCurrentPage[id];
- if (currPage - 1 >= 0) {
-  var framePageObj = document.getElementById("fp" + id + "_" + currPage);
-  framePageObj.style.visibility = "hidden";
-  framesCurrentPage[id]--;
-  var framePrevPageObj = document.getElementById("fp" + id + "_" + framesCurrentPage[id]);
-  framePrevPageObj.style.visibility = "visible";
-  updateFrameLabel(id);
-  websocket.send(id + "|PREV_PG");
- }
+ websocket.send(id + "|PREV_PG");
 }
 
 function setFramePage(id, page) {
@@ -159,16 +161,33 @@ function setFramePage(id, page) {
 /* VCSlider */
 function slVchange(id) {
  var slObj = document.getElementById(id);
- var obj = document.getElementById("slv" + id);
- obj.innerHTML = slObj.value;
  var sldMsg = id + "|" + slObj.value;
  websocket.send(sldMsg);
+}
+
+function wsSetSliderValue(id, sliderValue, displayValue) {
+ var obj = document.getElementById(id);
+ obj.value = sliderValue;
+ var labelObj = document.getElementById("slv" + id);
+ labelObj.innerHTML = displayValue;
 }
 
 /* VCAudioTriggers */
 function atButtonClick(id) {
  var obj = document.getElementById(id);
  if (obj.value === "0" || obj.value == undefined) {
+  obj.value = "255";
+ }
+ else {
+  obj.value = "0";
+ }
+ var btnMsg = id + "|" + obj.value;
+ websocket.send(btnMsg);
+}
+
+function wsSetAudioTriggersEnabled(id, enabled) {
+ var obj = document.getElementById(id);
+ if (enabled === "255") {
   obj.value = "255";
   obj.style.border = "3px solid #00E600";
   obj.style.backgroundColor = "#D7DE75";
@@ -178,6 +197,4 @@ function atButtonClick(id) {
   obj.style.border = "3px solid #A0A0A0";
   obj.style.backgroundColor = "#D6D2D0";
  }
- var btnMsg = id + "|" + obj.value;
- websocket.send(btnMsg);
 }

--- a/webaccess/res/websocket.js
+++ b/webaccess/res/websocket.js
@@ -41,7 +41,7 @@ window.onload = function() {
   //alert(ev.data);
   var msgParams = ev.data.split("|");
   if (msgParams[1] === "BUTTON") {
-    wsSetButtonState(msgParams[0], msgParams[2])
+    wsSetButtonState(msgParams[0], msgParams[2]);
   }
   else if (msgParams[1] === "SLIDER") {
     // Slider message is <ID>|SLIDER|<SLIDER VALUE>|<DISPLAY VALUE>

--- a/webaccess/res/websocket.js
+++ b/webaccess/res/websocket.js
@@ -40,34 +40,18 @@ window.onload = function() {
  websocket.onmessage = function(ev) {
   //alert(ev.data);
   var msgParams = ev.data.split("|");
-  var obj = document.getElementById(msgParams[0]);
   if (msgParams[1] === "BUTTON") {
-    if (msgParams[2] === "255") {
-      obj.value = "255";
-      obj.style.border = "3px solid #00E600"; 
-    } else if (msgParams[2] === "127") {
-      obj.value = "127";
-      obj.style.border = "3px solid #FFAA00";
-    } else {
-      obj.value = "0";
-      obj.style.border = "3px solid #A0A0A0";
-    }
+    wsSetButtonState(msgParams[0], msgParams[2])
   }
   else if (msgParams[1] === "SLIDER") {
     // Slider message is <ID>|SLIDER|<SLIDER VALUE>|<DISPLAY VALUE>
-    obj.value = msgParams[2];
-    var labelObj = document.getElementById("slv" + msgParams[0]);
-    labelObj.innerHTML = msgParams[3];
+    wsSetSliderValue(msgParams[0], msgParams[2], msgParams[3]);
+  }
+  else if (msgParams[1] === "AUDIOTRIGGERS") {
+    wsSetAudioTriggersEnabled(msgParams[0], msgParams[2]);
   }
   else if (msgParams[1] === "CUE") {
-    setCueIndex(msgParams[0], msgParams[2]);
-    var playBbj = document.getElementById("play" + msgParams[0]);
-    if (msgParams[2] === "-1") {
-      playBbj.innerHTML = "<img src=\"player_play.png\" width=\"27\">";
-    }
-    else {
-      playBbj.innerHTML = "<img src=\"player_pause.png\" width=\"27\">";
-    }
+    wsSetCueIndex(msgParams[0], msgParams[2]);
   }
   else if (msgParams[1] === "FRAME") {
     setFramePage(msgParams[0], msgParams[2]);

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -699,7 +699,10 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             case VCWidget::ButtonWidget:
             {
                 VCButton *button = qobject_cast<VCButton*>(widget);
-                button->pressFunction();
+                if(value)
+                    button->pressFunction();
+                else
+                    button->releaseFunction();
             }
             break;
             case VCWidget::SliderWidget:
@@ -737,12 +740,10 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             case VCWidget::SoloFrameWidget:
             {
                 VCFrame *frame = qobject_cast<VCFrame*>(widget);
-                frame->blockSignals(true);
                 if (cmdList[1] == "NEXT_PG")
                     frame->slotNextPage();
                 else if (cmdList[1] == "PREV_PG")
                     frame->slotPreviousPage();
-                frame->blockSignals(false);
             }
             break;
             default:
@@ -952,7 +953,9 @@ QString WebAccess::getButtonHTML(VCButton *btn)
             "left: " + QString::number(btn->x()) + "px; "
             "top: " + QString::number(btn->y()) + "px;\">\n";
     str +=  "<a class=\"vcbutton\" id=\"" + QString::number(btn->id()) + "\" "
-            "href=\"javascript:buttonClick(" + QString::number(btn->id()) + ");\" "
+            "href=\"javascript:return false;\" "
+            "onmousedown=\"buttonPress(" + QString::number(btn->id()) + ");\" "
+            "onmouseup=\"buttonRelease(" + QString::number(btn->id()) + ");\" "
             "style=\""
             "width: " + QString::number(btn->width()) + "px; "
             "height: " + QString::number(btn->height()) + "px; "
@@ -1034,6 +1037,23 @@ QString WebAccess::getLabelHTML(VCLabel *label)
     return str;
 }
 
+void WebAccess::slotAudioTriggersToggled(bool toggle)
+{
+    VCAudioTriggers *triggers = qobject_cast<VCAudioTriggers *>(sender());
+    if (triggers == NULL)
+        return;
+
+    qDebug() << "AudioTriggers state changed " << toggle;
+
+    QString wsMessage = QString::number(triggers->id());
+    if (toggle)
+        wsMessage.append("|AUDIOTRIGGERS|255");
+    else
+        wsMessage.append("|AUDIOTRIGGERS|0");
+
+    sendWebSocketMessage(wsMessage.toUtf8());
+}
+
 QString WebAccess::getAudioTriggersHTML(VCAudioTriggers *triggers)
 {
     QString str = "<div class=\"vcaudiotriggers\" style=\"left: " + QString::number(triggers->x()) +
@@ -1054,6 +1074,9 @@ QString WebAccess::getAudioTriggersHTML(VCAudioTriggers *triggers)
             + tr("Enable") + "</a>\n";
 
     str += "</div></div>\n";
+
+    connect(triggers, SIGNAL(captureEnabled(bool)),
+            this, SLOT(slotAudioTriggersToggled(bool)));
 
     return str;
 }

--- a/webaccess/src/webaccess.h
+++ b/webaccess/src/webaccess.h
@@ -80,6 +80,7 @@ protected slots:
     void slotVCLoaded();
     void slotButtonStateChanged(int state);
     void slotSliderValueChanged(QString val);
+    void slotAudioTriggersToggled(bool toggle);
     void slotCueIndexChanged(int idx);
     void slotFramePageChanged(int pageNum);
 


### PR DESCRIPTION
This PR is about fixing and enhancing some WebAccess items:

- Buttons: JS events `onmousedown` and `onmouseup` replace `onclick` to be able to use Flash mode
- AudioTriggers: new signal `captureEnabled(bool)` in VCAudioTriggers allows WebAccess AudioTriggers state to be updated when changed in QLC+ directly
- Frames: possibility to use circular scrolling of pages
- Cuelist: fixes which prevented Cuelist to work correctly

More generally, I refactored the JS code to be more simple:
- move style update code from websocket.js to virtualconsole.js
- style updates are done only when receiving messages from the WS, not when clicking on the elements of the Web UI

This prevents style updates (ie. a button going green) when the element isn't actually activated in QLC+ (ie. if QLC+ is not in operate mode). Web UI only sends UI events to QLC+, then QLC+ tells back the Web UI what to update.  
This also simplifies websocket.js which doesn't have style update code anymore, only calls to functions in virtualconsole.js  
Finally, this removes some duplication of code between websocket.js and virtualconsole.js