### PR TITLE
rgbscript: clone properties

### DIFF
--- a/engine/src/rgbscript.cpp
+++ b/engine/src/rgbscript.cpp
@@ -60,6 +60,10 @@ RGBScript::RGBScript(const RGBScript& s)
     , m_apiVersion(0)
 {
     evaluate();
+    foreach(RGBScriptProperty cap, s.m_properties)
+    {
+        setProperty(cap.m_name, s.property(cap.m_name));
+    }
 }
 
 RGBScript::~RGBScript()
@@ -355,7 +359,7 @@ bool RGBScript::setProperty(QString propertyName, QString value)
     return false;
 }
 
-QString RGBScript::property(QString propertyName)
+QString RGBScript::property(QString propertyName) const
 {
     QMutexLocker engineLocker(s_engineMutex);
 

--- a/engine/src/rgbscript.h
+++ b/engine/src/rgbscript.h
@@ -125,7 +125,7 @@ public:
     bool setProperty(QString propertyName, QString value);
 
     /** Read the value of the property with the given name */
-    QString property(QString propertyName);
+    QString property(QString propertyName) const;
 
 private:
     /** Load the script properties if any is available */


### PR DESCRIPTION
Hi,

A small patch to fix the fact that when cloning an rgbscript, the properties are not cloned and are set to default in the new rgbscript.