### PR TITLE
Implement a 'setFunctionStatus' websocket api method

### DIFF
--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -548,6 +548,24 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             else
                 wsAPIMessage.append(Function::typeToString(Function::Undefined));
         }
+        else if (apiCmd == "setFunctionStatus") {
+            if (cmdList.count() < 4)
+                return;
+
+            quint32 fID = cmdList[2].toUInt();
+            Function *f = m_doc->function(fID);
+
+            quint32 newStatus = cmdList[3].toUInt();
+
+            if (f != NULL)
+            {
+                if (!f->isRunning() && newStatus)
+                    f->start(m_doc->masterTimer(), FunctionParent::master());
+                else if (f->isRunning() && !newStatus)
+                    f->stop(FunctionParent::master());
+            }
+            return;
+        }
         else if (apiCmd == "getWidgetsNumber")
         {
             VCFrame *mainFrame = m_vc->contents();

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -548,14 +548,14 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             else
                 wsAPIMessage.append(Function::typeToString(Function::Undefined));
         }
-        else if (apiCmd == "setFunctionStatus") {
+        else if (apiCmd == "setFunctionStatus") 
+	{
             if (cmdList.count() < 4)
                 return;
 
             quint32 fID = cmdList[2].toUInt();
-            Function *f = m_doc->function(fID);
-
             quint32 newStatus = cmdList[3].toUInt();
+            Function *f = m_doc->function(fID);
 
             if (f != NULL)
             {


### PR DESCRIPTION
I needed a way to start a function (a show in my case) without having to create a button widget in the virtual console.
I think that such method might be useful to others so I opened this PR.
Let me know if something doesn't look right.