### PR TITLE
Remove spaces before punctuation

### DIFF
--- a/debian/changelog-old
+++ b/debian/changelog-old
@@ -783,7 +783,7 @@ qlcplus (4.3.0) stable; urgency=low
 
 qlcplus (4.2.2) stable; urgency=low
 
-  * Rewritten OSX audio renderer code. Tested on various OSX versions and should finally work fine !
+  * Rewritten OSX audio renderer code. Tested on various OSX versions and should finally work fine!
   * Fixed crash when ArtNet plugin is in output mode and receives DMX data
   * Fixed crash when changing ArtNet configuration
   * Fixed ArtNet plugin output on OSX (big thanks to David Geldreich)

--- a/debian/changelog-old
+++ b/debian/changelog-old
@@ -132,7 +132,7 @@ qlcplus (4.8.5) stable; urgency=low
   * New fixture: Kam KMH Series (thanks to Scott McKinney)
   * New fixtures: American DJ UVLed Bar 16 and 20, Dune Lighting Fireworks Pro-II, Chauvet Scorpion Storm FX RGB (thanks to Frédéric Combe)
   * New fixtures: JB-Systems COB-Plano, American DJ UV COB Cannon (thanks to Frédéric Combe)
-  * New Fixtures: Showtec LED Light Bar 8 (thanks to Adrian Kapka), Futurelight Genesis 575 (thanks to Dag Stenstad) 
+  * New Fixtures: Showtec LED Light Bar 8 (thanks to Adrian Kapka), Futurelight Genesis 575 (thanks to Dag Stenstad)
   * New fixture: Showtec XB-Wave (thanks to webdb22)
 
  -- Massimo Callegari <massimocallegari@yahoo.it>  Sun, 12 Apr 2015 20:21:22 +0200
@@ -147,7 +147,7 @@ qlcplus (4.8.4) stable; urgency=low
   * Monitor: save both DMX view and 2D view settings (only current mode settings were saved, Jano Svitok)
   * RGB Scripts: added new Plasma script and added 'radial' orientation to Gradient (thanks to Tim Cullingworth)
   * Virtual Console: Frame: allow pages circular scrolling (David Garyga)
-  * Virtual Console: Frame: Increased the maximum number of pages to 100 
+  * Virtual Console: Frame: Increased the maximum number of pages to 100
   * Virtual Console: Fix issues with cut-paste from one frame to another (David Garyga)
   * Virtual Console: Solo Frame: Fix regression: frame inside a solo frame not working (David Garyga)
   * Monitor: show color of color filters and shutter state (so far only RGB/CMY channels where shown, Jano Svitok)
@@ -181,7 +181,7 @@ qlcplus (4.8.3) stable; urgency=low
 
   * Engine/UI: Fixed and improved the Script Function. Please see the documentation
   * Virtual Console/Animation: added end color reset control
-  * Virtual Console/Animation: added R/G/B custom control knobs for start and end colors (David Garyga) 
+  * Virtual Console/Animation: added R/G/B custom control knobs for start and end colors (David Garyga)
   * Virtual Console/Audio Triggers: fix crash when changing the input device while a trigger is running (David Garyga)
   * Virtual Console/Audio Triggers: fixed incorrect number of bars when reconfiguring the widget
   * Virtual Console/Audio Triggers: multiple triggers at the same time and with different number of bars are now supported
@@ -266,7 +266,7 @@ qlcplus (4.8.1) stable; urgency=high
 
 qlcplus (4.8.0) stable; urgency=low
 
-  * NEW: Show Manager: it is now possible to add RGB Matrix and EFX functions to the timeline 
+  * NEW: Show Manager: it is now possible to add RGB Matrix and EFX functions to the timeline
   * NEW: Show Manager: it is now possible to use a function several times in the timeline
   * NEW: Show Manager: added a timing tool to set a Show item start position and total duration
   * NEW: Virtual Console: Sliders in level mode can now represent the channels they control only if they have all the same value (EXPERIMENTAL)
@@ -293,7 +293,7 @@ qlcplus (4.8.0) stable; urgency=low
   * Web access: correctly render and handle multipage frames
   * Web access: improved Cue List and Simple Desk look & feel
   * Web access: fixed Simple Desk changes on universes other than the first
-  * Web access: added Simple Desk universe reset button 
+  * Web access: added Simple Desk universe reset button
   * New input profiles: Akai APCMini and Novation Launchpad (thanks to Maikel Boerebach)
   * New fixture: ETC Desire D40 Vivid (thanks to Richard Manner)
   * New fixtures: American DJ Ultra Hex Par3, Chauvet Intimidator Spot 400 IRC, BoomToneDJ Quattro Scan LED (thanks to Robert Scheffler)
@@ -384,7 +384,7 @@ qlcplus (4.7.1) stable; urgency=low
   * Function Manager: fixed nested folders failure
   * Scene Editor: fixed crash when a group used by a Scene has been removed
   * Audio/OSX: fixed crash happening at the end of playback
-  * Audio/Linux: if the selected playback device is not present, fall back to the default device 
+  * Audio/Linux: if the selected playback device is not present, fall back to the default device
   * Webaccess: fixed Cue list play/stop sequence working only once
   * Webaccess: fixed sliders movement on a touchscreen
   * Plugins: Fixed ArtNet input universe indexing
@@ -401,7 +401,7 @@ qlcplus (4.7.1) stable; urgency=low
 qlcplus (4.7.0) stable; urgency=low
 
   * NEW: New EFX types Square, SquareChoppy & Leaf (thanks to David Garyga)
-  * NEW: Random order for chasers (Jano Svitok) 
+  * NEW: Random order for chasers (Jano Svitok)
   * Monitor: Added support for dimmer channels, Pan, Tilt, color gels and fixture labels
   * Monitor: can monitor universes even if they're not patched to an output
   * Audio Editor: added source file, speed dials and preview buttons
@@ -409,7 +409,7 @@ qlcplus (4.7.0) stable; urgency=low
   * Fixture selection: it is now possible to add groups or a whole universe to a Scene
   * Chaser Editor: fixed some cases of manual adjustments of steps timings
   * Scene Editor: fixed copy&paste of selected values in all fixtures view mode
-  * Plugins: Added enttecdmxusbopen/channels to tune the maximum number of transmitted channels for 
+  * Plugins: Added enttecdmxusbopen/channels to tune the maximum number of transmitted channels for
              Enttec Open and clones. This could solve flickering issues in some cases. (thanks to Daniel Torres)
   * Plugins: DMX USB FX5 is now supported on OSX too
   * Plugins: Added a +1 to the transmitted ArtNet universe
@@ -510,7 +510,7 @@ qlcplus (4.6.0) stable; urgency=low
   * NEW: MIDI plugin: added the possibility to send a SysEx initialization message on an input or output line (thanks to Joep Admiraal)
   * NEW: Added Audio fade in/out support (also in Show Manager)
   * NEW: It is now possible to control RGB Matrices intensity
-  * NEW: RGB Matrices can now be converted to Sequences and imported into Shows 
+  * NEW: RGB Matrices can now be converted to Sequences and imported into Shows
   * NEW: It is now possible to control fixture heads in EFX and XY Pad (thanks to Jano Svitok)
   * NEW: Virtual Console clock can be used also as a stopwatch or a countdown
   * Virtual Console: fixed audio triggers incorrect loading
@@ -548,7 +548,7 @@ qlcplus (4.5.1) stable; urgency=low
   * Virtual Console: fixed audio triggers thresholds save/load on projects (thanks to Jano Svitok)
   * Virtual Console: fixed knobs rendering on OSX
   * Virtual Console: fixed crash when enabling multipage on headerless frames
-  * Virtual Console: fixed copy of Click & Go feature when cloning sliders/knobs 
+  * Virtual Console: fixed copy of Click & Go feature when cloning sliders/knobs
   * MIDI plugin: fixed beat clock detection on OSX
   * Show Manager: Improved to fit on a 1024x768 resolution
   * Engine: fixed Collection potential crash (thanks to Jano Svitok)
@@ -650,7 +650,7 @@ qlcplus (4.4.0) stable; urgency=low
   * Added Fixture: Stairville MH-X50+ (thanks to Guillaume Rousseau)
 
  -- Massimo Callegari <massimocallegari@yahoo.it>  Tue, 5 July 2013 17:03:04 +0200
-  
+
 qlcplus (4.4.0.beta1) unstable; urgency=low
 
   * NEW: Shows can now be started at any position in time
@@ -692,7 +692,7 @@ qlcplus (4.3.3) stable; urgency=low
   * NEW: It is now possible to add notes to Chaser steps (either from Chaser Editor or Virtual Console Cue List)
   * NEW: Added "Snap to Grid" functionality to Show manager
   * NEW: Added "Align to cursor" option to Sequences and Audio item in Show Manager
-  * NEW: Show time position when dragging a Show Manager object  
+  * NEW: Show time position when dragging a Show Manager object
   * Gives more time to DMXking devices to respond to identification calls
   * When adding an existing Scene into Show Manager, a 10seconds Sequence is now created by default with the Scene values
   * Fixed crash when changing a fixture address or manufacturer
@@ -831,7 +831,7 @@ qlcplus (4.2.0) stable; urgency=low
   * Improved Fixture Add UI. Values can now be expanded
   * Added fixture: Chauvet Intimidator Spot 250 (thanks to Henning Borgen)
   * Added fixture: Stairville Matrixx FL 110 DMX (thanks to Heiko Fanieng)
-  
+
  -- Massimo Callegari <massimocallegari@yahoo.it>  Tue, 29 Jan 2013 18:17:42 +0200
 
 qlcplus (4.1.3) stable; urgency=low
@@ -908,12 +908,12 @@ qlcplus (4.0.1) unstable; urgency=low
 
   * Fixed channels groups for generic dimmers
   * Fixed multitrack view cursor accuracy. Now smoother as it should be.
-  
+
  -- Massimo Callegari <massimocallegari@yahoo.it>  Wed, 22 Nov 2012 22:39:42 +0200
 
 qlcplus (4.0.0) unstable; urgency=low
 
-  * Added offline desk capability. A brand new multitrack view has 
+  * Added offline desk capability. A brand new multitrack view has
     been added to allow disposition of scenes and sequences very easily
   * Added channels groups
   * Scene editor will be displayed always on screen bottom. Should be easier to find a Fixture now
@@ -921,4 +921,4 @@ qlcplus (4.0.0) unstable; urgency=low
   * Improved UI look & feel mostly with KDE's Humanity icon package
   * QLC forked on November 5th 2012
 
- -- Massimo Callegari <massimocallegari@yahoo.it>  Wed, 20 Nov 2012 10:44:42 +0200 
+ -- Massimo Callegari <massimocallegari@yahoo.it>  Wed, 20 Nov 2012 10:44:42 +0200

--- a/engine/audio/src/audiorenderer_coreaudio.cpp
+++ b/engine/audio/src/audiorenderer_coreaudio.cpp
@@ -92,7 +92,7 @@ bool AudioRendererCoreAudio::initialize(quint32 freq, int chan, AudioFormat form
     status = AudioQueueStart(m_queue, NULL);
     if (status)
     {
-        qDebug() << Q_FUNC_INFO << "Cannot start Audio Queue !";
+        qDebug() << Q_FUNC_INFO << "Cannot start Audio Queue!";
         return false;
     }
 

--- a/engine/audio/src/audiorenderer_null.h
+++ b/engine/audio/src/audiorenderer_null.h
@@ -39,7 +39,7 @@ public:
     bool initialize(quint32, int, AudioFormat) { return true; }
 
     /** @reimpl */
-    qint64 latency() { return 0; } // not bad for a null device huh ? ;)
+    qint64 latency() { return 0; } // not bad for a null device huh? ;)
 
 protected:
     /** @reimpl */

--- a/engine/audio/src/audiorenderer_portaudio.cpp
+++ b/engine/audio/src/audiorenderer_portaudio.cpp
@@ -217,11 +217,11 @@ void AudioRendererPortAudio::reset()
     PaError err;
     err = Pa_StopStream( m_paStream );
     if( err != paNoError )
-        qDebug() << "PortAudio Error: Stop stream failed !";
+        qDebug() << "PortAudio Error: Stop stream failed!";
 
     err = Pa_CloseStream( m_paStream );
     if( err != paNoError )
-        qDebug() << "PortAudio Error: Close stream failed !";
+        qDebug() << "PortAudio Error: Close stream failed!";
     m_buffer.clear();
     m_paStream = NULL;
 }

--- a/engine/audio/src/audiorenderer_portaudio.cpp
+++ b/engine/audio/src/audiorenderer_portaudio.cpp
@@ -56,11 +56,11 @@ int AudioRendererPortAudio::dataCallback ( const void *, void *outputBuffer,
     unsigned long requestedData = frameCount * PAobj->m_frameSize * PAobj->m_channels;
 
     QMutexLocker locker(&PAobj->m_paMutex);
-    // user stop requested ? Prevent this callback to be called again
+    // user stop requested? Prevent this callback to be called again
     if (PAobj->m_userStop == true)
         return paAbort;
 
-    // not enough data ? Wait for another writeAudio to add more
+    // not enough data? Wait for another writeAudio to add more
     if (requestedData > (unsigned long)PAobj->m_buffer.size())
     {
         Pa_Sleep(10);

--- a/engine/src/avolitesd4parser.cpp
+++ b/engine/src/avolitesd4parser.cpp
@@ -180,7 +180,7 @@ bool AvolitesD4Parser::loadXML(const QString& path, QLCFixtureDef* fixtureDef)
         else if (doc->name() == KD4TagPalettes)
         {
             // TODO TODO TODO
-            // Maybe also import preset palettes and macros ?!?!?!?!
+            // Maybe also import preset palettes and macros?!?!?!?!
             /**
                 Can't be done for now, as qxf files don't have any information on preset palettes or macros
                 for fixtures, they are automatically generated on the main application maybe in future... **/
@@ -344,7 +344,7 @@ bool AvolitesD4Parser::is16Bit(QString dmx) const
     if (dmxValues.value(0).toInt() > 256)
         return true;
 
-    // Is there aright side ? (there should always be something in the right side of the ~,
+    // Is there aright side? (there should always be something in the right side of the ~,
     // or avolites desks won't parse the file, anyway, there should be a check, ir some smart
     // dude will complain this crashes with his D4 file)
 

--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -449,7 +449,7 @@ void ChaserRunner::adjustIntensity(qreal fraction, int requestedStepIndex, int f
     if (fraction == qreal(0.0))
         return;
 
-    // not found ? It means we need to start a new step and crossfade kicks in !
+    // not found? It means we need to start a new step and crossfade kicks in !
     startNewStep(stepIndex, m_doc->masterTimer(), fraction, fadeControl);
 }
 

--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -449,7 +449,7 @@ void ChaserRunner::adjustIntensity(qreal fraction, int requestedStepIndex, int f
     if (fraction == qreal(0.0))
         return;
 
-    // not found? It means we need to start a new step and crossfade kicks in !
+    // not found? It means we need to start a new step and crossfade kicks in!
     startNewStep(stepIndex, m_doc->masterTimer(), fraction, fadeControl);
 }
 
@@ -528,7 +528,7 @@ void ChaserRunner::startNewStep(int index, MasterTimer* timer, qreal intensity,
     // might momentarily jump too high.
     newStep->m_intensityOverrideId = newStep->m_function->requestAttributeOverride(Function::Intensity, intensity);
     //newStep->m_function->adjustAttribute(intensity, newStep->m_intensityOverrideId);
-    // Start the fire up !
+    // Start the fire up!
     newStep->m_function->start(timer, functionParent(), 0, newStep->m_fadeIn, newStep->m_fadeOut,
                                newStep->m_function->defaultSpeed(), m_chaser->tempoType());
     m_runnerSteps.append(newStep);

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -96,7 +96,7 @@ Doc::~Doc()
 
     if (isKiosk() == false)
     {
-        // TODO: is this still needed ??
+        // TODO: is this still needed??
         //m_ioMap->saveDefaults();
     }
     delete m_ioMap;

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -1321,7 +1321,7 @@ int Function::adjustAttribute(qreal value, int attributeId)
         if (attributeId >= m_attributes.count() || m_attributes[attributeId].m_value == value)
             return -1;
 
-        // Adjust the original value of an attribute. Only Function editors should do this !
+        // Adjust the original value of an attribute. Only Function editors should do this!
         m_attributes[attributeId].m_value = CLAMP(value, m_attributes[attributeId].m_min, m_attributes[attributeId].m_max);
         attrIndex = attributeId;
     }

--- a/engine/src/function.h
+++ b/engine/src/function.h
@@ -894,7 +894,7 @@ public:
      * Adjust an attribute value with the given new $value.
      * If $attributeId is within the registered attributes range,
      * the oiginal attribute value will be changed.
-     * Warning: only Function editors or the Function itself should do this !
+     * Warning: only Function editors or the Function itself should do this!
      * Otherwise, if $attributeId is >= OVERRIDE_ATTRIBUTE_START_ID
      * it means the caller wants to control a value override.
      * This operation will then recalculate the final override value

--- a/engine/src/mastertimer-unix.cpp
+++ b/engine/src/mastertimer-unix.cpp
@@ -149,7 +149,7 @@ void MasterTimerPrivate::run()
          * to process all the running Functions :'( */
         if (compareTime(finish, current) <= 0)
         {
-            qDebug() << Q_FUNC_INFO << "MasterTimer is running late !";
+            qDebug() << Q_FUNC_INFO << "MasterTimer is running late!";
             /* No need to sleep. Immediately process the next tick */
             mt->timerTick();
             /* Now the finish time needs to be recalibrated */

--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -810,7 +810,7 @@ bool MonitorProperties::saveXML(QXmlStreamWriter *doc, const Doc *mainDocument) 
             doc->writeAttribute(KXMLQLCMonitorItemZScale, QString::number(item.m_scale.z()));
 
         if (item.m_resource.isEmpty() == false)
-        {            
+        {
             // perform normalization depending on the mesh location (mesh folder, project path, absolute path)
             QFileInfo res(item.m_resource);
 

--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -478,7 +478,7 @@ bool MonitorProperties::loadXML(QXmlStreamReader &root, const Doc *mainDocument)
 
     if (attrs.hasAttribute(KXMLQLCMonitorDisplay) == false)
     {
-        qWarning() << Q_FUNC_INFO << "Cannot determine Monitor display mode !";
+        qWarning() << Q_FUNC_INFO << "Cannot determine Monitor display mode!";
         return false;
     }
 

--- a/engine/src/qlcfixturedef.cpp
+++ b/engine/src/qlcfixturedef.cpp
@@ -190,7 +190,7 @@ QString QLCFixtureDef::author()
 
 void QLCFixtureDef::checkLoaded(QString mapPath)
 {
-    // Already loaded ? Nothing to do
+    // Already loaded? Nothing to do
     if (m_isLoaded == true)
         return;
 

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -774,7 +774,7 @@ QList <QStringList> Script::tokenizeLine(const QString& str, bool* ok)
             if (left != -1)
             {
                 // if we stumbled into a URL like http:// or ftp://
-                // then it's not a comment !
+                // then it's not a comment!
                 if (line.at(left - 1) != ':')
                     line.truncate(left);
                 left += 2;

--- a/engine/src/scriptrunner.cpp
+++ b/engine/src/scriptrunner.cpp
@@ -289,7 +289,7 @@ bool ScriptRunner::setFixture(quint32 fxID, quint32 channel, uchar value, uint t
     if (gf->channels().contains(fc) == true)
         fc.setStart(gf->channels()[fc].current());
     //else
-    //    fc.setStart(universes[uni]->preGMValue(address)); // TODO ?
+    //    fc.setStart(universes[uni]->preGMValue(address)); // TODO?
     fc.setCurrent(fc.start());
 
     gf->add(fc);

--- a/engine/src/scriptv4.cpp
+++ b/engine/src/scriptv4.cpp
@@ -387,7 +387,7 @@ QString Script::convertLine(const QString& str, bool *ok)
         if (left != -1)
         {
             // if we stumbled into a URL like http:// or ftp://
-            // then it's not a comment !
+            // then it's not a comment!
             if (line.at(left - 1) != ':')
             {
                 comment = line.mid(left);

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -138,7 +138,7 @@ void Universe::setPassthrough(bool enable)
         // we would have to synchronize with other threads
 
         // When enabling passthrough, make sure the array is allocated BEFORE m_passthrough is set to
-        // true. That way we only have to check for m_passthrough, and do not need to check 
+        // true. That way we only have to check for m_passthrough, and do not need to check
         // m_passthroughValues.isNull()
         m_passthroughValues.reset(new QByteArray(UNIVERSE_SIZE, char(0)));
     }
@@ -223,7 +223,7 @@ void Universe::reset(int address, int range)
 {
     if (address >= UNIVERSE_SIZE)
         return;
-    if (address + range > UNIVERSE_SIZE) 
+    if (address + range > UNIVERSE_SIZE)
        range = UNIVERSE_SIZE - address;
 
     memset(m_preGMValues->data() + address, 0, range * sizeof(*m_preGMValues->data()));
@@ -241,7 +241,7 @@ void Universe::zeroIntensityChannels()
     {
         short channel = channels[i] >> 16;
         short size = channels[i] & 0xffff;
-        
+
         reset(channel, size);
     }
 }
@@ -318,7 +318,7 @@ uchar Universe::preGMValue(int address) const
 {
     if (address >= m_preGMValues->size())
         return 0U;
- 
+
     return static_cast<uchar>(m_preGMValues->at(address));
 }
 

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -853,7 +853,7 @@ bool Universe::writeBlended(int channel, uchar value, Universe::BlendMode blend)
         }
         break;
         default:
-            qDebug() << "[Universe] Blend mode not handled. Implement me !" << blend;
+            qDebug() << "[Universe] Blend mode not handled. Implement me!" << blend;
         break;
     }
 

--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -490,7 +490,7 @@ void QLCFixtureEditor::slotRemoveChannel()
     Q_ASSERT(channel != NULL);
 
     if (QMessageBox::question(this, "Remove Channel",
-                              tr("Are you sure you wish to remove channel: %1 ?")
+                              tr("Are you sure you wish to remove channel: %1?")
                               .arg(channel->name()),
                               QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
     {
@@ -809,7 +809,7 @@ void QLCFixtureEditor::slotRemoveMode()
     QLCFixtureMode *mode = currentMode();
 
     if (QMessageBox::question(this, tr("Remove Mode"),
-                              tr("Are you sure you wish to remove mode: %1 ?").arg(mode->name()),
+                              tr("Are you sure you wish to remove mode: %1?").arg(mode->name()),
                               QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
     {
         m_fixtureDef->removeMode(mode);

--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -128,7 +128,7 @@ void QLCFixtureEditor::init()
     if (m_authorEdit->text().length() > 0)
     {
         // Temporarily allow editing author name since most definitions contain wrong name:
-        // m_authorEdit->setEnabled(false); 
+        // m_authorEdit->setEnabled(false);
     }
     else
     {

--- a/fixtureeditor/fixtureeditor_ca_ES.ts
+++ b/fixtureeditor/fixtureeditor_ca_ES.ts
@@ -983,12 +983,12 @@ No es pot desar el fixture.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Esteu segur que vol eliminar el canal: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Eteu segur que vol eliminar el mode: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_cz_CZ.ts
+++ b/fixtureeditor/fixtureeditor_cz_CZ.ts
@@ -910,7 +910,7 @@
         <source>Do you want to save changes to fixture
 &quot;%1&quot;
 before closing?</source>
-        <translation>Přejete si uložit změny v zařízení 
+        <translation>Přejete si uložit změny v zařízení
 &quot;%1&quot;
 před uzavřením?</translation>
     </message>
@@ -985,12 +985,12 @@ Nelze uložit zařízení.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Opravdu chcete odebrat kanál: %1 ?</translation>
+        <translation>Opravdu chcete odebrat kanál: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Opravdu chcete odebrat režim: %1 ?</translation>
+        <translation>Opravdu chcete odebrat režim: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_cz_CZ.ts
+++ b/fixtureeditor/fixtureeditor_cz_CZ.ts
@@ -984,12 +984,12 @@ Nelze uložit zařízení.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Opravdu chcete odebrat kanál: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Opravdu chcete odebrat režim: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_de_DE.ts
+++ b/fixtureeditor/fixtureeditor_de_DE.ts
@@ -992,12 +992,12 @@ Kann Gerät nicht speichern.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Bist du dir sicher, dass du den Kanal %1 entfernen möchtest ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Bist du dir sicher, dass du den Modus %1 entfernen möchtest ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_de_DE.ts
+++ b/fixtureeditor/fixtureeditor_de_DE.ts
@@ -993,12 +993,12 @@ Kann Gerät nicht speichern.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Bist du dir sicher, dass du den Kanal %1 entfernen möchtest ?</translation>
+        <translation>Bist du dir sicher, dass du den Kanal %1 entfernen möchtest?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Bist du dir sicher, dass du den Modus %1 entfernen möchtest ?</translation>
+        <translation>Bist du dir sicher, dass du den Modus %1 entfernen möchtest?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_es_ES.ts
+++ b/fixtureeditor/fixtureeditor_es_ES.ts
@@ -888,12 +888,12 @@ No se puede guardar el fixture.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>¿Está seguro que quiere quitar el canal: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>¿Está seguro que quiere quitar el modo: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_es_ES.ts
+++ b/fixtureeditor/fixtureeditor_es_ES.ts
@@ -889,12 +889,12 @@ No se puede guardar el fixture.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>¿Está seguro que quiere quitar el canal: %1 ?</translation>
+        <translation>¿Está seguro que quiere quitar el canal: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>¿Está seguro que quiere quitar el modo: %1 ?</translation>
+        <translation>¿Está seguro que quiere quitar el modo: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_fi_FI.ts
+++ b/fixtureeditor/fixtureeditor_fi_FI.ts
@@ -945,12 +945,12 @@ Valaisinta ei voida tallentaa.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_fr_FR.ts
+++ b/fixtureeditor/fixtureeditor_fr_FR.ts
@@ -908,12 +908,12 @@ Impossible d&apos;enregistrer l&apos;appareil.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Êtes-vous sûr(e) de vouloir supprimer le canal &quot;%1&quot; ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Êtes-vous sûr(e) de vouloir supprimer le mode &quot;%1&quot; ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_fr_FR.ts
+++ b/fixtureeditor/fixtureeditor_fr_FR.ts
@@ -835,7 +835,7 @@
 before closing?</source>
         <translation>Voulez vous enregistrer les modifications de l&apos;appareil
 &quot;%1&quot;
-avant de quitter ?</translation>
+avant de quitter&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="229"/>
@@ -892,7 +892,7 @@ Impossible d&apos;enregistrer l&apos;appareil.</translation>
         <location filename="fixtureeditor.cpp" line="424"/>
         <location filename="fixtureeditor.cpp" line="509"/>
         <source>A channel by the name &quot;%1&quot; already exists!</source>
-        <translation>Un canal avec le nom &quot;%1&quot; existe déjà !</translation>
+        <translation>Un canal avec le nom &quot;%1&quot; existe déjà&#x0a;!</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="431"/>
@@ -904,17 +904,17 @@ Impossible d&apos;enregistrer l&apos;appareil.</translation>
         <location filename="fixtureeditor.cpp" line="432"/>
         <location filename="fixtureeditor.cpp" line="516"/>
         <source>You must give the channel a descriptive name!</source>
-        <translation>Veuillez donner un nom au canal !</translation>
+        <translation>Veuillez donner un nom au canal&#x0a;!</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Êtes-vous sûr(e) de vouloir supprimer le canal &quot;%1&quot; ?</translation>
+        <translation>Êtes-vous sûr(e) de vouloir supprimer le canal &quot;%1&quot;&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Êtes-vous sûr(e) de vouloir supprimer le mode &quot;%1&quot; ?</translation>
+        <translation>Êtes-vous sûr(e) de vouloir supprimer le mode &quot;%1&quot;&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_it_IT.ts
+++ b/fixtureeditor/fixtureeditor_it_IT.ts
@@ -967,7 +967,7 @@ Impossibile Salvare.</translation>
         <location filename="fixtureeditor.cpp" line="424"/>
         <location filename="fixtureeditor.cpp" line="509"/>
         <source>A channel by the name &quot;%1&quot; already exists!</source>
-        <translation>il canale &quot;%1&quot; già esiste !</translation>
+        <translation>il canale &quot;%1&quot; già esiste!</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="431"/>
@@ -984,12 +984,12 @@ Impossibile Salvare.</translation>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Sei sicuro di vuoler rimuovere il canale: %1 ?</translation>
+        <translation>Sei sicuro di vuoler rimuovere il canale: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Sei sicuro di voler rimuovere la modalità: %1 ?</translation>
+        <translation>Sei sicuro di voler rimuovere la modalità: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_it_IT.ts
+++ b/fixtureeditor/fixtureeditor_it_IT.ts
@@ -983,12 +983,12 @@ Impossibile Salvare.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Sei sicuro di vuoler rimuovere il canale: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Sei sicuro di voler rimuovere la modalità: %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_ja_JP.ts
+++ b/fixtureeditor/fixtureeditor_ja_JP.ts
@@ -886,12 +886,12 @@ Unable to save fixture.</source>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>チャンネル %1 を削除しますか？</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>以下のモードを削除しますか: %1 ？</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_nl_NL.ts
+++ b/fixtureeditor/fixtureeditor_nl_NL.ts
@@ -985,12 +985,12 @@ Unable to save fixture.</source>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Kanaal verwijderen: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Verwijder mode %1 ?</translation>
     </message>
     <message>

--- a/fixtureeditor/fixtureeditor_nl_NL.ts
+++ b/fixtureeditor/fixtureeditor_nl_NL.ts
@@ -916,7 +916,7 @@
         <source>Do you want to save changes to fixture
 &quot;%1&quot;
 before closing?</source>
-        <translation>Wil je voor het sluiten de wijzigingen opslaan van fixture %1 ?</translation>
+        <translation>Wil je voor het sluiten de wijzigingen opslaan van fixture %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="229"/>
@@ -986,12 +986,12 @@ Unable to save fixture.</source>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
         <source>Are you sure you wish to remove channel: %1?</source>
-        <translation>Kanaal verwijderen: %1 ?</translation>
+        <translation>Kanaal verwijderen: %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
         <source>Are you sure you wish to remove mode: %1?</source>
-        <translation>Verwijder mode %1 ?</translation>
+        <translation>Verwijder mode %1?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="628"/>

--- a/fixtureeditor/fixtureeditor_pt_BR.ts
+++ b/fixtureeditor/fixtureeditor_pt_BR.ts
@@ -887,12 +887,12 @@ Não se pode guardar o fixture.</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="467"/>
-        <source>Are you sure you wish to remove channel: %1 ?</source>
+        <source>Are you sure you wish to remove channel: %1?</source>
         <translation>Tem a certezaque pretende remover o canal: %1 ?</translation>
     </message>
     <message>
         <location filename="fixtureeditor.cpp" line="783"/>
-        <source>Are you sure you wish to remove mode: %1 ?</source>
+        <source>Are you sure you wish to remove mode: %1?</source>
         <translation>Tem a certeza que pretende eliminar o modo: %1 ?</translation>
     </message>
     <message>

--- a/platforms/windows/qlcplus4Qt4.nsi
+++ b/platforms/windows/qlcplus4Qt4.nsi
@@ -33,7 +33,7 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "Japanese"
 !insertmacro MUI_LANGUAGE "Catalan"
 
-!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
+!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license?"
 
 !insertmacro MUI_PAGE_LICENSE "${QLCPLUS_HOME}\platforms\windows\apache_2.0.txt"
 

--- a/platforms/windows/qlcplus4Qt5.nsi
+++ b/platforms/windows/qlcplus4Qt5.nsi
@@ -20,7 +20,7 @@ InstallDir C:\QLC+
 InstallDirRegKey HKCU "Software\qlcplus" "Install_Dir"
 RequestExecutionLevel user
 
-!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
+!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license?"
 
 !insertmacro MUI_PAGE_LICENSE "${QLCPLUS_HOME}\platforms\windows\apache_2.0.txt"
 

--- a/platforms/windows/qlcplus5Qt5.nsi
+++ b/platforms/windows/qlcplus5Qt5.nsi
@@ -20,7 +20,7 @@ InstallDir C:\QLC+5
 InstallDirRegKey HKCU "Software\qlcplus" "Install_Dir"
 RequestExecutionLevel user
 
-!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license ?"
+!define MUI_LICENSEPAGE_TEXT_TOP "Do you accept the following statement of the Apache 2.0 license?"
 
 !insertmacro MUI_PAGE_LICENSE "${QLCPLUS_HOME}\platforms\windows\apache_2.0.txt"
 

--- a/plugins/artnet/src/artnetcontroller.h
+++ b/plugins/artnet/src/artnetcontroller.h
@@ -125,7 +125,7 @@ public:
     /** Get the number of packets received by this controller */
     quint64 getPacketReceivedNumber();
 
-    /** Is the UDP socket capable of receiving packets ? */
+    /** Is the UDP socket capable of receiving packets? */
     bool socketBound() const;
 
 private:

--- a/plugins/artnet/src/artnetpacketizer.cpp
+++ b/plugins/artnet/src/artnetpacketizer.cpp
@@ -95,13 +95,13 @@ void ArtNetPacketizer::setupArtNetPollReply(QByteArray &data, QHostAddress ipAdd
     for (i = 0; i < 64; i++)
         data.append((char)0x00); // Node report
     data.append((char)0x00);     // NumPort MSB
-    // FIXME: this should reflect the actual state of QLC+ output ports !
+    // FIXME: this should reflect the actual state of QLC+ output ports!
     data.append((char)0x01);     // NumPort LSB
     data.append((char)0x80);     // Port 1 type: can output DMX512 data
     data.append((char)0x80);     // Port 2 type: can output DMX512 data
     data.append((char)0x80);     // Port 3 type: can output DMX512 data
     data.append((char)0x80);     // Port 4 type: can output DMX512 data
-    // FIXME: this should reflect the actual state of QLC+ output ports !
+    // FIXME: this should reflect the actual state of QLC+ output ports!
     for (i = 0; i < 12; i++)
         data.append((char)0x00); // Set GoodInput[4], GoodOutput[4] and SwIn[4] all to unknown state
     data.append((char)0x00);     // SwOut0 - output 0

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -375,7 +375,7 @@ QList<ArtNetIO> ArtNetPlugin::getIOMapping()
 
 QSharedPointer<QUdpSocket> ArtNetPlugin::getUdpSocket()
 {
-    // Is the socket already present ?
+    // Is the socket already present?
     QSharedPointer<QUdpSocket> udpSocket(m_udpSocket);
     if (udpSocket)
         return udpSocket;

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -215,7 +215,7 @@ void ArtNetPlugin::writeUniverse(quint32 universe, quint32 output, const QByteAr
 
 /*************************************************************************
   * Inputs
-  *************************************************************************/  
+  *************************************************************************/
 QStringList ArtNetPlugin::inputs()
 {
     QStringList list;

--- a/plugins/dmxusb/src/dmxusbwidget.cpp
+++ b/plugins/dmxusb/src/dmxusbwidget.cpp
@@ -258,7 +258,7 @@ bool DMXUSBWidget::open(quint32 line, bool input)
     }
     else
     {
-        qWarning() << "[DMXUSBWidget] Line" << line << "doesn't belong to any mapped inputs nor to outputs !";
+        qWarning() << "[DMXUSBWidget] Line" << line << "doesn't belong to any mapped inputs nor to outputs!";
         return false;
     }
 
@@ -312,7 +312,7 @@ bool DMXUSBWidget::close(quint32 line, bool input)
     }
     else
     {
-        qWarning() << "Line" << line << "doesn't belong to any mapped inputs nor to outputs !";
+        qWarning() << "Line" << line << "doesn't belong to any mapped inputs nor to outputs!";
         return false;
     }
 

--- a/plugins/dmxusb/src/enttecdmxusbpro.cpp
+++ b/plugins/dmxusb/src/enttecdmxusbpro.cpp
@@ -107,10 +107,10 @@ bool EnttecDMXUSBPro::configureLine(ushort dmxLine, ushort midiLine)
         request.append(ENTTEC_PRO_ENABLE_API2); // Enable API2
         request.append(char(0x04)); // data length LSB
         request.append(ENTTEC_PRO_DMX_ZERO); // data length MSB
-        request.append(char(0xAD)); // Magic number. WTF ??
-        request.append(char(0x88)); // Magic number. WFT ??
-        request.append(char(0xD0)); // Magic number. WTF ??
-        request.append(char(0xC8)); // Magic number. WTF ??
+        request.append(char(0xAD)); // Magic number. WTF??
+        request.append(char(0x88)); // Magic number. WFT??
+        request.append(char(0xD0)); // Magic number. WTF??
+        request.append(char(0xC8)); // Magic number. WTF??
         request.append(ENTTEC_PRO_END_OF_MSG); // Stop byte
 
         /* Write "Set API Key Request" message */

--- a/plugins/dmxusb/src/enttecdmxusbpro.cpp
+++ b/plugins/dmxusb/src/enttecdmxusbpro.cpp
@@ -409,7 +409,7 @@ bool EnttecDMXUSBPro::writeUniverse(quint32 universe, quint32 output, const QByt
 {
     if (isOpen() == false)
     {
-        qDebug() << "[DMXUSB] writeUniverse: device is not open !";
+        qDebug() << "[DMXUSB] writeUniverse: device is not open!";
         return false;
     }
 

--- a/plugins/enttecwing/test/playbackwing_test.cpp
+++ b/plugins/enttecwing/test/playbackwing_test.cpp
@@ -326,7 +326,7 @@ void PlaybackWing_Test::faders_data()
 
 void PlaybackWing_Test::faders()
 {
-    // TODO: who did the page changes need to fix this !
+    // TODO: who did the page changes need to fix this!
     QFETCH(QByteArray, ba);
     //QFETCH(int, channel);
     //QFETCH(int, value);

--- a/plugins/gpio/gpioplugin.cpp
+++ b/plugins/gpio/gpioplugin.cpp
@@ -396,13 +396,13 @@ void GPIOPlugin::setParameter(quint32 universe, quint32 line, Capability type,
     QStringList param = name.split("-");
     if (param.count() < 2)
     {
-        qDebug() << "[GPIO] invalid parameter name !" << name;
+        qDebug() << "[GPIO] invalid parameter name!" << name;
         return;
     }
     int gpioNumber = param.at(1).toInt();
     if (gpioNumber < 0 || gpioNumber >= m_gpioList.count())
     {
-        qDebug() << "[GPIO] invalid PIN number !" << gpioNumber;
+        qDebug() << "[GPIO] invalid PIN number!" << gpioNumber;
         return;
     }
 

--- a/plugins/midi/src/alsa/alsamidiinputthread.cpp
+++ b/plugins/midi/src/alsa/alsamidiinputthread.cpp
@@ -251,7 +251,7 @@ void AlsaMidiInputThread::readEvent()
                 cmd = MIDI_CHANNEL_AFTERTOUCH | ev->data.control.channel;
                 data1 = ev->data.control.value;
                 break;
- 
+
             default:
                 break;
             }

--- a/plugins/midi/src/alsa/alsamidiinputthread.cpp
+++ b/plugins/midi/src/alsa/alsamidiinputthread.cpp
@@ -217,7 +217,7 @@ void AlsaMidiInputThread::readEvent()
         uchar data1 = 0;
         uchar data2 = 0;
 
-        //qDebug() << "ALSA MIDI event received !" << ev->type;
+        //qDebug() << "ALSA MIDI event received!" << ev->type;
 
         if (snd_seq_ev_is_control_type(ev))
         {

--- a/plugins/midi/src/alsa/alsamidioutputdevice.cpp
+++ b/plugins/midi/src/alsa/alsamidioutputdevice.cpp
@@ -104,7 +104,7 @@ void AlsaMidiOutputDevice::writeChannel(ushort channel, uchar value)
     if (channel < ushort(m_universe.size()) && m_universe[channel] != scaled)
     {
         QByteArray tmp(m_universe);
-        
+
         for (uchar ch = 0; ch < MAX_MIDI_DMX_CHANNELS && ch < tmp.size(); ++ch)
         {
            char midi = tmp[ch];

--- a/plugins/midi/src/alsa/alsamidioutputdevice.cpp
+++ b/plugins/midi/src/alsa/alsamidioutputdevice.cpp
@@ -227,7 +227,7 @@ void AlsaMidiOutputDevice::writeFeedback(uchar cmd, uchar data1, uchar data2)
         break;
 
     default:
-        // What to do here ??
+        // What to do here??
         invalidCmd = true;
         break;
     }

--- a/plugins/midi/src/macx/coremidiinputdevice.cpp
+++ b/plugins/midi/src/macx/coremidiinputdevice.cpp
@@ -62,7 +62,7 @@ static void MidiInProc(const MIDIPacketList* pktList, void* readProcRefCon,
                 if (packet->length > (i + 1) && !MIDI_IS_CMD(packet->data[i + 1]))
                     data2 = packet->data[++i];
                 else
-                    // no data2 ? Could be a Program Change, so act like Linux
+                    // no data2? Could be a Program Change, so act like Linux
                     // and give it a value
                     data2 = 127;
             }

--- a/plugins/osc/oscpacketizer.cpp
+++ b/plugins/osc/oscpacketizer.cpp
@@ -216,7 +216,7 @@ QList<QPair<QString, QByteArray> > OSCPacketizer::parsePacket(QByteArray const& 
         {
             if (data.size() < 20 || data.startsWith("#bundle") == false)
             {
-                qWarning() << "[OSC] Found an unsupported message type !" << data;
+                qWarning() << "[OSC] Found an unsupported message type!" << data;
                 return messages;
             }
             // 8 bytes for '#bundle\0' and 8 bytes for a timestamp that we don't handle

--- a/plugins/peperoni/unix/peperoni.cpp
+++ b/plugins/peperoni/unix/peperoni.cpp
@@ -115,7 +115,7 @@ QString Peperoni::outputInfo(quint32 output)
         str += m_devices[output]->outputInfoText(output);
     }
     else
-        qDebug() << "Peperoni invalid output !" << output << m_devices.size();
+        qDebug() << "Peperoni invalid output!" << output << m_devices.size();
 
     str += QString("</BODY>");
     str += QString("</HTML>");
@@ -133,7 +133,7 @@ void Peperoni::writeUniverse(quint32 universe, quint32 output, const QByteArray 
     if (m_devices[output] != NULL)
         m_devices[output]->outputDMX(output, data);
     else
-        qDebug() << "Peperoni invalid output !" << output << m_devices.size();
+        qDebug() << "Peperoni invalid output!" << output << m_devices.size();
 }
 
 /*************************************************************************
@@ -193,7 +193,7 @@ QString Peperoni::inputInfo(quint32 input)
         str += m_devices[input]->inputInfoText(input);
     }
     else
-        qDebug() << "Peperoni invalid input !" << input << m_devices.size();
+        qDebug() << "Peperoni invalid input!" << input << m_devices.size();
 
     str += QString("</BODY>");
     str += QString("</HTML>");

--- a/plugins/spi/spiplugin.cpp
+++ b/plugins/spi/spiplugin.cpp
@@ -81,7 +81,7 @@ bool SPIPlugin::openOutput(quint32 output, quint32 universe)
     m_spifd = open(SPI_DEFAULT_DEVICE, O_RDWR);
     if(m_spifd < 0)
     {
-        qWarning() << "Cannot open SPI device !";
+        qWarning() << "Cannot open SPI device!";
         return false;
     }
 

--- a/plugins/udmx/src/uDMX_cz_CZ.ts
+++ b/plugins/udmx/src/uDMX_cz_CZ.ts
@@ -11,7 +11,7 @@
     <message>
         <location filename="udmx.cpp" line="195"/>
         <source>Do you wish to re-scan your hardware?</source>
-        <translation>Přejete si znovu prohledat Váš hardware ?</translation>
+        <translation>Přejete si znovu prohledat Váš hardware?</translation>
     </message>
 </context>
 <context>

--- a/plugins/udmx/src/uDMX_fr_FR.ts
+++ b/plugins/udmx/src/uDMX_fr_FR.ts
@@ -11,7 +11,7 @@
     <message>
         <location filename="udmx.cpp" line="195"/>
         <source>Do you wish to re-scan your hardware?</source>
-        <translation>Souhaitez-vous redétecter le matériel ?</translation>
+        <translation>Souhaitez-vous redétecter le matériel&#xa0;?</translation>
     </message>
 </context>
 <context>

--- a/plugins/velleman/test/velleman_test.cpp
+++ b/plugins/velleman/test/velleman_test.cpp
@@ -94,7 +94,7 @@ void Velleman_Test::outputInfo()
     Velleman vo;
     vo.init();
 
-// is this seriously needed ??
+// is this seriously needed??
 /*
     QString info;
     info = vo.outputInfo(42);

--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -168,7 +168,7 @@ void App::startup()
     // Start up in non-modified state
     m_doc->resetModified();
 
-    // and here we go !
+    // and here we go!
     setSource(QUrl("qrc:/MainView.qml"));
 }
 

--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -107,19 +107,19 @@ QString App::appVersion() const
 
 void App::startup()
 {
-    qmlRegisterUncreatableType<Fixture>("org.qlcplus.classes", 1, 0, "Fixture", "Can't create a Fixture !");
-    qmlRegisterUncreatableType<Function>("org.qlcplus.classes", 1, 0, "QLCFunction", "Can't create a Function !");
+    qmlRegisterUncreatableType<Fixture>("org.qlcplus.classes", 1, 0, "Fixture", "Can't create a Fixture!");
+    qmlRegisterUncreatableType<Function>("org.qlcplus.classes", 1, 0, "QLCFunction", "Can't create a Function!");
     qmlRegisterType<ModelSelector>("org.qlcplus.classes", 1, 0, "ModelSelector");
-    qmlRegisterUncreatableType<App>("org.qlcplus.classes", 1, 0, "App", "Can't create an App !");
+    qmlRegisterUncreatableType<App>("org.qlcplus.classes", 1, 0, "App", "Can't create an App!");
 
     setTitle(APPNAME);
     setIcon(QIcon(":/qlcplus.svg"));
 
     if (QFontDatabase::addApplicationFont(":/RobotoCondensed-Regular.ttf") < 0)
-        qWarning() << "Roboto condensed cannot be loaded !";
+        qWarning() << "Roboto condensed cannot be loaded!";
 
     if (QFontDatabase::addApplicationFont(":/RobotoMono-Regular.ttf") < 0)
-        qWarning() << "Roboto mono cannot be loaded !";
+        qWarning() << "Roboto mono cannot be loaded!";
 
     rootContext()->setContextProperty("qlcplus", this);
 
@@ -161,9 +161,9 @@ void App::startup()
     m_contextManager->registerContext(m_ioManager);
 
     // register an uncreatable type just to use the enums in QML
-    qmlRegisterUncreatableType<ContextManager>("org.qlcplus.classes", 1, 0, "ContextManager", "Can't create a ContextManager !");
-    qmlRegisterUncreatableType<ShowManager>("org.qlcplus.classes", 1, 0, "ShowManager", "Can't create a ShowManager !");
-    qmlRegisterUncreatableType<NetworkManager>("org.qlcplus.classes", 1, 0, "NetworkManager", "Can't create a NetworkManager !");
+    qmlRegisterUncreatableType<ContextManager>("org.qlcplus.classes", 1, 0, "ContextManager", "Can't create a ContextManager!");
+    qmlRegisterUncreatableType<ShowManager>("org.qlcplus.classes", 1, 0, "ShowManager", "Can't create a ShowManager!");
+    qmlRegisterUncreatableType<NetworkManager>("org.qlcplus.classes", 1, 0, "NetworkManager", "Can't create a NetworkManager!");
 
     // Start up in non-modified state
     m_doc->resetModified();

--- a/qmlui/contextmanager.cpp
+++ b/qmlui/contextmanager.cpp
@@ -78,7 +78,7 @@ ContextManager::ContextManager(QQuickView *view, Doc *doc,
     registerContext(m_3DView);
     m_view->rootContext()->setContextProperty("View3D", m_3DView);
 
-    qmlRegisterUncreatableType<MonitorProperties>("org.qlcplus.classes", 1, 0, "MonitorProperties", "Can't create MonitorProperties !");
+    qmlRegisterUncreatableType<MonitorProperties>("org.qlcplus.classes", 1, 0, "MonitorProperties", "Can't create MonitorProperties!");
 
     connect(m_fixtureManager, &FixtureManager::newFixtureCreated, this, &ContextManager::slotNewFixtureCreated);
     connect(m_fixtureManager, &FixtureManager::fixtureDeleted, this, &ContextManager::slotFixtureDeleted);

--- a/qmlui/contextmanager.cpp
+++ b/qmlui/contextmanager.cpp
@@ -409,7 +409,7 @@ void ContextManager::resetContexts()
     if (m_3DView->isEnabled())
         m_3DView->slotRefreshView();
 
-    /** TODO: nothing to do on the other contexts ? */
+    /** TODO: nothing to do on the other contexts? */
 }
 
 void ContextManager::handleKeyPress(QKeyEvent *e)

--- a/qmlui/efxeditor.cpp
+++ b/qmlui/efxeditor.cpp
@@ -352,7 +352,7 @@ QVariant EFXEditor::groupsTreeModel()
         treeColumns << "classRef" << "type" << "id" << "subid" << "head";
         m_fixtureTree->setColumnNames(treeColumns);
         m_fixtureTree->enableSorting(false);
-        FixtureManager::updateGroupsTree(m_doc, m_fixtureTree); // TODO: search filter ?
+        FixtureManager::updateGroupsTree(m_doc, m_fixtureTree); // TODO: search filter?
     }
 
     return QVariant::fromValue(m_fixtureTree);

--- a/qmlui/fixturegroupeditor.cpp
+++ b/qmlui/fixturegroupeditor.cpp
@@ -34,7 +34,7 @@ FixtureGroupEditor::FixtureGroupEditor(QQuickView *view, Doc *doc, QObject *pare
     Q_ASSERT(m_doc != NULL);
 
     m_view->rootContext()->setContextProperty("fixtureGroupEditor", this);
-    qmlRegisterUncreatableType<FixtureGroupEditor>("org.qlcplus.classes", 1, 0,  "FixtureGroupEditor", "Can't create a FixtureGroupEditor !");
+    qmlRegisterUncreatableType<FixtureGroupEditor>("org.qlcplus.classes", 1, 0,  "FixtureGroupEditor", "Can't create a FixtureGroupEditor!");
 
     connect(m_doc, SIGNAL(loaded()), this, SLOT(slotDocLoaded()));
 }
@@ -356,7 +356,7 @@ void FixtureGroupEditor::transformSelection(int transformation)
         pointsList.append(QPoint(xPos, yPos));
         headsList.append(m_editGroup->head(QLCPoint(xPos, yPos)));
 
-        // WARNING: point of no return !
+        // WARNING: point of no return!
         m_editGroup->resignHead(QLCPoint(xPos, yPos));
     }
 

--- a/qmlui/fixturemanager.cpp
+++ b/qmlui/fixturemanager.cpp
@@ -62,9 +62,9 @@ FixtureManager::FixtureManager(QQuickView *view, Doc *doc, QObject *parent)
     m_monProps = m_doc->monitorProperties();
 
     m_view->rootContext()->setContextProperty("fixtureManager", this);
-    qmlRegisterUncreatableType<FixtureManager>("org.qlcplus.classes", 1, 0,  "FixtureManager", "Can't create a FixtureManager !");
-    qmlRegisterUncreatableType<QLCCapability>("org.qlcplus.classes", 1, 0, "QLCCapability", "Can't create a QLCCapability !");
-    qmlRegisterUncreatableType<ColorFilters>("org.qlcplus.classes", 1, 0, "ColorFilters", "Can't create a ColorFilters !");
+    qmlRegisterUncreatableType<FixtureManager>("org.qlcplus.classes", 1, 0,  "FixtureManager", "Can't create a FixtureManager!");
+    qmlRegisterUncreatableType<QLCCapability>("org.qlcplus.classes", 1, 0, "QLCCapability", "Can't create a QLCCapability!");
+    qmlRegisterUncreatableType<ColorFilters>("org.qlcplus.classes", 1, 0, "ColorFilters", "Can't create a ColorFilters!");
 
     connect(m_doc, SIGNAL(loaded()), this, SLOT(slotDocLoaded()));
     connect(m_doc, SIGNAL(fixtureAdded(quint32)), this, SLOT(slotFixtureAdded(quint32)));

--- a/qmlui/fixturemanager.cpp
+++ b/qmlui/fixturemanager.cpp
@@ -438,7 +438,7 @@ void FixtureManager::setItemRoleData(int itemID, int index, QString role, QVaria
         }
         else
         {
-            // TODO: flags per channel ?
+            // TODO: flags per channel?
         }
     }
     else if (role == "canFade")

--- a/qmlui/inputoutputmanager.cpp
+++ b/qmlui/inputoutputmanager.cpp
@@ -145,7 +145,7 @@ void InputOutputManager::removeLastUniverse()
     // Check if the universe is patched
     if (m_ioMap->isUniversePatched(index) == true)
     {
-        // Show popup ?
+        // Show popup?
     }
 
     // Check if there are fixtures using this universe

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -398,31 +398,31 @@ void MainView3D::createFixtureItem(quint32 fxID, quint16 headIndex, quint16 link
     {
         meshPath.append("par.dae");
         newItem->setProperty("meshType", FixtureMeshType::ParMeshType);
-    } 
-    else if (fixture->type() == QLCFixtureDef::MovingHead) 
+    }
+    else if (fixture->type() == QLCFixtureDef::MovingHead)
     {
         meshPath.append("moving_head.dae");
         newItem->setProperty("meshType", FixtureMeshType::MovingHeadMeshType);
     }
-     else if (fixture->type() == QLCFixtureDef::Scanner) 
+     else if (fixture->type() == QLCFixtureDef::Scanner)
     {
         meshPath.append("scanner.dae");
         newItem->setProperty("meshType", FixtureMeshType::DefaultMeshType);
-    } 
-    else if (fixture->type() == QLCFixtureDef::Hazer) 
+    }
+    else if (fixture->type() == QLCFixtureDef::Hazer)
     {
         meshPath.append("hazer.dae");
         newItem->setProperty("meshType", FixtureMeshType::DefaultMeshType);
-    } 
-    else if (fixture->type() == QLCFixtureDef::Smoke) 
+    }
+    else if (fixture->type() == QLCFixtureDef::Smoke)
     {
         meshPath.append("smoke.dae");
         newItem->setProperty("meshType", FixtureMeshType::DefaultMeshType);
-    } 
+    }
 
     newItem->setProperty("itemID", itemID);
     newItem->setProperty("itemSource", meshPath);
- 
+
     // at last, add the new fixture to the items map
     m_entitiesMap[itemID] = mesh;
 }
@@ -491,7 +491,7 @@ unsigned int MainView3D::getNewLightIndex()
 QVector3D MainView3D::lightPosition(quint32 itemID)
 {
     SceneItem *meshRef = m_entitiesMap.value(itemID, NULL);
-    if (meshRef == NULL)    
+    if (meshRef == NULL)
         return QVector3D();
 
     return meshRef->m_rootItem->property("lightPos").value<QVector3D>();
@@ -624,7 +624,7 @@ QEntity *MainView3D::inspectEntity(QEntity *entity, SceneItem *meshRef,
             Qt3DExtras::QPhongMaterial *pMaterial = qobject_cast<Qt3DExtras::QPhongMaterial *>(component);
 
             if (pMaterial)
-            {             
+            {
                 material->addParameter(new QParameter("diffuse", pMaterial->diffuse()));
                 material->addParameter(new QParameter("specular", pMaterial->specular()));
                 material->addParameter(new QParameter("shininess", pMaterial->shininess() ? pMaterial->shininess() : 1.0));
@@ -740,7 +740,7 @@ void MainView3D::initializeFixture(quint32 itemID, QEntity *fxEntity, QSceneLoad
 
     QTexture2D *tex = fxEntity->property("goboTexture").value<QTexture2D *>();
     //tex->setFormat(Qt3DRender::QAbstractTexture::RGBA8U);
-    tex->addTextureImage(meshRef->m_goboTexture); 
+    tex->addTextureImage(meshRef->m_goboTexture);
 
     // If this model has been already loaded, re-use the cached bounding volume
     if (m_boundingVolumesMap.contains(loader->source()))
@@ -843,7 +843,7 @@ void MainView3D::initializeFixture(quint32 itemID, QEntity *fxEntity, QSceneLoad
                 Q_ARG(QVariant, itemID),
                 Q_ARG(QVariant, QVariant::fromValue(meshRef->m_rootTransform)));
     }
-    
+
     if (itemFlags & MonitorProperties::HiddenFlag)
     {
         meshRef->m_rootItem->setProperty("enabled", false);
@@ -1142,7 +1142,7 @@ void MainView3D::updateLightMatrix(SceneItem *mesh)
             QMatrix4x4 armTransform = getTransform(mesh->m_armItem)->matrix();
             m.translate(armTransform.data()[12],armTransform.data()[13],armTransform.data()[14]);
         }
- 
+
         if (mesh->m_headItem) {
             QMatrix4x4 headTransform = getTransform(mesh->m_headItem)->matrix();
             m.translate(headTransform.data()[12],headTransform.data()[13],headTransform.data()[14]);
@@ -1151,11 +1151,11 @@ void MainView3D::updateLightMatrix(SceneItem *mesh)
         QVector4D xb = m * QVector4D(1,0,0,0);
         QVector4D yb = m * QVector4D(0,1,0,0);
         QVector4D zb = m * QVector4D(0,0,1,0);
-     
+
         QVector3D xa = QVector3D(xb.x(), xb.y(), xb.z()).normalized();
         QVector3D ya = QVector3D(yb.x(), yb.y(), yb.z()).normalized();
         QVector3D za = QVector3D(zb.x(), zb.y(), zb.z()).normalized();
-     
+
         QMatrix4x4 lightMatrix = QMatrix4x4(
             xa.x(), xa.y(), xa.z(), 0,
             ya.x(), ya.y(), ya.z(), 0,
@@ -1163,7 +1163,7 @@ void MainView3D::updateLightMatrix(SceneItem *mesh)
             0, 0, 0, 1
         ).transposed();
 
-        QVector4D result = m * QVector4D(0,0,0,1); 
+        QVector4D result = m * QVector4D(0,0,0,1);
 
         mesh->m_rootItem->setProperty("lightPos", QVector3D(result.x(), result.y(), result.z()) );
         mesh->m_rootItem->setProperty("lightMatrix", lightMatrix);
@@ -1677,7 +1677,7 @@ void GoboTextureImage::setSource(QString filename)
 }
 
 void GoboTextureImage::paint(QPainter *painter)
-{  
+{
     int w = painter->device()->width();
     int h = painter->device()->height();
 

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -63,7 +63,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     setContextTitle(tr("3D View"));
 
     qRegisterMetaType<Qt3DCore::QEntity*>();
-    qmlRegisterUncreatableType<MainView3D>("org.qlcplus.classes", 1, 0, "MainView3D", "Can't create an MainView3D !");
+    qmlRegisterUncreatableType<MainView3D>("org.qlcplus.classes", 1, 0, "MainView3D", "Can't create an MainView3D!");
 
     // the following two lists must always have the same items number and must respect
     // the order of StageType enum in MonitorProperties class
@@ -242,35 +242,35 @@ void MainView3D::initialize3DProperties()
 
     if (m_scene3D == NULL)
     {
-        qDebug() << "Scene3DItem not found !";
+        qDebug() << "Scene3DItem not found!";
         return;
     }
 
     m_sceneRootEntity = m_scene3D->findChild<QEntity *>("sceneRootEntity");
     if (m_sceneRootEntity == NULL)
     {
-        qDebug() << "sceneRootEntity not found !";
+        qDebug() << "sceneRootEntity not found!";
         return;
     }
 
     m_quadEntity = m_scene3D->findChild<QEntity *>("quadEntity");
     if (m_quadEntity == NULL)
     {
-        qDebug() << "quadEntity not found !";
+        qDebug() << "quadEntity not found!";
         return;
     }
 
     m_gBuffer = m_scene3D->findChild<QRenderTarget *>("gBuffer");
     if (m_gBuffer == NULL)
     {
-        qDebug() << "gBuffer not found !";
+        qDebug() << "gBuffer not found!";
         return;
     }
 
     m_frontDepthTarget = m_scene3D->findChild<QRenderTarget *>("depthTarget");
     if (m_frontDepthTarget == NULL)
     {
-        qDebug() << "frontDepth not found !";
+        qDebug() << "frontDepth not found!";
         return;
     }
 

--- a/qmlui/qlcplus_ca_ES.ts
+++ b/qmlui/qlcplus_ca_ES.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Voleu desar primer el projecte actual?
 Es perdran els canvis si no els guarda.</translation>
@@ -331,7 +331,7 @@ Es perdran els canvis si no els guarda.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Esteu segur que voleu eliminar els passos seleccionats?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ Es perdran els canvis si no els guarda.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Esteu segur que voleu eliminar la funció seleccionada?</translation>
     </message>
 </context>
@@ -2481,7 +2481,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Esteu segur que vols eliminar els següents elements?</translation>
     </message>
     <message>
@@ -2949,7 +2949,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Esteu segur que voleu eliminar els elements següents?
 (Tingueu en compte que les funcions originals no se suprimiran)</translation>
@@ -3624,7 +3624,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Estàs segur que vols esborrar la pàgina seleccionada?</translation>
     </message>
 </context>
@@ -3652,7 +3652,7 @@ Nivell d&apos;accés:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Estàs segur que vols esborrar els widgets següents?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_de_DE.ts
+++ b/qmlui/qlcplus_de_DE.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Willst du das aktuelle Projekt erst speichern?
 Ungesicherte Änderungen gehen verloren, wenn du sie nicht speicherst.</translation>
@@ -332,7 +332,7 @@ Ungesicherte Änderungen gehen verloren, wenn du sie nicht speicherst.</translat
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Willst du alle ausgewählten Schritte entfernen?</translation>
     </message>
     <message>
@@ -483,7 +483,7 @@ Ungesicherte Änderungen gehen verloren, wenn du sie nicht speicherst.</translat
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Willst du alle ausgewählten Funktionen entfernen?</translation>
     </message>
 </context>
@@ -2486,7 +2486,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Willst du alle folgenden Elemente löschen?</translation>
     </message>
     <message>
@@ -2955,7 +2955,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Willst du alle folgenden Elemente löschen?
 (Die ursprünglichen Funktionen werden nicht gelöscht)</translation>
@@ -3633,7 +3633,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Willst du die ausgewählte Seite entfernen?</translation>
     </message>
 </context>
@@ -3661,7 +3661,7 @@ Zugriffsstufe:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Willst du die folgenden Elemente löschen?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_es_ES.ts
+++ b/qmlui/qlcplus_es_ES.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>¿Desea guardar primero el proyecto?
 Los cambios que no guarde se perderán.</translation>
@@ -331,7 +331,7 @@ Los cambios que no guarde se perderán.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>¿Está seguro que quiere eliminar los pasos seleccionados?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ Los cambios que no guarde se perderán.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>¿Está seguro que quiere eliminar las funciones seleccionadas?</translation>
     </message>
 </context>
@@ -2481,7 +2481,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Está seguro que quiere eliminar los siguientes elementos?</translation>
     </message>
     <message>
@@ -2949,7 +2949,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>¿Está seguro que quiere eliminar los elementos siguientes ?
 (Las funciones originales NO se eliminarán)</translation>
@@ -3624,7 +3624,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>¿Está seguro que quiere eliminar la página seleccionada ?</translation>
     </message>
 </context>
@@ -3652,7 +3652,7 @@ Nivel de acceso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>¿Está seguro que quiere eliminar los widgets seleccionados?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_es_ES.ts
+++ b/qmlui/qlcplus_es_ES.ts
@@ -2951,7 +2951,7 @@ Nivel de acceso:</translation>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
         <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
-        <translation>¿Está seguro que quiere eliminar los elementos siguientes ?
+        <translation>¿Está seguro que quiere eliminar los elementos siguientes?
 (Las funciones originales NO se eliminarán)</translation>
     </message>
     <message>
@@ -3625,7 +3625,7 @@ Nivel de acceso:</translation>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
         <source>Are you sure you want to delete the selected page?</source>
-        <translation>¿Está seguro que quiere eliminar la página seleccionada ?</translation>
+        <translation>¿Está seguro que quiere eliminar la página seleccionada?</translation>
     </message>
 </context>
 <context>

--- a/qmlui/qlcplus_fr_FR.ts
+++ b/qmlui/qlcplus_fr_FR.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Souhaitez vous enregistrer le projet actuel&#xa0;?
 Les modifications seront perdues si vous ne les enregistrez pas.</translation>
@@ -331,7 +331,7 @@ Les modifications seront perdues si vous ne les enregistrez pas.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Êtes vous sûr de supprimer les étapes sélectionnées&#xa0;?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ Les modifications seront perdues si vous ne les enregistrez pas.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Êtes vous sûr de supprimer les fonctions sélectionnées&#xa0;?</translation>
     </message>
 </context>
@@ -2481,7 +2481,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Êtes vous sûr de supprimer les éléments suivants&#xa0;?</translation>
     </message>
     <message>
@@ -2949,7 +2949,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Êtes vous sûr de supprimer les éléments suivants&#xa0;?
 (Les fonctions originales ne seront pas supprimées)</translation>
@@ -3631,7 +3631,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Êtes vous sûrs de supprimer la page sélectionnée&#xa0;?</translation>
     </message>
 </context>
@@ -3659,7 +3659,7 @@ Niveau d&apos;accès&#xa0;:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Êtes vous sûr de supprimer les widgets suivants&#xa0;?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_it_IT.ts
+++ b/qmlui/qlcplus_it_IT.ts
@@ -41,7 +41,7 @@
     </message>
     <message>
         <location filename="qml/ActionsMenu.qml" line="95"/>
-        <source>Do you wish to save the current project first ?
+        <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
         <translation>Vuoi salvare il progetto corrente ?
 I cambiamenti verranno perduti se non salvati.</translation>
@@ -331,7 +331,7 @@ I cambiamenti verranno perduti se non salvati.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
-        <source>Are you sure you want to remove the selected steps ?</source>
+        <source>Are you sure you want to remove the selected steps?</source>
         <translation>Sei sicuro di voler rimuovere gli step selezionati ?</translation>
     </message>
     <message>
@@ -482,7 +482,7 @@ I cambiamenti verranno perduti se non salvati.</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
-        <source>Are you sure you want to remove the selected functions ?</source>
+        <source>Are you sure you want to remove the selected functions?</source>
         <translation>Sei sicuro di voler rimuovere le funzioni selezionate ?</translation>
     </message>
 </context>
@@ -2482,7 +2482,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
-        <source>Are you sure you want to delete the following items ?</source>
+        <source>Are you sure you want to delete the following items?</source>
         <translation>Sei sicuro di voler eliminare gli elementi seguenti ?</translation>
     </message>
     <message>
@@ -2950,7 +2950,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
-        <source>Are you sure you want to remove the following items ?
+        <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
         <translation>Sei sicuro di voler eliminare gli elementi seguenti ?
 (Le funzioni originali non verranno eliminate)</translation>
@@ -3625,7 +3625,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
-        <source>Are you sure you want to delete the selected page ?</source>
+        <source>Are you sure you want to delete the selected page?</source>
         <translation>Sei sicuro di voler eliminare la pagina selezionata ?</translation>
     </message>
 </context>
@@ -3653,7 +3653,7 @@ Livello di accesso:</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
-        <source>Are you sure you want to remove the following widgets ?</source>
+        <source>Are you sure you want to remove the following widgets?</source>
         <translation>Sei sicuro di voler eliminare i seguenti widget ?</translation>
     </message>
     <message>

--- a/qmlui/qlcplus_it_IT.ts
+++ b/qmlui/qlcplus_it_IT.ts
@@ -43,7 +43,7 @@
         <location filename="qml/ActionsMenu.qml" line="95"/>
         <source>Do you wish to save the current project first?
 Changes will be lost if you don&apos;t save them.</source>
-        <translation>Vuoi salvare il progetto corrente ?
+        <translation>Vuoi salvare il progetto corrente?
 I cambiamenti verranno perduti se non salvati.</translation>
     </message>
     <message>
@@ -332,7 +332,7 @@ I cambiamenti verranno perduti se non salvati.</translation>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="124"/>
         <source>Are you sure you want to remove the selected steps?</source>
-        <translation>Sei sicuro di voler rimuovere gli step selezionati ?</translation>
+        <translation>Sei sicuro di voler rimuovere gli step selezionati?</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/ChaserEditor.qml" line="157"/>
@@ -483,7 +483,7 @@ I cambiamenti verranno perduti se non salvati.</translation>
     <message>
         <location filename="qml/fixturesfunctions/CollectionEditor.qml" line="130"/>
         <source>Are you sure you want to remove the selected functions?</source>
-        <translation>Sei sicuro di voler rimuovere le funzioni selezionate ?</translation>
+        <translation>Sei sicuro di voler rimuovere le funzioni selezionate?</translation>
     </message>
 </context>
 <context>
@@ -2483,7 +2483,7 @@ Livello di accesso:</translation>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="219"/>
         <source>Are you sure you want to delete the following items?</source>
-        <translation>Sei sicuro di voler eliminare gli elementi seguenti ?</translation>
+        <translation>Sei sicuro di voler eliminare gli elementi seguenti?</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="226"/>
@@ -2952,7 +2952,7 @@ Livello di accesso:</translation>
         <location filename="qml/showmanager/ShowManager.qml" line="195"/>
         <source>Are you sure you want to remove the following items?
 (Note that the original functions will not be deleted)</source>
-        <translation>Sei sicuro di voler eliminare gli elementi seguenti ?
+        <translation>Sei sicuro di voler eliminare gli elementi seguenti?
 (Le funzioni originali non verranno eliminate)</translation>
     </message>
     <message>
@@ -3626,7 +3626,7 @@ Livello di accesso:</translation>
     <message>
         <location filename="qml/virtualconsole/VCPageProperties.qml" line="167"/>
         <source>Are you sure you want to delete the selected page?</source>
-        <translation>Sei sicuro di voler eliminare la pagina selezionata ?</translation>
+        <translation>Sei sicuro di voler eliminare la pagina selezionata?</translation>
     </message>
 </context>
 <context>
@@ -3654,7 +3654,7 @@ Livello di accesso:</translation>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="131"/>
         <source>Are you sure you want to remove the following widgets?</source>
-        <translation>Sei sicuro di voler eliminare i seguenti widget ?</translation>
+        <translation>Sei sicuro di voler eliminare i seguenti widget?</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCRightPanel.qml" line="138"/>

--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -92,7 +92,7 @@ Popup
     {
         id: saveFirstPopup
         title: qsTr("Your project has changes")
-        message: qsTr("Do you wish to save the current project first ?\nChanges will be lost if you don't save them.")
+        message: qsTr("Do you wish to save the current project first?\nChanges will be lost if you don't save them.")
         standardButtons: Dialog.Yes | Dialog.No | Dialog.Cancel
 
         property string action: ""

--- a/qmlui/qml/ChaserWidget.qml
+++ b/qmlui/qml/ChaserWidget.qml
@@ -93,7 +93,7 @@ Column
     ModelSelector
     {
         id: ceSelector
-        onItemsCountChanged: console.log("Chaser Editor selected items changed !")
+        onItemsCountChanged: console.log("Chaser Editor selected items changed!")
     }
 
     TimeEditTool

--- a/qmlui/qml/fixturesfunctions/2DView.qml
+++ b/qmlui/qml/fixturesfunctions/2DView.qml
@@ -219,7 +219,7 @@ Rectangle
                     // pressing on nothing starts to draw the selection rectangle
                     if (itemID === -1)
                     {
-                        //console.log("Starting selection rectangle !")
+                        //console.log("Starting selection rectangle!")
                         // initialize local variables to determine the selection orientation
                         initialXPos = mouse.x
                         initialYPos = mouse.y

--- a/qmlui/qml/fixturesfunctions/ChaserEditor.qml
+++ b/qmlui/qml/fixturesfunctions/ChaserEditor.qml
@@ -121,7 +121,7 @@ Rectangle
                     {
                         id: deleteItemsPopup
                         title: qsTr("Delete steps")
-                        message: qsTr("Are you sure you want to remove the selected steps ?")
+                        message: qsTr("Are you sure you want to remove the selected steps?")
                         onAccepted: functionManager.deleteEditorItems(chWidget.selector.itemsList())
                     }
                 }

--- a/qmlui/qml/fixturesfunctions/CollectionEditor.qml
+++ b/qmlui/qml/fixturesfunctions/CollectionEditor.qml
@@ -127,7 +127,7 @@ Rectangle
                     {
                         id: deleteItemsPopup
                         title: qsTr("Delete functions")
-                        message: qsTr("Are you sure you want to remove the selected functions ?")
+                        message: qsTr("Are you sure you want to remove the selected functions?")
                         onAccepted: functionManager.deleteEditorItems(ceSelector.itemsList())
                     }
                 }

--- a/qmlui/qml/fixturesfunctions/CollectionEditor.qml
+++ b/qmlui/qml/fixturesfunctions/CollectionEditor.qml
@@ -37,7 +37,7 @@ Rectangle
     ModelSelector
     {
         id: ceSelector
-        //onItemsCountChanged: console.log("Collection Editor selected items changed !")
+        //onItemsCountChanged: console.log("Collection Editor selected items changed!")
     }
 
     SplitView

--- a/qmlui/qml/fixturesfunctions/EFXEditor.qml
+++ b/qmlui/qml/fixturesfunctions/EFXEditor.qml
@@ -39,7 +39,7 @@ Rectangle
     ModelSelector
     {
         id: eeSelector
-        onItemsCountChanged: console.log("EFX Editor selected items changed !")
+        onItemsCountChanged: console.log("EFX Editor selected items changed!")
     }
 
     TimeEditTool

--- a/qmlui/qml/fixturesfunctions/RightPanel.qml
+++ b/qmlui/qml/fixturesfunctions/RightPanel.qml
@@ -216,7 +216,7 @@ SidePanel
                 {
                     var selNames = functionManager.selectedItemNames()
                     //console.log(selNames)
-                    deleteItemsPopup.message = qsTr("Are you sure you want to delete the following items ?") + "\n" + selNames
+                    deleteItemsPopup.message = qsTr("Are you sure you want to delete the following items?") + "\n" + selNames
                     deleteItemsPopup.open()
                 }
 

--- a/qmlui/qml/fixturesfunctions/SceneEditor.qml
+++ b/qmlui/qml/fixturesfunctions/SceneEditor.qml
@@ -39,7 +39,7 @@ Rectangle
     ModelSelector
     {
         id: seSelector
-        onItemsCountChanged: console.log("Scene Editor selected items changed !")
+        onItemsCountChanged: console.log("Scene Editor selected items changed!")
     }
 
     TimeEditTool

--- a/qmlui/qml/showmanager/ShowManager.qml
+++ b/qmlui/qml/showmanager/ShowManager.qml
@@ -550,7 +550,7 @@ Rectangle
                     {
                         var args = []
                         actionManager.requestActionPopup(ActionManager.None,
-                                                         qsTr("Cannot drag a Show into itself !"),
+                                                         qsTr("Cannot drag a Show into itself!"),
                                                          ActionManager.OK, args)
                     }
 */

--- a/qmlui/qml/showmanager/ShowManager.qml
+++ b/qmlui/qml/showmanager/ShowManager.qml
@@ -192,7 +192,7 @@ Rectangle
                 {
                     var selNames = showManager.selectedItemNames()
                     //console.log(selNames)
-                    deleteItemsPopup.message = qsTr("Are you sure you want to remove the following items ?\n(Note that the original functions will not be deleted)") + "\n" + selNames,
+                    deleteItemsPopup.message = qsTr("Are you sure you want to remove the following items?\n(Note that the original functions will not be deleted)") + "\n" + selNames,
                     deleteItemsPopup.open()
                 }
 
@@ -481,7 +481,7 @@ Rectangle
             contentX: xViewOffset
             ScrollBar.horizontal: CustomScrollBar { orientation: Qt.Horizontal }
 
-            onContentXChanged: xViewOffset = contentX           
+            onContentXChanged: xViewOffset = contentX
 
             MouseArea
             {

--- a/qmlui/qml/virtualconsole/VCPageProperties.qml
+++ b/qmlui/qml/virtualconsole/VCPageProperties.qml
@@ -164,7 +164,7 @@ Rectangle
             {
                 id: deletePagePopup
                 title: qsTr("Delete page")
-                message: qsTr("Are you sure you want to delete the selected page ?")
+                message: qsTr("Are you sure you want to delete the selected page?")
                 onAccepted: virtualConsole.deletePage(virtualConsole.selectedPage)
             }
         }

--- a/qmlui/qml/virtualconsole/VCRightPanel.qml
+++ b/qmlui/qml/virtualconsole/VCRightPanel.qml
@@ -128,7 +128,7 @@ SidePanel
                 {
                     var selNames = virtualConsole.selectedWidgetNames()
                     //console.log(selNames)
-                    deleteWidgetsPopup.message = qsTr("Are you sure you want to remove the following widgets ?") + "\n" + selNames
+                    deleteWidgetsPopup.message = qsTr("Are you sure you want to remove the following widgets?") + "\n" + selNames
                     deleteWidgetsPopup.open()
                 }
 

--- a/qmlui/rgbmatrixeditor.cpp
+++ b/qmlui/rgbmatrixeditor.cpp
@@ -567,7 +567,7 @@ void RGBMatrixEditor::slotPreviewTimeout()
                 m_previewData[ptIdx] = QVariant(QColor(map[pt.y()][pt.x()]));
         }
 
-        //qDebug() << "Preview data changed !";
+        //qDebug() << "Preview data changed!";
         emit previewDataChanged(m_previewData);
     }
 }

--- a/qmlui/showmanager.cpp
+++ b/qmlui/showmanager.cpp
@@ -189,7 +189,7 @@ void ShowManager::addItems(QQuickItem *parent, int trackIdx, int startTime, QVar
         Function *f = qobject_cast<Function*>(m_currentShow);
         if (m_doc->addFunction(f) == false)
         {
-            qDebug() << "Error in creating a new Show !";
+            qDebug() << "Error in creating a new Show!";
             m_currentShow = NULL;
             return;
         }
@@ -213,7 +213,7 @@ void ShowManager::addItems(QQuickItem *parent, int trackIdx, int startTime, QVar
     {
         if (trackIdx >= m_currentShow->tracks().count())
         {
-            qDebug() << "Track index out of bounds !" << trackIdx;
+            qDebug() << "Track index out of bounds!" << trackIdx;
             return;
         }
         selectedTrack = m_currentShow->tracks().at(trackIdx);

--- a/qmlui/tardis/networkmanager.cpp
+++ b/qmlui/tardis/networkmanager.cpp
@@ -603,7 +603,7 @@ void NetworkManager::slotProcessTCPPackets()
                     QByteArray decrPayload = paramsList.at(0).toByteArray();
                     if (QString::fromUtf8(decrPayload) == QString::number(defaultKey, 16))
                     {
-                        qDebug() << "Key matches !";
+                        qDebug() << "Key matches!";
                         success = true;
                     }
                 }
@@ -722,7 +722,7 @@ void NetworkManager::slotHostDisconnected()
 {
     QTcpSocket *socket = (QTcpSocket *)sender();
     QHostAddress senderAddress = socket->peerAddress();
-    qDebug() << "Host with address" << senderAddress.toString() << "disconnected !";
+    qDebug() << "Host with address" << senderAddress.toString() << "disconnected!";
 
     if (m_hostsMap.contains(senderAddress) == true)
     {

--- a/qmlui/tardis/tardis.cpp
+++ b/qmlui/tardis/tardis.cpp
@@ -374,7 +374,7 @@ QByteArray Tardis::actionToByteArray(int code, quint32 objID, QVariant data)
         }
         break;
         default:
-            qWarning() << "Buffered action" << code << "not implemented !";
+            qWarning() << "Buffered action" << code << "not implemented!";
         break;
     }
 
@@ -385,7 +385,7 @@ bool Tardis::processBufferedAction(int action, quint32 objID, QVariant &value)
 {
     if (value.type() != QVariant::ByteArray)
     {
-        qWarning("Action 0x%02X is not buffered !", action);
+        qWarning("Action 0x%02X is not buffered!", action);
         return false;
     }
 
@@ -1094,7 +1094,7 @@ int Tardis::processAction(TardisAction &action, bool undo)
         break;
 
         default:
-            qWarning() << "Action" << action.m_action << "not implemented !";
+            qWarning() << "Action" << action.m_action << "not implemented!";
         break;
     }
 

--- a/qmlui/treemodel.cpp
+++ b/qmlui/treemodel.cpp
@@ -109,7 +109,7 @@ TreeModelItem *TreeModel::addItem(QString label, QVariantList data, QString path
 
     // fewer roles are allowed, while exceeding are probably a mistake
     if (data.count() > m_roles.count())
-        qDebug() << "Item roles exceeds tree roles !" << data.count() << m_roles.count();
+        qDebug() << "Item roles exceeds tree roles!" << data.count() << m_roles.count();
 
     if (m_checkable)
         flags |= Checkable;

--- a/qmlui/videoprovider.cpp
+++ b/qmlui/videoprovider.cpp
@@ -32,7 +32,7 @@ VideoProvider::VideoProvider(QQuickView *view, Doc *doc, QObject *parent)
 {
     Q_ASSERT(doc != NULL);
 
-    qmlRegisterUncreatableType<Video>("org.qlcplus.classes", 1, 0, "VideoFunction", "Can't create a Video !");
+    qmlRegisterUncreatableType<Video>("org.qlcplus.classes", 1, 0, "VideoFunction", "Can't create a Video!");
 
     for (Function *f : m_doc->functionsByType(Function::VideoType))
         slotFunctionAdded(f->id());

--- a/qmlui/virtualconsole/vcbutton.cpp
+++ b/qmlui/virtualconsole/vcbutton.cpp
@@ -104,7 +104,7 @@ bool VCButton::copyFrom(const VCWidget* widget)
         return false;
 
     /* Copy button-specific stuff */
-    //setIconPath(button->iconPath()); // TODO ?
+    //setIconPath(button->iconPath()); // TODO?
     setFunctionID(button->functionID());
     setStartupIntensityEnabled(button->startupIntensityEnabled());
     setStartupIntensity(button->startupIntensity());

--- a/qmlui/virtualconsole/vcframe.cpp
+++ b/qmlui/virtualconsole/vcframe.cpp
@@ -766,7 +766,7 @@ void VCFrame::slotFunctionStarting(VCWidget *widget, quint32 fid, qreal fIntensi
     Q_UNUSED(fIntensity)
 
     if (xmlTagName() == KXMLQLCVCFrame)
-        qDebug() << "[VCFrame] ERROR ! This should never happen !";
+        qDebug() << "[VCFrame] ERROR ! This should never happen!";
 }
 
 /*********************************************************************

--- a/qmlui/virtualconsole/vcpage.cpp
+++ b/qmlui/virtualconsole/vcpage.cpp
@@ -171,7 +171,7 @@ void VCPage::inputValueChanged(quint32 universe, quint32 channel, uchar value)
      *  check also if the page matches and finally inform the VC widget
      *  about the event, including the source ID
      */
-    for(QPair<QSharedPointer<QLCInputSource>, VCWidget *> match : m_inputSourcesMap.values(key)) // C++11...yay !
+    for(QPair<QSharedPointer<QLCInputSource>, VCWidget *> match : m_inputSourcesMap.values(key)) // C++11...yay!
     {
         if (match.second->isDisabled() == false &&
             match.second->isEditing() == false &&
@@ -255,7 +255,7 @@ void VCPage::handleKeyEvent(QKeyEvent *e, bool pressed)
 {
     QKeySequence seq(e->key() | e->modifiers());
 
-    for(QPair<quint32, VCWidget *> match : m_keySequencesMap.values(seq)) // C++11...yay !
+    for(QPair<quint32, VCWidget *> match : m_keySequencesMap.values(seq)) // C++11...yay!
     {
         if (match.second->isDisabled() == false &&
             match.second->isEditing() == false)

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -1094,7 +1094,7 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
             quint32 dmx_ch = fxi->address() + scv.channel;
             int uni = fxi->universe();
 
-            // Dirty channel group check: is the channel HTP or LTP ?
+            // Dirty channel group check: is the channel HTP or LTP?
             QLCChannel::Group group = qlcch->group();
             if (fxi->forcedLTPChannels().contains(scv.channel))
                 group = QLCChannel::Effect;

--- a/qmlui/virtualconsole/vcwidget.cpp
+++ b/qmlui/virtualconsole/vcwidget.cpp
@@ -634,7 +634,7 @@ int VCWidget::controlIndex(quint8 id)
         if (m_externalControlList.at(i).id == id)
             return i;
 
-    qDebug() << "ERROR: id" << id << "not registered in controls list !";
+    qDebug() << "ERROR: id" << id << "not registered in controls list!";
 
     return 0;
 }
@@ -873,7 +873,7 @@ void VCWidget::deleteKeySequence(const QKeySequence &keySequence)
 void VCWidget::updateKeySequence(QKeySequence oldSequence, QKeySequence newSequence, const quint32 id)
 {
     if (m_keySequenceMap.contains(oldSequence) == false)
-        qDebug() << "Old key sequence not found !";
+        qDebug() << "Old key sequence not found!";
 
     m_keySequenceMap.remove(oldSequence);
     m_keySequenceMap[newSequence] = id;

--- a/qmlui/virtualconsole/virtualconsole.cpp
+++ b/qmlui/virtualconsole/virtualconsole.cpp
@@ -87,8 +87,8 @@ VirtualConsole::VirtualConsole(QQuickView *view, Doc *doc,
         m_pages.append(page);
     }
 
-    qmlRegisterUncreatableType<GrandMaster>("org.qlcplus.classes", 1, 0, "GrandMaster", "Can't create a GrandMaster !");
-    qmlRegisterUncreatableType<QLCInputChannel>("org.qlcplus.classes", 1, 0, "QLCInputChannel", "Can't create a QLCInputChannel !");
+    qmlRegisterUncreatableType<GrandMaster>("org.qlcplus.classes", 1, 0, "GrandMaster", "Can't create a GrandMaster!");
+    qmlRegisterUncreatableType<QLCInputChannel>("org.qlcplus.classes", 1, 0, "QLCInputChannel", "Can't create a QLCInputChannel!");
 
     qmlRegisterType<VCWidget>("org.qlcplus.classes", 1, 0, "VCWidget");
     qmlRegisterType<VCFrame>("org.qlcplus.classes", 1, 0, "VCFrame");

--- a/qmlui/virtualconsole/virtualconsole.cpp
+++ b/qmlui/virtualconsole/virtualconsole.cpp
@@ -440,7 +440,7 @@ quint32 VirtualConsole::newWidgetId()
 
 void VirtualConsole::addWidgetToMap(VCWidget* widget)
 {
-    // Valid ID ?
+    // Valid ID?
     if (widget->id() != VCWidget::invalidId())
     {
         // Maybe we don't know this widget yet
@@ -826,7 +826,7 @@ void VirtualConsole::pasteFromClipboard()
         }
     }
 
-    // no selected frame found ? Paste on current page
+    // no selected frame found? Paste on current page
     if (frame == NULL)
     {
         frame = qobject_cast<VCFrame*>(m_pages.at(selectedPage()));

--- a/resources/docs/html_en_EN/dmxdump.html
+++ b/resources/docs/html_en_EN/dmxdump.html
@@ -12,9 +12,9 @@
 <P>
 The DMX Dump functionality allows you to save the current DMX values that are being sent to the output universes
 at a particular moment. Basically it takes a "snapshot" of DMX channels and saves them for a later use.<br>
-DMX Dump can save values to a new <A HREF="file:concept.html#Scene">Scene</A> or overwite the values of an existing 
-Scene. The "dumped" Scene can also be added to an existing 
-<A HREF="file:concept.html#Chaser">Chaser</A>, Virtual Console <A HREF="file:vcbutton.html">button</A> 
+DMX Dump can save values to a new <A HREF="file:concept.html#Scene">Scene</A> or overwite the values of an existing
+Scene. The "dumped" Scene can also be added to an existing
+<A HREF="file:concept.html#Chaser">Chaser</A>, Virtual Console <A HREF="file:vcbutton.html">button</A>
 or <A HREF="file:vcslider.html">slider</A><br><br>
 
 Please note that:
@@ -29,7 +29,7 @@ When opening the DMX Dump window, the following options will appear:
  <TR>
   <TD><b>Scene name</b></TD>
   <TD>
-   Defines the name of the Scene that will be created. If no name is specified, a default 
+   Defines the name of the Scene that will be created. If no name is specified, a default
    name like "New Scene From Live" and a numeric identification will be set, allowing fast use of this functionality.
   </TD>
  </TR>
@@ -37,14 +37,14 @@ When opening the DMX Dump window, the following options will appear:
   <TD><img src="qrc:/scene.png" ALIGN="absmiddle"> <B>Select an existing Scene</B></TD>
   <TD>By clicking on this button, a Function selection window will be displayed, allowing
       to select an existing Scene to be overwritten with the current DMX values.<br><br>
-      <B>Note:</B> Overwriting a Scene doesn't ask for confirmation and can be a potentially 
+      <B>Note:</B> Overwriting a Scene doesn't ask for confirmation and can be a potentially
       dangerous operation if you select the wrong Scene by mistake. So be careful when using this functionality.<br>
       <br>
       When a Scene is selected, the DMX Dump window will automatically set two things for you:
       <UL>
        <LI>The "Dump selected channels" option will be checked</LI>
-       <LI>The Fixtures tree will be updated, and only the channels enabled in the Scene channels 
-         will be selected. If you need to overwrite different channels, just select/unselect 
+       <LI>The Fixtures tree will be updated, and only the channels enabled in the Scene channels
+         will be selected. If you need to overwrite different channels, just select/unselect
          them manually before confirming the operation
        </LI>
       </UL>
@@ -53,7 +53,7 @@ When opening the DMX Dump window, the following options will appear:
   <TD><B>Dump all channels</B></TD>
   <TD>
    If this option is selected, QLC+ will dump all the channels of all the universes and all the fixtures.
-   To inform the user about what this option will do, a report in the form of (Universes, Fixtures, Channels) 
+   To inform the user about what this option will do, a report in the form of (Universes, Fixtures, Channels)
    will be displayed.
   </TD>
  </TR>
@@ -74,7 +74,7 @@ When opening the DMX Dump window, the following options will appear:
    <UL>
     <LI><B>Chaser</B>: The list contains all the chasers present when DMX Dump window is opened. Each Chaser
      has a checkbox that, if checked, will tell QLC+ to add the newly created Scene to the selected chasers.<br>
-     This feature is very useful when using <A HREF="file:vccuelist.html">Cue Lists</A> in the 
+     This feature is very useful when using <A HREF="file:vccuelist.html">Cue Lists</A> in the
      <A HREF="file:virtualconsole.html">Virtual Console</A> panel, because the newly created Scene will appear
      in the Cue List for immediate use during a live performance.
     </LI>

--- a/resources/docs/html_en_EN/dmxdump.html
+++ b/resources/docs/html_en_EN/dmxdump.html
@@ -82,13 +82,13 @@ When opening the DMX Dump window, the following options will appear:
     <LI><B>Button</B>: The list contains all the buttons currently present in your Virtual Console space.<br>
      When selected, the buttons will be set to activate/deactivate the Scene just captured. You will see the button
      label chaning to "Scene from live ..." and a progress number to identify it.<br>
-     <b>Note:</b> Any previous function associated to the selected buttons will be overwritten !
+     <b>Note:</b> Any previous function associated to the selected buttons will be overwritten!
     </LI>
     <br>
     <LI><B>Slider</B>: The list contains all the sliders currently present in your Virtual Console space.<br>
      As with buttons, all the selected sliders will be set to control the Scene just captured.<br>
      <b>Note 1:</b> A slider must be in <B>playback mode</B> to work as an intensity controller for a Scene.<br>
-     <b>Note 2:</b> Any previous function associated with the selected sliders will be overwritten !
+     <b>Note 2:</b> Any previous function associated with the selected sliders will be overwritten!
     </LI>
   </TD>
  </TR>

--- a/resources/docs/html_en_EN/dmxusbplugin.html
+++ b/resources/docs/html_en_EN/dmxusbplugin.html
@@ -31,9 +31,9 @@ The DMX USB plugin supports a variety of FTDI-based USB-to-DMX devices:
 <P>
 DMX USB devices should be automatically detected from QLC+ and displayed in the input/output panels list.<br>
 If for some reason the auto-detection fails, you can "force" the type of your DMX USB adapter manually.<br>
-Click on the name of your device and open the configuration dialog by clicking on 
+Click on the name of your device and open the configuration dialog by clicking on
 the <IMG SRC="qrc:/configure.png" width=32> icon on the bottom-right side of the panel.<br>
-You will see a list of DMX USB devices currently connected to your computer. Each one has a drop down menu 
+You will see a list of DMX USB devices currently connected to your computer. Each one has a drop down menu
 where you can force the device type.<br>
 Here's the meaning of each one:
 <UL>
@@ -55,7 +55,7 @@ in the <A HREF="questionsandanswers.html#osx-mavericks">Questions and Answers</A
 On all Linux distributions, you need to install libftdi. If you install QLC+ with the Ubuntu
 Software Center or some other automatic installer tool, this library will be installed
 automatically for you.<br>
-In some cases, if the device doesn't output anything, it might be useful to add your user 
+In some cases, if the device doesn't output anything, it might be useful to add your user
 to the "dialout" group with the following command:<br>
 <PRE>sudo adduser your_user_name dialout</PRE>
 </P>
@@ -80,7 +80,7 @@ Consult the <A HREF="http://www.ftdichip.com/Support/Documents/InstallGuides.htm
 <H1>4 ENTTEC DMX USB Pro supported modes</H1>
 <P>
 Following a grid showing the IO modes supported by QLC+ for devices like DMX USB Pro and Pro Mk2.<br>
-If a mode is not listed here, it means it is not supported by QLC+ or the device itself because of hardware limitations, 
+If a mode is not listed here, it means it is not supported by QLC+ or the device itself because of hardware limitations,
 so please do not report them as issues in the QLC+ forum.<br>
 <br>
 <TABLE BORDER=1 class="qlcTable">

--- a/resources/docs/html_en_EN/dmxusbplugin.html
+++ b/resources/docs/html_en_EN/dmxusbplugin.html
@@ -117,7 +117,7 @@ from 1 to 512 as described in the <a href="midiplugin.html#channelsmap">MIDI plu
 
 <H1>5 Tuning</H1>
 <P>
-<B>Note: Manual tuning should never be performed except for some very particular cases. Use it at your own risk !</B><BR>
+<B>Note: Manual tuning should never be performed except for some very particular cases. Use it at your own risk!</B><BR>
 It is possible to change the DMX frame frequency for Enttec Open (and like) devices with a
 hidden settings key on each platform. The key tells QLC+ how many times each DMX frame (512 channels)
 should be sent to the universe per second. A value of "30" means 30 times per second (30Hz).<BR>

--- a/resources/docs/html_en_EN/fixturesremap.html
+++ b/resources/docs/html_en_EN/fixturesremap.html
@@ -18,7 +18,7 @@ faulty fixture or when you want to use hired in equipment alongside your own.<br
 For example, you can set up a project with just one PAR, one moving head and one scanner.
 When reaching the venue where the show is going to take place, you can remap your fixtures
 to those you find there, for example 50 PARs, 30 moving heads and 15 scanners.<br>
-With QLC+, it takes just a few minutes to do this operation !<br>
+With QLC+, it takes just a few minutes to do this operation!<br>
 <br>
 Fixtures remapping allows you to perform 1-to-1 or 1-to-many reassignments of entire fixtures or single channels.
 QLC+ will try as far as possible to reassign the original channels used in the project to new channels in the same category.<br>

--- a/resources/docs/html_en_EN/fixturesremap.html
+++ b/resources/docs/html_en_EN/fixturesremap.html
@@ -10,10 +10,10 @@
 <H1><img src="qrc:/remap.png" width=32> Fixtures remapping</H1>
 <P>
 Starting from version 4.4.1, QLC+ offers a functionality called fixtures remapping.<br>
-When performing live shows in different venues, you may only be able to find out at the 
+When performing live shows in different venues, you may only be able to find out at the
 last minute which <A HREF="file:concept.html#Fixtures">fixtures</A> are
 installed there. Well, fixtures remapping helps you to use your
-existing projects in this and many other situations, such as when you need to replace a 
+existing projects in this and many other situations, such as when you need to replace a
 faulty fixture or when you want to use hired in equipment alongside your own.<br>
 For example, you can set up a project with just one PAR, one moving head and one scanner.
 When reaching the venue where the show is going to take place, you can remap your fixtures
@@ -61,15 +61,15 @@ And now, here is a detailed explanation of each element of the remapping window.
  <TR>
   <TD><IMG SRC="qrc:/remap.png"></TD>
   <TD>This is probably the most important button in the window. It allows you to
-    determine the connection between a source ficture and a remapped fixture. 
+    determine the connection between a source ficture and a remapped fixture.
     The connections can be performed either between single channels or on whole fixtures.<br>
-    In the first case you will need to select the source channel from the source fixtures list 
+    In the first case you will need to select the source channel from the source fixtures list
     and a target channel from the remapped fixtures list.<br>
-    In the second case you will need to select a fixture from the source fixtures list and a 
+    In the second case you will need to select a fixture from the source fixtures list and a
     target fixture from the remapped fixtures list.<br>
-    Wrong selections will cause an error message to popup. For example you cannot remap a channel 
+    Wrong selections will cause an error message to popup. For example you cannot remap a channel
     to a fixture and vice-versa.<br>
-    If the connection is valid, it will be represented as a line in the white area between 
+    If the connection is valid, it will be represented as a line in the white area between
     the source list and the remapped list.
     </TD>
  </TR>
@@ -84,7 +84,7 @@ And now, here is a detailed explanation of each element of the remapping window.
  </TR>
  <TR>
   <TD><b>Destination project name</b></TD>
-  <TD>The absolute path and name of the remapped project. For convenience, QLC+ will automatically 
+  <TD>The absolute path and name of the remapped project. For convenience, QLC+ will automatically
   take the original project name and will add "(remapped)" at the end of it.</TD>
  </TR>
 </TABLE>

--- a/resources/docs/html_en_EN/guicustomstyles.html
+++ b/resources/docs/html_en_EN/guicustomstyles.html
@@ -24,7 +24,7 @@ The style file must also be placed in a specific path which is:<BR>
 </UL>
 
 The style file must have a CSS syntax. If you're comfortable with web designing, you should
-find the creation of this file very easy !<BR>
+find the creation of this file very easy!<BR>
 Since the style file is strictly related to the inner Qt objects, you might want
 to read the following articles to find out the elements' names and the additional
 CSS properties the Qt team added to the default CSS syntax.<br>

--- a/resources/docs/html_en_EN/howto-input-profiles.html
+++ b/resources/docs/html_en_EN/howto-input-profiles.html
@@ -221,8 +221,8 @@ administrator.
 </P>
 
 <P>
-That's all !<br>
-Now you can start using your preferred profile. When assigining 
+That's all!<br>
+Now you can start using your preferred profile. When assigining
 an input channel to a QLC+ element (like Virtual Console sliders, channel groups, etc..)
 you will see that your Input profile mapping will be used.
 </P>

--- a/resources/docs/html_en_EN/howto-input-profiles.html
+++ b/resources/docs/html_en_EN/howto-input-profiles.html
@@ -91,7 +91,7 @@ enter individual channel information by hand for each channel.<BR>
 <P>
 <IMG SRC="qrc:/wizard.png" ALIGN="absmiddle"> Click the automatic wizard
 button to attempt automatic channel detection. You'll receive further
-instructions from QLC+. You must have an 
+instructions from QLC+. You must have an
 <A HREF="file:howto-input-output-mapping.html">input plugin</A> assigned to the current
 universe for this feature to work. Also, you must first stop the wizard to
 be able to navigate away from this dialog page.
@@ -100,7 +100,7 @@ be able to navigate away from this dialog page.
 
 <H3>Channel properties</H3>
 <P>
-When you add <IMG SRC="qrc:/edit_add.png" ALIGN="absmiddle"> or 
+When you add <IMG SRC="qrc:/edit_add.png" ALIGN="absmiddle"> or
 edit <IMG SRC="qrc:/edit.png" ALIGN="absmiddle"> a channel, a small window
 will be displayed, asking you to fill or change some parameters:
 <ul>
@@ -108,15 +108,15 @@ will be displayed, asking you to fill or change some parameters:
      input plugins, the channel number might not be intuitive, so only edit this if
      you know what you're doing.
  </li>
- <li><b>Name</b>: The channel name. This is an arbitrary string to indicate 
+ <li><b>Name</b>: The channel name. This is an arbitrary string to indicate
      the purpose of a channel.
  </li>
- <li><b>Type</b>: The channel type. This can be: 
-   <IMG SRC="qrc:/slider.png" ALIGN="absmiddle"> Slider, 
+ <li><b>Type</b>: The channel type. This can be:
+   <IMG SRC="qrc:/slider.png" ALIGN="absmiddle"> Slider,
    <IMG SRC="qrc:/knob.png" ALIGN="absmiddle"> Knob,
    <IMG SRC="qrc:/button.png" ALIGN="absmiddle"> Button or
    <IMG SRC="qrc:/knob.png" ALIGN="absmiddle"> Encoder<BR>
-   Other types:  
+   Other types:
    <IMG SRC="qrc:/back.png" ALIGN="absmiddle"> Previous page,
    <IMG SRC="qrc:/forward.png" ALIGN="absmiddle"> Next Page,
    <IMG SRC="qrc:/star.png" ALIGN="absmiddle"> Set Page are used to control multipage frames.
@@ -143,14 +143,14 @@ where you can enter the channel specification (which translates to channel numbe
 <P>
 If your input profile includes slider channels,
 when you click on them you'll notice some extra properties showing up at the bottom of
-the input profile editor main window. With those, you can set how values received 
+the input profile editor main window. With those, you can set how values received
 from a slider should act within QLC+.<br><br>
 There are two behaviours: <u>Absolute</u> and <u>Relative</u>.<br><br>
 <b>Absolute</b> is the default setting and basically tells QLC+ to use the slider values
 exactly as they are received from an external controller.<br>
 <br>
 <b>Relative</b> is a more advanced behaviour that comes handy when using a HID Joystick
-with a QLC+ <A HREF="file:vcxypad.html">XY Pad widget</a> or a 
+with a QLC+ <A HREF="file:vcxypad.html">XY Pad widget</a> or a
 <A HREF="file:vcslider.html">Slider widget</a>. Values received from an external controller
 are treated as relative movement starting from the current position of a Virtual Console
 widget.<br>
@@ -185,12 +185,12 @@ the following properties will be used globally in QLC+.
 <br><br>
 <B>Generate an extra Press/Release when toggled</B>: this is a quite specific option used for
 example when dealing with TouchOSC or the Behringer BCF2000.<br>
-QLC+ toggle events are triggered when a high+low sequence is received. This means that QLC+ expects a 
+QLC+ toggle events are triggered when a high+low sequence is received. This means that QLC+ expects a
 non zero value (typically 255) followed by a zero value to toggle, for example, a button.<br>
 Devices like BCF2000 or softwares like TouchOSC, instead, send just a non zero value when activating
 a button, and a zero value when deactivating it.<br>
 When checking this option, QLC+ will generate the "missing" events to standardize the way some controller
-work. So, for example, the BCF2000 will look like sending 255+0 when pressing a button, and 
+work. So, for example, the BCF2000 will look like sending 255+0 when pressing a button, and
 another 255+0 when pressing it again.<br><br>
 <B>Custom feedback</B>: with the "Lower value" and "Upper value" boxes, it is possible to force
 custom values to be sent when the selected button sends a non-zero and a zero value.<br>

--- a/resources/docs/html_en_EN/parameterstuning.html
+++ b/resources/docs/html_en_EN/parameterstuning.html
@@ -39,8 +39,8 @@ Here's the quick command to access it from a terminal:<br>
 <code>cd $HOME/Library/Preferences</code><br>
 The QLC+ configuration file is called <code>net.sf.Q Light Controller Plus.plist</code> while the Fixture editor 
 configuration file is called <code>net.sf.Fixture Definition Editor.plist</code>.<br><br>
-<B>Please note that preferences are cached !</B> Basically OSX loads all the plist files in memory at boot, 
-and if you change them manually it will ignore the changes. Even worse, periodically it refreshes the files, 
+<B>Please note that preferences are cached!</B> Basically OSX loads all the plist files in memory at boot,
+and if you change them manually it will ignore the changes. Even worse, periodically it refreshes the files,
 so it overwrites your changes.<br>
 The solution is, after changing a .plist file, open a terminal and type this:<br>
 <code>killall -u yourusername cfprefsd</code><br>

--- a/resources/docs/html_en_EN/parameterstuning.html
+++ b/resources/docs/html_en_EN/parameterstuning.html
@@ -37,7 +37,7 @@ Configuration files are located in your user $HOME directory, in the Library/Pre
 which is by default hidden by OSX.<br>
 Here's the quick command to access it from a terminal:<br>
 <code>cd $HOME/Library/Preferences</code><br>
-The QLC+ configuration file is called <code>net.sf.Q Light Controller Plus.plist</code> while the Fixture editor 
+The QLC+ configuration file is called <code>net.sf.Q Light Controller Plus.plist</code> while the Fixture editor
 configuration file is called <code>net.sf.Fixture Definition Editor.plist</code>.<br><br>
 <B>Please note that preferences are cached!</B> Basically OSX loads all the plist files in memory at boot,
 and if you change them manually it will ignore the changes. Even worse, periodically it refreshes the files,
@@ -64,7 +64,7 @@ Due to Qt differences on different platforms, parameters are stored in different
 your Operating System.
 
 <H2>Linux</H2>
-Parameters are stored in a plain text file that you can modify with a plain text 
+Parameters are stored in a plain text file that you can modify with a plain text
 editor like gedit, kwrite, kate, nano, vim or similar. They are presented as follows:
 <PRE>
     [category]
@@ -81,12 +81,12 @@ included in every Windows version. They are presented as follows:
 </PRE>
 
 <H2>Mac OSX</H2>
-Parameters are stored in a plain text file that you can modify with a plain text 
+Parameters are stored in a plain text file that you can modify with a plain text
 editor like <a href="http://www.barebones.com/products/textwrangler/">TextWrangler</a> or similar. They are presented as follows:
 <PRE>
     &lt;key&gt;category.name&lt;/key&gt;
-    &lt;string&gt;value&lt;/string&gt; 
-    or 
+    &lt;string&gt;value&lt;/string&gt;
+    or
     &lt;integer&gt;42&lt;/integer&gt;
 </PRE>
 </P>

--- a/resources/docs/html_en_EN/questionsandanswers.html
+++ b/resources/docs/html_en_EN/questionsandanswers.html
@@ -26,7 +26,7 @@ Here you can either find the answer directly or find help to point you in the ri
       If you are using Windows and your device is manufactured by Peperoni or Velleman, please read the information on how to get
       them working on these help pages. For licensing issues they both need an extra DLL file to work.
       Please check <A HREF="file:peperonioutput.html">Peperoni output plugin</A> or <A HREF="file:vellemanoutput.html">Velleman output plugin</A><BR>
-      If you're using Linux, please check if your distribution detected the device when plugged in. Basically, the 
+      If you're using Linux, please check if your distribution detected the device when plugged in. Basically, the
       "<CODE>dmesg</CODE>" command should tell you something.
   </TD>
  </TR>
@@ -62,7 +62,7 @@ Here you can either find the answer directly or find help to point you in the ri
       Otherwise, you can download the <A HREF="http://www.dmxis.com/release/FtdiDriverControl.zip">ENTTEC FTDI Driver Control tool</A>
       and try to enable/disable the Apple driver with it.<BR><BR>
 
-      <B>Note 1: this can compromise the behaviour of other USB devices, so do it only 
+      <B>Note 1: this can compromise the behaviour of other USB devices, so do it only
       if you know what you're doing! </B><br>
       <B>Note 2: every time Mac OS receives an update, you need to perform this procedure again!</B><br>
       <B>Note 3: Most likely, when you disable/enable the Apple driver, you need to reboot your Mac</B>
@@ -89,7 +89,7 @@ Here you can either find the answer directly or find help to point you in the ri
       Please keep in mind that fixures and input profiles found in the user folder will have precedence
       over the same files in the QLC+ system folder.<br>
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 <BR>
 <TABLE BORDER=1 class="qlcTable">
@@ -101,16 +101,16 @@ Here you can either find the answer directly or find help to point you in the ri
  <TR>
   <TD></TD>
   <TD><SPAN>A:</SPAN></TD>
-  <TD>The system folder is where QLC+ resources (fixtures, input profiles, RGB scripts, etc) are installed 
+  <TD>The system folder is where QLC+ resources (fixtures, input profiles, RGB scripts, etc) are installed
       and it changes depending on your operating system:<br>
       <B>Linux</B>: it's a fixed folder named /usr/share/qlcplus<br>
       <B>Windows</B>: it is the folder where you actually installed QLC+. By default: C:\QLC+<br>
-      <B>Mac OS</B>: it is a folder inside the QLC+ bundle (.app file). It is possible to browse the QLC+.app bundle contents simply with Finder. 
+      <B>Mac OS</B>: it is a folder inside the QLC+ bundle (.app file). It is possible to browse the QLC+.app bundle contents simply with Finder.
       Just right click on the file and select "Show Package Contents".<br>
       Otherwise, the system folder can be reached with a terminal but it depends on where you installed QLC+.<br>
       For example if you dragged QLC+ into Applications it will be: /Applications/QLC+.app/Contents/Resources
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 <BR>
 <TABLE BORDER=1 class="qlcTable">
@@ -126,7 +126,7 @@ Here you can either find the answer directly or find help to point you in the ri
       Unfortunately the basic codecs supported by Windows are quite poor, so you need to install some extra
       codecs package like K-Lite, <A HREF="http://www.codecguide.com/download_kl.htm">available here</A>.
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 <BR>
 <TABLE BORDER=1 class="qlcTable">
@@ -145,7 +145,7 @@ Here you can either find the answer directly or find help to point you in the ri
       <PRE><b>Mac OS (from terminal)</b>: QT_AUTO_SCREEN_SCALE_FACTOR=1 QLC+.app\Contents\MacOS\qlcplus</PRE>
       In case, see the <A HREF="file:commandlineparameters.html">command line parameters page</a> for further information.
   </TD>
- </TR>  
+ </TR>
 </TABLE>
 </BODY>
 </HTML>

--- a/resources/docs/html_en_EN/questionsandanswers.html
+++ b/resources/docs/html_en_EN/questionsandanswers.html
@@ -64,7 +64,7 @@ Here you can either find the answer directly or find help to point you in the ri
 
       <B>Note 1: this can compromise the behaviour of other USB devices, so do it only 
       if you know what you're doing! </B><br>
-      <B>Note 2: every time Mac OS receives an update, you need to perform this procedure again !</B><br>
+      <B>Note 2: every time Mac OS receives an update, you need to perform this procedure again!</B><br>
       <B>Note 3: Most likely, when you disable/enable the Apple driver, you need to reboot your Mac</B>
   </TD>
  </TR>

--- a/resources/docs/html_en_EN/questionsandanswers.html
+++ b/resources/docs/html_en_EN/questionsandanswers.html
@@ -37,7 +37,7 @@ Here you can either find the answer directly or find help to point you in the ri
   <TD><SPAN>2</SPAN></TD>
   <TD><SPAN id="solo-frame">Q:</SPAN></TD>
   <TD>I've got several <A HREF="file:vcbutton.html">buttons</A> in my Virtual Console. I need a way to disable the currently
-      active button when I enable another one. How do I do that ?
+      active button when I enable another one. How do I do that?
   </TD>
  </TR>
  <TR>
@@ -74,7 +74,7 @@ Here you can either find the answer directly or find help to point you in the ri
  <TR>
   <TD><SPAN>4</SPAN></TD>
   <TD><SPAN id="user-folder">Q:</SPAN></TD>
-  <TD>Where is the QLC+ user folder located in my system ?</TD>
+  <TD>Where is the QLC+ user folder located in my system?</TD>
  </TR>
  <TR>
   <TD></TD>
@@ -96,7 +96,7 @@ Here you can either find the answer directly or find help to point you in the ri
  <TR>
   <TD><SPAN>5</SPAN></TD>
   <TD><SPAN id="system-folder">Q:</SPAN></TD>
-  <TD>Where is the QLC+ system folder located in my system ?</TD>
+  <TD>Where is the QLC+ system folder located in my system?</TD>
  </TR>
  <TR>
   <TD></TD>

--- a/resources/docs/html_en_EN/showmanager.html
+++ b/resources/docs/html_en_EN/showmanager.html
@@ -17,8 +17,8 @@ completely graphical way.<br>
 The graphic interface shows a multitrack view, typical of audio sequencers or video editing softwares,
 and with it users are allowed to place QLC+ <A HREF="file:concept.html#Functions">Functions</A> at the desired
 place and time in the view.<br>
-Show Manager gives a lot of flexibility during a <A HREF="file:concept.html#Show">Show</a> creation thanks 
-to its visual-oriented approach. Once understood the basic elements, it is very easy to create, move or edit 
+Show Manager gives a lot of flexibility during a <A HREF="file:concept.html#Show">Show</a> creation thanks
+to its visual-oriented approach. Once understood the basic elements, it is very easy to create, move or edit
 the existing functions and improve a Show by adding new tracks to it.<br>
 <br>
 Typical use cases of Shows are those gigs where a band plays songs following a metronome and the light show has
@@ -32,9 +32,9 @@ of the difference between a Chaser and a Sequence.<br>
 
 <H2>Sequences vs Chasers</H2>
 <P>
-Even if the <A HREF="file:concept.html#Sequence">Sequence</a> and the 
+Even if the <A HREF="file:concept.html#Sequence">Sequence</a> and the
 <A HREF="file:concept.html#Chaser">Chaser</a> functions have some common ground, they're not the same thing.<br>
-If not done yet, you are invited to read once again their definitions in the 
+If not done yet, you are invited to read once again their definitions in the
 <A HREF="file:concept.html">Basic Concepts &amp; Glossary</a> page of this documentation.<br>
 The main differences are:
 <ul>
@@ -43,14 +43,14 @@ The main differences are:
         In other words, a Chaser is an independent function, while a Sequence can exist only
         on top of a Scene.<br>
         The reason for this is, as mentioned before, the visual approach of the Show Manager.
-        If a track of a Show is the graphical representation of a Scene, then it's more intuitive 
+        If a track of a Show is the graphical representation of a Scene, then it's more intuitive
         to think that each Sequence created on that track is a function controlling the values of that Scene.
  </li>
  <li><b>Order</b>: Chasers can be reproduced in any order (Forward, Backward, Ping-Pong, Random) while
         in the Show Manager, Sequences are always reproduced from the beginning to the end (Forward).
         Again, this is related to the visual aspect of the Show Manager, where the playback
         has a natural time forward direction.<br>
-        On the other hand, Sequences created with the Function Manager can have the 
+        On the other hand, Sequences created with the Function Manager can have the
         same order properties of Chasers.
  </li>
  <li><b>Editing</b>: The editing approach between Sequences and Chaser is different too.<br>
@@ -99,7 +99,7 @@ The main differences are:
   <TD>Create a new track or add existing functions to the Show. When clicking on this button
   a window is displayed, allowing you to perform the following operations:
   <ul>
-   <li>Create a new track: This creates a new empty track that will serve as a container 
+   <li>Create a new track: This creates a new empty track that will serve as a container
        for Sequences and Audio functions.
    </li>
    <li>Import an existing Scene. This will create a new track and a 10 seconds Sequence
@@ -111,16 +111,16 @@ The main differences are:
        If no compatible track is found, a new track will be created and bound to the
        Sequence's bound Scene.
    </li>
-   <li>Import an existing <A HREF="file:concept.html#Chaser">Chaser</A>: add a Chaser function at the cursor 
+   <li>Import an existing <A HREF="file:concept.html#Chaser">Chaser</A>: add a Chaser function at the cursor
        position on the selected track. If no track is available, it will create a new one.
    </li>
-   <li>Import an existing <A HREF="file:concept.html#Audio">Audio</A>: add an Audio function at the cursor 
+   <li>Import an existing <A HREF="file:concept.html#Audio">Audio</A>: add an Audio function at the cursor
        position on the selected track. If no track is available, it will create a new one.
    </li>
-   <li>Import an existing <A HREF="file:concept.html#EFX">EFX</A>: add an EFX function at the cursor 
+   <li>Import an existing <A HREF="file:concept.html#EFX">EFX</A>: add an EFX function at the cursor
        position on the selected track. If no track is available, it will create a new one.
    </li>
-   <li>Import an existing <A HREF="file:concept.html#RGBMatrix">RGB Matrix</A>: add a RGB Matrix function at the cursor 
+   <li>Import an existing <A HREF="file:concept.html#RGBMatrix">RGB Matrix</A>: add a RGB Matrix function at the cursor
        position on the selected track. If no track is available, it will create a new one.
    </li>
   </ul>
@@ -154,12 +154,12 @@ The main differences are:
  <TR>
   <TD><IMG SRC="qrc:/editpaste.png"/></TD>
   <TD>CTRL+V</TD>
-  <TD>Paste QLC+ clipboard content at the cursor position. When performing this 
+  <TD>Paste QLC+ clipboard content at the cursor position. When performing this
   operation two checks are performed:
     <UL>
-     <LI>Overlapping: checks if the item you're going to paste overlaps with an 
+     <LI>Overlapping: checks if the item you're going to paste overlaps with an
      existing item in the selected track</LI>
-     <LI>Validity: If you're pasting a Sequence, QLC+ will verify that the 
+     <LI>Validity: If you're pasting a Sequence, QLC+ will verify that the
      Sequence contents are compatible with the currently selected track</LI>
   </TD>
  </TR>
@@ -168,7 +168,7 @@ The main differences are:
   <TD>Del</TD>
   <TD>Delete the currently selected item. This can be a sequence, an audio item or a track.
   Note that deleting a track will delete also all its sequences/audio children.<br>
-  <B>Note: Show Manager will only perform a "visual removal" of functions. To permanently 
+  <B>Note: Show Manager will only perform a "visual removal" of functions. To permanently
   delete them, please use the <A HREF="file:functionmanager.html">Function Manager</A></B></TD>
  </TR>
  <TR></TR>
@@ -234,8 +234,8 @@ The main differences are:
   to set for you Show. This ranges from 20 to 240.<br>
   This can be quite useful when dealing with electronic music or BPM synchronized shows</TD>
  </TR>
- 
- 
+
+
 </TABLE>
 
 <H2>Just 4 steps</H2>
@@ -256,9 +256,9 @@ When done, a new track will be created. All the sequences created on this track
 will act only on the associated Scene, not affecting any of the other tracks.<br>
 A newly created track will be set automatically as active. An active track has a green light on the left hand side.<br>
 A Track can be set to <IMG SRC="file:../images/track-mute.png" ALIGN="absmiddle"> mute and
-<IMG SRC="file:../images/track-solo.png" ALIGN="absmiddle"> solo states. The mute state will exclude the track from the playback, 
+<IMG SRC="file:../images/track-solo.png" ALIGN="absmiddle"> solo states. The mute state will exclude the track from the playback,
 while the solo state will mute all the other tracks of the Show.<br>
-When right clicking on a track, it is possible to move it up <IMG SRC="qrc:/up.png" ALIGN="absmiddle"> or 
+When right clicking on a track, it is possible to move it up <IMG SRC="qrc:/up.png" ALIGN="absmiddle"> or
 down <IMG SRC="qrc:/down.png" ALIGN="absmiddle"> for logical ordering.<br>
 Once selected, a track will display its <A HREF="file:sceneeditor.html">Scene Editor</A> on the bottom of the screen.
 
@@ -272,7 +272,7 @@ QLC+ Functions and add them to the Show timeline.<br>
 A new item will be placed at the cursor position, but it is always possible to move it to the desired time
 just by dragging it along the timeline.<br>
 An item cannot be moved to another track, since it is bound to the track where it has originally been created.<br>
-An item can be copied <IMG SRC="qrc:/editcopy.png" ALIGN="absmiddle">, pasted <IMG SRC="qrc:/editpaste.png" ALIGN="absmiddle"> or 
+An item can be copied <IMG SRC="qrc:/editcopy.png" ALIGN="absmiddle">, pasted <IMG SRC="qrc:/editpaste.png" ALIGN="absmiddle"> or
 deleted <IMG SRC="qrc:/editdelete.png" ALIGN="absmiddle"> with the toolbar icons. The pasted item will be placed at the current cursor position.<br>
 The item background color can be changed with the toolbar icon <IMG SRC="qrc:/color.png" ALIGN="absmiddle">. The assigned color will be saved
 in your project file.<br>

--- a/resources/docs/html_en_EN/showmanager.html
+++ b/resources/docs/html_en_EN/showmanager.html
@@ -68,7 +68,7 @@ The main differences are:
         synchronize the new functions to the existing ones.<br>
         An example. Let's say your project controls 50 fixtures that are a mixture of moving heads, PARs and scanners.
         At some point you buy a couple of lasers and you want them to become active in existing scenes
-        at precise moments in time. The Show Manager allows you to do that in a few minutes !
+        at precise moments in time. The Show Manager allows you to do that in a few minutes!
         You just need to add the 2 new fixtures to the project, add a track to the Shows affected by
         the change and create a few Sequences to control the lasers.<br>
         The Show Manager resume functionality will also save you a lot of time when testing the new
@@ -300,7 +300,7 @@ different steps/loops will be divided by vertical lines.<br>
 To increase the complexity of the Show, more Functions can be added. Just repeat the above steps
 depending on your needs.<br>
 
-<H2>And finally...play ! <IMG SRC="qrc:/player_play.png"></H2>
+<H2>And finally...play! <IMG SRC="qrc:/player_play.png"></H2>
 When a complete show has finally been created, it can be played just by clicking on the Play icon.<br>
 Playback always starts from the current cursor postion. The cursor position can be changed by clicking on the time line.
 </BODY>

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -218,7 +218,7 @@ def update_fixture(path, filename, destpath):
                 select = raw_input("Replacement preset code (0 = keep) (enter = " + preset + "): ")
                 if select == "":
                     if preset == "":
-                        print "Select an option !"
+                        print "Select an option!"
                     else:
                         break
                 else:
@@ -441,7 +441,7 @@ def validate_fixture(path, filename):
         chCount += 1
 
     if chCount == 0:
-        print absname + ": Invalid fixture. No channels found !"
+        print absname + ": Invalid fixture. No channels found!"
         errNum += 1
 
     ###################################### CHECK MODES ###################################
@@ -488,7 +488,7 @@ def validate_fixture(path, filename):
         modeCount += 1
 
     if modeCount == 0:
-        print absname + ": Invalid fixture. No modes found !"
+        print absname + ": Invalid fixture. No modes found!"
         errNum += 1
 
     ################################ CHECK GLOBAL PHYSICAL ################################

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -394,7 +394,7 @@ def validate_fixture(path, filename):
                 print absname + "/" + chName + "/" + capName + ": Overlapping values detected " + str(currMin) + "/" + str(lastMax)
                 errNum += 1
 
-            # disabled for now. 710 errors with this !
+            # disabled for now. 710 errors with this!
             #if currMin != lastMax + 1:
             #    print absname + "/" + chName + "/" + capName + ": Non contiguous range detected " + str(currMin) + "/" + str(lastMax)
             #    errNum += 1

--- a/ui/src/addchannelsgroup.cpp
+++ b/ui/src/addchannelsgroup.cpp
@@ -73,7 +73,7 @@ AddChannelsGroup::AddChannelsGroup(QWidget* parent, Doc* doc, ChannelsGroup *gro
                 break;
             }
         }
-        // Haven't found this universe node ? Create it.
+        // Haven't found this universe node? Create it.
         if (topItem == NULL)
         {
             topItem = new QTreeWidgetItem(m_tree);

--- a/ui/src/addfixture.ui
+++ b/ui/src/addfixture.ui
@@ -180,7 +180,7 @@
       <item row="5" column="2">
        <widget class="QLabel" name="m_addrErrorLabel">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/ui/src/addrgbpanel.ui
+++ b/ui/src/addrgbpanel.ui
@@ -95,7 +95,7 @@
         <item row="3" column="1">
          <widget class="QLabel" name="m_addrErrorLabel">
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -843,10 +843,10 @@ bool App::saveModifiedDoc(const QString & title, const QString & message)
     if (result == QMessageBox::Yes)
     {
         slotFileSave();
-        // we check whether m_doc is not modified anymore, rather than 
+        // we check whether m_doc is not modified anymore, rather than
         // result of slotFileSave() since the latter returns NoError
         // in cases like when the user pressed cancel in the save dialog
-        if (m_doc->isModified() == false) 
+        if (m_doc->isModified() == false)
         {
             return true;
         }

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -1244,7 +1244,7 @@ void App::slotRecentFileClicked(QAction *recent)
     if (testFile.exists() == false)
     {
         QMessageBox::critical(this, tr("Error"),
-                              tr("File not found !\nThe selected file has been moved or deleted."),
+                              tr("File not found!\nThe selected file has been moved or deleted."),
                               QMessageBox::Close);
         return;
     }

--- a/ui/src/app.h
+++ b/ui/src/app.h
@@ -63,7 +63,7 @@ protected slots:
     void closeEvent(QCloseEvent *ev)
     {
         emit closing();
-        // avoid the real context to be destroyed !
+        // avoid the real context to be destroyed!
         setCentralWidget(NULL);
         QMainWindow::closeEvent(ev);
     }

--- a/ui/src/channelmodifiereditor.cpp
+++ b/ui/src/channelmodifiereditor.cpp
@@ -179,7 +179,7 @@ void ChannelModifierEditor::slotSaveClicked()
     ChannelModifier *modifier = m_doc->modifiersCache()->modifier(m_templateNameEdit->text());
     if (modifier != NULL && modifier->type() == ChannelModifier::SystemTemplate)
     {
-        // cannot overwrite a system template !
+        // cannot overwrite a system template!
         QMessageBox::critical(this, tr("Error"),
                               tr("You are trying to overwrite a system template! Please choose another name "
                                  "and the template will be saved in your channel modifier's user folder."),

--- a/ui/src/channelmodifiereditor.cpp
+++ b/ui/src/channelmodifiereditor.cpp
@@ -181,7 +181,7 @@ void ChannelModifierEditor::slotSaveClicked()
     {
         // cannot overwrite a system template !
         QMessageBox::critical(this, tr("Error"),
-                              tr("You are trying to overwrite a system template ! Please choose another name "
+                              tr("You are trying to overwrite a system template! Please choose another name "
                                  "and the template will be saved in your channel modifier's user folder."),
                               QMessageBox::Close);
         return;

--- a/ui/src/channelmodifiergraphicsview.cpp
+++ b/ui/src/channelmodifiergraphicsview.cpp
@@ -56,7 +56,7 @@ void ChannelModifierGraphicsView::setHandlerDMXValue(uchar pos, uchar value)
 
 void ChannelModifierGraphicsView::addNewHandler()
 {
-    // always give the fact that there are at least two handlers !
+    // always give the fact that there are at least two handlers!
     HandlerItem *prevHandler = getSelectedHandler();
     if (prevHandler == NULL)
         prevHandler = m_handlers.at(0);

--- a/ui/src/channelsselection.cpp
+++ b/ui/src/channelsselection.cpp
@@ -114,7 +114,7 @@ void ChannelsSelection::updateFixturesTree()
                 break;
             }
         }
-        // Haven't found this universe node ? Create it.
+        // Haven't found this universe node? Create it.
         if (topItem == NULL)
         {
             topItem = new QTreeWidgetItem(m_channelsTree);

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -249,7 +249,7 @@ ChaserEditor::~ChaserEditor()
         m_speedDials->deleteLater();
     m_speedDials = NULL;
 
-    // double check that the Chaser still exists !
+    // double check that the Chaser still exists!
     if (m_liveMode == false &&
         m_doc->functions().contains(m_chaser) == true)
         m_chaser->stopAndWait();

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -776,7 +776,7 @@ void ChaserEditor::slotPasteClicked()
         ChaserStep step(it.next());
         if (step.resolveFunction(m_doc) == NULL) // Function has been removed
         {
-            qWarning() << Q_FUNC_INFO << "Trying to paste an invalid function (removed function ?)";
+            qWarning() << Q_FUNC_INFO << "Trying to paste an invalid function (removed function?)";
             continue;
         }
         updateItem(item, step);

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -531,7 +531,7 @@ void ChaserEditor::slotShuffleClicked()
 
     QList <QTreeWidgetItem*> selectedItems(m_tree->selectedItems());
     int indicesToShuffle[selectedCount];
-    
+
     // save the selected scenes and their indices into a sorted array
     QListIterator <QTreeWidgetItem*> it(selectedItems);
     for (i = 0; i < selectedCount; i++)

--- a/ui/src/ctkrangeslider.cpp
+++ b/ui/src/ctkrangeslider.cpp
@@ -71,7 +71,7 @@ public:
   int m_MaximumPosition;
   int m_MinimumPosition;
 
-  /// Controls selected ?
+  /// Controls selected?
   QStyle::SubControl m_MinimumSliderSelected;
   QStyle::SubControl m_MaximumSliderSelected;
 

--- a/ui/src/ctkrangeslider.cpp
+++ b/ui/src/ctkrangeslider.cpp
@@ -62,7 +62,7 @@ public:
   /// Draw the bottom and top sliders.
   void drawMinimumSlider( QStylePainter* painter ) const;
   void drawMaximumSlider( QStylePainter* painter ) const;
-    
+
   /// End points of the range on the Model
   int m_MaximumValue;
   int m_MinimumValue;
@@ -75,14 +75,14 @@ public:
   QStyle::SubControl m_MinimumSliderSelected;
   QStyle::SubControl m_MaximumSliderSelected;
 
-  /// See QSliderPrivate::clickOffset. 
+  /// See QSliderPrivate::clickOffset.
   /// Overrides this ivar
   int m_SubclassClickOffset;
-    
+
   /// See QSliderPrivate::position
   /// Overrides this ivar.
   int m_SubclassPosition;
-  
+
   /// Original width between the 2 bounds before any moves
   int m_SubclassWidth;
 
@@ -137,7 +137,7 @@ ctkRangeSliderPrivate::Handle ctkRangeSliderPrivate::handleAtPos(const QPoint& p
   // The functinos hitTestComplexControl only know about 1 handle. As we have
   // 2, we change the position of the handle and test if the pos correspond to
   // any of the 2 positions.
-  
+
   // Test the MinimumHandle
   option.sliderPosition = this->m_MinimumPosition;
   option.sliderValue    = this->m_MinimumValue;
@@ -147,7 +147,7 @@ ctkRangeSliderPrivate::Handle ctkRangeSliderPrivate::handleAtPos(const QPoint& p
   QRect minimumHandleRect = q->style()->subControlRect(
       QStyle::CC_Slider, &option, QStyle::SC_SliderHandle, q);
 
-  // Test if the pos is under the Maximum handle 
+  // Test if the pos is under the Maximum handle
   option.sliderPosition = this->m_MaximumPosition;
   option.sliderValue    = this->m_MaximumValue;
 
@@ -165,12 +165,12 @@ ctkRangeSliderPrivate::Handle ctkRangeSliderPrivate::handleAtPos(const QPoint& p
     if (q->orientation() == Qt::Horizontal)
       {
       minDist = pos.x() - minimumHandleRect.left();
-      maxDist = maximumHandleRect.right() - pos.x(); 
+      maxDist = maximumHandleRect.right() - pos.x();
       }
     else //if (q->orientation() == Qt::Vertical)
       {
       minDist = minimumHandleRect.bottom() - pos.y();
-      maxDist = pos.y() - maximumHandleRect.top(); 
+      maxDist = pos.y() - maximumHandleRect.top();
       }
     Q_ASSERT( minDist >= 0 && maxDist >= 0);
     minimumControl = minDist < maxDist ? minimumControl : QStyle::SC_None;
@@ -199,16 +199,16 @@ int ctkRangeSliderPrivate::pixelPosToRangeValue( int pos ) const
   QStyleOptionSlider option;
   q->initStyleOption( &option );
 
-  QRect gr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderGroove, 
+  QRect gr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderGroove,
                                             q );
-  QRect sr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  QRect sr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             q );
   int sliderMin, sliderMax, sliderLength;
-  if (option.orientation == Qt::Horizontal) 
+  if (option.orientation == Qt::Horizontal)
     {
     sliderLength = sr.width();
     sliderMin = gr.x();
@@ -221,10 +221,10 @@ int ctkRangeSliderPrivate::pixelPosToRangeValue( int pos ) const
     sliderMax = gr.bottom() - sliderLength + 1;
     }
 
-  return QStyle::sliderValueFromPosition( q->minimum(), 
-                                          q->maximum(), 
+  return QStyle::sliderValueFromPosition( q->minimum(),
+                                          q->maximum(),
                                           pos - sliderMin,
-                                          sliderMax - sliderMin, 
+                                          sliderMax - sliderMin,
                                           option.upsideDown );
 }
 
@@ -235,16 +235,16 @@ int ctkRangeSliderPrivate::pixelPosFromRangeValue( int val ) const
   QStyleOptionSlider option;
   q->initStyleOption( &option );
 
-  QRect gr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderGroove, 
+  QRect gr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderGroove,
                                             q );
-  QRect sr = q->style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  QRect sr = q->style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             q );
   int sliderMin, sliderMax, sliderLength;
-  if (option.orientation == Qt::Horizontal) 
+  if (option.orientation == Qt::Horizontal)
     {
     sliderLength = sr.width();
     sliderMin = gr.x();
@@ -257,10 +257,10 @@ int ctkRangeSliderPrivate::pixelPosFromRangeValue( int val ) const
     sliderMax = gr.bottom() - sliderLength + 1;
     }
 
-  return QStyle::sliderPositionFromValue( q->minimum(), 
-                                          q->maximum(), 
+  return QStyle::sliderPositionFromValue( q->minimum(),
+                                          q->maximum(),
                                           val,
-                                          sliderMax - sliderMin, 
+                                          sliderMax - sliderMin,
                                           option.upsideDown ) + sliderMin;
 }
 
@@ -389,23 +389,23 @@ void ctkRangeSlider::setMaximumValue( int max )
 void ctkRangeSlider::setValues(int l, int u)
 {
   Q_D(ctkRangeSlider);
-  const int minValue = 
+  const int minValue =
     qBound(this->minimum(), qMin(l,u), this->maximum());
-  const int maxValue = 
+  const int maxValue =
     qBound(this->minimum(), qMax(l,u), this->maximum());
   bool emitMinValChanged = (minValue != d->m_MinimumValue);
   bool emitMaxValChanged = (maxValue != d->m_MaximumValue);
-  
+
   d->m_MinimumValue = minValue;
   d->m_MaximumValue = maxValue;
-  
-  bool emitMinPosChanged = 
+
+  bool emitMinPosChanged =
     (minValue != d->m_MinimumPosition);
-  bool emitMaxPosChanged = 
+  bool emitMaxPosChanged =
     (maxValue != d->m_MaximumPosition);
   d->m_MinimumPosition = minValue;
   d->m_MaximumPosition = maxValue;
-  
+
   if (isSliderDown())
     {
     if (emitMinPosChanged || emitMaxPosChanged)
@@ -423,7 +423,7 @@ void ctkRangeSlider::setValues(int l, int u)
     }
   if (emitMinValChanged || emitMaxValChanged)
     {
-    emit valuesChanged(d->m_MinimumValue, 
+    emit valuesChanged(d->m_MinimumValue,
                        d->m_MaximumValue);
     }
   if (emitMinValChanged)
@@ -434,7 +434,7 @@ void ctkRangeSlider::setValues(int l, int u)
     {
     emit maximumValueChanged(d->m_MaximumValue);
     }
-  if (emitMinPosChanged || emitMaxPosChanged || 
+  if (emitMinPosChanged || emitMaxPosChanged ||
       emitMinValChanged || emitMaxValChanged)
     {
     this->update();
@@ -473,14 +473,14 @@ void ctkRangeSlider::setMaximumPosition(int u)
 void ctkRangeSlider::setPositions(int min, int max)
 {
   Q_D(ctkRangeSlider);
-  const int minPosition = 
+  const int minPosition =
     qBound(this->minimum(), qMin(min, max), this->maximum());
-  const int maxPosition = 
+  const int maxPosition =
     qBound(this->minimum(), qMax(min, max), this->maximum());
 
   bool emitMinPosChanged = (minPosition != d->m_MinimumPosition);
   bool emitMaxPosChanged = (maxPosition != d->m_MaximumPosition);
-  
+
   if (!emitMinPosChanged && !emitMaxPosChanged)
     {
     return;
@@ -556,20 +556,20 @@ void ctkRangeSlider::paintEvent( QPaintEvent* )
   painter.drawComplexControl(QStyle::CC_Slider, option);
 
   option.sliderPosition = d->m_MinimumPosition;
-  const QRect lr = style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  const QRect lr = style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             this);
   option.sliderPosition = d->m_MaximumPosition;
 
-  const QRect ur = style()->subControlRect( QStyle::CC_Slider, 
-                                            &option, 
-                                            QStyle::SC_SliderHandle, 
+  const QRect ur = style()->subControlRect( QStyle::CC_Slider,
+                                            &option,
+                                            QStyle::SC_SliderHandle,
                                             this);
 
-  QRect sr = style()->subControlRect( QStyle::CC_Slider, 
-                                      &option, 
-                                      QStyle::SC_SliderGroove, 
+  QRect sr = style()->subControlRect( QStyle::CC_Slider,
+                                      &option,
+                                      QStyle::SC_SliderGroove,
                                       this);
   QRect rangeBox;
   if (option.orientation == Qt::Horizontal)
@@ -588,9 +588,9 @@ void ctkRangeSlider::paintEvent( QPaintEvent* )
   // -----------------------------
   // Render the range
   //
-  QRect groove = this->style()->subControlRect( QStyle::CC_Slider, 
-                                                &option, 
-                                                QStyle::SC_SliderGroove, 
+  QRect groove = this->style()->subControlRect( QStyle::CC_Slider,
+                                                &option,
+                                                QStyle::SC_SliderGroove,
                                                 this );
   groove.adjust(0, 0, -1, 0);
 
@@ -677,7 +677,7 @@ void ctkRangeSlider::mousePressEvent(QMouseEvent* mouseEvent)
 
   // if we are here, no handles have been pressed
   // Check if we pressed on the groove between the 2 handles
-  
+
   QStyle::SubControl control = this->style()->hitTestComplexControl(
     QStyle::CC_Slider, &option, mouseEvent->pos(), this);
   QRect sr = style()->subControlRect(
@@ -697,8 +697,8 @@ void ctkRangeSlider::mousePressEvent(QMouseEvent* mouseEvent)
     this->setSliderDown(true);
     if (!this->isMinimumSliderDown() || !this->isMaximumSliderDown())
       {
-      d->m_SelectedHandles = 
-        QFlags<ctkRangeSliderPrivate::Handle>(ctkRangeSliderPrivate::MinimumHandle) | 
+      d->m_SelectedHandles =
+        QFlags<ctkRangeSliderPrivate::Handle>(ctkRangeSliderPrivate::MinimumHandle) |
         QFlags<ctkRangeSliderPrivate::Handle>(ctkRangeSliderPrivate::MaximumHandle);
       this->update(handleRect.united(sr));
       }

--- a/ui/src/fixturemanager.cpp
+++ b/ui/src/fixturemanager.cpp
@@ -1258,13 +1258,13 @@ void FixtureManager::removeFixture()
         QTreeWidgetItem* item(it.next());
         Q_ASSERT(item != NULL);
 
-        // Is the item a fixture ?
+        // Is the item a fixture?
         QVariant var = item->data(KColumnName, PROP_ID);
         if (var.isValid() == true)
             fixturesToDelete << var.toUInt();
         else
         {
-            // Is the item a fixture group ?
+            // Is the item a fixture group?
             var = item->data(KColumnName, PROP_GROUP);
             if (var.isValid() == true)
                 groupsToDelete << var.toUInt();

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -707,7 +707,7 @@ void FixtureRemap::accept()
     foreach (ChannelsGroup *grp, m_doc->channelsGroups())
     {
         QList<SceneValue> grpChannels = grp->getChannels();
-        // this is crucial: here all the "unmapped" channels will be lost forever !
+        // this is crucial: here all the "unmapped" channels will be lost forever!
         grp->resetChannels();
         QList <SceneValue> newList = remapSceneValues(grpChannels, sourceList, targetList);
         foreach (SceneValue val, newList)
@@ -728,7 +728,7 @@ void FixtureRemap::accept()
                 Scene *s = qobject_cast<Scene*>(func);
                 qDebug() << "Analyzing Scene #" << s->id();
                 QList <SceneValue> newList = remapSceneValues(s->values(), sourceList, targetList);
-                // this is crucial: here all the "unmapped" channels will be lost forever !
+                // this is crucial: here all the "unmapped" channels will be lost forever!
                 s->clear();
 
                 for (int i = 0; i < newList.count(); i++)
@@ -746,7 +746,7 @@ void FixtureRemap::accept()
                     ChaserStep *cs = s->stepAt(idx);
                     QList <SceneValue> newList = remapSceneValues(cs->values, sourceList, targetList);
                     //qDebug() << "Step" << idx << "remapped" << cs.values.count() << "to" << newList.count();
-                    // this is crucial: here all the "unmapped" channels will be lost forever !
+                    // this is crucial: here all the "unmapped" channels will be lost forever!
                     cs->values.clear();
                     cs->values = newList;
                     //s->replaceStep(cs, idx);
@@ -764,7 +764,7 @@ void FixtureRemap::accept()
                     ef->copyFrom(efxFix);
                     fixListCopy.append(ef);
                 }
-                // this is crucial: here all the "unmapped" fixtures will be lost forever !
+                // this is crucial: here all the "unmapped" fixtures will be lost forever!
                 e->removeAllFixtures();
                 QList<quint32>remappedFixtures;
 
@@ -838,7 +838,7 @@ void FixtureRemap::accept()
                         }
                     }
                 }
-                // this is crucial: here all the "unmapped" channels will be lost forever !
+                // this is crucial: here all the "unmapped" channels will be lost forever!
                 slider->clearLevelChannels();
                 foreach (SceneValue rmpChan, newChannels)
                     slider->addLevelChannel(rmpChan.fxi, rmpChan.channel);
@@ -852,7 +852,7 @@ void FixtureRemap::accept()
                 if (bar->m_type == AudioBar::DMXBar)
                 {
                     QList <SceneValue> newList = remapSceneValues(bar->m_dmxChannels, sourceList, targetList);
-                    // this is crucial: here all the "unmapped" channels will be lost forever !
+                    // this is crucial: here all the "unmapped" channels will be lost forever!
                     bar->attachDmxChannels(m_doc, newList);
                 }
             }
@@ -884,7 +884,7 @@ void FixtureRemap::accept()
                     }
                 }
             }
-            // this is crucial: here all the "unmapped" fixtures will be lost forever !
+            // this is crucial: here all the "unmapped" fixtures will be lost forever!
             xypad->clearFixtures();
             foreach (VCXYPadFixture fix, copyFixtures)
                 xypad->appendFixture(fix);

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -154,7 +154,7 @@ QTreeWidgetItem *FixtureRemap::getUniverseItem(Doc *doc, quint32 universe, QTree
         }
     }
 
-    // Haven't found this universe node ? Create it.
+    // Haven't found this universe node? Create it.
     if (topItem == NULL)
     {
         topItem = new QTreeWidgetItem(tree);
@@ -327,13 +327,13 @@ void FixtureRemap::slotRemoveTargetFixture()
 void FixtureRemap::slotCloneSourceFixture()
 {
     if (m_sourceTree->selectedItems().count() == 0)
-        return; // popup here ??
+        return; // popup here??
 
     QTreeWidgetItem *sItem = m_sourceTree->selectedItems().first();
     quint32 fxID = sItem->text(KColumnID).toUInt();
     Fixture *srcFix = m_doc->fixture(fxID);
     if (srcFix == NULL)
-        return; // popup here ?
+        return; // popup here?
 
     quint32 srcAddr = srcFix->universeAddress();
     for (quint32 i = srcAddr; i < srcAddr + srcFix->channels(); i++)

--- a/ui/src/fixturetreewidget.cpp
+++ b/ui/src/fixturetreewidget.cpp
@@ -350,7 +350,7 @@ void FixtureTreeWidget::updateSelections()
 
         qDebug() << "uni ID:" << uniIDVar;
 
-        // Case 1: is there a valid fixture ID ?
+        // Case 1: is there a valid fixture ID?
         if (fxIDVar.isValid())
         {
             quint32 fxi = fxIDVar.toUInt();
@@ -375,7 +375,7 @@ void FixtureTreeWidget::updateSelections()
                 }
             }
         }
-        // Case 2: is there a valid group ID ?
+        // Case 2: is there a valid group ID?
         else if (grpIDVar.isValid())
         {
             // in this case cycle through the children and get each
@@ -388,7 +388,7 @@ void FixtureTreeWidget::updateSelections()
                     m_selectedFixtures << chFxIDVar.toUInt();
             }
         }
-        // Case 3: is there a valid head index ?
+        // Case 3: is there a valid head index?
         else if (headVar.isValid())
         {
             Q_ASSERT(item->parent() != NULL);
@@ -397,7 +397,7 @@ void FixtureTreeWidget::updateSelections()
             if (m_selectedHeads.contains(gh) == false)
                 m_selectedHeads << gh;
         }
-        // Case 4: is there a valid universe index ?
+        // Case 4: is there a valid universe index?
         else if (uniIDVar.isValid())
         {
             qDebug() << "Valid universe....";
@@ -455,7 +455,7 @@ void FixtureTreeWidget::updateTree()
                 }
             }
         }
-        // Haven't found this universe node ? Create it.
+        // Haven't found this universe node? Create it.
         if (topItem == NULL)
         {
             topItem = new QTreeWidgetItem(this);

--- a/ui/src/functionwizard.ui
+++ b/ui/src/functionwizard.ui
@@ -115,7 +115,7 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -308,7 +308,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -70,7 +70,7 @@ InputOutputManager::InputOutputManager(QWidget* parent, Doc* doc)
     s_instance = this;
 
     Q_ASSERT(doc != NULL);
-    
+
     m_ioMap = doc->inputOutputMap();
 
     /* Create a new layout for this widget */

--- a/ui/src/inputoutputmanager.cpp
+++ b/ui/src/inputoutputmanager.cpp
@@ -359,7 +359,7 @@ void InputOutputManager::slotDeleteUniverse()
         // Ask for user's confirmation
         if (QMessageBox::question(
                     this, tr("Delete Universe"),
-                    tr("The universe you are trying to delete is patched. Are you sure you want to delete it ?"),
+                    tr("The universe you are trying to delete is patched. Are you sure you want to delete it?"),
                     QMessageBox::Yes, QMessageBox::No) == QMessageBox::No)
         {
             return;
@@ -378,7 +378,7 @@ void InputOutputManager::slotDeleteUniverse()
             // Ask for user's confirmation
             if (QMessageBox::question(
                         this, tr("Delete Universe"),
-                        tr("There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?"),
+                        tr("There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?"),
                         QMessageBox::Yes, QMessageBox::No) == QMessageBox::No)
             {
                 return;

--- a/ui/src/qlcplus_ca_ES.ts
+++ b/ui/src/qlcplus_ca_ES.ts
@@ -167,7 +167,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: ¡Direcció ja està en us!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -315,7 +315,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: ¡Direcció ja està en us!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -600,7 +600,7 @@
         <location filename="app.cpp" line="589"/>
         <source>There are still running functions.
 Really stop them and switch back to Design mode?</source>
-        <translation>Encara hi ha funcions en execució. 
+        <translation>Encara hi ha funcions en execució.
 Voleu aturar-les i tornar a Mode Disseny?</translation>
     </message>
     <message>
@@ -874,7 +874,7 @@ Els canvis es perdran si no els guarda.</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>¡Arxiu no trobat!
 L&apos;arxiu seleccionat s&apos;ha mogut o esborrat.</translation>
@@ -1228,7 +1228,7 @@ L&apos;arxiu seleccionat s&apos;ha mogut o esborrat.</translation>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>Estau intentant sobreescriure una plantilla del sistema ! Si us plau escolliu un altre nom i la plantilla es desarà al directori de modificadors de canal del usuari.</translation>
     </message>
 </context>
@@ -2910,7 +2910,7 @@ L&apos;arxiu seleccionat s&apos;ha mogut o esborrat.</translation>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -3008,7 +3008,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3227,12 +3227,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>L&apos;univers que està intentant esborrar està assignat. Estau segur de voler esborrar-lo?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Alguns fixtures estan emprant l&apos;univers que està intentant esborrar. Està segur de voler-lo esborrar?</translation>
     </message>
 </context>
@@ -4767,7 +4767,7 @@ Note that the wizard cannot tell the difference between a knob and a slider so y
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>Si us plau trieu un arxiu executable !</translation>
     </message>
     <message>
@@ -7399,7 +7399,7 @@ Si us plau seleccionau un d&apos;aquests canals.</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation>Si us plau, seleccioneu al menys un fixture o capçal per crear aquest tipus de preset !</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_cz_CZ.ts
+++ b/ui/src/qlcplus_cz_CZ.ts
@@ -168,7 +168,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;CHYBA: Tato adresa je již použita u jiného zařízení&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;CHYBA: Tato adresa je již použita u jiného zařízení&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -876,7 +876,7 @@ Veškeré změny budou zahozeny, pokud je teď neuložíte.</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>Soubor nebyl nalezen!
 Zvolený soubor byl asi smazán nebo přesunut.</translation>
@@ -1230,7 +1230,7 @@ Zvolený soubor byl asi smazán nebo přesunut.</translation>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>Pokoušíte se přepsat systémovou šablonu! Zvolte prosím jiný název a šablona bude uložena do Vaší složky modifikací a změn kanálů.</translation>
     </message>
 </context>
@@ -2915,7 +2915,7 @@ Zvolený soubor byl asi smazán nebo přesunut.</translation>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2982,7 +2982,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3232,12 +3232,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>Vetvev, kterou se snažíte smazat je propojená. Opravdu si ji přejete smazat ?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Některá zařízení používají větev, kterou se pokoušíte smazat. Opravdu ji chcete smazat ?</translation>
     </message>
 </context>
@@ -4767,7 +4767,7 @@ Note that the wizard cannot tell the difference between a knob and a slider so y
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>Zvolit spustitelný soubor</translation>
     </message>
     <message>
@@ -7398,7 +7398,7 @@ Vyberte prosím některý z těchto kanálů.</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation type="unfinished">Prosím zvolte alespoň jedno zařízení nebo halvu pro vytvoření tohohle presetu!</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_cz_CZ.ts
+++ b/ui/src/qlcplus_cz_CZ.ts
@@ -567,17 +567,17 @@
     <message>
         <location filename="app.cpp" line="379"/>
         <source>Do you wish to save the current workspace before closing the application?</source>
-        <translation>Přejete si uložit rozdělanou práci před ukončením aplikace ?</translation>
+        <translation>Přejete si uložit rozdělanou práci před ukončením aplikace?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="393"/>
         <source>Close the application?</source>
-        <translation>Zavřít aplikaci ?</translation>
+        <translation>Zavřít aplikaci?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="394"/>
         <source>Do you wish to close the application?</source>
-        <translation>Opravdu si přejete uzavřít aplikaci ?</translation>
+        <translation>Opravdu si přejete uzavřít aplikaci?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="436"/>
@@ -2928,7 +2928,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Vítejte v průvodci QLC+ !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Vítejte v průvodci QLC+!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Toto je řízený proces, který vám umožní začít používat QLC + během několika minut.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;V zásadě je rozložen do tří jednoduchých kroků:&lt;/p&gt;
@@ -3233,12 +3233,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
         <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
-        <translation>Vetvev, kterou se snažíte smazat je propojená. Opravdu si ji přejete smazat ?</translation>
+        <translation>Vetvev, kterou se snažíte smazat je propojená. Opravdu si ji přejete smazat?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
         <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
-        <translation>Některá zařízení používají větev, kterou se pokoušíte smazat. Opravdu ji chcete smazat ?</translation>
+        <translation>Některá zařízení používají větev, kterou se pokoušíte smazat. Opravdu ji chcete smazat?</translation>
     </message>
 </context>
 <context>
@@ -3360,7 +3360,7 @@ p, li { white-space: pre-wrap; }
         <source>An error occurred while trying to open the selected device line.
 This can be caused either by a wrong system configuration or an unsupported input/output mode.
 Please refer to the plugins documentation to troubleshoot this.</source>
-        <translation>Nastala chyba při pokusu o otevření zvoleného zařízení. 
+        <translation>Nastala chyba při pokusu o otevření zvoleného zařízení.
 To může být způsobeno nesprávnou konfigurací systému nebo nepodporovaným režimem vstupu/výstupu.
 Použijte nápovědu k pluginu (zásuvnému modulu) pro vyřešení tohoto problému.</translation>
     </message>
@@ -3374,7 +3374,7 @@ Použijte nápovědu k pluginu (zásuvnému modulu) pro vyřešení tohoto probl
         <location filename="inputoutputpatcheditor.cpp" line="703"/>
         <location filename="inputoutputpatcheditor.cpp" line="837"/>
         <source>An input profile at %1 already exists. Do you wish to overwrite it?</source>
-        <translation>Profil vstupu na %1 již existuje. Opravdu si přejete jej přepsat a nahradit ?</translation>
+        <translation>Profil vstupu na %1 již existuje. Opravdu si přejete jej přepsat a nahradit?</translation>
     </message>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="712"/>
@@ -3599,7 +3599,7 @@ Použijte nápovědu k pluginu (zásuvnému modulu) pro vyřešení tohoto probl
     <message>
         <location filename="inputprofileeditor.cpp" line="334"/>
         <source>Delete all %1 selected channels?</source>
-        <translation>Smazat všechny %1 zvolené kanály ?</translation>
+        <translation>Smazat všechny %1 zvolené kanály?</translation>
     </message>
     <message>
         <location filename="inputprofileeditor.cpp" line="451"/>
@@ -7747,7 +7747,7 @@ Vyberte prosím některý z těchto kanálů.</translation>
     <message>
         <location filename="virtualconsole/virtualconsole.cpp" line="1162"/>
         <source>Do you wish to delete the selected widgets?</source>
-        <translation>Přejete si smazat zvolený prvek/ovladač ?</translation>
+        <translation>Přejete si smazat zvolený prvek/ovladač?</translation>
     </message>
     <message>
         <location filename="virtualconsole/virtualconsole.cpp" line="1163"/>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -85,7 +85,7 @@
     <message>
         <location filename="addfixture.ui" line="253"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Fehler: Addresse wird bereits verwendet !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Fehler: Addresse wird bereits verwendet!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="addfixture.ui" line="284"/>
@@ -232,7 +232,7 @@
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Fehler: Addresse wird bereits verwendet !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Fehler: Addresse wird bereits verwendet!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="198"/>
@@ -695,7 +695,7 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
         <location filename="app.cpp" line="1248"/>
         <source>File not found!
 The selected file has been moved or deleted.</source>
-        <translation>Datei nich gefunden !
+        <translation>Datei nicht gefunden!
 Die ausgewählte Datei wurde verschoben oder gelöscht.</translation>
     </message>
     <message>
@@ -1233,7 +1233,7 @@ Changes will be lost if you don&apos;t save them.</source>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
         <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
-        <translation>Du versucht eine Systemvorlage zu überschreiben! Bitte wähle einen anderen Name. Die Vorlage wird im User-Verzeichnis des Kanaländerungseditors gespeichert.</translation>
+        <translation>Du versuchst, eine Systemvorlage zu überschreiben! Bitte wähle einen anderen Namen. Die Vorlage wird im User-Verzeichnis des Kanaländerungseditors gespeichert.</translation>
     </message>
 </context>
 <context>
@@ -2935,7 +2935,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Wilkommen beim QLC+ Assistenten !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Wilkommen beim QLC+ Assistenten!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Diese geführte Einleitung hilft beim Start von QLC+ in ein paar Minuten.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Sie besteht aus 3 einachen Schritten:&lt;/p&gt;
@@ -2994,7 +2994,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Basierend auf den hinzugefügten Geräten, kann ich die links gelisteten Funktionen erstellen. Benötigte  auswählen, Anzeige erfolgt auf der rechten Seite !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Basierend auf den hinzugefügten Geräten, kann ich die links gelisteten Funktionen erstellen. Benötigte auswählen, Anzeige erfolgt auf der rechten Seite!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="functionwizard.ui" line="319"/>
@@ -7413,7 +7413,7 @@ Please select one with such channels.</source>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
         <source>Please select at least one fixture or head to create this type of preset!</source>
-        <translation>Bitte mindestens ein Gerät oder Kopf auswählen um diese Art Voreinstellung zu erzeugen !</translation>
+        <translation>Bitte mindestens ein Gerät oder Kopf auswählen um diese Art Voreinstellung zu erzeugen!</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="775"/>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Fehler: Addresse wird bereits verwendet !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Fehler: Addresse wird bereits verwendet !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -693,7 +693,7 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>Datei nich gefunden !
 Die ausgewählte Datei wurde verschoben oder gelöscht.</translation>
@@ -1232,7 +1232,7 @@ Changes will be lost if you don&apos;t save them.</source>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>Du versucht eine Systemvorlage zu überschreiben! Bitte wähle einen anderen Name. Die Vorlage wird im User-Verzeichnis des Kanaländerungseditors gespeichert.</translation>
     </message>
 </context>
@@ -2922,7 +2922,7 @@ Changes will be lost if you don&apos;t save them.</source>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2989,7 +2989,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3240,12 +3240,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>Das Universum, welchs gelöscht werden soll ist gepatched, soll es wirklich gelöscht werden?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Das Universum, welches gelöscht werden soll wird von einigen Geräten verwendet, soll es wirklich gelöscht werden?</translation>
     </message>
 </context>
@@ -4776,7 +4776,7 @@ Der Assistent kennt keinen Unterschied zwischen einem Schalter und einem Regler,
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>Bitte eine ausführbare Datei auswählen!</translation>
     </message>
     <message>
@@ -7412,7 +7412,7 @@ Please select one with such channels.</source>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation>Bitte mindestens ein Gerät oder Kopf auswählen um diese Art Voreinstellung zu erzeugen !</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_es_ES.ts
+++ b/ui/src/qlcplus_es_ES.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: ¡Dirección ya usada!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: ¡Dirección ya usada!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -878,7 +878,7 @@ Los cambios se perderán si no los guarda.</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>¡Archivo no encontrado!
 El archivo seleccionado ha sido movido o borrado.</translation>
@@ -1232,7 +1232,7 @@ El archivo seleccionado ha sido movido o borrado.</translation>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>Está intentando sobreescribir una plantilla del sistema ! Por favor escoja otro nombre y la plantilla se guardará en el directorio de modificadores de canal del usuario.</translation>
     </message>
 </context>
@@ -2923,7 +2923,7 @@ El archivo seleccionado ha sido movido o borrado.</translation>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2990,7 +2990,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3241,12 +3241,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>El universo que está tratando de borrar está patcheado. ¿Está seguro de querer borrarlo?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Algunos fixtures están usando el universo que está tratando de borrar. ¿Está seguro de querer borrarlo?</translation>
     </message>
 </context>
@@ -4778,7 +4778,7 @@ Tenga en cuenta que el asistente no puede diferenciar entre una perilla y un sli
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>¡Por favor, seleccionar un archivo ejecutable!</translation>
     </message>
     <message>
@@ -7412,7 +7412,7 @@ Por favor elija una que tenga esos canales.</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation>Por favor, seleccionar al menos un fixture o cabeza para crear este tipo de preset !</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_es_ES.ts
+++ b/ui/src/qlcplus_es_ES.ts
@@ -1233,7 +1233,7 @@ El archivo seleccionado ha sido movido o borrado.</translation>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
         <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
-        <translation>Está intentando sobreescribir una plantilla del sistema ! Por favor escoja otro nombre y la plantilla se guardará en el directorio de modificadores de canal del usuario.</translation>
+        <translation>¡Está intentando sobreescribir una plantilla del sistema! Por favor escoja otro nombre y la plantilla se guardará en el directorio de modificadores de canal del usuario.</translation>
     </message>
 </context>
 <context>
@@ -2936,7 +2936,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;¡Bienvenido al Asistente de QLC+ !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;¡Bienvenido al Asistente de QLC+!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Esta es una quía que le permitirá empezar a usar QLC+ en unos pocos minutos.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Básicamente consiste en tres simples pasos:&lt;/p&gt;
@@ -7413,7 +7413,7 @@ Por favor elija una que tenga esos canales.</translation>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
         <source>Please select at least one fixture or head to create this type of preset!</source>
-        <translation>Por favor, seleccionar al menos un fixture o cabeza para crear este tipo de preset !</translation>
+        <translation>Por favor, ¡seleccionar al menos un fixture o cabeza para crear este tipo de preset!</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="775"/>

--- a/ui/src/qlcplus_fi_FI.ts
+++ b/ui/src/qlcplus_fi_FI.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -878,7 +878,7 @@ Menetät muutokset jos et tallenna niitä.</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1231,7 +1231,7 @@ The selected file has been moved or deleted.</source>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2921,7 +2921,7 @@ The selected file has been moved or deleted.</source>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2972,7 +2972,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3214,12 +3214,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4749,7 +4749,7 @@ Huomaa, että velho ei osaa erottaa pyöritettävää nuppia ja liukua toisistaa
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7376,7 +7376,7 @@ Please select one with such channels.</source>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/src/qlcplus_fr_FR.ts
+++ b/ui/src/qlcplus_fr_FR.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERREUR: Cette addresse est déjà utilisée !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERREUR: Cette addresse est déjà utilisée !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -880,7 +880,7 @@ Les changements seront perdus si vous ne les sauvegardez pas.</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>Fichier introuvable !
 Celui-ci a dû être déplacé ou effacé.</translation>
@@ -1236,7 +1236,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>Vous tentez d&apos;écraser un modèle système ! Merci de choisir un nom différent et le modèle sera enregistré dans votre dossier personnel.</translation>
     </message>
 </context>
@@ -2929,7 +2929,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -3246,12 +3246,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>Cet univers est actuellement patché. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Des appareils utilisent actuellement cet univers. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
     </message>
 </context>
@@ -4783,7 +4783,7 @@ Notez que l&apos;assistant ne peut pas différencier un bouton rotatif d&apos;un
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>Veuillez sélectioner un fichier exécutable !</translation>
     </message>
     <message>
@@ -7417,7 +7417,7 @@ Veuillez en choisir une qui affecte un des deux.</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation>Veuillez sélectionner au moins un appareil ou une tête pour créer ce type de préréglage !</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_fr_FR.ts
+++ b/ui/src/qlcplus_fr_FR.ts
@@ -85,7 +85,7 @@
     <message>
         <location filename="addfixture.ui" line="253"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERREUR: Cette addresse est déjà utilisée !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERREUR: Cette addresse est déjà utilisée&#xa0;!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="addfixture.ui" line="284"/>
@@ -232,7 +232,7 @@
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERREUR: Cette addresse est déjà utilisée !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERREUR: Cette addresse est déjà utilisée&#xa0;!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="198"/>
@@ -537,7 +537,7 @@
     <message>
         <location filename="app.cpp" line="379"/>
         <source>Do you wish to save the current workspace before closing the application?</source>
-        <translation>Voulez-vous enregistrer le projet en cours avant de quitter l&apos;application ?</translation>
+        <translation>Voulez-vous enregistrer le projet en cours avant de quitter l&apos;application&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="436"/>
@@ -560,7 +560,7 @@
         <source>There are still running functions.
 Really stop them and switch back to Design mode?</source>
         <translation>Des fonctions sont encore en cours d&apos;exécution.
-Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translation>
+Voulez-vous vraiment les arrêter et basculer vers le mode Création&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="624"/>
@@ -714,12 +714,12 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translat
     <message>
         <location filename="app.cpp" line="393"/>
         <source>Close the application?</source>
-        <translation>Quitter QLCPlus ?</translation>
+        <translation>Quitter QLCPlus&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="394"/>
         <source>Do you wish to close the application?</source>
-        <translation>Voulez-vous quitter l&apos;application ?</translation>
+        <translation>Voulez-vous quitter l&apos;application&#xa0;?</translation>
     </message>
     <message>
         <location filename="app.cpp" line="571"/>
@@ -750,7 +750,7 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translat
     <message>
         <location filename="app.cpp" line="694"/>
         <source>Stop ALL functions!</source>
-        <translation>Arrêter TOUTES les fonctions !</translation>
+        <translation>Arrêter TOUTES les fonctions&#xa0;!</translation>
     </message>
     <message>
         <location filename="app.cpp" line="699"/>
@@ -835,7 +835,7 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création ?</translat
         <source>Do you wish to save the current workspace?
 Changes will be lost if you don&apos;t save them.</source>
         <translatorcomment>Tiens tiens...perspicace!</translatorcomment>
-        <translation>Voulez-vous enregistrer le projet actuel ?
+        <translation>Voulez-vous enregistrer le projet actuel&#xa0;?
 Les changements seront perdus si vous ne les sauvegardez pas.</translation>
     </message>
     <message>
@@ -882,7 +882,7 @@ Les changements seront perdus si vous ne les sauvegardez pas.</translation>
         <location filename="app.cpp" line="1248"/>
         <source>File not found!
 The selected file has been moved or deleted.</source>
-        <translation>Fichier introuvable !
+        <translation>Fichier introuvable&#xa0;
 Celui-ci a dû être déplacé ou effacé.</translation>
     </message>
     <message>
@@ -1237,7 +1237,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
         <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
-        <translation>Vous tentez d&apos;écraser un modèle système ! Merci de choisir un nom différent et le modèle sera enregistré dans votre dossier personnel.</translation>
+        <translation>Vous tentez d&apos;écraser un modèle système&#xa0;! Merci de choisir un nom différent et le modèle sera enregistré dans votre dossier personnel.</translation>
     </message>
 </context>
 <context>
@@ -2107,7 +2107,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="efxeditor.cpp" line="740"/>
         <source>Do you want to remove the selected fixture(s)?</source>
-        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s) ?</translation>
+        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s)&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -2285,7 +2285,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1244"/>
         <source>Do you want to delete the selected items?</source>
-        <translation>Voulez-vous supprimer les éléments sélectionnés ?</translation>
+        <translation>Voulez-vous supprimer les éléments sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1299"/>
@@ -2324,12 +2324,12 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1495"/>
         <source>Ungroup fixtures?</source>
-        <translation>Dégrouper les appareils ?</translation>
+        <translation>Dégrouper les appareils&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1496"/>
         <source>Do you want to ungroup the selected fixtures?</source>
-        <translation>Voulez-vous dégrouper les appareils sélectionnés ?</translation>
+        <translation>Voulez-vous dégrouper les appareils sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1611"/>
@@ -2377,7 +2377,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1300"/>
         <source>Do you want to delete the selected groups?</source>
-        <translation>Voulez-vous supprimer les groupes sélectionnés ?</translation>
+        <translation>Voulez-vous supprimer les groupes sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1360"/>
@@ -2462,7 +2462,7 @@ Celui-ci a dû être déplacé ou effacé.</translation>
     <message>
         <location filename="fixtureremap.cpp" line="297"/>
         <source>Do you want to delete the selected items?</source>
-        <translation>Voulez-vous supprimer l&apos;élément cible sélectionné ?</translation>
+        <translation>Voulez-vous supprimer l&apos;élément cible sélectionné&#xa0;?</translation>
     </message>
     <message>
         <location filename="fixtureremap.cpp" line="345"/>
@@ -2942,7 +2942,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bienvenue dans l&apos;assistant QLC+ !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bienvenue dans l&apos;assistant QLC+&#xa0;!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Cette procédure guidée va vous permettre de commencer à utiliser QLC+ en quelques minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Elle est composée de 3 étapes :&lt;/p&gt;
@@ -2996,12 +2996,12 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Avec ces appareils, je peux créer les fonctions listées à gauche. Choisissez celles que vous désirez, elles apparaîtront à droite !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Avec ces appareils, je peux créer les fonctions listées à gauche. Choisissez celles que vous désirez, elles apparaîtront à droite&#xa0;!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="functionwizard.ui" line="319"/>
@@ -3247,12 +3247,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
         <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
-        <translation>Cet univers est actuellement patché. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
+        <translation>Cet univers est actuellement patché. Êtes-vous sûr(e) de vouloir le supprimer&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
         <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
-        <translation>Des appareils utilisent actuellement cet univers. Êtes-vous sûr(e) de vouloir le supprimer ?</translation>
+        <translation>Des appareils utilisent actuellement cet univers. Êtes-vous sûr(e) de vouloir le supprimer&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -3388,7 +3388,7 @@ Veuillez vous référer à la documentation du plugin.</translation>
         <location filename="inputoutputpatcheditor.cpp" line="703"/>
         <location filename="inputoutputpatcheditor.cpp" line="837"/>
         <source>An input profile at %1 already exists. Do you wish to overwrite it?</source>
-        <translation>Un profil d&apos;entrée existe déjà en &apos;%1&apos;. Voulez-vous l&apos;écraser ?</translation>
+        <translation>Un profil d&apos;entrée existe déjà en &apos;%1&apos;. Voulez-vous l&apos;écraser&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="712"/>
@@ -3421,7 +3421,7 @@ Veuillez vous référer à la documentation du plugin.</translation>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="765"/>
         <source>Do you wish to permanently delete profile &quot;%1&quot;?</source>
-        <translation>Voulez-vous supprimer définitivement le profil &quot;%1&quot; ?</translation>
+        <translation>Voulez-vous supprimer définitivement le profil &quot;%1&quot;&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputoutputpatcheditor.cpp" line="793"/>
@@ -3613,7 +3613,7 @@ Veuillez vous référer à la documentation du plugin.</translation>
     <message>
         <location filename="inputprofileeditor.cpp" line="334"/>
         <source>Delete all %1 selected channels?</source>
-        <translation>Supprimer les %1 canaux sélectionnés ?</translation>
+        <translation>Supprimer les %1 canaux sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="inputprofileeditor.cpp" line="451"/>
@@ -4641,7 +4641,7 @@ Notez que l&apos;assistant ne peut pas différencier un bouton rotatif d&apos;un
     <message>
         <location filename="sceneeditor.cpp" line="1288"/>
         <source>Do you want to remove the selected fixture(s)?</source>
-        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s) ?</translation>
+        <translation>Voulez-vous enlever le(s) appareil(s) sélectionné(s)&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -4784,7 +4784,7 @@ Notez que l&apos;assistant ne peut pas différencier un bouton rotatif d&apos;un
     <message>
         <location filename="scripteditor.cpp" line="381"/>
         <source>Please select an executable file!</source>
-        <translation>Veuillez sélectioner un fichier exécutable !</translation>
+        <translation>Veuillez sélectioner un fichier exécutable&#xa0;!</translation>
     </message>
     <message>
         <location filename="scripteditor.cpp" line="387"/>
@@ -5440,7 +5440,7 @@ Durée : %3
     <message>
         <location filename="virtualconsole/vcbutton.cpp" line="581"/>
         <source>Stop ALL functions!</source>
-        <translation>Arrêter TOUTES les fonctions !</translation>
+        <translation>Arrêter TOUTES les fonctions&#xa0;!</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbutton.cpp" line="818"/>
@@ -7400,7 +7400,7 @@ Durée : %3
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="365"/>
         <source>Do you want to remove the selected fixtures?</source>
-        <translation>Voulez-vous enlever le(s) appareils(s) sélectionné(s) ?</translation>
+        <translation>Voulez-vous enlever le(s) appareils(s) sélectionné(s)&#xa0;?</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="718"/>
@@ -7418,7 +7418,7 @@ Veuillez en choisir une qui affecte un des deux.</translation>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
         <source>Please select at least one fixture or head to create this type of preset!</source>
-        <translation>Veuillez sélectionner au moins un appareil ou une tête pour créer ce type de préréglage !</translation>
+        <translation>Veuillez sélectionner au moins un appareil ou une tête pour créer ce type de préréglage&#xa0;!</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="775"/>
@@ -7771,7 +7771,7 @@ Veuillez en choisir une qui affecte un des deux.</translation>
     <message>
         <location filename="virtualconsole/virtualconsole.cpp" line="1162"/>
         <source>Do you wish to delete the selected widgets?</source>
-        <translation>Voulez-vous supprimer les widgets sélectionnés ?</translation>
+        <translation>Voulez-vous supprimer les widgets sélectionnés&#xa0;?</translation>
     </message>
     <message>
         <location filename="virtualconsole/virtualconsole.cpp" line="1163"/>

--- a/ui/src/qlcplus_it_IT.ts
+++ b/ui/src/qlcplus_it_IT.ts
@@ -85,7 +85,7 @@
     <message>
         <location filename="addfixture.ui" line="253"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRORE: Indirizzo già in uso !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRORE: Indirizzo già in uso!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="addfixture.ui" line="284"/>
@@ -232,7 +232,7 @@
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRORE: Indirizzo già in uso !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRORE: Indirizzo già in uso!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="198"/>
@@ -880,7 +880,7 @@ Tutti i cambiamenti andranno persi senza salvataggio..</translation>
         <location filename="app.cpp" line="1248"/>
         <source>File not found!
 The selected file has been moved or deleted.</source>
-        <translation>File non trovato !
+        <translation>File non trovato!
 Il file selezionato è stato spostato o eliminato.</translation>
     </message>
     <message>
@@ -1233,7 +1233,7 @@ Il file selezionato è stato spostato o eliminato.</translation>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
         <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
-        <translation>Stai cercando di sovrascrivere un template di sistema ! Per favore scegli un altro nome e il template verrà salvato nella cartella utente dei modificatori di canali.</translation>
+        <translation>Stai cercando di sovrascrivere un template di sistema! Per favore scegli un altro nome e il template verrà salvato nella cartella utente dei modificatori di canali.</translation>
     </message>
 </context>
 <context>
@@ -2279,7 +2279,7 @@ Il file selezionato è stato spostato o eliminato.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1244"/>
         <source>Do you want to delete the selected items?</source>
-        <translation>Vuoi eliminare gli elementi selezionati ?</translation>
+        <translation>Vuoi eliminare gli elementi selezionati?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1299"/>
@@ -2323,7 +2323,7 @@ Il file selezionato è stato spostato o eliminato.</translation>
     <message>
         <location filename="fixturemanager.cpp" line="1496"/>
         <source>Do you want to ungroup the selected fixtures?</source>
-        <translation>Vuoi separare le fixture selezionate ?</translation>
+        <translation>Vuoi separare le fixture selezionate?</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1611"/>
@@ -2456,7 +2456,7 @@ Il file selezionato è stato spostato o eliminato.</translation>
     <message>
         <location filename="fixtureremap.cpp" line="297"/>
         <source>Do you want to delete the selected items?</source>
-        <translation>Vuoi eliminare gli elementi selezionati ?</translation>
+        <translation>Vuoi eliminare gli elementi selezionati?</translation>
     </message>
     <message>
         <location filename="fixtureremap.cpp" line="345"/>
@@ -2936,7 +2936,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Benvenuto nel wizard di QLC+ !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Benvenuto nel wizard di QLC+!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Questa è una procedura guidata che ti consentirà di cominciare ad usare QLC+ in pochi minuti.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Fondamentalmente consiste in tre semplici passaggi:&lt;/p&gt;
@@ -2995,7 +2995,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Basandomi sulle fixture che hai aggiunto, posso creare le funzioni elencate a sinistra. Devi solo selezionare quelle che ti servono e verificare i risultati a destra !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Basandomi sulle fixture che hai aggiunto, posso creare le funzioni elencate a sinistra. Devi solo selezionare quelle che ti servono e verificare i risultati a destra!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="functionwizard.ui" line="319"/>
@@ -3241,12 +3241,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
         <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
-        <translation>L&apos;universo che stai per eliminare è connesso. Sei sicuro di volerlo eliminare ?</translation>
+        <translation>L&apos;universo che stai per eliminare è connesso. Sei sicuro di volerlo eliminare?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
         <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
-        <translation>Ci sono delle fixture che usano l&apos;universo che vuoi eliminare. Sei sicuro di volerlo eliminare ?</translation>
+        <translation>Ci sono delle fixture che usano l&apos;universo che vuoi eliminare. Sei sicuro di volerlo eliminare?</translation>
     </message>
 </context>
 <context>
@@ -4778,7 +4778,7 @@ Si noti che la procedura guidata non può dire la differenza tra una manopola e 
     <message>
         <location filename="scripteditor.cpp" line="381"/>
         <source>Please select an executable file!</source>
-        <translation>Devi selezionare un file eseguibile !</translation>
+        <translation>Devi selezionare un file eseguibile!</translation>
     </message>
     <message>
         <location filename="scripteditor.cpp" line="387"/>
@@ -7412,7 +7412,7 @@ Selezionarne una con i suddetti canali.</translation>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
         <source>Please select at least one fixture or head to create this type of preset!</source>
-        <translation>Selezionare almeno una fixture o una testa per creare questo tipo di preset !</translation>
+        <translation>Selezionare almeno una fixture o una testa per creare questo tipo di preset!</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="775"/>

--- a/ui/src/qlcplus_it_IT.ts
+++ b/ui/src/qlcplus_it_IT.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRORE: Indirizzo già in uso !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRORE: Indirizzo già in uso !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -878,7 +878,7 @@ Tutti i cambiamenti andranno persi senza salvataggio..</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>File non trovato !
 Il file selezionato è stato spostato o eliminato.</translation>
@@ -1232,7 +1232,7 @@ Il file selezionato è stato spostato o eliminato.</translation>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>Stai cercando di sovrascrivere un template di sistema ! Per favore scegli un altro nome e il template verrà salvato nella cartella utente dei modificatori di canali.</translation>
     </message>
 </context>
@@ -2923,7 +2923,7 @@ Il file selezionato è stato spostato o eliminato.</translation>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2990,7 +2990,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3240,12 +3240,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>L&apos;universo che stai per eliminare è connesso. Sei sicuro di volerlo eliminare ?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Ci sono delle fixture che usano l&apos;universo che vuoi eliminare. Sei sicuro di volerlo eliminare ?</translation>
     </message>
 </context>
@@ -4777,7 +4777,7 @@ Si noti che la procedura guidata non può dire la differenza tra una manopola e 
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>Devi selezionare un file eseguibile !</translation>
     </message>
     <message>
@@ -7411,7 +7411,7 @@ Selezionarne una con i suddetti canali.</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation>Selezionare almeno una fixture o una testa per creare questo tipo di preset !</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_ja_JP.ts
+++ b/ui/src/qlcplus_ja_JP.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;エラー: そのアドレスは既に使われています&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -223,7 +223,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;エラー:そのアドレスは既に使われています&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -874,7 +874,7 @@ Changes will be lost if you don&apos;t save them.</source>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>ファイルが見つかりません。
 移動または削除された可能性があります。</translation>
@@ -1228,7 +1228,7 @@ The selected file has been moved or deleted.</source>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>QLC+のデフォルトから入っているテンプレートは上書きできません、別名で保存してください</translation>
     </message>
 </context>
@@ -2924,7 +2924,7 @@ The selected file has been moved or deleted.</source>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2991,7 +2991,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3241,12 +3241,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>この Universe は接続されています。本当に削除しますか？</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>この Universe には使用中の機器があります。本当に削除しますか？</translation>
     </message>
 </context>
@@ -4775,7 +4775,7 @@ Note that the wizard cannot tell the difference between a knob and a slider so y
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>実行できるファイルを指定してください</translation>
     </message>
     <message>
@@ -7406,7 +7406,7 @@ Please select one with such channels.</source>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation>選択したフィクスチャーにはPan,Tiltが定義されていません。ポジション操作が定義されているフィクスチャーを選択してください</translation>
     </message>
     <message>

--- a/ui/src/qlcplus_nl_NL.ts
+++ b/ui/src/qlcplus_nl_NL.ts
@@ -168,7 +168,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;FOUT: Adres al in gebruik!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -230,7 +230,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;FOUT: Adres is al in gebruik!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -874,7 +874,7 @@ Changes will be lost if you don&apos;t save them.</source>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>Bestand niet gevonden! Het geselecteerde bestand is verplaatst of verwijderd.</translation>
     </message>
@@ -1227,7 +1227,7 @@ The selected file has been moved or deleted.</source>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation>U probeert een systeem template te overschrijven ! Kies een andere naam zodat het template opgeslagen kan worden in de kanaal aanpassingen gebruikers map.</translation>
     </message>
 </context>
@@ -2912,7 +2912,7 @@ The selected file has been moved or deleted.</source>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2979,7 +2979,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3230,12 +3230,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>De universe die u probeert te verwijderen is gepatched. Weet u zeker dat u deze wilt verwijderen?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Er zijn fixtures die gebruik maken van de universe die u wilt verwijderen. Weet u zeker dat u deze wilt verwijderen?</translation>
     </message>
 </context>
@@ -4771,7 +4771,7 @@ De wizard kent het verschil tussen een knop en een slider niet. Deze dient handm
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation>Voer een uitvoerbaar bestand in!</translation>
     </message>
     <message>
@@ -7399,7 +7399,7 @@ Selecteer een Scene met zo&apos;n kanaal.</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/src/qlcplus_nl_NL.ts
+++ b/ui/src/qlcplus_nl_NL.ts
@@ -1228,7 +1228,7 @@ The selected file has been moved or deleted.</source>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
         <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
-        <translation>U probeert een systeem template te overschrijven ! Kies een andere naam zodat het template opgeslagen kan worden in de kanaal aanpassingen gebruikers map.</translation>
+        <translation>U probeert een systeem template te overschrijven! Kies een andere naam zodat het template opgeslagen kan worden in de kanaal aanpassingen gebruikers map.</translation>
     </message>
 </context>
 <context>
@@ -2925,7 +2925,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welkom bij de QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welkom bij de QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Dit is een begeleid proces zodat u QLC+ binnen een paar minuten kunt gebruiken.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Het bestaat uit drie stappen:&lt;/p&gt;

--- a/ui/src/qlcplus_pt_BR.ts
+++ b/ui/src/qlcplus_pt_BR.ts
@@ -84,7 +84,7 @@
     </message>
     <message>
         <location filename="addfixture.ui" line="253"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRO: Endereço já usado!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <location filename="addrgbpanel.ui" line="98"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used !&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERROR: Address already used!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;ERRO: Endereço já usado!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -878,7 +878,7 @@ As alterações serão perdidas se não as gravar.</translation>
     </message>
     <message>
         <location filename="app.cpp" line="1248"/>
-        <source>File not found !
+        <source>File not found!
 The selected file has been moved or deleted.</source>
         <translation>Ficheiro não encontrado!
 O ficheiro seleccionado foi movido ou apagado.</translation>
@@ -1232,7 +1232,7 @@ O ficheiro seleccionado foi movido ou apagado.</translation>
     </message>
     <message>
         <location filename="channelmodifiereditor.cpp" line="184"/>
-        <source>You are trying to overwrite a system template ! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
+        <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2925,7 +2925,7 @@ O ficheiro seleccionado foi movido ou apagado.</translation>
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard !&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to the QLC+ wizard!&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This is a guided procedure that will allow you to start using QLC+ in a few minutes.&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It basically consists in three simple steps:&lt;/p&gt;
@@ -2992,7 +2992,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/wizard.png&quot; width=&quot;24&quot; /&gt; Based on the fixtures you added, I can create the functions listed on the left. Just select what you need and see the results on the right!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -3242,12 +3242,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="362"/>
-        <source>The universe you are trying to delete is patched. Are you sure you want to delete it ?</source>
+        <source>The universe you are trying to delete is patched. Are you sure you want to delete it?</source>
         <translation>O universo que está a tentar apagar tem patch efectuado. Tem a certeza que deseja apagá-lo?</translation>
     </message>
     <message>
         <location filename="inputoutputmanager.cpp" line="381"/>
-        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it ?</source>
+        <source>There are some fixtures using the universe you are trying to delete. Are you sure you want to delete it?</source>
         <translation>Existem alguns fixtures a usar o universo que está a tentar apagar. Tem a certeza que deseja apagá-lo?</translation>
     </message>
 </context>
@@ -4780,7 +4780,7 @@ Note que o assistente não diferencia entre uma roda e um fader pelo que terá d
     </message>
     <message>
         <location filename="scripteditor.cpp" line="381"/>
-        <source>Please select an executable file !</source>
+        <source>Please select an executable file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7407,7 +7407,7 @@ Please select one with such channels.</source>
     </message>
     <message>
         <location filename="virtualconsole/vcxypadproperties.cpp" line="768"/>
-        <source>Please select at least one fixture or head to create this type of preset !</source>
+        <source>Please select at least one fixture or head to create this type of preset!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -1066,7 +1066,7 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
                 }
             }
             // !! Important !! matrix's heads can be displaced randomly but in a sequence
-            // we absolutely need ordered values. So do it now !
+            // we absolutely need ordered values. So do it now!
             qSort(step.values.begin(), step.values.end());
 
             sequence->addStep(step);

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -378,7 +378,7 @@ void ScriptEditor::slotAddSystemCommand()
 #if !defined(WIN32) && !defined(Q_OS_WIN)
     if (fInfo.isExecutable() == false)
     {
-        QMessageBox::warning(this, tr("Invalid executable"), tr("Please select an executable file !"));
+        QMessageBox::warning(this, tr("Invalid executable"), tr("Please select an executable file!"));
         return;
     }
 #endif

--- a/ui/src/showmanager/multitrackview.cpp
+++ b/ui/src/showmanager/multitrackview.cpp
@@ -40,7 +40,7 @@ MultiTrackView::MultiTrackView(QWidget *parent) :
     m_scene->setSceneRect(0, 0, VIEW_DEFAULT_WIDTH, VIEW_DEFAULT_HEIGHT);
     setSceneRect(0, 0, VIEW_DEFAULT_WIDTH, VIEW_DEFAULT_HEIGHT);
     setScene(m_scene);
-	
+
     m_timeSlider = new QSlider(Qt::Horizontal);
     m_timeSlider->setRange(1, 15);
     m_timeSlider->setValue(3);

--- a/ui/src/showmanager/multitrackview.cpp
+++ b/ui/src/showmanager/multitrackview.cpp
@@ -578,7 +578,7 @@ void MultiTrackView::slotItemMoved(QGraphicsSceneMouseEvent *event, ShowItem *it
     }
     else if (shift < 3) // a drag of less than 3 pixel doesn't move the item
     {
-        qDebug() << "Drag too short (" << shift << "px) not allowed !";
+        qDebug() << "Drag too short (" << shift << "px) not allowed!";
         item->setPos(item->getDraggingPos());
         s_time = item->getStartTime();
         moved = false;

--- a/ui/src/showmanager/showeditor.cpp
+++ b/ui/src/showmanager/showeditor.cpp
@@ -103,7 +103,7 @@ void ShowEditor::updateFunctionList()
 
     if (m_show == NULL)
     {
-        qDebug() << Q_FUNC_INFO << "Invalid show !";
+        qDebug() << Q_FUNC_INFO << "Invalid show!";
         return;
     }
 

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -149,7 +149,7 @@ ShowManager::ShowManager(QWidget* parent, Doc* doc)
     container->setLayout(new QVBoxLayout);
     container->layout()->setContentsMargins(0, 0, 0, 0);
     m_splitter->widget(1)->hide();
-    
+
     connect(m_doc, SIGNAL(clearing()), this, SLOT(slotDocClearing()));
     connect(m_doc, SIGNAL(functionRemoved(quint32)), this, SLOT(slotFunctionRemoved(quint32)));
     connect(m_doc, SIGNAL(loaded()), this, SLOT(slotDocLoaded()));

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -658,7 +658,7 @@ void ShowManager::slotAddItem()
         else
         {
             Function *selectedFunc = m_doc->function(selectedID);
-            if (selectedFunc == NULL) // maybe a popup here ?
+            if (selectedFunc == NULL) // maybe a popup here?
                 return;
 
             /** 2) an existing scene */
@@ -775,7 +775,7 @@ void ShowManager::slotAddItem()
         if (selectedID != Function::invalidId())
         {
             Function *selectedFunc = m_doc->function(selectedID);
-            if (selectedFunc == NULL) // maybe a popup here ?
+            if (selectedFunc == NULL) // maybe a popup here?
                 return;
 
             /** 2) create a 10 seconds Sequence on the current track */

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -1638,7 +1638,7 @@ void ShowManager::updateMultiTrackView()
     m_show = qobject_cast<Show *>(m_doc->function(showID));
     if (m_show == NULL)
     {
-        qDebug() << Q_FUNC_INFO << "Invalid show !";
+        qDebug() << Q_FUNC_INFO << "Invalid show!";
         return;
     }
 

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -1018,7 +1018,7 @@ void VCCueList::setPlaybackLayout(VCCueList::PlaybackLayout layout)
     }
     else
     {
-        qWarning() << "Playback layout" << layout << "doesn't exist !";
+        qWarning() << "Playback layout" << layout << "doesn't exist!";
         layout = PlayPauseStop;
     }
 
@@ -1201,7 +1201,7 @@ void VCCueList::slotSlider2ValueChanged(int value)
 {
     if (slidersMode() == Steps)
     {
-        qWarning() << "[VCCueList] ERROR ! Slider2 value change should never happen !";
+        qWarning() << "[VCCueList] ERROR ! Slider2 value change should never happen!";
         return;
     }
 

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -115,7 +115,7 @@ VCCueList::VCCueList(QWidget* parent, Doc* doc) : VCWidget(parent, doc)
     grid->addWidget(m_linkCheck, 1, 0, 1, 2, Qt::AlignVCenter | Qt::AlignLeft);
 
     QFontMetrics m_fm = QFontMetrics(this->font());
-    
+
     m_sl1TopLabel = new QLabel("100%");
     m_sl1TopLabel->setAlignment(Qt::AlignHCenter);
     m_sl1TopLabel->setFixedWidth(m_fm.width("100%"));

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -1106,7 +1106,7 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
             quint32 dmx_ch = fxi->address() + lch.channel;
             int uni = fxi->universe();
 
-            // Dirty channel group check: is the channel HTP or LTP ?
+            // Dirty channel group check: is the channel HTP or LTP?
             QLCChannel::Group group = qlcch->group();
             if (fxi->forcedLTPChannels().contains(lch.channel))
                 group = QLCChannel::Effect;

--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -765,7 +765,7 @@ void VCXYPadProperties::slotAddFixtureGroupClicked()
         if (selectedGH.isEmpty())
         {
             QMessageBox::critical(this, tr("Error"),
-                                  tr("Please select at least one fixture or head to create this type of preset !"),
+                                  tr("Please select at least one fixture or head to create this type of preset!"),
                                   QMessageBox::Close);
             return;
         }

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1533,7 +1533,7 @@ void VirtualConsole::resetContents()
 
 void VirtualConsole::addWidgetInMap(VCWidget* widget)
 {
-    // Valid ID ?
+    // Valid ID?
     if (widget->id() != VCWidget::invalidId())
     {
         // Maybe we don't know this widget yet

--- a/unittest.sh
+++ b/unittest.sh
@@ -34,7 +34,7 @@ else
       HAS_XSERVER="1"
     fi
 
-    # no X server ? Let's look for xvfb. This is how Travis is setup
+    # no X server? Let's look for xvfb. This is how Travis is setup
     if [ -n "$TRAVIS" ]; then
         HAS_XSERVER="1"
     fi

--- a/unittest.sh
+++ b/unittest.sh
@@ -20,7 +20,7 @@ if [ "$CURRUSER" == "buildbot" ] || [ "$CURRUSER" == "abuild" ]; then
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "We're on OSX. Any prefix needed ?"
+    echo "We're on OSX. Any prefix needed?"
   fi
 
 else

--- a/webaccess/res/Test_Web_API.html
+++ b/webaccess/res/Test_Web_API.html
@@ -11,7 +11,7 @@ var isConnected = false;
 var wshost = "http://127.0.0.1:9999";
 
 // helper function to send QLC+ API commands
-function requestAPI(cmd) 
+function requestAPI(cmd)
 {
   if (isConnected === true)
     websocket.send("QLC+API|" + cmd);
@@ -22,7 +22,7 @@ function requestAPI(cmd)
 // helper function to send a QLC+ API with one parameter.
 // The specified parameter is not a value, but a CSS object
 // from which a value is retrieved (usually a <input> box)
-function requestAPIWithParam(cmd, paramObjName) 
+function requestAPIWithParam(cmd, paramObjName)
 {
   var obj = document.getElementById(paramObjName);
   if (obj)
@@ -34,7 +34,7 @@ function requestAPIWithParam(cmd, paramObjName)
   }
 }
 
-function requestChannelsRange(cmd, uniObjName, addressObjName, rangeObjName) 
+function requestChannelsRange(cmd, uniObjName, addressObjName, rangeObjName)
 {
   var uniObj = document.getElementById(uniObjName);
   var addrObj = document.getElementById(addressObjName);
@@ -128,7 +128,7 @@ function connectToWebSocket(host) {
   websocket.onerror = function(ev) {
     alert("QLC+ connection error!");
   };
- 
+
   // WebSocket message handler. This is where async events
   // will be shown or processed as needed
   websocket.onmessage = function(ev) {
@@ -139,13 +139,13 @@ function connectToWebSocket(host) {
     // Arguments vary depending on the API called
 
     var msgParams = ev.data.split('|');
-    
+
     if (msgParams[0] === "QLC+API")
     {
       if (msgParams[1] === "getFunctionsNumber")
 	document.getElementById('getFunctionsNumberBox').innerHTML = msgParams[2];
-      
-      // Arguments is an array formatted as follows: 
+
+      // Arguments is an array formatted as follows:
       // Function ID|Function name|Function ID|Function name|...
       else if (msgParams[1] === "getFunctionsList")
       {
@@ -166,8 +166,8 @@ function connectToWebSocket(host) {
 
       else if (msgParams[1] === "getWidgetsNumber")
 	document.getElementById('getWidgetsNumberBox').innerHTML = msgParams[2];
-      
-      // Arguments is an array formatted as follows: 
+
+      // Arguments is an array formatted as follows:
       // Widget ID|Widget name|Widget ID|Widget name|...
       else if (msgParams[1] === "getWidgetsList")
       {
@@ -179,10 +179,10 @@ function connectToWebSocket(host) {
 	tableCode += "</table>";
 	document.getElementById('getWidgetsListBox').innerHTML = tableCode;
       }
-      
+
       else if (msgParams[1] === "getWidgetType")
 	document.getElementById('getWidgetTypeBox').innerHTML = msgParams[2];
-	
+
       else if (msgParams[1] === "getWidgetStatus")
       {
 	var status = msgParams[2];
@@ -190,7 +190,7 @@ function connectToWebSocket(host) {
 	  status = msgParams[2] + "(Step: " + msgParams[3] + ")";
 	document.getElementById('getWidgetStatusBox').innerHTML = status;
       }
-      
+
       else if (msgParams[1] === "getChannelsValues")
       {
 	var tableCode = "<table class='apiTable'><tr><th>Index</th><th>Value</th><th>Type</th></tr>";
@@ -214,7 +214,7 @@ function loadProject () {
 
 <style type="text/css">
 
-body { 
+body {
   background-color: #45484d;
   color: white;
   font:normal 18px/1.2em sans-serif;
@@ -228,12 +228,12 @@ iframe {
   width: 100%;
 
   -moz-border-radius: 12px;
-  -webkit-border-radius: 12px; 
-  border-radius: 12px; 
+  -webkit-border-radius: 12px;
+  border-radius: 12px;
 
-  -moz-box-shadow: 4px 4px 14px #000; 
-  -webkit-box-shadow: 4px 4px 14px #000; 
-  box-shadow: 4px 4px 14px #000; 
+  -moz-box-shadow: 4px 4px 14px #000;
+  -webkit-box-shadow: 4px 4px 14px #000;
+  box-shadow: 4px 4px 14px #000;
 }
 
 #prjBox {
@@ -255,7 +255,7 @@ iframe {
 }
 
 .apiTable tr {
-  font-size: 14px; 
+  font-size: 14px;
   border: solid 1px white;
 }
 
@@ -266,7 +266,7 @@ iframe {
 }
 
 .apiButton {
-  display: table-cell; 
+  display: table-cell;
   vertical-align: middle;
   text-align: center;
   color: black;
@@ -278,8 +278,8 @@ iframe {
   background: -moz-linear-gradient(-90deg, #81a8cb, #4477a1);
 
   -moz-border-radius: 6px;
-  -webkit-border-radius: 6px; 
-  border-radius: 6px; 
+  -webkit-border-radius: 6px;
+  border-radius: 6px;
 }
 
 .apiButton:hover {
@@ -296,7 +296,7 @@ iframe {
   width: 150px;
   height: 30px;
   background-color: #aaaaaa;
-  border-radius: 6px; 
+  border-radius: 6px;
 }
 
 </style>
@@ -309,7 +309,7 @@ iframe {
 <div id="prjBox"><iframe name="projectFrame" src="" id="projectFrame"></iframe></div>
 
 <!-- ############## Websocket connection code ####################### -->
-QLC+ IP: 
+QLC+ IP:
 <input type="text" id="qlcplusIP" value="127.0.0.1:9999"/>
 <input type="button" value="Connect" onclick="javascript:connectToWebSocket(document.getElementById('qlcplusIP').value);">
 <div id="connStatus" style="display: inline-block;"><font color=red>Not connected</font></div>
@@ -331,7 +331,7 @@ Load a project:
   <th width=30%><b>Description</b></th>
   <th width=40%><b>Result</b></th>
  </tr>
- 
+
 <!-- ############## Channels API tests ####################### -->
 
  <tr>
@@ -350,7 +350,7 @@ Load a project:
  </tr>
 
 <!-- ############## Functions API tests ####################### -->
- 
+
  <tr>
   <td colspan="3" align="center"><b>Function APIs</b></td>
  </tr>
@@ -380,7 +380,7 @@ Load a project:
   <td>Retrieve the status of a function with the given ID. Possible values are "Running", "Stopped" and "Undefined"</td>
   <td><div id="getFunctionStatusBox" class="resultBox"></div></td>
   </tr>
-  
+
 <!-- ############## Widgets API tests ####################### -->
 
  <tr>
@@ -412,7 +412,7 @@ Load a project:
   <td>Retrieve the status of a Virtual Console Widget with the given ID</td>
   <td><div id="getWidgetStatusBox" class="resultBox"></div></td>
  </tr>
- 
+
 <!-- ############## High rate API tests ####################### -->
 
  <tr>
@@ -457,7 +457,7 @@ Load a project:
     and Sliders will accept all the values in the 0-255 range.
   </td>
  </tr>
- 
+
  <tr>
   <td>
    <div class="apiButton" onclick="javascript:vcCueListControl('clWidgetID', 'clOperation', 'clStep');">Cue list control</div>
@@ -484,7 +484,7 @@ Load a project:
    Operation:<input id="frOperation" type="text" value="NEXT_PG">
   </td>
   <td colspan="2">
-    This API demonstrates how to change page of a Virtual Console Frame widget in multipage mode. 
+    This API demonstrates how to change page of a Virtual Console Frame widget in multipage mode.
     The parameters to be used are:<br>
     <b>Frame ID</b>: The Frame widget ID as retrieved with the 'getWidgetsList' API<br>
     <b>Operation</b>: The Frame operation to perform. Accepted values are 'NEXT_PG' and 'PREV_PG'.

--- a/webaccess/res/Test_Web_API.html
+++ b/webaccess/res/Test_Web_API.html
@@ -16,7 +16,7 @@ function requestAPI(cmd)
   if (isConnected === true)
     websocket.send("QLC+API|" + cmd);
   else
-    alert("You must connect to QLC+ WebSocket first !");
+    alert("You must connect to QLC+ WebSocket first!");
 }
 
 // helper function to send a QLC+ API with one parameter.
@@ -30,7 +30,7 @@ function requestAPIWithParam(cmd, paramObjName)
     if (isConnected === true)
       websocket.send("QLC+API|" + cmd + "|" + obj.value);
     else
-      alert("You must connect to QLC+ WebSocket first !");
+      alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -44,7 +44,7 @@ function requestChannelsRange(cmd, uniObjName, addressObjName, rangeObjName)
     if (isConnected === true)
       websocket.send("QLC+API|" + cmd + "|" + uniObj.value + "|" + addrObj.value + "|" + rangeObj.value);
     else
-      alert("You must connect to QLC+ WebSocket first !");
+      alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -57,7 +57,7 @@ function setSimpleDeskChannel(addressObjName, channelValueObjName)
     if (isConnected === true)
       websocket.send("CH|" + addrObj.value + "|" + valObj.value);
     else
-      alert("You must connect to QLC+ WebSocket first !");
+      alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -70,7 +70,7 @@ function vcWidgetSetValue(wIDObjName, wValueObjName)
     if (isConnected === true)
       websocket.send(wObj.value + "|" + valObj.value);
     else
-      alert("You must connect to QLC+ WebSocket first !");
+      alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -89,7 +89,7 @@ function vcCueListControl(clIDObjName, clOpObjName, clStepObjName)
         websocket.send(clObj.value + "|" + opObj.value);
     }
     else
-      alert("You must connect to QLC+ WebSocket first !");
+      alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -105,7 +105,7 @@ function vcFrameControl(frIDObjName, frOperation)
         websocket.send(frObj.value + "|" + opObj.value);
     }
     else
-      alert("You must connect to QLC+ WebSocket first !");
+      alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -122,7 +122,7 @@ function connectToWebSocket(host) {
   };
 
   websocket.onclose = function(ev) {
-    alert("QLC+ connection lost !");
+    alert("QLC+ connection lost!");
   };
 
   websocket.onerror = function(ev) {

--- a/webaccess/res/keypad.html
+++ b/webaccess/res/keypad.html
@@ -88,7 +88,7 @@ var channels, c, v, first, last, step, range;
 var reqchan;
 var addval;
 var values=[];
-window.onload = function() 
+window.onload = function()
 {
   var url = 'ws://' + window.location.host + '/qlcplusWS';
   websocket = new WebSocket(url);
@@ -105,9 +105,9 @@ window.onload = function()
     //alert(ev.data);
     var msg=ev.data;
     var msgParams = ev.data.split('|');
-    if (msgParams[0] === "QLC+API") 
+    if (msgParams[0] === "QLC+API")
     {
-      if (msgParams[1] === "getChannelsValues") 
+      if (msgParams[1] === "getChannelsValues")
       {
         values=[];
         for (i = 2; i < msgParams.length; i+=3)
@@ -121,7 +121,7 @@ window.onload = function()
   };
 };
 
-function composeCommand(cmd) 
+function composeCommand(cmd)
 {
   if (isConnected === true)
   {
@@ -160,7 +160,7 @@ function resetUniverse()
 }
 
 function resetCh(chNum)
-{   
+{
   document.getElementById('commInput').value = '';
   if (isConnected === true)
   {
@@ -173,7 +173,7 @@ function resetCh(chNum)
 }
 // Modified set Channel Function
 function setChannel(c, v)
-{ 
+{
   // This function set a channel passed with param c at value passed with param v
   if (isConnected === true)
   {
@@ -185,7 +185,7 @@ function setChannel(c, v)
   }
 }
 
-function zip() 
+function zip()
 {
   var args = [].slice.call(arguments);
   var longest = args.reduce(function(a,b)
@@ -203,7 +203,7 @@ function chval(c)
   // This function evaluates string that could contain
   //  'T' = THRU, 'B' = BY
   // Returns three values first, last and step values
-  // first, last and step should be channels number or values. 
+  // first, last and step should be channels number or values.
   //addval=0;
   if (c.split(pl).length>1)
   {
@@ -221,7 +221,7 @@ function chval(c)
     first=range.split(th)[0];
     last=range.split(th)[1];
   }
-  else 
+  else
   {
     if (c.split(th).length>1)
     {
@@ -230,7 +230,7 @@ function chval(c)
       first=range.split(th)[0];
       last=range.split(th)[1];
     }
-    else 
+    else
     {
       step=1;
       range=c.split(th);
@@ -245,7 +245,7 @@ function chval(c)
 function chans_vals(c)
 {
   // Main function. Split command at "AT" string.
-  // Left part are single channel number, a range of channels and optionally a step value. 
+  // Left part are single channel number, a range of channels and optionally a step value.
   // Right part are a single value, a range of values and optionally a step value.
   // Calls to chval fucntion to evaluate channels numbers and values.
   // Arrange it on an array used later to assign channels values
@@ -273,7 +273,7 @@ function chans_vals(c)
         vall.push(vals[0]);
       }
     }
-    else 
+    else
     {
       llarg = chanl.length - 1;
       for (var i = vals[0]; i <= vals[1]; i += Math.round(vals[1] / llarg))
@@ -301,7 +301,7 @@ function chans_vals(c)
           {
             v=255
           }
-          else 
+          else
           {
             v = parseInt(values[c-1]) + parseInt(v * 2.55);
           }
@@ -312,7 +312,7 @@ function chans_vals(c)
           {
             v=0
           }
-          else 
+          else
           {
             v = parseInt(values[c-1]) + parseInt(v * 2.55);
           }

--- a/webaccess/res/keypad.html
+++ b/webaccess/res/keypad.html
@@ -96,7 +96,7 @@ window.onload = function()
     isConnected = true;
   };
   websocket.onclose = function(ev) {
-    alert("QLC+ connection lost !");
+    alert("QLC+ connection lost!");
   };
   websocket.onerror = function(ev) {
     alert("QLC+ connection error!");
@@ -129,7 +129,7 @@ function composeCommand(cmd)
   }
   else
   {
-    alert("You must connect to QLC+ WebSocket first !");
+    alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -142,7 +142,7 @@ function reqChannelsRange(univ, chan, range)
   }
   else
   {
-    alert("You must connect to QLC+ WebSocket first !");
+    alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -155,7 +155,7 @@ function resetUniverse()
   }
   else
   {
-    alert("You must connect to QLC+ WebSocket first !");
+    alert("You must connect to QLC+ WebSocket first!");
   }
 }
 
@@ -168,7 +168,7 @@ function resetCh(chNum)
   }
   else
   {
-    alert("You must connect to QLC+ WebSocket first !");
+    alert("You must connect to QLC+ WebSocket first!");
   }
 }
 // Modified set Channel Function
@@ -181,7 +181,7 @@ function setChannel(c, v)
   }
   else
   {
-    alert("You must connect to QLC+ WebSocket first !");
+    alert("You must connect to QLC+ WebSocket first!");
   }
 }
 

--- a/webaccess/res/simpledesk.js
+++ b/webaccess/res/simpledesk.js
@@ -1,7 +1,7 @@
 /*
   Q Light Controller Plus
   simpledesk.js
-  
+
   Copyright (c) Massimo Callegari
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/webaccess/res/simpledesk.js
+++ b/webaccess/res/simpledesk.js
@@ -32,7 +32,7 @@ window.onload = function() {
     getPage(1, 1);
    };
    websocket.onclose = function(ev) {
-    alert("QLC+ connection lost !");
+    alert("QLC+ connection lost!");
    };
    websocket.onerror = function(ev) {
     alert("QLC+ connection error!");

--- a/webaccess/res/websocket.js
+++ b/webaccess/res/websocket.js
@@ -1,7 +1,7 @@
 /*
   Q Light Controller Plus
   websocket.js
-  
+
   Copyright (c) Massimo Callegari
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/webaccess/res/websocket.js
+++ b/webaccess/res/websocket.js
@@ -30,7 +30,7 @@ window.onload = function() {
  };
 
  websocket.onclose = function(ev) {
-  alert("QLC+ connection lost !");
+  alert("QLC+ connection lost!");
  };
 
  websocket.onerror = function(ev) {

--- a/webaccess/src/qhttpserver/qhttpconnection.cpp
+++ b/webaccess/src/qhttpserver/qhttpconnection.cpp
@@ -430,7 +430,7 @@ void QHttpConnection::webSocketRead(QByteArray data)
         }
         else if (dataLen == 127)
         {
-            // TODO: 64bit length...really ?
+            // TODO: 64bit length...really?
             dataPos+=8;
         }
 

--- a/webaccess/src/qhttpserver/qhttpconnection.cpp
+++ b/webaccess/src/qhttpserver/qhttpconnection.cpp
@@ -63,7 +63,7 @@ QHttpConnection::QHttpConnection(QTcpSocket *socket, QObject *parent)
     connect(socket, SIGNAL(disconnected()), this, SLOT(socketDisconnected()));
     connect(socket, SIGNAL(bytesWritten(qint64)), this, SLOT(updateWriteCount(qint64)));
 
-    qDebug() << "HTTP connection created !";
+    qDebug() << "HTTP connection created!";
 }
 
 QHttpConnection::~QHttpConnection()
@@ -80,7 +80,7 @@ QHttpConnection::~QHttpConnection()
     if (m_isWebSocket == true)
         Q_EMIT webSocketConnectionClose(this);
 
-    qDebug() << "HTTP connection destroyed !";
+    qDebug() << "HTTP connection destroyed!";
 }
 
 void QHttpConnection::socketDisconnected()

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -377,7 +377,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
                 settings.setValue(SETTINGS_AUDIO_OUTPUT_DEVICE, cmdList[2]);
         }
         else
-            qDebug() << "[webaccess] Command" << cmdList[1] << "not supported !";
+            qDebug() << "[webaccess] Command" << cmdList[1] << "not supported!";
 
         return;
     }
@@ -432,8 +432,8 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             m_auth->setUserLevel(username, (WebAccessUserLevel)level);
         }
         else
-            qDebug() << "[webaccess] Command" << cmdList[1] << "not supported !";
-        
+            qDebug() << "[webaccess] Command" << cmdList[1] << "not supported!";
+
         if(! m_auth->savePasswordsFile())
         {
             QString wsMessage = QString("ALERT|" + tr("Error while saving passwords file."));
@@ -456,7 +456,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
                 return;
             }
             else
-                qDebug() << "[webaccess] Error writing network configuration file !";
+                qDebug() << "[webaccess] Error writing network configuration file!";
 
             return;
         }

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -111,14 +111,14 @@ void WebAccess::slotHandleRequest(QHttpRequest *req, QHttpResponse *resp)
     if(m_auth)
     {
         user = m_auth->authenticateRequest(req, resp);
-    
+
         if(user.level < LOGGED_IN_LEVEL)
         {
             m_auth->sendUnauthorizedResponse(resp);
             return;
         }
     }
-    
+
     QString reqUrl = req->url().toString();
     QString content;
 
@@ -295,7 +295,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
 {
     if (conn == NULL)
         return;
-    
+
     WebAccessUser* user = static_cast<WebAccessUser*>(conn->userData);
 
     qDebug() << "[websocketDataHandler]" << data;
@@ -318,7 +318,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
     {
         if(m_auth && user && user->level < SUPER_ADMIN_LEVEL)
             return;
-        
+
         if (cmdList.count() < 3)
             return;
 
@@ -385,7 +385,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
     {
         if(user && user->level < SUPER_ADMIN_LEVEL)
             return;
-        
+
         if (cmdList.at(1) == "ADD_USER")
         {
             QString username = cmdList.at(2);
@@ -446,7 +446,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
     {
         if(m_auth && user && user->level < SUPER_ADMIN_LEVEL)
             return;
-        
+
         if (cmdList.at(1) == "NETWORK")
         {
             if (m_netConfig->updateNetworkFile(cmdList) == true)
@@ -490,7 +490,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
     {
         if(m_auth && user && user->level < VC_ONLY_LEVEL)
             return;
-        
+
         if (cmdList.count() < 2)
             return;
 
@@ -620,7 +620,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
         {
             if(m_auth && user && user->level < SIMPLE_DESK_AND_VC_LEVEL)
                 return;
-            
+
             if (cmdList.count() < 4)
                 return;
 
@@ -667,7 +667,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
     {
         if(m_auth && user && user->level < SIMPLE_DESK_AND_VC_LEVEL)
             return;
-        
+
         if (cmdList.count() < 3)
             return;
 
@@ -685,7 +685,7 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
 
     if(m_auth && user && user->level < VC_ONLY_LEVEL)
         return;
-    
+
     quint32 widgetID = cmdList[0].toUInt();
     VCWidget *widget = m_vc->widget(widgetID);
     uchar value = 0;

--- a/webaccess/src/webaccessnetwork.cpp
+++ b/webaccess/src/webaccessnetwork.cpp
@@ -463,7 +463,7 @@ bool WebAccessNetwork::writeNetworkFile()
                 dhcpcdCacheWritten = true;
             }
             else
-                qDebug() << "[writeNetworkFile] ERROR. No dhcpcd cache found !";
+                qDebug() << "[writeNetworkFile] ERROR. No dhcpcd cache found!";
 
             dhcpcdFile.write((QString("interface %1\n").arg(iface.name)).toLatin1());
             dhcpcdFile.write((QString("static ip_address=%1/%2\n").arg(iface.address).arg(stringToNetmask(iface.netmask))).toLatin1());


### PR DESCRIPTION
This is basically #1102 again, but this time also for exclamation marks and the commits are split better to help ease reviewing.

* :us: :gb: English: No space before question mark (?) or exclamation mark (!) [<sup>Source</sup>](https://english.stackexchange.com/q/4645)
* :czech_republic: Czech: No space [<sup>Source: janosvitok</sup>](https://github.com/mcallegari/qlcplus/pull/1102#issuecomment-407924137)
* :de: German: No space <sup>Source: How I learned it in school ;)</sup>
* :it: Italian: No space [<sup>Source: mcallegari</sup>](https://github.com/mcallegari/qlcplus/pull/1102#issuecomment-407909930)
* :netherlands: Dutch: No space [<sup>Source: Netflix subtitle translator guidelines, section 14</sup>](https://partnerhelp.netflixstudios.com/hc/en-us/articles/215350158-Dutch-Timed-Text-Style-Guide)
* :es: Spanish: No space, but upside-down question/exclamation mark in front of the (sub)sentence [<sup>Source</sup>](https://www.thoughtco.com/upside-down-punctuation-in-spanish-3080317)
* :fr: French: Spaces mandatory; in software, use non-breaking spaces [<sup>Source: Duolingo</sup>](https://www.duolingo.com/comment/7344/Spaces-before-punctuation-marks)

I've included the updated code comments again; maybe someone else can review them quickly (shouldn't be too difficult in this case). If you prefer, we can revert the respective commits again.