### PR TITLE
Added flash button support at webaccess for Mobile Devices

### DIFF
--- a/webaccess/res/virtualconsole.js
+++ b/webaccess/res/virtualconsole.js
@@ -19,21 +19,7 @@
 
 /* VCButton */
 
-window.addEventListener("load",() => {
-    var buttons = document.getElementsByClassName("vcbutton");
 
-    for (var btn of buttons) {
-        btn.addEventListener("touchstart", (event) => {
-                 event.preventDefault();
-                buttonPress(this.id)
-        }, false);
-
-        btn.addEventListener("touchend", (event) => {
-                 event.preventDefault();
-                buttonRelease(this.id)
-        }, false);
-    }
-});
 
 function buttonPress(id) {
  websocket.send(id + "|255");
@@ -56,6 +42,20 @@ function wsSetButtonState(id, state) {
   obj.style.border = "3px solid #A0A0A0";
  }
 }
+
+window.addEventListener("load",() => {
+    var buttons = document.getElementsByClassName("vcbutton");
+    for (var btn of buttons) {
+        btn.addEventListener("touchstart", (event) => {
+                event.preventDefault();
+                buttonPress(this.id);
+        }, false);
+        btn.addEventListener("touchend", (event) => {
+                event.preventDefault();
+                buttonRelease(this.id);
+        }, false);
+    }
+});
 
 /* VCCueList */
 var cueListsIndices = new Array();

--- a/webaccess/res/virtualconsole.js
+++ b/webaccess/res/virtualconsole.js
@@ -18,6 +18,23 @@
 */
 
 /* VCButton */
+
+window.addEventListener("load",() => {
+    var buttons = document.getElementsByClassName("vcbutton");
+
+    for (var btn of buttons) {
+        btn.addEventListener("touchstart", (event) => {
+                 event.preventDefault();
+                buttonPress(this.id)
+        }, false);
+
+        btn.addEventListener("touchend", (event) => {
+                 event.preventDefault();
+                buttonRelease(this.id)
+        }, false);
+    }
+});
+
 function buttonPress(id) {
  websocket.send(id + "|255");
 }

--- a/webaccess/res/virtualconsole.js
+++ b/webaccess/res/virtualconsole.js
@@ -18,9 +18,6 @@
 */
 
 /* VCButton */
-
-
-
 function buttonPress(id) {
  websocket.send(id + "|255");
 }


### PR DESCRIPTION
I noticed some time ago that flash buttons where not working at all in the web access mode if you are using a mobile device, and I tought it will be nice to have them working because that would make the web access even more powerful when using mobile devices.

I tested it and it works great.

Also 
```
make check
~/qlcplus_fork/qlcplus
Unit tests passed.
```