### PR TITLE
plugins/dmxusb: fix leading "&&" error with single nametool command

### DIFF
--- a/plugins/dmxusb/src/src.pro
+++ b/plugins/dmxusb/src/src.pro
@@ -145,7 +145,14 @@ macx {
     # This must be after "TARGET = " and before target installation so that
     # install_name_tool can be run before target installation
     include(../../../platforms/macos/nametool.pri)
-    nametool.commands += && $$pkgConfigNametool(libftdi, libftdi.1.dylib)
+
+    # Add leading "&&" only if there are
+    # more commands to chain together
+    !isEmpty(nametool.commands) {
+        nametool.commands += "&&"
+    }
+
+    nametool.commands += $$pkgConfigNametool(libftdi, libftdi.1.dylib)
 }
 
 # Plugin installation


### PR DESCRIPTION
I get errors while creating the app bundle in macOS (make install), as the shell complains for an unexpected "&&" token when installing libftdi from dmxusb.

It turns out that token is hard-coded at the bottom of **plugins/dmxusb/src/src.pro**. As such, it generates errors whenever that line is the only command in **nametool.commands**, so I added a check for this that manages the "&&" operator aside from the real command.