### PR TITLE
Remove spaces before question marks

### DIFF
--- a/engine/audio/src/audiorenderer_null.h
+++ b/engine/audio/src/audiorenderer_null.h
@@ -39,7 +39,7 @@ public:
     bool initialize(quint32, int, AudioFormat) { return true; }
 
     /** @reimpl */
-    qint64 latency() { return 0; } // not bad for a null device huh ? ;)
+    qint64 latency() { return 0; } // not bad for a null device huh? ;)
 
 protected:
     /** @reimpl */

--- a/engine/audio/src/audiorenderer_portaudio.cpp
+++ b/engine/audio/src/audiorenderer_portaudio.cpp
@@ -56,11 +56,11 @@ int AudioRendererPortAudio::dataCallback ( const void *, void *outputBuffer,
     unsigned long requestedData = frameCount * PAobj->m_frameSize * PAobj->m_channels;
 
     QMutexLocker locker(&PAobj->m_paMutex);
-    // user stop requested ? Prevent this callback to be called again
+    // user stop requested? Prevent this callback to be called again
     if (PAobj->m_userStop == true)
         return paAbort;
 
-    // not enough data ? Wait for another writeAudio to add more
+    // not enough data? Wait for another writeAudio to add more
     if (requestedData > (unsigned long)PAobj->m_buffer.size())
     {
         Pa_Sleep(10);

--- a/engine/src/avolitesd4parser.cpp
+++ b/engine/src/avolitesd4parser.cpp
@@ -180,7 +180,7 @@ bool AvolitesD4Parser::loadXML(const QString& path, QLCFixtureDef* fixtureDef)
         else if (doc->name() == KD4TagPalettes)
         {
             // TODO TODO TODO
-            // Maybe also import preset palettes and macros ?!?!?!?!
+            // Maybe also import preset palettes and macros?!?!?!?!
             /**
                 Can't be done for now, as qxf files don't have any information on preset palettes or macros
                 for fixtures, they are automatically generated on the main application maybe in future... **/
@@ -344,7 +344,7 @@ bool AvolitesD4Parser::is16Bit(QString dmx) const
     if (dmxValues.value(0).toInt() > 256)
         return true;
 
-    // Is there aright side ? (there should always be something in the right side of the ~,
+    // Is there aright side? (there should always be something in the right side of the ~,
     // or avolites desks won't parse the file, anyway, there should be a check, ir some smart
     // dude will complain this crashes with his D4 file)
 

--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -449,7 +449,7 @@ void ChaserRunner::adjustIntensity(qreal fraction, int requestedStepIndex, int f
     if (fraction == qreal(0.0))
         return;
 
-    // not found ? It means we need to start a new step and crossfade kicks in !
+    // not found? It means we need to start a new step and crossfade kicks in !
     startNewStep(stepIndex, m_doc->masterTimer(), fraction, fadeControl);
 }
 

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -96,7 +96,7 @@ Doc::~Doc()
 
     if (isKiosk() == false)
     {
-        // TODO: is this still needed ??
+        // TODO: is this still needed??
         //m_ioMap->saveDefaults();
     }
     delete m_ioMap;

--- a/engine/src/qlcfixturedef.cpp
+++ b/engine/src/qlcfixturedef.cpp
@@ -190,7 +190,7 @@ QString QLCFixtureDef::author()
 
 void QLCFixtureDef::checkLoaded(QString mapPath)
 {
-    // Already loaded ? Nothing to do
+    // Already loaded? Nothing to do
     if (m_isLoaded == true)
         return;
 

--- a/engine/src/scriptrunner.cpp
+++ b/engine/src/scriptrunner.cpp
@@ -289,7 +289,7 @@ bool ScriptRunner::setFixture(quint32 fxID, quint32 channel, uchar value, uint t
     if (gf->channels().contains(fc) == true)
         fc.setStart(gf->channels()[fc].current());
     //else
-    //    fc.setStart(universes[uni]->preGMValue(address)); // TODO ?
+    //    fc.setStart(universes[uni]->preGMValue(address)); // TODO?
     fc.setCurrent(fc.start());
 
     gf->add(fc);

--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -490,7 +490,7 @@ void QLCFixtureEditor::slotRemoveChannel()
     Q_ASSERT(channel != NULL);
 
     if (QMessageBox::question(this, "Remove Channel",
-                              tr("Are you sure you wish to remove channel: %1 ?")
+                              tr("Are you sure you wish to remove channel: %1?")
                               .arg(channel->name()),
                               QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
     {
@@ -809,7 +809,7 @@ void QLCFixtureEditor::slotRemoveMode()
     QLCFixtureMode *mode = currentMode();
 
     if (QMessageBox::question(this, tr("Remove Mode"),
-                              tr("Are you sure you wish to remove mode: %1 ?").arg(mode->name()),
+                              tr("Are you sure you wish to remove mode: %1?").arg(mode->name()),
                               QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
     {
         m_fixtureDef->removeMode(mode);

--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -128,7 +128,7 @@ void QLCFixtureEditor::init()
     if (m_authorEdit->text().length() > 0)
     {
         // Temporarily allow editing author name since most definitions contain wrong name:
-        // m_authorEdit->setEnabled(false); 
+        // m_authorEdit->setEnabled(false);
     }
     else
     {

--- a/fixtureeditor/fixtureeditor_ca_ES.ts
+++ b/fixtureeditor/fixtureeditor_ca_ES.ts
@@ -983,12 +983,12 @@ No es pot desar el fixture.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Esteu segur que vol eliminar el canal: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Eteu segur que vol eliminar el mode: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_cz_CZ.ts
+++ b/fixtureeditor/fixtureeditor_cz_CZ.ts
@@ -984,12 +984,12 @@ Nelze uložit zařízení.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Opravdu chcete odebrat kanál: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Opravdu chcete odebrat režim: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_de_DE.ts
+++ b/fixtureeditor/fixtureeditor_de_DE.ts
@@ -992,12 +992,12 @@ Kann Gerät nicht speichern.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Bist du dir sicher, dass du den Kanal %1 entfernen möchtest ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Bist du dir sicher, dass du den Modus %1 entfernen möchtest ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_de_DE.ts
+++ b/fixtureeditor/fixtureeditor_de_DE.ts
@@ -993,12 +993,12 @@ Kann Gerät nicht speichern.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Bist du dir sicher, dass du den Kanal %1 entfernen möchtest ?</translation>
+        <translation>Bist du dir sicher, dass du den Kanal %1 entfernen möchtest?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Bist du dir sicher, dass du den Modus %1 entfernen möchtest ?</translation>
+        <translation>Bist du dir sicher, dass du den Modus %1 entfernen möchtest?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_es_ES.ts
+++ b/fixtureeditor/fixtureeditor_es_ES.ts
@@ -888,12 +888,12 @@ No se puede guardar el fixture.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>¿Está seguro que quiere quitar el canal: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>¿Está seguro que quiere quitar el modo: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_es_ES.ts
+++ b/fixtureeditor/fixtureeditor_es_ES.ts
@@ -889,12 +889,12 @@ No se puede guardar el fixture.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>¿Está seguro que quiere quitar el canal: %1 ?</translation>
+        <translation>¿Está seguro que quiere quitar el canal: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>¿Está seguro que quiere quitar el modo: %1 ?</translation>
+        <translation>¿Está seguro que quiere quitar el modo: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_fi_FI.ts
+++ b/fixtureeditor/fixtureeditor_fi_FI.ts
@@ -945,12 +945,12 @@ Valaisinta ei voida tallentaa.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_fr_FR.ts
+++ b/fixtureeditor/fixtureeditor_fr_FR.ts
@@ -908,12 +908,12 @@ Impossible d&apos;enregistrer l&apos;appareil.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Êtes-vous sûr(e) de vouloir supprimer le canal &quot;%1&quot; ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Êtes-vous sûr(e) de vouloir supprimer le mode &quot;%1&quot; ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_fr_FR.ts
+++ b/fixtureeditor/fixtureeditor_fr_FR.ts
@@ -835,7 +835,7 @@
 before closing?</source>
         <translation>Voulez vous enregistrer les modifications de l&apos;appareil
 &quot;%1&quot;
-avant de quitter ?</translation>
+avant de quitter&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="229"/>
@@ -909,12 +909,12 @@ Impossible d&apos;enregistrer l&apos;appareil.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Êtes-vous sûr(e) de vouloir supprimer le canal &quot;%1&quot; ?</translation>
+        <translation>Êtes-vous sûr(e) de vouloir supprimer le canal &quot;%1&quot;&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Êtes-vous sûr(e) de vouloir supprimer le mode &quot;%1&quot; ?</translation>
+        <translation>Êtes-vous sûr(e) de vouloir supprimer le mode &quot;%1&quot;&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_it_IT.ts
+++ b/fixtureeditor/fixtureeditor_it_IT.ts
@@ -983,12 +983,12 @@ Impossibile Salvare.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Sei sicuro di vuoler rimuovere il canale: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Sei sicuro di voler rimuovere la modalità: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_ja_JP.ts
+++ b/fixtureeditor/fixtureeditor_ja_JP.ts
@@ -886,12 +886,12 @@ Unable to save fixture.</source>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>チャンネル %1 を削除しますか？</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>以下のモードを削除しますか: %1 ？</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_nl_NL.ts
+++ b/fixtureeditor/fixtureeditor_nl_NL.ts
@@ -985,12 +985,12 @@ Unable to save fixture.</source>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Kanaal verwijderen: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Verwijder mode %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_pt_BR.ts
+++ b/fixtureeditor/fixtureeditor_pt_BR.ts
@@ -887,12 +887,12 @@ Não se pode guardar o fixture.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Tem a certezaque pretende remover o canal: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Tem a certeza que pretende eliminar o modo: %1 ?</translation>
     </message>
     <message>

--- a/platforms/windows/qlcplus4Qt4.nsi
+++ b/platforms/windows/qlcplus4Qt4.nsi
@@ -33,7 +33,7 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "Japanese"
 !insertmacro MUI_LANGUAGE "Catalan"
 
-!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
+!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license?"
 
 !insertmacro MUI_PAGE_LICENSE "${QLCPLUS_HOME}\platforms\windows\apache_2.0.txt"
 

--- a/platforms/windows/qlcplus4Qt5.nsi
+++ b/platforms/windows/qlcplus4Qt5.nsi
@@ -20,7 +20,7 @@ InstallDir C:\QLC+
 InstallDirRegKey HKCU "Software\qlcplus" "Install_Dir"
 RequestExecutionLevel user
 
-!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
+!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license?"
 
 !insertmacro MUI_PAGE_LICENSE "${QLCPLUS_HOME}\platforms\windows\apache_2.0.txt"
 

--- a/platforms/windows/qlcplus5Qt5.nsi
+++ b/platforms/windows/qlcplus5Qt5.nsi
@@ -20,7 +20,7 @@ InstallDir C:\QLC+5
 InstallDirRegKey HKCU "Software\qlcplus" "Install_Dir"
 RequestExecutionLevel user
 
-!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
+!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license?"
 
 !insertmacro MUI_PAGE_LICENSE "${QLCPLUS_HOME}\platforms\windows\apache_2.0.txt"
 

--- a/plugins/artnet/src/artnetcontroller.h
+++ b/plugins/artnet/src/artnetcontroller.h
@@ -125,7 +125,7 @@ public:
     /** Get the number of packets received by this controller */
     quint64 getPacketReceivedNumber();
 
-    /** Is the UDP socket capable of receiving packets ? */
+    /** Is the UDP socket capable of receiving packets? */
     bool socketBound() const;
 
 private:

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -375,7 +375,7 @@ QList<ArtNetIO> ArtNetPlugin::getIOMapping()
 
 QSharedPointer<QUdpSocket> ArtNetPlugin::getUdpSocket()
 {
-    // Is the socket already present ?
+    // Is the socket already present?
     QSharedPointer<QUdpSocket> udpSocket(m_udpSocket);
     if (udpSocket)
         return udpSocket;

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -215,7 +215,7 @@ void ArtNetPlugin::writeUniverse(quint32 universe, quint32 output, const QByteAr
 
 /*************************************************************************
   * Inputs
-  *************************************************************************/  
+  *************************************************************************/
 QStringList ArtNetPlugin::inputs()
 {
     QStringList list;

--- a/plugins/dmxusb/src/enttecdmxusbpro.cpp
+++ b/plugins/dmxusb/src/enttecdmxusbpro.cpp
@@ -107,10 +107,10 @@ bool EnttecDMXUSBPro::configureLine(ushort dmxLine, ushort midiLine)
         request.append(ENTTEC_PRO_ENABLE_API2); // Enable API2
         request.append(char(0x04)); // data length LSB
         request.append(ENTTEC_PRO_DMX_ZERO); // data length MSB
-        request.append(char(0xAD)); // Magic number. WTF ??
-        request.append(char(0x88)); // Magic number. WFT ??
-        request.append(char(0xD0)); // Magic number. WTF ??
-        request.append(char(0xC8)); // Magic number. WTF ??
+        request.append(char(0xAD)); // Magic number. WTF??
+        request.append(char(0x88)); // Magic number. WFT??
+        request.append(char(0xD0)); // Magic number. WTF??
+        request.append(char(0xC8)); // Magic number. WTF??
         request.append(ENTTEC_PRO_END_OF_MSG); // Stop byte
 
         /* Write "Set API Key Request" message */

--- a/plugins/midi/src/alsa/alsamidioutputdevice.cpp
+++ b/plugins/midi/src/alsa/alsamidioutputdevice.cpp
@@ -104,7 +104,7 @@ void AlsaMidiOutputDevice::writeChannel(ushort channel, uchar value)
     if (channel < ushort(m_universe.size()) && m_universe[channel] != scaled)
     {
         QByteArray tmp(m_universe);
-        
+
         for (uchar ch = 0; ch < MAX_MIDI_DMX_CHANNELS && ch < tmp.size(); ++ch)
         {
            char midi = tmp[ch];

--- a/plugins/midi/src/alsa/alsamidioutputdevice.cpp
+++ b/plugins/midi/src/alsa/alsamidioutputdevice.cpp
@@ -227,7 +227,7 @@ void AlsaMidiOutputDevice::writeFeedback(uchar cmd, uchar data1, uchar data2)
         break;
 
     default:
-        // What to do here ??
+        // What to do here??
         invalidCmd = true;
         break;
     }

--- a/plugins/midi/src/macx/coremidiinputdevice.cpp
+++ b/plugins/midi/src/macx/coremidiinputdevice.cpp
@@ -62,7 +62,7 @@ static void MidiInProc(const MIDIPacketList* pktList, void* readProcRefCon,
                 if (packet->length > (i + 1) && !MIDI_IS_CMD(packet->data[i + 1]))
                     data2 = packet->data[++i];
                 else
-                    // no data2 ? Could be a Program Change, so act like Linux
+                    // no data2? Could be a Program Change, so act like Linux
                     // and give it a value
                     data2 = 127;
             }

--- a/plugins/velleman/test/velleman_test.cpp
+++ b/plugins/velleman/test/velleman_test.cpp
@@ -94,7 +94,7 @@ void Velleman_Test::outputInfo()
     Velleman vo;
     vo.init();
 
-// is this seriously needed ??
+// is this seriously needed??
 /*
     QString info;
     info = vo.outputInfo(42);

--- a/qmlui/contextmanager.cpp
+++ b/qmlui/contextmanager.cpp
@@ -409,7 +409,7 @@ void ContextManager::resetContexts()
     if (m_3DView->isEnabled())
         m_3DView->slotRefreshView();
 
-    /** TODO: nothing to do on the other contexts ? */
+    /** TODO: nothing to do on the other contexts? */
 }
 
 void ContextManager::handleKeyPress(QKeyEvent *e)

--- a/qmlui/efxeditor.cpp
+++ b/qmlui/efxeditor.cpp
@@ -352,7 +352,7 @@ QVariant EFXEditor::groupsTreeModel()
         treeColumns << "classRef" << "type" << "id" << "subid" << "head";
         m_fixtureTree->setColumnNames(treeColumns);
         m_fixtureTree->enableSorting(false);
-        FixtureManager::updateGroupsTree(m_doc, m_fixtureTree); // TODO: search filter ?
+        FixtureManager::updateGroupsTree(m_doc, m_fixtureTree); // TODO: search filter?
     }
 
     return QVariant::fromValue(m_fixtureTree);

--- a/qmlui/fixturemanager.cpp
+++ b/qmlui/fixturemanager.cpp
@@ -438,7 +438,7 @@ void FixtureManager::setItemRoleData(int itemID, int index, QString role, QVaria
         }
         else
         {
-            // TODO: flags per channel ?
+            // TODO: flags per channel?
         }
     }
     else if (role == "canFade")

--- a/qmlui/inputoutputmanager.cpp
+++ b/qmlui/inputoutputmanager.cpp
@@ -145,7 +145,7 @@ void InputOutputManager::removeLastUniverse()
     // Check if the universe is patched
     if (m_ioMap->isUniversePatched(index) == true)
     {
-        // Show popup ?
+        // Show popup?
     }
 
     // Check if there are fixtures using this universe

--- a/qmlui/qlcplus_ca_ES.ts
+++ b/qmlui/qlcplus_ca_ES.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Voleu desar primer el projecte actual?
 Es perdran els canvis si no els guarda.</translation>
@@ -331,7 +331,7 @@ Es perdran els canvis si no els guarda.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Esteu segur que voleu eliminar els passos seleccionats?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ Es perdran els canvis si no els guarda.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Esteu segur que voleu eliminar la funció seleccionada?</translation>
     </message>
 </context>
@@ -2481,7 +2481,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Esteu segur que vols eliminar els següents elements?</translation>
     </message>
     <message>
@@ -2949,7 +2949,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Esteu segur que voleu eliminar els elements següents?
 (Tingueu en compte que les funcions originals no se suprimiran)</translation>
@@ -3624,7 +3624,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Estàs segur que vols esborrar la pàgina seleccionada?</translation>
     </message>
 </context>
@@ -3652,7 +3652,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Estàs segur que vols esborrar els widgets següents?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_de_DE.ts
+++ b/qmlui/qlcplus_de_DE.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Willst du das aktuelle Projekt erst speichern?
 Ungesicherte Änderungen gehen verloren, wenn du sie nicht speicherst.</translation>
@@ -332,7 +332,7 @@ Ungesicherte Änderungen gehen verloren, wenn du sie nicht speicherst.</translat
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Willst du alle ausgewählten Schritte entfernen?</translation>
     </message>
     <message>
@@ -483,7 +483,7 @@ Ungesicherte Änderungen gehen verloren, wenn du sie nicht speicherst.</translat
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Willst du alle ausgewählten Funktionen entfernen?</translation>
     </message>
 </context>
@@ -2486,7 +2486,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Willst du alle folgenden Elemente löschen?</translation>
     </message>
     <message>
@@ -2955,7 +2955,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Willst du alle folgenden Elemente löschen?
 (Die ursprünglichen Funktionen werden nicht gelöscht)</translation>
@@ -3633,7 +3633,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Willst du die ausgewählte Seite entfernen?</translation>
     </message>
 </context>
@@ -3661,7 +3661,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Willst du die folgenden Elemente löschen?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_es_ES.ts
+++ b/qmlui/qlcplus_es_ES.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>¿Desea guardar primero el proyecto?
 Los cambios que no guarde se perderán.</translation>
@@ -331,7 +331,7 @@ Los cambios que no guarde se perderán.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>¿Está seguro que quiere eliminar los pasos seleccionados?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ Los cambios que no guarde se perderán.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>¿Está seguro que quiere eliminar las funciones seleccionadas?</translation>
     </message>
 </context>
@@ -2481,7 +2481,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Está seguro que quiere eliminar los siguientes elementos?</translation>
     </message>
     <message>
@@ -2949,7 +2949,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>¿Está seguro que quiere eliminar los elementos siguientes ?
 (Las funciones originales NO se eliminarán)</translation>
@@ -3624,7 +3624,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>¿Está seguro que quiere eliminar la página seleccionada ?</translation>
     </message>
 </context>
@@ -3652,7 +3652,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>¿Está seguro que quiere eliminar los widgets seleccionados?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_es_ES.ts
+++ b/qmlui/qlcplus_es_ES.ts
@@ -2951,7 +2951,7 @@ Nivel de acceso:</translation>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
         <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
-        <translation>¿Está seguro que quiere eliminar los elementos siguientes ?
+        <translation>¿Está seguro que quiere eliminar los elementos siguientes?
 (Las funciones originales NO se eliminarán)</translation>
     </message>
     <message>
@@ -3625,7 +3625,7 @@ Nivel de acceso:</translation>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
         <source>Are you sure you want to delete the selected page?</source>
-        <translation>¿Está seguro que quiere eliminar la página seleccionada ?</translation>
+        <translation>¿Está seguro que quiere eliminar la página seleccionada?</translation>
     </message>
 </context>
 <context>

--- a/qmlui/qlcplus_fr_FR.ts
+++ b/qmlui/qlcplus_fr_FR.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Souhaitez vous enregistrer le projet actuel&#xa0;?
 Les modifications seront perdues si vous ne les enregistrez pas.</translation>
@@ -331,7 +331,7 @@ Les modifications seront perdues si vous ne les enregistrez pas.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Êtes vous sûr de supprimer les étapes sélectionnées&#xa0;?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ Les modifications seront perdues si vous ne les enregistrez pas.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Êtes vous sûr de supprimer les fonctions sélectionnées&#xa0;?</translation>
     </message>
 </context>
@@ -2481,7 +2481,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Êtes vous sûr de supprimer les éléments suivants&#xa0;?</translation>
     </message>
     <message>
@@ -2949,7 +2949,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Êtes vous sûr de supprimer les éléments suivants&#xa0;?
 (Les fonctions originales ne seront pas supprimées)</translation>
@@ -3631,7 +3631,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Êtes vous sûrs de supprimer la page sélectionnée&#xa0;?</translation>
     </message>
 </context>
@@ -3659,7 +3659,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Êtes vous sûr de supprimer les widgets suivants&#xa0;?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_it_IT.ts
+++ b/qmlui/qlcplus_it_IT.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Vuoi salvare il progetto corrente ?
 I cambiamenti verranno perduti se non salvati.</translation>
@@ -331,7 +331,7 @@ I cambiamenti verranno perduti se non salvati.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Sei sicuro di voler rimuovere gli step selezionati ?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ I cambiamenti verranno perduti se non salvati.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Sei sicuro di voler rimuovere le funzioni selezionate ?</translation>
     </message>
 </context>
@@ -2482,7 +2482,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Sei sicuro di voler eliminare gli elementi seguenti ?</translation>
     </message>
     <message>
@@ -2950,7 +2950,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Sei sicuro di voler eliminare gli elementi seguenti ?
 (Le funzioni originali non verranno eliminate)</translation>
@@ -3625,7 +3625,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Sei sicuro di voler eliminare la pagina selezionata ?</translation>
     </message>
 </context>
@@ -3653,7 +3653,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Sei sicuro di voler eliminare i seguenti widget ?</translation>
     </message>
     <message>

--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -92,7 +92,7 @@ Popup
     {
         id: saveFirstPopup
         title: qsTr("Your project has changes")
-        message: qsTr("Do you wish to save the current project first ?\nChanges will be lost if you don't save them.")
+        message: qsTr("Do you wish to save the current project first?\nChanges will be lost if you don't save them.")
         standardButtons: Dialog.Yes | Dialog.No | Dialog.Cancel
 
         property string action: ""

--- a/qmlui/qml/fixturesfunctions/ChaserEditor.qml
+++ b/qmlui/qml/fixturesfunctions/ChaserEditor.qml
@@ -121,7 +121,7 @@ Rectangle
                     {
                         id: deleteItemsPopup
                         title: qsTr("Delete steps")
-                        message: qsTr("Are you sure you want to remove the selected steps ?")
+                        message: qsTr("Are you sure you want to remove the selected steps?")
                         onAccepted: functionManager.deleteEditorItems(chWidget.selector.itemsList())
                     }
                 }

--- a/qmlui/qml/fixturesfunctions/CollectionEditor.qml
+++ b/qmlui/qml/fixturesfunctions/CollectionEditor.qml
@@ -127,7 +127,7 @@ Rectangle
                     {
                         id: deleteItemsPopup
                         title: qsTr("Delete functions")
-                        message: qsTr("Are you sure you want to remove the selected functions ?")
+                        message: qsTr("Are you sure you want to remove the selected functions?")
                         onAccepted: functionManager.deleteEditorItems(ceSelector.itemsList())
                     }
                 }

--- a/qmlui/qml/fixturesfunctions/RightPanel.qml
+++ b/qmlui/qml/fixturesfunctions/RightPanel.qml
@@ -216,7 +216,7 @@ SidePanel
                 {
                     var selNames = functionManager.selectedItemNames()
                     //console.log(selNames)
-                    deleteItemsPopup.message = qsTr("Are you sure you want to delete the following items ?") + "\n" + selNames
+                    deleteItemsPopup.message = qsTr("Are you sure you want to delete the following items?") + "\n" + selNames
                     deleteItemsPopup.open()
                 }
 

--- a/qmlui/qml/virtualconsole/VCPageProperties.qml
+++ b/qmlui/qml/virtualconsole/VCPageProperties.qml
@@ -164,7 +164,7 @@ Rectangle
             {
                 id: deletePagePopup
                 title: qsTr("Delete page")
-                message: qsTr("Are you sure you want to delete the selected page ?")
+                message: qsTr("Are you sure you want to delete the selected page?")
                 onAccepted: virtualConsole.deletePage(virtualConsole.selectedPage)
             }
         }

--- a/qmlui/qml/virtualconsole/VCRightPanel.qml
+++ b/qmlui/qml/virtualconsole/VCRightPanel.qml
@@ -128,7 +128,7 @@ SidePanel
                 {
                     var selNames = virtualConsole.selectedWidgetNames()
                     //console.log(selNames)
-                    deleteWidgetsPopup.message = qsTr("Are you sure you want to remove the following widgets ?") + "\n" + selNames
+                    deleteWidgetsPopup.message = qsTr("Are you sure you want to remove the following widgets?") + "\n" + selNames
                     deleteWidgetsPopup.open()
                 }
 

--- a/qmlui/virtualconsole/vcbutton.cpp
+++ b/qmlui/virtualconsole/vcbutton.cpp
@@ -104,7 +104,7 @@ bool VCButton::copyFrom(const VCWidget* widget)
         return false;
 
     /* Copy button-specific stuff */
-    //setIconPath(button->iconPath()); // TODO ?
+    //setIconPath(button->iconPath()); // TODO?
     setFunctionID(button->functionID());
     setStartupIntensityEnabled(button->startupIntensityEnabled());
     setStartupIntensity(button->startupIntensity());

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -1094,7 +1094,7 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
             quint32 dmx_ch = fxi->address() + scv.channel;
             int uni = fxi->universe();
 
-            // Dirty channel group check: is the channel HTP or LTP ?
+            // Dirty channel group check: is the channel HTP or LTP?
             QLCChannel::Group group = qlcch->group();
             if (fxi->forcedLTPChannels().contains(scv.channel))
                 group = QLCChannel::Effect;

--- a/qmlui/virtualconsole/virtualconsole.cpp
+++ b/qmlui/virtualconsole/virtualconsole.cpp
@@ -440,7 +440,7 @@ quint32 VirtualConsole::newWidgetId()
 
 void VirtualConsole::addWidgetToMap(VCWidget* widget)
 {
-    // Valid ID ?
+    // Valid ID?
     if (widget->id() != VCWidget::invalidId())
     {
         // Maybe we don't know this widget yet
@@ -826,7 +826,7 @@ void VirtualConsole::pasteFromClipboard()
         }
     }
 
-    // no selected frame found ? Paste on current page
+    // no selected frame found? Paste on current page
     if (frame == NULL)
     {
         frame = qobject_cast<VCFrame*>(m_pages.at(selectedPage()));

--- a/resources/docs/html_en_EN/questionsandanswers.html
+++ b/resources/docs/html_en_EN/questionsandanswers.html
@@ -37,7 +37,7 @@ Here you can either find the answer directly or find help to point you in the ri
   <TD><SPAN>2</SPAN></TD>
   <TD><SPAN id="solo-frame">Q:</SPAN></TD>
   <TD>I've got several <A HREF="file:vcbutton.html">buttons</A> in my Virtual Console. I need a way to disable the currently
-      active button when I enable another one. How do I do that ?
+      active button when I enable another one. How do I do that?
   </TD>
  </TR>
  <TR>
@@ -74,7 +74,7 @@ Here you can either find the answer directly or find help to point you in the ri
  <TR>
   <TD><SPAN>4</SPAN></TD>
   <TD><SPAN id="user-folder">Q:</SPAN></TD>
-  <TD>Where is the QLC+ user folder located in my system ?</TD>
+  <TD>Where is the QLC+ user folder located in my system?</TD>
  </TR>
  <TR>
   <TD></TD>
@@ -96,7 +96,7 @@ Here you can either find the answer directly or find help to point you in the ri
  <TR>
   <TD><SPAN>5</SPAN></TD>
   <TD><SPAN id="system-folder">Q:</SPAN></TD>
-  <TD>Where is the QLC+ system folder located in my system ?</TD>
+  <TD>Where is the QLC+ system folder located in my system?</TD>
  </TR>
  <TR>
   <TD></TD>

--- a/resources/docs/html_en_EN/questionsandanswers.html
+++ b/resources/docs/html_en_EN/questionsandanswers.html
@@ -26,7 +26,7 @@ Here you can either find the answer directly or find help to point you in the ri
       If you are using Windows and your device is manufactured by Peperoni or Velleman, please read the information on how to get
       them working on these help pages. For licensing issues they both need an extra DLL file to work.
       Please check <A HREF="file:peperonioutput.html">Peperoni output plugin</A> or <A HREF="file:vellemanoutput.html">Velleman output plugin</A><BR>
-      If you're using Linux, please check if your distribution detected the device when plugged in. Basically, the 
+      If you're using Linux, please check if your distribution detected the device when plugged in. Basically, the
       "<CODE>dmesg</CODE>" command should tell you something.
   </TD>
  </TR>
@@ -62,7 +62,7 @@ Here you can either find the answer directly or find help to point you in the ri
       Otherwise, you can download the <A HREF="http://www.dmxis.com/release/FtdiDriverControl.zip">ENTTEC FTDI Driver Control tool</A>
       and try to enable/disable the Apple driver with it.<BR><BR>
 
-      <B>Note 1: this can compromise the behaviour of other USB devices, so do it only 
+      <B>Note 1: this can compromise the behaviour of other USB devices, so do it only
       if you know what you're doing! </B><br>
       <B>Note 2: every time Mac OS receives an update, you need to perform this procedure again !</B><br>
       <B>Note 3: Most likely, when you disable/enable the Apple driver, you need to reboot your Mac</B>
@@ -89,7 +89,7 @@ Here you can either find the answer directly or find help to point you in the ri
       Please keep in mind that fixures and input profiles found in the user folder will have precedence
       over the same files in the QLC+ system folder.<br>
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 <BR>
 <TABLE BORDER=1 class="qlcTable">
@@ -101,16 +101,16 @@ Here you can either find the answer directly or find help to point you in the ri
  <TR>
   <TD></TD>
   <TD><SPAN>A:</SPAN></TD>
-  <TD>The system folder is where QLC+ resources (fixtures, input profiles, RGB scripts, etc) are installed 
+  <TD>The system folder is where QLC+ resources (fixtures, input profiles, RGB scripts, etc) are installed
       and it changes depending on your operating system:<br>
       <B>Linux</B>: it's a fixed folder named /usr/share/qlcplus<br>
       <B>Windows</B>: it is the folder where you actually installed QLC+. By default: C:\QLC+<br>
-      <B>Mac OS</B>: it is a folder inside the QLC+ bundle (.app file). It is possible to browse the QLC+.app bundle contents simply with Finder. 
+      <B>Mac OS</B>: it is a folder inside the QLC+ bundle (.app file). It is possible to browse the QLC+.app bundle contents simply with Finder.
       Just right click on the file and select "Show Package Contents".<br>
       Otherwise, the system folder can be reached with a terminal but it depends on where you installed QLC+.<br>
       For example if you dragged QLC+ into Applications it will be: /Applications/QLC+.app/Contents/Resources
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 <BR>
 <TABLE BORDER=1 class="qlcTable">
@@ -126,7 +126,7 @@ Here you can either find the answer directly or find help to point you in the ri
       Unfortunately the basic codecs supported by Windows are quite poor, so you need to install some extra
       codecs package like K-Lite, <A HREF="http://www.codecguide.com/download_kl.htm">available here</A>.
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 <BR>
 <TABLE BORDER=1 class="qlcTable">
@@ -145,7 +145,7 @@ Here you can either find the answer directly or find help to point you in the ri
       <PRE><b>Mac OS (from terminal)</b>: QT_AUTO_SCREEN_SCALE_FACTOR=1 QLC+.app\Contents\MacOS\qlcplus</PRE>
       In case, see the <A HREF="file:commandlineparameters.html">command line parameters page</a> for further information.
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 </BODY>
 </HTML>

--- a/ui/src/addchannelsgroup.cpp
+++ b/ui/src/addchannelsgroup.cpp
@@ -73,7 +73,7 @@ AddChannelsGroup::AddChannelsGroup(QWidget* parent, Doc* doc, ChannelsGroup *gro
                 break;
             }
         }
-        // Haven't found this universe node ? Create it.
+        // Haven't found this universe node? Create it.
         if (topItem == NULL)
         {
             topItem = new QTreeWidgetItem(m_tree);

--- a/ui/src/channelsselection.cpp
+++ b/ui/src/channelsselection.cpp
@@ -114,7 +114,7 @@ void ChannelsSelection::updateFixturesTree()
                 break;
             }
         }
-        // Haven't found this universe node ? Create it.
+        // Haven't found this universe node? Create it.
         if (topItem == NULL)
         {
             topItem = new QTreeWidgetItem(m_channelsTree);

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -776,7 +776,7 @@ void ChaserEditor::slotPasteClicked()
         ChaserStep step(it.next());
         if (step.resolveFunction(m_doc) == NULL) // Function has been removed
         {
-            qWarning() << Q_FUNC_INFO << "Trying to paste an invalid function (removed function ?)";
+            qWarning() << Q_FUNC_INFO << "Trying to paste an invalid function (removed function?)";
             continue;
         }
         updateItem(item, step);

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -531,7 +531,7 @@ void ChaserEditor::slotShuffleClicked()
 
     QList <QTreeWidgetItem*> selectedItems(m_tree->selectedItems());
     int indicesToShuffle[selectedCount];
-    
+
     // save the selected scenes and their indices into a sorted array
     QListIterator <QTreeWidgetItem*> it(selectedItems);
     for (i = 0; i < selectedCount; i++)

--- a/ui/src/ctkrangeslider.cpp
+++ b/ui/src/ctkrangeslider.cpp
@@ -71,7 +71,7 @@ public:
   int m_MaximumPosition;
   int m_MinimumPosition;
 
-  /// Controls selected ?
+  /// Controls selected?
   QStyle::SubControl m_MinimumSliderSelected;
   QStyle::SubControl m_MaximumSliderSelected;
 

--- a/ui/src/ctkrangeslider.cpp
+++ b/ui/src/ctkrangeslider.cpp
@@ -62,7 +62,7 @@ public:
   /// Draw the bottom and top sliders.
   void drawMinimumSlider( QStylePainter* painter ) const;
   void drawMaximumSlider( QStylePainter* painter ) const;
-    
+
   /// End points of the range on the Model
   int m_MaximumValue;
   int m_MinimumValue;
@@ -75,14 +75,14 @@ public:
   QStyle::SubControl m_MinimumSliderSelected;
   QStyle::SubControl m_MaximumSliderSelected;
 
-  /// See QSliderPrivate::clickOffset. 
+  /// See QSliderPrivate::clickOffset.
   /// Overrides this ivar
   int m_SubclassClickOffset;
-    
+
   /// See QSliderPrivate::position
   /// Overrides this ivar.
   int m_SubclassPosition;
-  
+
   /// Original width between the 2 bounds before any moves
   int m_SubclassWidth;
 
@@ -137,7 +137,7 @@ ctkRangeSliderPrivate::Handle ctkRangeSliderPrivate::handleAtPos(const QPoint& p
   // The functinos hitTestComplexControl only know about 1 handle. As we have
   // 2, we change the position of the handle and test if the pos correspond to
   // any of the 2 positions.
-  
+
   // Test the MinimumHandle
   option.sliderPosition = this->m_MinimumPosition;
   option.sliderValue    = this->m_MinimumValue;
@@ -147,7 +147,7 @@ ctkRangeSliderPrivate::Handle ctkRangeSliderPrivate::handleAtPos(const QPoint& p
   QRect minimumHandleRect = q->style()->subControlRect(
       QStyle::CC_Slider, &option, QStyle::SC_SliderHandle, q);
 
-  // Test if the pos is under the Maximum handle 
+  // Test if the pos is under the Maximum handle
   option.sliderPosition = this->m_MaximumPosition;
   option.sliderValue    = this->m_MaximumValue;
 
@@ -165,12 +165,12 @@ ctkRangeSliderPrivate::Handle ctkRangeSliderPrivate::handleAtPos(const QPoint& p
     if (q->orientation() == Qt::Horizontal)
       {
       minDist = pos.x() - minimumHandleRect.left();
-      maxDist = maximumHandleRect.right() - pos.x(); 
+      maxDist = maximumHandleRect.right() - pos.x();
       }
     else //if (q->orientation() == Qt::Vertical)
       {
       minDist = minimumHandleRect.bottom() - pos.y();
-      maxDist = pos.y() - maximumHandleRect.top(); 
+      maxDist = pos.y() - maximumHandleRect.top();
       }
     Q_ASSERT( minDist >= 0 && maxDist >= 0);
     minimumControl = minDist < maxDist ? minimumControl : QStyle::SC_None;
@@ -199,16 +199,16 @@ int ctkRangeSliderPrivate::pixelPosToRangeValue( int pos ) const
   QStyleOptionSlider option;
   q->initStyleOption( &option );
 
-  QRect gr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderGroove, 
+  QRect gr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderGroove,
                                             q );
-  QRect sr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  QRect sr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             q );
   int sliderMin, sliderMax, sliderLength;
-  if (option.orientation == Qt::Horizontal) 
+  if (option.orientation == Qt::Horizontal)
     {
     sliderLength = sr.width();
     sliderMin = gr.x();
@@ -221,10 +221,10 @@ int ctkRangeSliderPrivate::pixelPosToRangeValue( int pos ) const
     sliderMax = gr.bottom() - sliderLength + 1;
     }
 
-  return QStyle::sliderValueFromPosition( q->minimum(), 
-                                          q->maximum(), 
+  return QStyle::sliderValueFromPosition( q->minimum(),
+                                          q->maximum(),
                                           pos - sliderMin,
-                                          sliderMax - sliderMin, 
+                                          sliderMax - sliderMin,
                                           option.upsideDown );
 }
 
@@ -235,16 +235,16 @@ int ctkRangeSliderPrivate::pixelPosFromRangeValue( int val ) const
   QStyleOptionSlider option;
   q->initStyleOption( &option );
 
-  QRect gr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderGroove, 
+  QRect gr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderGroove,
                                             q );
-  QRect sr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  QRect sr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             q );
   int sliderMin, sliderMax, sliderLength;
-  if (option.orientation == Qt::Horizontal) 
+  if (option.orientation == Qt::Horizontal)
     {
     sliderLength = sr.width();
     sliderMin = gr.x();
@@ -257,10 +257,10 @@ int ctkRangeSliderPrivate::pixelPosFromRangeValue( int val ) const
     sliderMax = gr.bottom() - sliderLength + 1;
     }
 
-  return QStyle::sliderPositionFromValue( q->minimum(), 
-                                          q->maximum(), 
+  return QStyle::sliderPositionFromValue( q->minimum(),
+                                          q->maximum(),
                                           val,
-                                          sliderMax - sliderMin, 
+                                          sliderMax - sliderMin,
                                           option.upsideDown ) + sliderMin;
 }
 
@@ -389,23 +389,23 @@ void ctkRangeSlider::setMaximumValue( int max )
 void ctkRangeSlider::setValues(int l, int u)
 {
   Q_D(ctkRangeSlider);
-  const int minValue = 
+  const int minValue =
     qBound(this->minimum(), qMin(l,u), this->maximum());
-  const int maxValue = 
+  const int maxValue =
     qBound(this->minimum(), qMax(l,u), this->maximum());
   bool emitMinValChanged = (minValue != d->m_MinimumValue);
   bool emitMaxValChanged = (maxValue != d->m_MaximumValue);
-  
+
   d->m_MinimumValue = minValue;
   d->m_MaximumValue = maxValue;
-  
-  bool emitMinPosChanged = 
+
+  bool emitMinPosChanged =
     (minValue != d->m_MinimumPosition);
-  bool emitMaxPosChanged = 
+  bool emitMaxPosChanged =
     (maxValue != d->m_MaximumPosition);
   d->m_MinimumPosition = minValue;
   d->m_MaximumPosition = maxValue;
-  
+
   if (isSliderDown())
     {
     if (emitMinPosChanged || emitMaxPosChanged)
@@ -423,7 +423,7 @@ void ctkRangeSlider::setValues(int l, int u)
     }
   if (emitMinValChanged || emitMaxValChanged)
     {
-    emit valuesChanged(d->m_MinimumValue, 
+    emit valuesChanged(d->m_MinimumValue,
                        d->m_MaximumValue);
     }
   if (emitMinValChanged)
@@ -434,7 +434,7 @@ void ctkRangeSlider::setValues(int l, int u)
     {
     emit maximumValueChanged(d->m_MaximumValue);
     }
-  if (emitMinPosChanged || emitMaxPosChanged || 
+  if (emitMinPosChanged || emitMaxPosChanged ||
       emitMinValChanged || emitMaxValChanged)
     {
     this->update();
@@ -473,14 +473,14 @@ void ctkRangeSlider::setMaximumPosition(int u)
 void ctkRangeSlider::setPositions(int min, int max)
 {
   Q_D(ctkRangeSlider);
-  const int minPosition = 
+  const int minPosition =
     qBound(this->minimum(), qMin(min, max), this->maximum());
-  const int maxPosition = 
+  const int maxPosition =
     qBound(this->minimum(), qMax(min, max), this->maximum());
 
   bool emitMinPosChanged = (minPosition != d->m_MinimumPosition);
   bool emitMaxPosChanged = (maxPosition != d->m_MaximumPosition);
-  
+
   if (!emitMinPosChanged && !emitMaxPosChanged)
     {
     return;
@@ -556,20 +556,20 @@ void ctkRangeSlider::paintEvent( QPaintEvent* )
   painter.drawComplexControl(QStyle::CC_Slider, option);
 
   option.sliderPosition = d->m_MinimumPosition;
-  const QRect lr = style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  const QRect lr = style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             this);
   option.sliderPosition = d->m_MaximumPosition;
 
-  const QRect ur = style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  const QRect ur = style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             this);
 
-  QRect sr = style()->subControlRect( QStyle::CC_Slider, 
-                                      &option, 
-                                      QStyle::SC_SliderGroove, 
+  QRect sr = style()->subControlRect( QStyle::CC_Slider,
+                                      &option,
+                                      QStyle::SC_SliderGroove,
                                       this);
   QRect rangeBox;
   if (option.orientation == Qt::Horizontal)
@@ -588,9 +588,9 @@ void ctkRangeSlider::paintEvent( QPaintEvent* )
   // -----------------------------
   // Render the range
   //
-  QRect groove = this->style()->subControlRect( QStyle::CC_Slider, 
-                                                &option, 
-                                                QStyle::SC_SliderGroove, 
+  QRect groove = this->style()->subControlRect( QStyle::CC_Slider,
+                                                &option,
+                                                QStyle::SC_SliderGroove,
                                                 this );
   groove.adjust(0, 0, -1, 0);
 
@@ -677,7 +677,7 @@ void ctkRangeSlider::mousePressEvent(QMouseEvent* mouseEvent)
 
   // if we are here, no handles have been pressed
   // Check if we pressed on the groove between the 2 handles
-  
+
   QStyle::SubControl control = this->style()->hitTestComplexControl(
     QStyle::CC_Slider, &option, mouseEvent->pos(), this);
   QRect sr = style()->subControlRect(
@@ -697,8 +697,8 @@ void ctkRangeSlider::mousePressEvent(QMouseEvent* mouseEvent)
     this->setSliderDown(true);
     if (!this->isMinimumSliderDown() || !this->isMaximumSliderDown())
       {
-      d->m_SelectedHandles = 
-        QFlags<ctkRangeSliderPrivate::Handle>(ctkRangeSliderPrivate::MinimumHandle) | 
+      d->m_SelectedHandles =
+        QFlags<ctkRangeSliderPrivate::Handle>(ctkRangeSliderPrivate::MinimumHandle) |
         QFlags<ctkRangeSliderPrivate::Handle>(ctkRangeSliderPrivate::MaximumHandle);
       this->update(handleRect.united(sr));
       }

--- a/ui/src/fixturemanager.cpp
+++ b/ui/src/fixturemanager.cpp
@@ -1258,13 +1258,13 @@ void FixtureManager::removeFixture()
         QTreeWidgetItem* item(it.next());
         Q_ASSERT(item != NULL);
 
-        // Is the item a fixture ?
+        // Is the item a fixture?
         QVariant var = item->data(KColumnName, PROP_ID);
         if (var.isValid() == true)
             fixturesToDelete << var.toUInt();
         else
         {
-            // Is the item a fixture group ?
+            // Is the item a fixture group?
             var = item->data(KColumnName, PROP_GROUP);
             if (var.isValid() == true)
                 groupsToDelete << var.toUInt();

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -154,7 +154,7 @@ QTreeWidgetItem *FixtureRemap::getUniverseItem(Doc *doc, quint32 universe, QTree
         }
     }
 
-    // Haven't found this universe node ? Create it.
+    // Haven't found this universe node? Create it.
     if (topItem == NULL)
     {
         topItem = new QTreeWidgetItem(tree);
@@ -327,13 +327,13 @@ void FixtureRemap::slotRemoveTargetFixture()
 void FixtureRemap::slotCloneSourceFixture()
 {
     if (m_sourceTree->selectedItems().count() == 0)
-        return; // popup here ??
+        return; // popup here??
 
     QTreeWidgetItem *sItem = m_sourceTree->selectedItems().first();
     quint32 fxID = sItem->text(KColumnID).toUInt();
     Fixture *srcFix = m_doc->fixture(fxID);
     if (srcFix == NULL)
-        return; // popup here ?
+        return; // popup here?
 
     quint32 srcAddr = srcFix->universeAddress();
     for (quint32 i = srcAddr; i < srcAddr + srcFix->channels(); i++)

--- a/ui/src/fixturetreewidget.cpp
+++ b/ui/src/fixturetreewidget.cpp
@@ -350,7 +350,7 @@ void FixtureTreeWidget::updateSelections()
 
         qDebug() << "uni ID:" << uniIDVar;
 
-        // Case 1: is there a valid fixture ID ?
+        // Case 1: is there a valid fixture ID?
         if (fxIDVar.isValid())
         {
             quint32 fxi = fxIDVar.toUInt();
@@ -375,7 +375,7 @@ void FixtureTreeWidget::updateSelections()
                 }
             }
         }
-        // Case 2: is there a valid group ID ?
+        // Case 2: is there a valid group ID?
         else if (grpIDVar.isValid())
         {
             // in this case cycle through the children and get each
@@ -388,7 +388,7 @@ void FixtureTreeWidget::updateSelections()
                     m_selectedFixtures << chFxIDVar.toUInt();
             }
         }
-        // Case 3: is there a valid head index ?
+        // Case 3: is there a valid head index?
         else if (headVar.isValid())
         {
             Q_ASSERT(item->parent() != NULL);
@@ -397,7 +397,7 @@ void FixtureTreeWidget::updateSelections()
             if (m_selectedHeads.contains(gh) == false)
                 m_selectedHeads << gh;
         }
-        // Case 4: is there a valid universe index ?
+        // Case 4: is there a valid universe index?
         else if (uniIDVar.isValid())
         {
             qDebug() << "Valid universe....";
@@ -455,7 +455,7 @@ void FixtureTreeWidget::updateTree()
                 }
             }
         }
-        // Haven't found this universe node ? Create it.
+        // Haven't found this universe node? Create it.
         if (topItem == NULL)
         {
             topItem = new QTreeWidgetItem(this);

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -70,7 +70,7 @@ InputOutputManager::InputOutputManager(QWidget* parent, Doc* doc)
     s_instance = this;
 
     Q_ASSERT(doc != NULL);
-    
+
     m_ioMap = doc->inputOutputMap();
 
     /* Create a new layout for this widget */

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -359,7 +359,7 @@ void InputOutputManager::slotDeleteUniverse()
         // Ask for user's confirmation
         if (QMessageBox::question(
                     this, tr("Delete Universe"),
-                    tr("The universe you are trying to delete is patched. Are you sure you want to delete it ?"),
+                    tr("The universe you are trying to delete is patched. Are you sure you want to delete it?"),
                     QMessageBox::Yes, QMessageBox::No) == QMessageBox::No)
         {
             return;
@@ -378,7 +378,7 @@ void InputOutputManager::slotDeleteUniverse()
             // Ask for user's confirmation
             if (QMessageBox::question(
                         this, tr("Delete Universe"),
-                        tr("There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?"),
+                        tr("There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?"),
                         QMessageBox::Yes, QMessageBox::No) == QMessageBox::No)
             {
                 return;

--- a/ui/src/qlcplus_ca_ES.ts
+++ b/ui/src/qlcplus_ca_ES.ts
@@ -3227,12 +3227,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>L&apos;univers que està intentant esborrar està assignat. Estau segur de voler esborrar-lo?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Alguns fixtures estan emprant l&apos;univers que està intentant esborrar. Està segur de voler-lo esborrar?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_cz_CZ.ts
+++ b/ui/src/qlcplus_cz_CZ.ts
@@ -567,17 +567,17 @@
     <message>
         <location filename="app.cpp" line="379"/>
         <source>Do you wish to save the current workspace before closing the application?</source>
-        <translation>Přejete si uložit rozdělanou práci před ukončením aplikace ?</translation>
+        <translation>Přejete si uložit rozdělanou práci před ukončením aplikace?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="393"/>
         <source>Close the application?</source>
-        <translation>Zavřít aplikaci ?</translation>
+        <translation>Zavřít aplikaci?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="394"/>
         <source>Do you wish to close the application?</source>
-        <translation>Opravdu si přejete uzavřít aplikaci ?</translation>
+        <translation>Opravdu si přejete uzavřít aplikaci?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="436"/>
@@ -3232,12 +3232,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>Vetvev, kterou se snažíte smazat je propojená. Opravdu si ji přejete smazat ?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Některá zařízení používají větev, kterou se pokoušíte smazat. Opravdu ji chcete smazat ?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -3240,12 +3240,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>Das Universum, welchs gelöscht werden soll ist gepatched, soll es wirklich gelöscht werden?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Das Universum, welches gelöscht werden soll wird von einigen Geräten verwendet, soll es wirklich gelöscht werden?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_es_ES.ts
+++ b/ui/src/qlcplus_es_ES.ts
@@ -3241,12 +3241,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>El universo que está tratando de borrar está patcheado. ¿Está seguro de querer borrarlo?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Algunos fixtures están usando el universo que está tratando de borrar. ¿Está seguro de querer borrarlo?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_fi_FI.ts
+++ b/ui/src/qlcplus_fi_FI.ts
@@ -3214,12 +3214,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/src/qlcplus_fr_FR.ts
+++ b/ui/src/qlcplus_fr_FR.ts
@@ -537,7 +537,7 @@
     <message>
         <location filename="app.cpp" line="379"/>
         <source>Do you wish to save the current workspace before closing the application?</source>
-        <translation>Voulez-vous enregistrer le projet en cours avant de quitter l&apos;application ?</translation>
+        <translation>Voulez-vous enregistrer le projet en cours avant de quitter l&apos;application&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="436"/>
@@ -560,7 +560,7 @@
         <source>There are still running functions.
 Really stop them and switch back to Design mode?</source>
         <translation>Des fonctions sont encore en cours d&apos;exécution.
-Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translation>
+Voulez-vous vraiment les arrêter et basculer vers le mode Création&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="624"/>
@@ -714,12 +714,12 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translat
     <message>
         <location filename="app.cpp" line="393"/>
         <source>Close the application?</source>
-        <translation>Quitter QLCPlus ?</translation>
+        <translation>Quitter QLCPlus&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="394"/>
         <source>Do you wish to close the application?</source>
-        <translation>Voulez-vous quitter l&apos;application ?</translation>
+        <translation>Voulez-vous quitter l&apos;application&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="571"/>
@@ -835,7 +835,7 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translat
         <source>Do you wish to save the current workspace?
 Changes will be lost if you don&apos;t save them.</source>
         <translatorcomment>Tiens tiens...perspicace!</translatorcomment>
-        <translation>Voulez-vous enregistrer le projet actuel ?
+        <translation>Voulez-vous enregistrer le projet actuel&#xa0;?
 Les changements seront perdus si vous ne les sauvegardez pas.</translation>
     </message>
     <message>
@@ -2107,7 +2107,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="efxeditor.cpp" line="740"/>
         <source>Do you want to remove the selected fixture(s)?</source>
-        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s) ?</translation>
+        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s)&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -2285,7 +2285,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1244"/>
         <source>Do you want to delete the selected items?</source>
-        <translation>Voulez-vous supprimer les éléments sélectionnés ?</translation>
+        <translation>Voulez-vous supprimer les éléments sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1299"/>
@@ -2324,12 +2324,12 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1495"/>
         <source>Ungroup fixtures?</source>
-        <translation>Dégrouper les appareils ?</translation>
+        <translation>Dégrouper les appareils&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1496"/>
         <source>Do you want to ungroup the selected fixtures?</source>
-        <translation>Voulez-vous dégrouper les appareils sélectionnés ?</translation>
+        <translation>Voulez-vous dégrouper les appareils sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1611"/>
@@ -2377,7 +2377,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1300"/>
         <source>Do you want to delete the selected groups?</source>
-        <translation>Voulez-vous supprimer les groupes sélectionnés ?</translation>
+        <translation>Voulez-vous supprimer les groupes sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1360"/>
@@ -2462,7 +2462,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixtureremap.cpp" line="297"/>
         <source>Do you want to delete the selected items?</source>
-        <translation>Voulez-vous supprimer l&apos;élément cible sélectionné ?</translation>
+        <translation>Voulez-vous supprimer l&apos;élément cible sélectionné&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureremap.cpp" line="345"/>
@@ -3247,12 +3247,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
         <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
-        <translation>Cet univers est actuellement patché. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
+        <translation>Cet univers est actuellement patché. Êtes-vous sûr(e) de vouloir le supprimer&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
         <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
-        <translation>Des appareils utilisent actuellement cet univers. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
+        <translation>Des appareils utilisent actuellement cet univers. Êtes-vous sûr(e) de vouloir le supprimer&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -3388,7 +3388,7 @@ Veuillez vous référer à la documentation du plugin.</translation>
         <location filename="inputoutputpatcheditor.cpp" line="703"/>
         <location filename="inputoutputpatcheditor.cpp" line="837"/>
         <source>An input profile at %1 already exists. Do you wish to overwrite it?</source>
-        <translation>Un profil d&apos;entrée existe déjà en &apos;%1&apos;. Voulez-vous l&apos;écraser ?</translation>
+        <translation>Un profil d&apos;entrée existe déjà en &apos;%1&apos;. Voulez-vous l&apos;écraser&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="712"/>
@@ -3421,7 +3421,7 @@ Veuillez vous référer à la documentation du plugin.</translation>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="765"/>
         <source>Do you wish to permanently delete profile &quot;%1&quot;?</source>
-        <translation>Voulez-vous supprimer définitivement le profil &quot;%1&quot; ?</translation>
+        <translation>Voulez-vous supprimer définitivement le profil &quot;%1&quot;&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="793"/>
@@ -3613,7 +3613,7 @@ Veuillez vous référer à la documentation du plugin.</translation>
     <message>
         <location filename="inputprofileeditor.cpp" line="334"/>
         <source>Delete all %1 selected channels?</source>
-        <translation>Supprimer les %1 canaux sélectionnés ?</translation>
+        <translation>Supprimer les %1 canaux sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputprofileeditor.cpp" line="451"/>
@@ -4641,7 +4641,7 @@ Notez que l&apos;assistant ne peut pas différencier un bouton rotatif d&apos;un
     <message>
         <location filename="sceneeditor.cpp" line="1288"/>
         <source>Do you want to remove the selected fixture(s)?</source>
-        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s) ?</translation>
+        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s)&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -7400,7 +7400,7 @@ Durée : %3
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="365"/>
         <source>Do you want to remove the selected fixtures?</source>
-        <translation>Voulez-vous enlever le(s) appareils(s) sélectionné(s) ?</translation>
+        <translation>Voulez-vous enlever le(s) appareils(s) sélectionné(s)&#xa0;?</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="718"/>
@@ -7771,7 +7771,7 @@ Veuillez en choisir une qui affecte un des deux.</translation>
     <message>
         <location filename="virtualconsole/virtualconsole.cpp" line="1162"/>
         <source>Do you wish to delete the selected widgets?</source>
-        <translation>Voulez-vous supprimer les widgets sélectionnés ?</translation>
+        <translation>Voulez-vous supprimer les widgets sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="virtualconsole/virtualconsole.cpp" line="1163"/>

--- a/ui/src/qlcplus_fr_FR.ts
+++ b/ui/src/qlcplus_fr_FR.ts
@@ -3246,12 +3246,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>Cet univers est actuellement patché. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Des appareils utilisent actuellement cet univers. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_it_IT.ts
+++ b/ui/src/qlcplus_it_IT.ts
@@ -3240,12 +3240,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>L&apos;universo che stai per eliminare è connesso. Sei sicuro di volerlo eliminare ?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Ci sono delle fixture che usano l&apos;universo che vuoi eliminare. Sei sicuro di volerlo eliminare ?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_ja_JP.ts
+++ b/ui/src/qlcplus_ja_JP.ts
@@ -3241,12 +3241,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>この Universe は接続されています。本当に削除しますか？</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>この Universe には使用中の機器があります。本当に削除しますか？</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_nl_NL.ts
+++ b/ui/src/qlcplus_nl_NL.ts
@@ -3230,12 +3230,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>De universe die u probeert te verwijderen is gepatched. Weet u zeker dat u deze wilt verwijderen?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Er zijn fixtures die gebruik maken van de universe die u wilt verwijderen. Weet u zeker dat u deze wilt verwijderen?</translation>
     </message>
 </context>

--- a/ui/src/qlcplus_pt_BR.ts
+++ b/ui/src/qlcplus_pt_BR.ts
@@ -3242,12 +3242,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>O universo que está a tentar apagar tem patch efectuado. Tem a certeza que deseja apagá-lo?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Existem alguns fixtures a usar o universo que está a tentar apagar. Tem a certeza que deseja apagá-lo?</translation>
     </message>
 </context>

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -149,7 +149,7 @@ ShowManager::ShowManager(QWidget* parent, Doc* doc)
     container->setLayout(new QVBoxLayout);
     container->layout()->setContentsMargins(0, 0, 0, 0);
     m_splitter->widget(1)->hide();
-    
+
     connect(m_doc, SIGNAL(clearing()), this, SLOT(slotDocClearing()));
     connect(m_doc, SIGNAL(functionRemoved(quint32)), this, SLOT(slotFunctionRemoved(quint32)));
     connect(m_doc, SIGNAL(loaded()), this, SLOT(slotDocLoaded()));

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -658,7 +658,7 @@ void ShowManager::slotAddItem()
         else
         {
             Function *selectedFunc = m_doc->function(selectedID);
-            if (selectedFunc == NULL) // maybe a popup here ?
+            if (selectedFunc == NULL) // maybe a popup here?
                 return;
 
             /** 2) an existing scene */
@@ -775,7 +775,7 @@ void ShowManager::slotAddItem()
         if (selectedID != Function::invalidId())
         {
             Function *selectedFunc = m_doc->function(selectedID);
-            if (selectedFunc == NULL) // maybe a popup here ?
+            if (selectedFunc == NULL) // maybe a popup here?
                 return;
 
             /** 2) create a 10 seconds Sequence on the current track */

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -1106,7 +1106,7 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
             quint32 dmx_ch = fxi->address() + lch.channel;
             int uni = fxi->universe();
 
-            // Dirty channel group check: is the channel HTP or LTP ?
+            // Dirty channel group check: is the channel HTP or LTP?
             QLCChannel::Group group = qlcch->group();
             if (fxi->forcedLTPChannels().contains(lch.channel))
                 group = QLCChannel::Effect;

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1533,7 +1533,7 @@ void VirtualConsole::resetContents()
 
 void VirtualConsole::addWidgetInMap(VCWidget* widget)
 {
-    // Valid ID ?
+    // Valid ID?
     if (widget->id() != VCWidget::invalidId())
     {
         // Maybe we don't know this widget yet

--- a/unittest.sh
+++ b/unittest.sh
@@ -34,7 +34,7 @@ else
       HAS_XSERVER="1"
     fi
 
-    # no X server ? Let's look for xvfb. This is how Travis is setup
+    # no X server? Let's look for xvfb. This is how Travis is setup
     if [ -n "$TRAVIS" ]; then
         HAS_XSERVER="1"
     fi

--- a/unittest.sh
+++ b/unittest.sh
@@ -20,7 +20,7 @@ if [ "$CURRUSER" == "buildbot" ] || [ "$CURRUSER" == "abuild" ]; then
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "We're on OSX. Any prefix needed ?"
+    echo "We're on OSX. Any prefix needed?"
   fi
 
 else

--- a/webaccess/src/qhttpserver/qhttpconnection.cpp
+++ b/webaccess/src/qhttpserver/qhttpconnection.cpp
@@ -430,7 +430,7 @@ void QHttpConnection::webSocketRead(QByteArray data)
         }
         else if (dataLen == 127)
         {
-            // TODO: 64bit length...really ?
+            // TODO: 64bit length...really?
             dataPos+=8;
         }
 


### PR DESCRIPTION
Putting a space before question marks is a mistake in English ([source](https://english.stackexchange.com/q/4645)), as it is in German.

In French, however, they are required, so I replaced them with a non-breaking space (`&#xa0;`) like @nils-van-zuijlen did in the French QLC+ 5 translation.

In Spanish, I assumed that it's always *¿Lorem ipsum dolor?* (without spaces), but I'm not sure.

I don't know about all other translations. If someone else knows though, here is the list of files still containing ` ?`:

* `fixtureeditor/fixtureeditor_ca_ES.ts`
* `fixtureeditor/fixtureeditor_cz_CZ.ts`
* `fixtureeditor/fixtureeditor_it_IT.ts`
* `fixtureeditor/fixtureeditor_nl_NL.ts`
* `fixtureeditor/fixtureeditor_pt_BR.ts`
* `plugins/udmx/src/uDMX_cz_CZ.ts`
* `qmlui/qlcplus_it_IT.ts`
* `ui/src/qlcplus_ca_ES.ts`
* `ui/src/qlcplus_cz_CZ.ts`
* `ui/src/qlcplus_it_IT.ts`