### PR TITLE
Tidy up channel presets

### DIFF
--- a/engine/src/qlccapability.cpp
+++ b/engine/src/qlccapability.cpp
@@ -92,6 +92,9 @@ void QLCCapability::setPreset(QLCCapability::Preset preset)
     m_preset = preset;
 }
 
+/* please see
+https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+when changing this function */
 QLCCapability::PresetType QLCCapability::presetType() const
 {
     switch (m_preset)
@@ -119,6 +122,9 @@ QLCCapability::PresetType QLCCapability::presetType() const
     }
 }
 
+/* please see
+https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+when changing this function */
 QString QLCCapability::presetUnits() const
 {
     switch (m_preset)

--- a/engine/src/qlccapability.h
+++ b/engine/src/qlccapability.h
@@ -95,7 +95,11 @@ public:
     bool operator<(const QLCCapability& capability) const;
 
     /********************************************************************
-     * Preset
+     * Presets
+     *
+     * please see
+     * https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+     * when changing this list
      ********************************************************************/
 public:
     enum Preset

--- a/engine/src/qlcchannel.cpp
+++ b/engine/src/qlcchannel.cpp
@@ -318,10 +318,6 @@ void QLCChannel::setPreset(QLCChannel::Preset preset)
             grp = Pan;
             prname = KXMLQLCChannelGroupPan;
         break;
-        case PositionPanCounterClockwise:
-            grp = Pan;
-            prname = KXMLQLCChannelGroupPan + " counterclockwise";
-        break;
         case PositionPanFine:
             grp = Pan;
             prname = KXMLQLCChannelGroupPan + " fine";
@@ -505,7 +501,6 @@ QLCCapability *QLCChannel::addPresetCapability()
         case IntensityLightnessFine:
         case IntensityValueFine:
         case PositionPan:
-        case PositionPanCounterClockwise:
         case PositionPanFine:
         case PositionTilt:
         case PositionTiltFine:

--- a/engine/src/qlcchannel.cpp
+++ b/engine/src/qlcchannel.cpp
@@ -148,6 +148,9 @@ QLCChannel::Preset QLCChannel::preset() const
     return m_preset;
 }
 
+/* please see
+https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+when changing this function */
 void QLCChannel::setPreset(QLCChannel::Preset preset)
 {
     if (preset == m_preset)
@@ -457,6 +460,9 @@ void QLCChannel::setPreset(QLCChannel::Preset preset)
     setControlByte(cb);
 }
 
+/* please see
+https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+when changing this function */
 QLCCapability *QLCChannel::addPresetCapability()
 {
     QLCCapability *cap = new QLCCapability();

--- a/engine/src/qlcchannel.cpp
+++ b/engine/src/qlcchannel.cpp
@@ -519,6 +519,7 @@ QLCCapability *QLCChannel::addPresetCapability()
         case GoboWheelFine:
         case GoboIndexFine:
         case ShutterIrisFine:
+        case BeamFocusFine:
         case BeamZoomFine:
         case NoFunction:
             cap->setName(name());

--- a/engine/src/qlcchannel.h
+++ b/engine/src/qlcchannel.h
@@ -132,7 +132,6 @@ public:
         IntensityValue,
         IntensityValueFine,
         PositionPan,
-        PositionPanCounterClockwise,
         PositionPanFine,
         PositionTilt,
         PositionTiltFine,

--- a/engine/src/qlcchannel.h
+++ b/engine/src/qlcchannel.h
@@ -92,6 +92,10 @@ public:
 
     /*********************************************************************
      * Presets
+     *
+     * please see
+     * https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+     * when changing this list
      *********************************************************************/
 public:
     enum Preset

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -25,7 +25,7 @@ def getPresetsArray():
         "ColorMacro", "ColorWheel", "ColorWheelFine", "ColorRGBMixer", "ColorCTOMixer", "ColorCTCMixer", "ColorCTBMixer",
         "GoboWheel", "GoboWheelFine", "GoboIndex", "GoboIndexFine",
         "ShutterStrobeSlowFast", "ShutterStrobeFastSlow", "ShutterIrisMinToMax", "ShutterIrisMaxToMin", "ShutterIrisFine"
-        "BeamFocusNearFar", "BeamFocusFarNear", "BeamZoomSmallBig", "BeamZoomBigSmall", "BeamZoomFine",
+        "BeamFocusNearFar", "BeamFocusFarNear", "BeamFocusFine", "BeamZoomSmallBig", "BeamZoomBigSmall", "BeamZoomFine",
         "PrismRotationSlowFast", "PrismRotationFastSlow",
         "NoFunction" ]
 

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -10,6 +10,7 @@ singleCapCount = 0
 
 namespace = "http://www.qlcplus.org/FixtureDefinition"
 
+# please see https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets when changing this list
 def getPresetsArray():
     return [
         "Custom",

--- a/resources/schemas/fixture.xsd
+++ b/resources/schemas/fixture.xsd
@@ -146,6 +146,9 @@ elementFormDefault="qualified"
    <xs:attribute name="Color2" type="xs:string"/>
 </xs:complexType>
 
+<!-- please see
+https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+when changing this list -->
 <xs:simpleType name="channelPresetType">
     <xs:restriction base="xs:string">
         <xs:enumeration value="IntensityMasterDimmer"/>
@@ -222,6 +225,9 @@ elementFormDefault="qualified"
     </xs:restriction>
 </xs:simpleType>
 
+<!-- please see
+https://github.com/mcallegari/qlcplus/wiki/Fixture-definition-presets
+when changing this list -->
 <xs:simpleType name="capabilityPresetType">
     <xs:restriction base="xs:string">
         <xs:enumeration value="SlowToFast" />

--- a/resources/schemas/fixture.xsd
+++ b/resources/schemas/fixture.xsd
@@ -212,6 +212,7 @@ elementFormDefault="qualified"
         <xs:enumeration value="ShutterIrisFine"/>
         <xs:enumeration value="BeamFocusNearFar"/>
         <xs:enumeration value="BeamFocusFarNear"/>
+        <xs:enumeration value="BeamFocusFine"/>
         <xs:enumeration value="BeamZoomSmallBig"/>
         <xs:enumeration value="BeamZoomBigSmall"/>
         <xs:enumeration value="BeamZoomFine"/>

--- a/resources/schemas/fixture.xsd
+++ b/resources/schemas/fixture.xsd
@@ -183,7 +183,6 @@ elementFormDefault="qualified"
         <xs:enumeration value="IntensityValue"/>
         <xs:enumeration value="IntensityValueFine"/>
         <xs:enumeration value="PositionPan"/>
-        <xs:enumeration value="PositionPanCounterClockwise"/>
         <xs:enumeration value="PositionPanFine"/>
         <xs:enumeration value="PositionTilt"/>
         <xs:enumeration value="PositionTiltFine"/>

--- a/resources/schemas/fixture.xsd
+++ b/resources/schemas/fixture.xsd
@@ -198,6 +198,7 @@ elementFormDefault="qualified"
         <xs:enumeration value="ColorMacro"/>
         <xs:enumeration value="ColorWheel"/>
         <xs:enumeration value="ColorWheelFine"/>
+        <xs:enumeration value="ColorRGBMixer"/>
         <xs:enumeration value="ColorCTOMixer"/>
         <xs:enumeration value="ColorCTCMixer"/>
         <xs:enumeration value="ColorCTBMixer"/>


### PR DESCRIPTION
Some inconsistencies in channel preset lists I noticed during the development of Open Fixture Library's QLC+ 4.12.0 plugin (see [OpenLightingProject/open-fixture-library#547](https://github.com/OpenLightingProject/open-fixture-library/pull/547)).

Also, there is the `PositionPanCounterClockwise` channel preset, but no matching clockwise or Tilt presets. Is this a mistake?

When adding / removing / renaming a preset, one always needs to do so in various different places:

* XSD schema
* fixture tool
* qlcchannel.h
* qlcchannel.cpp 2 times
* qlccapability.h
* qlccapability.cpp
* maybe more "fixed" places
* and of course everywhere it is used, i.e. fixtures and code like strobe frequency preview

Would it be a good idea to add some kind of a checklist somewhere to reduce the risk of missing something? (We have this for OFL, too; see https://github.com/OpenLightingProject/open-fixture-library/blob/master/docs/capability-types.md#how-to-add-new-capability-types--type-specific-properties)