### PR TITLE
plugins/ola: enable pkg-config on macx platform

### DIFF
--- a/plugins/ola/ola.pro
+++ b/plugins/ola/ola.pro
@@ -12,13 +12,19 @@ QTPLUGIN  =
 INCLUDEPATH += ../interfaces
 
 macx: {
-    #CONFIG    += link_pkgconfig
-    #PKGCONFIG += libola libolaserver
     #QMAKE_CXXFLAGS_X86_64 -= -mmacosx-version-min=10.5
     #QMAKE_CXXFLAGS_X86_64 = -mmacosx-version-min=10.7
     QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
-    INCLUDEPATH += /opt/local/include
-    LIBS      += -L/opt/local/lib -lolaserver -lola -lolacommon
+
+    # Check for pkg-config and setup queries accordingly.
+    # Otherwise, use MacPorts default paths.
+    packagesExist(libola libolaserver){
+        CONFIG    += link_pkgconfig
+        PKGCONFIG += libola libolaserver
+    } else {
+        INCLUDEPATH += /opt/local/include
+        LIBS      += -L/opt/local/lib -lolaserver -lola -lolacommon
+    }
 } else {
     LIBS      += -L/usr/local/lib -lolaserver -lola -lolacommon
 }


### PR DESCRIPTION
I get errors when building **qlcplus** on macOS out of the box because I've installed **ola** from source.

This change to **plugins/ola/ola.pro** enables pkg-config queries on those macs where it's available, while behaving exactly as it did before otherwise (ola installed through MacPorts).

It reuses commented instructions, choosing between the two methods based on a qmake test for pkg-config existence.