### PR TITLE
connected the global smoke amount to the shaders

### DIFF
--- a/qmlui/qml/fixturesfunctions/3DView/SpotlightConeEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SpotlightConeEntity.qml
@@ -107,7 +107,10 @@ Entity
 
             parameters.push(uniformComp.createObject(spotlightConeMaterial,
                             { name: "goboTex", value: Qt.binding(function() { return fxItem.goboTexture }) }))
-                         
+
+            parameters.push(uniformComp.createObject(spotlightConeMaterial,
+                            { name: "smokeAmount", value: Qt.binding(function() { return View3D.smokeAmount }) }))
+
             // dump the uniform list (uncomment for debug purposes)
             // parameters.forEach(function (p) { console.log(p.name, '=', p.value); })
 

--- a/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_scattering.frag
+++ b/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_scattering.frag
@@ -38,6 +38,8 @@ uniform float coneTopRadius;
 uniform float coneBottomRadius;
 uniform float coneDistCutoff;
 
+uniform float smokeAmount;
+
 uniform sampler2D depthTex;
 uniform mat4 viewProjectionMatrix;
 uniform mat4 inverseViewProjectionMatrix;
@@ -143,6 +145,6 @@ void main()
 
         p += rd * stepLength;
     }
-    MGL_FRAG_COLOR = vec4(accum * lightIntensity * lightColor, 0.0);
+    MGL_FRAG_COLOR = vec4(accum * lightIntensity * smokeAmount * lightColor, 0.0);
     //MGL_FRAG_COLOR = vec4(1.0, 0.0, 0.0, 0.0);
 }


### PR DESCRIPTION
This commit properly connects the global smoke amount setting to the volumetric scattering shader.

![capture](https://user-images.githubusercontent.com/602313/43087570-0665879e-8e55-11e8-8db5-72f6867a43f3.PNG)