### PR TITLE
Adaptations for Qt 5.13

### DIFF
--- a/engine/src/chaserstep.cpp
+++ b/engine/src/chaserstep.cpp
@@ -71,7 +71,7 @@ int ChaserStep::setValue(SceneValue value, int index, bool *created)
         if (index == -1)
         {
             values.append(value);
-	    std::sort(values.begin(), values.end());
+            std::sort(values.begin(), values.end());
             if (created != NULL)
                 *created = true;
             return values.indexOf(value);

--- a/engine/src/chaserstep.cpp
+++ b/engine/src/chaserstep.cpp
@@ -71,7 +71,11 @@ int ChaserStep::setValue(SceneValue value, int index, bool *created)
         if (index == -1)
         {
             values.append(value);
+#if (QT_VERSION < QT_VERSION_CHECK(5,13,0))
             qSort(values.begin(), values.end());
+#else
+	    std::sort(values.begin(), values.end());
+#endif
             if (created != NULL)
                 *created = true;
             return values.indexOf(value);

--- a/engine/src/chaserstep.cpp
+++ b/engine/src/chaserstep.cpp
@@ -71,11 +71,7 @@ int ChaserStep::setValue(SceneValue value, int index, bool *created)
         if (index == -1)
         {
             values.append(value);
-#if (QT_VERSION < QT_VERSION_CHECK(5,13,0))
-            qSort(values.begin(), values.end());
-#else
 	    std::sort(values.begin(), values.end());
-#endif
             if (created != NULL)
                 *created = true;
             return values.indexOf(value);

--- a/engine/src/cuestack.cpp
+++ b/engine/src/cuestack.cpp
@@ -238,7 +238,11 @@ void CueStack::removeCues(const QList <int>& indexes)
     // Sort the list so that the items can be removed in reverse order.
     // This way, the indices are always correct.
     QList <int> indexList = indexes;
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(indexList.begin(), indexList.end());
+#else
+    std::sort(indexList.begin(), indexList.end());
+#endif
 
     QListIterator <int> it(indexList);
     it.toBack();

--- a/engine/src/cuestack.cpp
+++ b/engine/src/cuestack.cpp
@@ -238,11 +238,7 @@ void CueStack::removeCues(const QList <int>& indexes)
     // Sort the list so that the items can be removed in reverse order.
     // This way, the indices are always correct.
     QList <int> indexList = indexes;
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(indexList.begin(), indexList.end());
-#else
     std::sort(indexList.begin(), indexList.end());
-#endif
 
     QListIterator <int> it(indexList);
     it.toBack();

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -326,7 +326,7 @@ void Fixture::setChannelCanFade(int idx, bool canFade)
     if (canFade == false && m_excludeFadeIndices.contains(idx) == false)
     {
         m_excludeFadeIndices.append(idx);
-	std::sort(m_excludeFadeIndices.begin(), m_excludeFadeIndices.end());
+        std::sort(m_excludeFadeIndices.begin(), m_excludeFadeIndices.end());
     }
     else if (canFade == true && m_excludeFadeIndices.contains(idx) == true)
     {

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -326,7 +326,11 @@ void Fixture::setChannelCanFade(int idx, bool canFade)
     if (canFade == false && m_excludeFadeIndices.contains(idx) == false)
     {
         m_excludeFadeIndices.append(idx);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(m_excludeFadeIndices.begin(), m_excludeFadeIndices.end());
+#else
+	std::sort(m_excludeFadeIndices.begin(), m_excludeFadeIndices.end());
+#endif
     }
     else if (canFade == true && m_excludeFadeIndices.contains(idx) == true)
     {

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -326,11 +326,7 @@ void Fixture::setChannelCanFade(int idx, bool canFade)
     if (canFade == false && m_excludeFadeIndices.contains(idx) == false)
     {
         m_excludeFadeIndices.append(idx);
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(m_excludeFadeIndices.begin(), m_excludeFadeIndices.end());
-#else
 	std::sort(m_excludeFadeIndices.begin(), m_excludeFadeIndices.end());
-#endif
     }
     else if (canFade == true && m_excludeFadeIndices.contains(idx) == true)
     {

--- a/engine/src/qlcchannel.cpp
+++ b/engine/src/qlcchannel.cpp
@@ -1041,11 +1041,7 @@ static bool capsort(const QLCCapability* cap1, const QLCCapability* cap2)
 
 void QLCChannel::sortCapabilities()
 {
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_capabilities.begin(), m_capabilities.end(), capsort);
-#else
     std::sort(m_capabilities.begin(), m_capabilities.end(), capsort);
-#endif
 }
 
 /*****************************************************************************

--- a/engine/src/qlcchannel.cpp
+++ b/engine/src/qlcchannel.cpp
@@ -1041,7 +1041,11 @@ static bool capsort(const QLCCapability* cap1, const QLCCapability* cap2)
 
 void QLCChannel::sortCapabilities()
 {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_capabilities.begin(), m_capabilities.end(), capsort);
+#else
+    std::sort(m_capabilities.begin(), m_capabilities.end(), capsort);
+#endif
 }
 
 /*****************************************************************************

--- a/engine/src/qlcfixturehead.cpp
+++ b/engine/src/qlcfixturehead.cpp
@@ -206,8 +206,13 @@ void QLCFixtureHead::cacheChannels(const QLCFixtureMode* mode)
     if (channelNumber(QLCChannel::Tilt, QLCChannel::LSB) == QLCChannel::invalid())
         setMapIndex(QLCChannel::Tilt, QLCChannel::LSB, mode->channelNumber(QLCChannel::Tilt, QLCChannel::LSB));
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_colorWheels);
     qSort(m_shutterChannels);
+#else
+    std::sort(m_colorWheels.begin(), m_colorWheels.end());
+    std::sort(m_shutterChannels.begin(), m_shutterChannels.end());
+#endif
 
     // Allow only one caching round per head
     m_channelsCached = true;

--- a/engine/src/qlcfixturehead.cpp
+++ b/engine/src/qlcfixturehead.cpp
@@ -206,13 +206,8 @@ void QLCFixtureHead::cacheChannels(const QLCFixtureMode* mode)
     if (channelNumber(QLCChannel::Tilt, QLCChannel::LSB) == QLCChannel::invalid())
         setMapIndex(QLCChannel::Tilt, QLCChannel::LSB, mode->channelNumber(QLCChannel::Tilt, QLCChannel::LSB));
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_colorWheels);
-    qSort(m_shutterChannels);
-#else
     std::sort(m_colorWheels.begin(), m_colorWheels.end());
     std::sort(m_shutterChannels.begin(), m_shutterChannels.end());
-#endif
 
     // Allow only one caching round per head
     m_channelsCached = true;

--- a/engine/src/rgbtext.cpp
+++ b/engine/src/rgbtext.cpp
@@ -165,7 +165,7 @@ int RGBText::scrollingTextStepCount() const
 #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         return fm.width(m_text);
 #else
-	return fm.horizontalAdvance(m_text);
+        return fm.horizontalAdvance(m_text);
 #endif
     }
 }

--- a/engine/src/rgbtext.cpp
+++ b/engine/src/rgbtext.cpp
@@ -161,8 +161,13 @@ int RGBText::scrollingTextStepCount() const
     QFontMetrics fm(m_font);
     if (animationStyle() == Vertical)
         return m_text.length() * fm.ascent();
-    else
+    else{
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         return fm.width(m_text);
+#else
+	return fm.horizontalAdvance(m_text);
+#endif
+    }
 }
 
 RGBMap RGBText::renderScrollingText(const QSize& size, uint rgb, int step) const

--- a/engine/src/sequence.cpp
+++ b/engine/src/sequence.cpp
@@ -172,7 +172,7 @@ bool Sequence::loadXML(QXmlStreamReader &root)
 #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(sceneValues.begin(), sceneValues.end());
 #else
-	(sceneValues.begin(), sceneValues.end());
+	std::sort(sceneValues.begin(), sceneValues.end());
 #endif
         m_needFixup = false;
     }

--- a/engine/src/sequence.cpp
+++ b/engine/src/sequence.cpp
@@ -169,7 +169,7 @@ bool Sequence::loadXML(QXmlStreamReader &root)
     if (scene != NULL)
     {
         sceneValues = scene->values();
-	std::sort(sceneValues.begin(), sceneValues.end());
+        std::sort(sceneValues.begin(), sceneValues.end());
         m_needFixup = false;
     }
 
@@ -251,7 +251,7 @@ void Sequence::postLoad()
             return;
         }
 
-	std::sort(sceneValues.begin(), sceneValues.end());
+        std::sort(sceneValues.begin(), sceneValues.end());
     }
 
     int stepIndex = 0;

--- a/engine/src/sequence.cpp
+++ b/engine/src/sequence.cpp
@@ -169,11 +169,7 @@ bool Sequence::loadXML(QXmlStreamReader &root)
     if (scene != NULL)
     {
         sceneValues = scene->values();
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(sceneValues.begin(), sceneValues.end());
-#else
 	std::sort(sceneValues.begin(), sceneValues.end());
-#endif
         m_needFixup = false;
     }
 
@@ -255,11 +251,7 @@ void Sequence::postLoad()
             return;
         }
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(sceneValues.begin(), sceneValues.end());
-#else
 	std::sort(sceneValues.begin(), sceneValues.end());
-#endif
     }
 
     int stepIndex = 0;

--- a/engine/src/sequence.cpp
+++ b/engine/src/sequence.cpp
@@ -169,7 +169,11 @@ bool Sequence::loadXML(QXmlStreamReader &root)
     if (scene != NULL)
     {
         sceneValues = scene->values();
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(sceneValues.begin(), sceneValues.end());
+#else
+	(sceneValues.begin(), sceneValues.end());
+#endif
         m_needFixup = false;
     }
 
@@ -251,7 +255,11 @@ void Sequence::postLoad()
             return;
         }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(sceneValues.begin(), sceneValues.end());
+#else
+	std::sort(sceneValues.begin(), sceneValues.end());
+#endif
     }
 
     int stepIndex = 0;

--- a/engine/src/showrunner.cpp
+++ b/engine/src/showrunner.cpp
@@ -85,7 +85,11 @@ ShowRunner::ShowRunner(const Doc* doc, quint32 showID, quint32 startTime)
         m_intensityMap[track->id()] = 1.0;
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_functions.begin(), m_functions.end(), compareShowFunctions);
+#else
+    std::sort(m_functions.begin(), m_functions.end(), compareShowFunctions);
+#endif
 
 #if 1
     qDebug() << "Ordered list of ShowFunctions:";

--- a/engine/src/showrunner.cpp
+++ b/engine/src/showrunner.cpp
@@ -85,11 +85,7 @@ ShowRunner::ShowRunner(const Doc* doc, quint32 showID, quint32 startTime)
         m_intensityMap[track->id()] = 1.0;
     }
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_functions.begin(), m_functions.end(), compareShowFunctions);
-#else
     std::sort(m_functions.begin(), m_functions.end(), compareShowFunctions);
-#endif
 
 #if 1
     qDebug() << "Ordered list of ShowFunctions:";

--- a/engine/test/rgbtext/rgbtext_test.cpp
+++ b/engine/test/rgbtext/rgbtext_test.cpp
@@ -363,13 +363,21 @@ void RGBText_Test::horizontalScroll()
     text.setAnimationStyle(RGBText::Horizontal);
 
     QFontMetrics fm(text.font());
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     QCOMPARE(text.rgbMapStepCount(QSize()), fm.width("QLC"));
+#else
+    QCOMPARE(text.rgbMapStepCount(QSize()), fm.horizontalAdvance("QLC"));
+#endif
 
     // Since fonts and their rendering differs from installation to installation,
     // these tests are here only to check that nothing crashes. The end result is
     // more or less OS, platform, HW and SW dependent and testing individual pixels
     // would thus be rather pointless.
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     for (int i = 0; i < fm.width("QLC"); i++)
+#else
+    for (int i = 0; i < fm.horizontalAdvance("QLC"); i++)
+#endif
     {
         RGBMap map = text.rgbMap(QSize(10, 10), QRgb(0xFFFFFFFF), i);
         QCOMPARE(map.size(), 10);
@@ -378,7 +386,11 @@ void RGBText_Test::horizontalScroll()
     }
 
     // Invalid step
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     RGBMap map = text.rgbMap(QSize(10, 10), QRgb(0xFFFFFFFF), fm.width("QLC"));
+#else
+    RGBMap map = text.rgbMap(QSize(10, 10), QRgb(0xFFFFFFFF), fm.horizontalAdvance("QLC"));
+#endif
     QCOMPARE(map.size(), 10);
     for (int i = 0; i < 10; i++)
     {

--- a/fixtureeditor/editmode.cpp
+++ b/fixtureeditor/editmode.cpp
@@ -364,7 +364,11 @@ void EditMode::refreshHeadList()
         QLCFixtureHead head = m_mode->heads().at(i);
 
         QList <quint32> channels(head.channels());
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(channels.begin(), channels.end());
+#else
+	std::sort(channels.begin(), channels.end());
+#endif
 
         QString summary;
 

--- a/fixtureeditor/editmode.cpp
+++ b/fixtureeditor/editmode.cpp
@@ -364,11 +364,7 @@ void EditMode::refreshHeadList()
         QLCFixtureHead head = m_mode->heads().at(i);
 
         QList <quint32> channels(head.channels());
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(channels.begin(), channels.end());
-#else
 	std::sort(channels.begin(), channels.end());
-#endif
 
         QString summary;
 

--- a/fixtureeditor/editmode.cpp
+++ b/fixtureeditor/editmode.cpp
@@ -364,7 +364,7 @@ void EditMode::refreshHeadList()
         QLCFixtureHead head = m_mode->heads().at(i);
 
         QList <quint32> channels(head.channels());
-	std::sort(channels.begin(), channels.end());
+        std::sort(channels.begin(), channels.end());
 
         QString summary;
 

--- a/plugins/enttecwing/src/enttecwing.cpp
+++ b/plugins/enttecwing/src/enttecwing.cpp
@@ -265,11 +265,7 @@ void EnttecWing::addDevice(Wing* device)
        between sessions they need to be sorted according to some
        (semi-)permanent criteria. Their addresses shouldn't change too
        often, so let's use that. */
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_devices.begin(), m_devices.end(), wing_device_sort);
-#else
     std::sort(m_devices.begin(), m_devices.end(), wing_device_sort);
-#endif
 
     emit configurationChanged();
 }

--- a/plugins/enttecwing/src/enttecwing.cpp
+++ b/plugins/enttecwing/src/enttecwing.cpp
@@ -265,7 +265,11 @@ void EnttecWing::addDevice(Wing* device)
        between sessions they need to be sorted according to some
        (semi-)permanent criteria. Their addresses shouldn't change too
        often, so let's use that. */
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_devices.begin(), m_devices.end(), wing_device_sort);
+#else
+    std::sort(m_devices.begin(), m_devices.end(), wing_device_sort);
+#endif
 
     emit configurationChanged();
 }

--- a/qmlui/chasereditor.cpp
+++ b/qmlui/chasereditor.cpp
@@ -169,11 +169,7 @@ bool ChaserEditor::moveSteps(QVariantList indicesList, int insertIndex)
         int idx = vIndex.toInt();
         sortedList.append(idx);
     }
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(sortedList);
-#else
     std::sort(sortedList.begin(), sortedList.end());
-#endif
 
     for (int index : sortedList)
     {
@@ -244,11 +240,7 @@ void ChaserEditor::deleteItems(QVariantList list)
     if (m_chaser == nullptr)
         return;
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(list.begin(), list.end());
-#else
     std::sort(list.begin(), list.end());
-#endif
     qDebug() << "Chaser delete list" << list;
 
     while (!list.isEmpty())

--- a/qmlui/chasereditor.cpp
+++ b/qmlui/chasereditor.cpp
@@ -169,8 +169,11 @@ bool ChaserEditor::moveSteps(QVariantList indicesList, int insertIndex)
         int idx = vIndex.toInt();
         sortedList.append(idx);
     }
-
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(sortedList);
+#else
+    std::sort(sortedList.begin(), sortedList.end());
+#endif
 
     for (int index : sortedList)
     {
@@ -241,7 +244,11 @@ void ChaserEditor::deleteItems(QVariantList list)
     if (m_chaser == nullptr)
         return;
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(list.begin(), list.end());
+#else
+    std::sort(list.begin(), list.end());
+#endif
     qDebug() << "Chaser delete list" << list;
 
     while (!list.isEmpty())

--- a/qmlui/importmanager.cpp
+++ b/qmlui/importmanager.cpp
@@ -133,7 +133,7 @@ void ImportManager::apply()
 #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_fixtureIDList.begin(), m_fixtureIDList.end());
 #else
-    std::sort(m_devices.begin(), m_devices.end(), wing_device_sort);
+    std::sort(m_fixtureIDList.begin(), m_fixtureIDList.end());
 #endif
     importFixtures();
 

--- a/qmlui/importmanager.cpp
+++ b/qmlui/importmanager.cpp
@@ -130,11 +130,7 @@ bool ImportManager::loadWorkspace(const QString &fileName)
 void ImportManager::apply()
 {
     // try to preserve the Fixture order
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_fixtureIDList.begin(), m_fixtureIDList.end());
-#else
     std::sort(m_fixtureIDList.begin(), m_fixtureIDList.end());
-#endif
     importFixtures();
 
     /* Functions need to be imported respecting their
@@ -443,11 +439,7 @@ void ImportManager::importFunctionID(quint32 funcID)
 
             if (removeList.isEmpty() == false)
             {
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-                qSort(removeList.begin(), removeList.end());
-#else
 		std::sort(removeList.begin(), removeList.end());
-#endif
                 for (int i = removeList.count() - 1; i >= 0; i--)
                     chaser->removeStep(removeList.at(i));
             }

--- a/qmlui/importmanager.cpp
+++ b/qmlui/importmanager.cpp
@@ -130,7 +130,11 @@ bool ImportManager::loadWorkspace(const QString &fileName)
 void ImportManager::apply()
 {
     // try to preserve the Fixture order
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_fixtureIDList.begin(), m_fixtureIDList.end());
+#else
+    std::sort(m_devices.begin(), m_devices.end(), wing_device_sort);
+#endif
     importFixtures();
 
     /* Functions need to be imported respecting their
@@ -439,7 +443,11 @@ void ImportManager::importFunctionID(quint32 funcID)
 
             if (removeList.isEmpty() == false)
             {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
                 qSort(removeList.begin(), removeList.end());
+#else
+		std::sort(removeList.begin(), removeList.end());
+#endif
                 for (int i = removeList.count() - 1; i >= 0; i--)
                     chaser->removeStep(removeList.at(i));
             }

--- a/qmlui/importmanager.cpp
+++ b/qmlui/importmanager.cpp
@@ -439,7 +439,7 @@ void ImportManager::importFunctionID(quint32 funcID)
 
             if (removeList.isEmpty() == false)
             {
-		std::sort(removeList.begin(), removeList.end());
+                std::sort(removeList.begin(), removeList.end());
                 for (int i = removeList.count() - 1; i >= 0; i--)
                     chaser->removeStep(removeList.at(i));
             }

--- a/qmlui/virtualconsole/vcclock.cpp
+++ b/qmlui/virtualconsole/vcclock.cpp
@@ -357,7 +357,11 @@ void VCClock::addSchedule(VCClockSchedule *schedule)
 {
     if (schedule->functionID() != Function::invalidId())
         m_scheduleList.append(schedule);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_scheduleList);
+#else
+    std::sort(m_scheduleList.begin(), m_scheduleList.end());
+#endif
     QQmlEngine::setObjectOwnership(schedule, QQmlEngine::CppOwnership);
     emit scheduleListChanged();
 }
@@ -376,7 +380,11 @@ void VCClock::addSchedules(QVariantList idsList)
         m_scheduleList.append(sch);
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_scheduleList);
+#else
+    std::sort(m_scheduleList.begin(), m_scheduleList.end());
+#endif
     emit scheduleListChanged();
 }
 

--- a/qmlui/virtualconsole/vcclock.cpp
+++ b/qmlui/virtualconsole/vcclock.cpp
@@ -357,11 +357,7 @@ void VCClock::addSchedule(VCClockSchedule *schedule)
 {
     if (schedule->functionID() != Function::invalidId())
         m_scheduleList.append(schedule);
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_scheduleList);
-#else
     std::sort(m_scheduleList.begin(), m_scheduleList.end());
-#endif
     QQmlEngine::setObjectOwnership(schedule, QQmlEngine::CppOwnership);
     emit scheduleListChanged();
 }
@@ -380,11 +376,7 @@ void VCClock::addSchedules(QVariantList idsList)
         m_scheduleList.append(sch);
     }
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_scheduleList);
-#else
     std::sort(m_scheduleList.begin(), m_scheduleList.end());
-#endif
     emit scheduleListChanged();
 }
 

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -606,7 +606,11 @@ void VCSlider::slotTreeDataChanged(TreeModelItem *item, int role, const QVariant
     else
     {
         addLevelChannel(fixtureID, chIndex);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(m_levelChannels.begin(), m_levelChannels.end());
+#else
+	std::sort(m_levelChannels.begin(), m_levelChannels.end());
+#endif
     }
 
     if (clickAndGoType() == CnGPreset)
@@ -1381,9 +1385,13 @@ bool VCSlider::loadXMLLevel(QXmlStreamReader &level_root)
         } while (level_root.readNextStartElement());
     }
 
-    if (m_levelChannels.count())
+    if (m_levelChannels.count()){
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(m_levelChannels.begin(), m_levelChannels.end());
-
+#else
+	std::sort(m_levelChannels.begin(), m_levelChannels.end());
+#endif
+    }
     return true;
 }
 

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -606,7 +606,7 @@ void VCSlider::slotTreeDataChanged(TreeModelItem *item, int role, const QVariant
     else
     {
         addLevelChannel(fixtureID, chIndex);
-	std::sort(m_levelChannels.begin(), m_levelChannels.end());
+        std::sort(m_levelChannels.begin(), m_levelChannels.end());
    }
 
     if (clickAndGoType() == CnGPreset)
@@ -1381,9 +1381,9 @@ bool VCSlider::loadXMLLevel(QXmlStreamReader &level_root)
         } while (level_root.readNextStartElement());
     }
 
-    if (m_levelChannels.count()){
-	std::sort(m_levelChannels.begin(), m_levelChannels.end());
-    }
+    if (m_levelChannels.count())
+        std::sort(m_levelChannels.begin(), m_levelChannels.end());
+
     return true;
 }
 

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -606,12 +606,8 @@ void VCSlider::slotTreeDataChanged(TreeModelItem *item, int role, const QVariant
     else
     {
         addLevelChannel(fixtureID, chIndex);
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(m_levelChannels.begin(), m_levelChannels.end());
-#else
 	std::sort(m_levelChannels.begin(), m_levelChannels.end());
-#endif
-    }
+   }
 
     if (clickAndGoType() == CnGPreset)
     {
@@ -1386,11 +1382,7 @@ bool VCSlider::loadXMLLevel(QXmlStreamReader &level_root)
     }
 
     if (m_levelChannels.count()){
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(m_levelChannels.begin(), m_levelChannels.end());
-#else
 	std::sort(m_levelChannels.begin(), m_levelChannels.end());
-#endif
     }
     return true;
 }

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -615,7 +615,7 @@ QList<SceneValue> FixtureRemap::remapSceneValues(QList<SceneValue> funcList,
             }
         }
     }
-    qSort(newValuesList.begin(), newValuesList.end());
+    std::sort(newValuesList.begin(), newValuesList.end());
     return newValuesList;
 }
 

--- a/ui/src/monitor/monitorlayout.cpp
+++ b/ui/src/monitor/monitorlayout.cpp
@@ -108,7 +108,11 @@ static bool MonitorLayoutLessThan(MonitorLayoutItem* i1, MonitorLayoutItem* i2)
 
 void MonitorLayout::sort()
 {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_items.begin(), m_items.end(), MonitorLayoutLessThan);
+#else
+    std::sort(m_items.begin(), m_items.end(), MonitorLayoutLessThan);
+#endif
 }
 
 /****************************************************************************

--- a/ui/src/monitor/monitorlayout.cpp
+++ b/ui/src/monitor/monitorlayout.cpp
@@ -108,11 +108,7 @@ static bool MonitorLayoutLessThan(MonitorLayoutItem* i1, MonitorLayoutItem* i2)
 
 void MonitorLayout::sort()
 {
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_items.begin(), m_items.end(), MonitorLayoutLessThan);
-#else
     std::sort(m_items.begin(), m_items.end(), MonitorLayoutLessThan);
-#endif
 }
 
 /****************************************************************************

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -1067,11 +1067,7 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
             }
             // !! Important !! matrix's heads can be displaced randomly but in a sequence
             // we absolutely need ordered values. So do it now !
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-            qSort(step.values.begin(), step.values.end());
-#else
 	    std::sort(step.values.begin(), step.values.end());
-#endif
 
             sequence->addStep(step);
             currentStep += increment;

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -1067,7 +1067,7 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
             }
             // !! Important !! matrix's heads can be displaced randomly but in a sequence
             // we absolutely need ordered values. So do it now !
-	    std::sort(step.values.begin(), step.values.end());
+            std::sort(step.values.begin(), step.values.end());
 
             sequence->addStep(step);
             currentStep += increment;

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -1067,7 +1067,11 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
             }
             // !! Important !! matrix's heads can be displaced randomly but in a sequence
             // we absolutely need ordered values. So do it now !
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
             qSort(step.values.begin(), step.values.end());
+#else
+	    std::sort(step.values.begin(), step.values.end());
+#endif
 
             sequence->addStep(step);
             currentStep += increment;

--- a/ui/src/virtualconsole/vcclock.cpp
+++ b/ui/src/virtualconsole/vcclock.cpp
@@ -143,11 +143,7 @@ void VCClock::addSchedule(VCClockSchedule schedule)
     qDebug() << Q_FUNC_INFO << "--- ID:" << schedule.function() << ", time:" << schedule.time().time().toString();
     if (schedule.function() != Function::invalidId())
         m_scheduleList.append(schedule);
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(m_scheduleList);
-#else
     std::sort(m_scheduleList.begin(), m_scheduleList.end());
-#endif
 }
 
 void VCClock::removeSchedule(int index)

--- a/ui/src/virtualconsole/vcclock.cpp
+++ b/ui/src/virtualconsole/vcclock.cpp
@@ -143,7 +143,11 @@ void VCClock::addSchedule(VCClockSchedule schedule)
     qDebug() << Q_FUNC_INFO << "--- ID:" << schedule.function() << ", time:" << schedule.time().time().toString();
     if (schedule.function() != Function::invalidId())
         m_scheduleList.append(schedule);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(m_scheduleList);
+#else
+    std::sort(m_scheduleList.begin(), m_scheduleList.end());
+#endif
 }
 
 void VCClock::removeSchedule(int index)

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -743,7 +743,11 @@ void VCMatrix::resetCustomControls()
 QList<VCMatrixControl *> VCMatrix::customControls() const
 {
     QList<VCMatrixControl*> controls = m_controls.values();
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(controls.begin(), controls.end(), VCMatrixControl::compare);
+#else
+    std::sort(controls.begin(), controls.end(), VCMatrixControl::compare);
+#endif
     return controls;
 }
 

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -743,11 +743,7 @@ void VCMatrix::resetCustomControls()
 QList<VCMatrixControl *> VCMatrix::customControls() const
 {
     QList<VCMatrixControl*> controls = m_controls.values();
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(controls.begin(), controls.end(), VCMatrixControl::compare);
-#else
     std::sort(controls.begin(), controls.end(), VCMatrixControl::compare);
-#endif
     return controls;
 }
 

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -549,11 +549,7 @@ void VCSlider::addLevelChannel(quint32 fixture, quint32 channel)
     if (m_levelChannels.contains(lch) == false)
     {
         m_levelChannels.append(lch);
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-        qSort(m_levelChannels.begin(), m_levelChannels.end());
-#else
 	std::sort(m_levelChannels.begin(), m_levelChannels.end());
-#endif
     }
 }
 

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -549,7 +549,11 @@ void VCSlider::addLevelChannel(quint32 fixture, quint32 channel)
     if (m_levelChannels.contains(lch) == false)
     {
         m_levelChannels.append(lch);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         qSort(m_levelChannels.begin(), m_levelChannels.end());
+#else
+	std::sort(m_levelChannels.begin(), m_levelChannels.end());
+#endif
     }
 }
 

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -549,7 +549,7 @@ void VCSlider::addLevelChannel(quint32 fixture, quint32 channel)
     if (m_levelChannels.contains(lch) == false)
     {
         m_levelChannels.append(lch);
-	std::sort(m_levelChannels.begin(), m_levelChannels.end());
+        std::sort(m_levelChannels.begin(), m_levelChannels.end());
     }
 }
 

--- a/ui/src/virtualconsole/vcspeeddial.cpp
+++ b/ui/src/virtualconsole/vcspeeddial.cpp
@@ -404,7 +404,11 @@ void VCSpeedDial::resetPresets()
 QList<VCSpeedDialPreset*> VCSpeedDial::presets() const
 {
     QList<VCSpeedDialPreset*> presetsList = m_presets.values();
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(presetsList.begin(), presetsList.end(), VCSpeedDialPreset::compare);
+#else
+    std::sort(presetsList.begin(), presetsList.end(), VCSpeedDialPreset::compare);
+#endif
     return presetsList;
 }
 

--- a/ui/src/virtualconsole/vcspeeddial.cpp
+++ b/ui/src/virtualconsole/vcspeeddial.cpp
@@ -404,11 +404,7 @@ void VCSpeedDial::resetPresets()
 QList<VCSpeedDialPreset*> VCSpeedDial::presets() const
 {
     QList<VCSpeedDialPreset*> presetsList = m_presets.values();
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(presetsList.begin(), presetsList.end(), VCSpeedDialPreset::compare);
-#else
     std::sort(presetsList.begin(), presetsList.end(), VCSpeedDialPreset::compare);
-#endif
     return presetsList;
 }
 

--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -680,7 +680,11 @@ void VCXYPad::resetPresets()
 QList<VCXYPadPreset *> VCXYPad::presets() const
 {
     QList<VCXYPadPreset*> presets = m_presets.values();
+#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
     qSort(presets.begin(), presets.end(), VCXYPadPreset::compare);
+#else
+    std::sort(presets.begin(), presets.end(), VCXYPadPreset::compare);
+#endif
     return presets;
 }
 

--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -680,11 +680,7 @@ void VCXYPad::resetPresets()
 QList<VCXYPadPreset *> VCXYPad::presets() const
 {
     QList<VCXYPadPreset*> presets = m_presets.values();
-#if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
-    qSort(presets.begin(), presets.end(), VCXYPadPreset::compare);
-#else
     std::sort(presets.begin(), presets.end(), VCXYPadPreset::compare);
-#endif
     return presets;
 }
 


### PR DESCRIPTION
This patch replaces "qSort" with "std::sort" and "QFontMetrics::width" with "QFontMetrics::horizontalAdvance" if compiled with QT 5.13.