### PR TITLE
Introducing Open RX : a way to read DMX signals via simple RSR232 FTDI chips

### DIFF
--- a/plugins/dmxusb/src/dmxinterface.cpp
+++ b/plugins/dmxusb/src/dmxinterface.cpp
@@ -126,4 +126,8 @@ void DMXInterface::storeFrequencyMap(const QMap<QString, QVariant> map)
     settings.setValue(SETTINGS_FREQ_MAP, map);
 }
 
-
+bool DMXInterface::setLowLatency(bool lowLatency)
+{
+    Q_UNUSED(lowLatency)
+    return true;
+}

--- a/plugins/dmxusb/src/dmxinterface.h
+++ b/plugins/dmxusb/src/dmxinterface.h
@@ -176,6 +176,22 @@ public:
 
     /** Read exactly one byte. $ok tells if a byte was read or not. */
     virtual uchar readByte(bool* ok = NULL) = 0;
+
+    /**
+     * Set the widget in "low latency mode". Some DMX controllers send DMX
+     * frames at a much higher rate than the specified value. USB widget may
+     * have difficulties to read independant frames in this case and need
+     * some configuration.
+     *
+     * This method let implementations call specific backend functions in
+     * order to help reading DMX frames.
+     *
+     * The default implementation does nothing.
+     *
+     * @param lowLatency true for low latency, false otherwise
+     * @return true if the interface was set in low latency state
+     */
+    virtual bool setLowLatency(bool lowLatency);
 };
 
 #endif

--- a/plugins/dmxusb/src/dmxusb.cpp
+++ b/plugins/dmxusb/src/dmxusb.cpp
@@ -269,6 +269,8 @@ QString DMXUSB::inputInfo(quint32 input)
         str += QString("<H3>%1</H3>").arg(inputs()[input]);
         str += QString("<P>");
         str += tr("Device is operating correctly.");
+        str += QString("<BR>");
+        str += tr("Driver in use: %1").arg(m_inputs[input]->interfaceTypeString());
         str += QString("</P>");
         QString add = m_inputs[input]->additionalInfo();
         if (add.isEmpty() == false)

--- a/plugins/dmxusb/src/dmxusb.cpp
+++ b/plugins/dmxusb/src/dmxusb.cpp
@@ -155,10 +155,10 @@ QString DMXUSB::outputInfo(quint32 output)
         if (m_outputs.size() == 0)
         {
             str += QString("<BR><B>%1</B>").arg(tr("No output support available."));
-            str += QString("<P>");
+            /*str += QString("<P>");
             str += tr("Make sure that you have your hardware firmly plugged in. "
                       "NOTE: FTDI VCP interface is not supported by this plugin.");
-            str += QString("</P>");
+            str += QString("</P>");*/
         }
     }
     else if (output < quint32(m_outputs.size()))
@@ -201,6 +201,7 @@ bool DMXUSB::openInput(quint32 input, quint32 universe)
         DMXUSBWidget *widget = m_inputs.at(input);
         if (widget->type() == DMXUSBWidget::ProRXTX ||
             widget->type() == DMXUSBWidget::ProMk2 ||
+            widget->type() == DMXUSBWidget::OpenRX ||
             widget->type() == DMXUSBWidget::UltraPro)
         {
             EnttecDMXUSBPro *pro = static_cast<EnttecDMXUSBPro*>(widget);

--- a/plugins/dmxusb/src/dmxusb.cpp
+++ b/plugins/dmxusb/src/dmxusb.cpp
@@ -155,10 +155,10 @@ QString DMXUSB::outputInfo(quint32 output)
         if (m_outputs.size() == 0)
         {
             str += QString("<BR><B>%1</B>").arg(tr("No output support available."));
-            /*str += QString("<P>");
+            str += QString("<P>");
             str += tr("Make sure that you have your hardware firmly plugged in. "
                       "NOTE: FTDI VCP interface is not supported by this plugin.");
-            str += QString("</P>");*/
+            str += QString("</P>");
         }
     }
     else if (output < quint32(m_outputs.size()))

--- a/plugins/dmxusb/src/dmxusbconfig.cpp
+++ b/plugins/dmxusb/src/dmxusbconfig.cpp
@@ -143,6 +143,7 @@ QComboBox *DMXUSBConfig::createTypeCombo(DMXUSBWidget *widget)
     combo->setProperty(PROP_SERIAL, widget->serial());
     combo->addItem(QString("Pro RX/TX"), DMXUSBWidget::ProRXTX);
     combo->addItem(QString("Open TX"), DMXUSBWidget::OpenTX);
+    combo->addItem(QString("Open RX"), DMXUSBWidget::OpenRX);
     combo->addItem(QString("Pro Mk2"), DMXUSBWidget::ProMk2);
     combo->addItem(QString("Ultra Pro"), DMXUSBWidget::UltraPro);
     combo->addItem(QString("DMX4ALL"), DMXUSBWidget::DMX4ALL);

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -54,22 +54,6 @@ DMXUSBOpenRx::DMXUSBOpenRx(DMXInterface *interface,
     m_inputLines[0].m_universeData = QByteArray();
     m_inputLines[0].m_compareData = QByteArray();
 
-    /*QSettings settings;
-    QVariant var = settings.value(SETTINGS_CHANNELS);
-    if (var.isValid() == true)
-    {
-        int channels = var.toInt();
-        if (channels > DMX_CHANNELS || channels <= 0)
-            channels = DMX_CHANNELS;
-        // channels + 1 Because the first byte is always zero
-        // to break a full DMX universe transmission
-        m_outputLines[0].m_universeData = QByteArray(channels + 1, 0);
-    }
-    else
-    {
-        m_outputLines[0].m_universeData = QByteArray(DMX_CHANNELS + 1, 0);
-    }*/
-
 // on macOS, QtSerialPort cannot handle an OpenDMX device
 // so, unfortunately, we need to switch back to libftdi
 #if defined(Q_OS_OSX) && defined(QTSERIAL) && (defined(LIBFTDI1) || defined(LIBFTDI))

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -1,0 +1,314 @@
+/*
+  Q Light Controller
+  dmxusbopenrx.cpp
+
+  Copyright (C) Heikki Junnila
+                Christopher Staite
+                Emmanuel Coirier
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QSettings>
+#include <QDebug>
+#include <math.h>
+#include <QTime>
+
+#include "dmxusbopenrx.h"
+#include "qlcmacros.h"
+
+#define DMX_MAB 16
+#define DMX_BREAK 110
+#define DMX_CHANNELS 512
+#define DEFAULT_OPEN_DMX_FREQUENCY    30  // crap
+#define SETTINGS_CHANNELS "dmxusbopenrx/channels"
+
+/****************************************************************************
+ * Initialization
+ ****************************************************************************/
+
+DMXUSBOpenRx::DMXUSBOpenRx(DMXInterface *interface,
+                                   quint32 inputLine, QObject* parent)
+    : QThread(parent)
+    , DMXUSBWidget(interface, 0, DEFAULT_OPEN_DMX_FREQUENCY)
+    , m_running(false)
+    , m_granularity(Unknown)
+    , m_reader_state(Idling)
+{
+    qDebug() << "Open RX contructor, line" << inputLine;
+
+    m_inputBaseLine = inputLine;
+    setOutputsNumber(0);
+    setInputsNumber(1);
+
+    m_inputLines[0].m_universeData = QByteArray();
+    m_inputLines[0].m_compareData = QByteArray();
+
+    /*QSettings settings;
+    QVariant var = settings.value(SETTINGS_CHANNELS);
+    if (var.isValid() == true)
+    {
+        int channels = var.toInt();
+        if (channels > DMX_CHANNELS || channels <= 0)
+            channels = DMX_CHANNELS;
+        // channels + 1 Because the first byte is always zero
+        // to break a full DMX universe transmission
+        m_outputLines[0].m_universeData = QByteArray(channels + 1, 0);
+    }
+    else
+    {
+        m_outputLines[0].m_universeData = QByteArray(DMX_CHANNELS + 1, 0);
+    }*/
+
+// on macOS, QtSerialPort cannot handle an OpenDMX device
+// so, unfortunately, we need to switch back to libftdi
+#if defined(Q_OS_OSX) && defined(QTSERIAL) && (defined(LIBFTDI1) || defined(LIBFTDI))
+    if (interface->type() == DMXInterface::QtSerial)
+        forceInterfaceDriver(DMXInterface::libFTDI);
+#endif
+    qDebug() << "Open RX contructor end";
+}
+
+DMXUSBOpenRx::~DMXUSBOpenRx()
+{
+    qDebug() << "Open RX destructor";
+    stop();
+    qDebug() << "Open RX stopped in destructor";
+}
+
+DMXUSBWidget::Type DMXUSBOpenRx::type() const
+{
+    return DMXUSBWidget::OpenRX;
+}
+
+/****************************************************************************
+ * Open & Close
+ ****************************************************************************/
+
+bool DMXUSBOpenRx::open(quint32 line, bool input)
+{
+    if (input == false) {
+        qWarning() << "DMX USB Open RX opened for output, giving up.";
+        return false;
+    }
+
+    qDebug() << "DMX USB Open RX, opening line" << line;
+
+    if (interface()->type() != DMXInterface::QtSerial)
+    {
+        if (DMXUSBWidget::open(line, input) == false)
+            return close(line);
+
+        if (interface()->clearRts() == false)
+            return close(line);
+    }
+    qDebug() << "Starting Open RX";
+    start(QThread::TimeCriticalPriority);
+    qDebug() << "Open RX started";
+    return true;
+}
+
+bool DMXUSBOpenRx::close(quint32 line, bool input)
+{
+    qDebug() << "Open RX close" << line << "input:" << input;
+    stop();
+    return DMXUSBWidget::close(line, input);
+}
+
+/****************************************************************************
+ * Name & Serial
+ ****************************************************************************/
+
+QString DMXUSBOpenRx::additionalInfo() const
+{
+    QString info;
+    QString gran;
+    QString state;
+
+    info += QString("<P>");
+    info += QString("<B>%1:</B> %2").arg(tr("Protocol")).arg("Open DMX USB (Receiving mode (RX))");
+    info += QString("<BR>");
+    info += QString("<B>%1:</B> %2").arg(QObject::tr("Manufacturer"))
+                                         .arg(vendor());
+    info += QString("<BR>");
+
+    if (m_reader_state == Idling)
+        state = QString("<FONT COLOR=\"#aa0000\">%1</FONT>").arg(tr("Idling"));
+    else
+        state = QString("<FONT COLOR=\"#00aa00\">%1</FONT>").arg(tr("Receiving"));
+
+    info += QString("<B>%1:</B> %2").arg(tr("Receiver state")).arg(state);
+    info += QString("<BR>");
+
+    if (m_reader_state == Receiving) {
+        info += QString("<B>%1:</B> %2").arg(tr("Received DMX Channels"))
+                                        .arg(m_inputLines[0].m_compareData.length() - 2);
+
+        info += QString("<BR>");
+        info += QString("<B>%1:</B> %2 Hz").arg(tr("DMX Frame Frequency"))
+                                        .arg(1000 / m_frameTimeUs);
+    }
+    info += QString("<BR>");
+    if (m_granularity == Bad)
+        gran = QString("<FONT COLOR=\"#aa0000\">%1</FONT>").arg(tr("Bad"));
+    else if (m_granularity == Good)
+        gran = QString("<FONT COLOR=\"#00aa00\">%1</FONT>").arg(tr("Good"));
+    else
+        gran = tr("Patch this widget to a universe to find out.");
+    info += QString("<B>%1:</B> %2").arg(tr("System Timer Accuracy")).arg(gran);
+    info += QString("</P>");
+
+    return info;
+}
+
+/****************************************************************************
+ * Thread
+ ****************************************************************************/
+
+bool DMXUSBOpenRx::writeUniverse(quint32 universe, quint32 output, const QByteArray& data)
+{
+    Q_UNUSED(universe)
+    Q_UNUSED(output)
+    Q_UNUSED(data)
+    // not used at runtime but needed for compilation
+    return true;
+}
+
+
+void DMXUSBOpenRx::stop()
+{
+    if (isRunning() == true)
+    {
+        qDebug() << "Waiting for receiving thread to stop";
+        m_running = false;
+        wait();
+        qDebug() << "Receiving thread stopped";
+    } else {
+        qDebug() << "Already stopped";
+    }
+}
+
+void DMXUSBOpenRx::compareAndEmit(const QByteArray& last_payload, const QByteArray& current_payload)
+{
+    int max_bound = qMax(last_payload.length(), current_payload.length());
+
+    // bytes 0 and 1 are not in use
+    for (int i = 2; i < max_bound; i++) {
+        if (i < last_payload.length() && i < current_payload.length()) {
+            // value exists in both, just compare
+            if (last_payload[i] != current_payload[i]) {
+                emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, current_payload[i]);
+                qDebug() << "Channel" << i - 2 << "changed to" << QString::number((uchar) current_payload[i], 10);
+            }
+        } else if (i < last_payload.length() && i >= current_payload.length()) {
+            // This frame is shorter. So put a 0 instead.
+            emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, 0);
+            qDebug() << "Channel" << i - 2 << "changed to \"0\"";
+        } else if (i < current_payload.length() && i >= last_payload.length()) {
+            // Last frame was shorter, just put the current value
+            emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, current_payload[i]);
+            qDebug() << "Channel" << i - 2 << "changed to" << QString::number((uchar) current_payload[i], 10);
+        }
+    }
+}
+
+void DMXUSBOpenRx::run()
+{
+    // Wait for device to settle in case the device was opened just recently
+    // Also measure, whether timer granularity is OK
+    QTime time;
+    time.start();
+    usleep(1000);
+    if (time.elapsed() > 3)
+        m_granularity = Bad;
+    else
+        m_granularity = Good;
+
+    if (interface()->type() == DMXInterface::QtSerial)
+    {
+        if (DMXUSBWidget::open(0) == false)
+        {
+            close(0);
+            return;
+        }
+
+        if (interface()->clearRts() == false)
+        {
+            close(0);
+            return;
+        }
+    }
+
+    m_running = true;
+
+    QByteArray payload;
+    QByteArray& last_payload = m_inputLines[0].m_compareData;
+    QByteArray& current_payload = m_inputLines[0].m_universeData;
+
+    quint32 missed_frames = 0;
+    quint32 erroneous_frames = 0;
+
+    m_frameTimeUs = 0;
+
+
+    while (m_running == true)
+    {
+        payload = interface()->read(520);
+
+        if (payload.length() == 0) {
+            usleep(1000); // nothing to read, don't waste CPU
+            missed_frames += 1;
+        } else if (payload.length() == 1) {
+            // a new frame has begun, the chip returns us the first byte
+            current_payload.append(payload);
+            usleep(500); // wait a little for the other bytes to be read
+        } else {
+            current_payload.append(payload);
+
+            if (current_payload.length() != last_payload.length() && erroneous_frames < 5) {
+                qDebug() << "Bogus frame" << current_payload.length() << "bytes instead of" << last_payload.length();
+                current_payload.clear();
+                erroneous_frames += 1;
+                continue;
+            }
+
+            // a frame has been received
+
+            if (missed_frames > 300) {
+                qDebug() << "Receiving";
+            }
+
+            m_reader_state = Receiving;
+            missed_frames = 0;
+            erroneous_frames = 0;
+
+            m_frameTimeUs = time.elapsed();
+            time.restart();
+
+            compareAndEmit(last_payload, current_payload);
+
+            last_payload.clear();
+            last_payload.append(current_payload);
+            current_payload.clear();
+        }
+
+        if (missed_frames == 300) {
+            m_reader_state = Idling;
+            qDebug() << "Idling";
+        } else if (missed_frames == UINT_MAX) {
+            missed_frames = 300;
+        }
+
+    }
+    qDebug() << "Requested to stop";
+}

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -286,7 +286,7 @@ void DMXUSBOpenRx::run()
 
             if (current_payload.length() != last_payload.length() && erroneous_frames < 5)
             {
-                qDebug() << "Bogus frame" << current_payload.length() << "bytes instead of" << last_payload.length();
+                qDebug() << interface()->serial() << "Bogus frame" << current_payload.length() << "bytes instead of" << last_payload.length();
                 current_payload.clear();
                 erroneous_frames += 1;
                 continue;
@@ -295,7 +295,7 @@ void DMXUSBOpenRx::run()
             // a frame has been received
             if (missed_frames > 300) // only to emit the debug message once, not at each frame
             {
-                qDebug() << "Receiving";
+                qDebug() << interface()->serial() << "Receiving";
             }
 
             m_reader_state = Receiving;
@@ -316,7 +316,7 @@ void DMXUSBOpenRx::run()
         if (missed_frames == 300)
         {
             m_reader_state = Idling;
-            qDebug() << "Idling";
+            qDebug() << interface()->serial() << "Idling";
         } else if (missed_frames == UINT_MAX)
         {
             missed_frames = 300;

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -122,8 +122,7 @@ QString DMXUSBOpenRx::additionalInfo() const
     info += QString("<P>");
     info += QString("<B>%1:</B> %2").arg(tr("Protocol")).arg("Open DMX USB (Receiving mode (RX))");
     info += QString("<BR>");
-    info += QString("<B>%1:</B> %2").arg(QObject::tr("Manufacturer"))
-                                         .arg(vendor());
+    info += QString("<B>%1:</B> %2").arg(QObject::tr("Manufacturer")).arg(vendor());
     info += QString("<BR>");
 
     if (!m_running)
@@ -149,12 +148,14 @@ QString DMXUSBOpenRx::additionalInfo() const
                                                .arg(1000 / m_frameTimeUs);
     }
     info += QString("<BR>");
+
     if (m_granularity == Bad)
         gran = QString("<FONT COLOR=\"#aa0000\">%1</FONT>").arg(tr("Bad"));
     else if (m_granularity == Good)
         gran = QString("<FONT COLOR=\"#00aa00\">%1</FONT>").arg(tr("Good"));
     else
         gran = tr("Patch this widget to a universe to find out.");
+
     info += QString("<B>%1:</B> %2").arg(tr("System Timer Accuracy")).arg(gran);
     info += QString("</P>");
 
@@ -182,7 +183,9 @@ void DMXUSBOpenRx::stop()
         m_running = false;
         wait();
         qDebug() << "Receiving thread stopped";
-    } else {
+    } 
+    else 
+    {
         qDebug() << "Already stopped";
     }
 }
@@ -202,12 +205,14 @@ void DMXUSBOpenRx::compareAndEmit(const QByteArray& last_payload, const QByteArr
                 emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, current_payload[i]);
                 qDebug() << "Channel" << i - 2 << "changed to" << QString::number((uchar) current_payload[i], 10);
             }
-        } else if (i < last_payload.length() && i >= current_payload.length())
+        } 
+        else if (i < last_payload.length() && i >= current_payload.length())
         {
             // This frame is shorter. So put a 0 instead.
             emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, 0);
             qDebug() << "Channel" << i - 2 << "changed to \"0\"";
-        } else if (i < current_payload.length() && i >= last_payload.length())
+        } 
+        else if (i < current_payload.length() && i >= last_payload.length())
         {
             // Last frame was shorter, just put the current value
             emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, current_payload[i]);
@@ -263,12 +268,14 @@ void DMXUSBOpenRx::run()
         {
             usleep(1000); // nothing to read, don't waste CPU
             missed_frames += 1;
-        } else if (payload.length() == 1)
+        } 
+        else if (payload.length() == 1)
         {
             // a new frame has begun, the chip returns us the first byte
             current_payload.append(payload);
             usleep(500); // wait a little for the other bytes to be read
-        } else
+        } 
+        else
         {
             current_payload.append(payload);
 
@@ -298,9 +305,7 @@ void DMXUSBOpenRx::run()
 
             // a frame has been received
             if (missed_frames > 300) // only to emit the debug message once, not at each frame
-            {
                 qDebug() << interface()->serial() << "Receiving";
-            }
 
             m_reader_state = Receiving;
             missed_frames = 0;
@@ -321,7 +326,8 @@ void DMXUSBOpenRx::run()
         {
             m_reader_state = Idling;
             qDebug() << interface()->serial() << "Idling";
-        } else if (missed_frames == UINT_MAX)
+        } 
+        else if (missed_frames == UINT_MAX)
         {
             missed_frames = 300;
         }

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -1,9 +1,8 @@
 /*
-  Q Light Controller
+  Q Light Controller Plus
   dmxusbopenrx.cpp
 
-  Copyright (C) Heikki Junnila
-                Christopher Staite
+  Copyright (C) Massimo Callegari
                 Emmanuel Coirier
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -140,8 +140,9 @@ QString DMXUSBOpenRx::additionalInfo() const
                                         .arg(m_inputLines[0].m_compareData.length() - 2);
 
         info += QString("<BR>");
-        info += QString("<B>%1:</B> %2 Hz").arg(tr("DMX Frame Frequency"))
-                                        .arg(1000 / m_frameTimeUs);
+        if (m_frameTimeUs > 0)
+            info += QString("<B>%1:</B> %2 Hz").arg(tr("DMX Frame Frequency"))
+                                               .arg(1000 / m_frameTimeUs);
     }
     info += QString("<BR>");
     if (m_granularity == Bad)

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -42,7 +42,7 @@ DMXUSBOpenRx::DMXUSBOpenRx(DMXInterface *interface,
     , DMXUSBWidget(interface, 0, DEFAULT_OPEN_DMX_FREQUENCY)
     , m_running(false)
     , m_granularity(Unknown)
-    , m_reader_state(Idling)
+    , m_reader_state(Calibrating)
 {
     qDebug() << "Open RX contructor, line" << inputLine;
 
@@ -126,8 +126,12 @@ QString DMXUSBOpenRx::additionalInfo() const
                                          .arg(vendor());
     info += QString("<BR>");
 
-    if (m_reader_state == Idling)
+    if (!m_running)
+        state = QString("<FONT COLOR=\"#000000\">%1</FONT>").arg(tr("Stopped"));
+    else if (m_reader_state == Idling)
         state = QString("<FONT COLOR=\"#aa0000\">%1</FONT>").arg(tr("Idling"));
+    else if (m_reader_state == Calibrating)
+        state = QString("<FONT COLOR=\"#aa5500\">%1</FONT>").arg(tr("Calibrating"));
     else
         state = QString("<FONT COLOR=\"#00aa00\">%1</FONT>").arg(tr("Receiving"));
 
@@ -324,4 +328,5 @@ void DMXUSBOpenRx::run()
     }
     qDebug() << interface()->serial() << "Requested to stop";
     interface()->setLowLatency(false);
+    m_reader_state = Calibrating;
 }

--- a/plugins/dmxusb/src/dmxusbopenrx.cpp
+++ b/plugins/dmxusb/src/dmxusbopenrx.cpp
@@ -80,7 +80,8 @@ DMXUSBWidget::Type DMXUSBOpenRx::type() const
 
 bool DMXUSBOpenRx::open(quint32 line, bool input)
 {
-    if (input == false) {
+    if (input == false)
+    {
         qWarning() << "DMX USB Open RX opened for output, giving up.";
         return false;
     }
@@ -133,7 +134,8 @@ QString DMXUSBOpenRx::additionalInfo() const
     info += QString("<B>%1:</B> %2").arg(tr("Receiver state")).arg(state);
     info += QString("<BR>");
 
-    if (m_reader_state == Receiving) {
+    if (m_reader_state == Receiving)
+    {
         info += QString("<B>%1:</B> %2").arg(tr("Received DMX Channels"))
                                         .arg(m_inputLines[0].m_compareData.length() - 2);
 
@@ -167,7 +169,6 @@ bool DMXUSBOpenRx::writeUniverse(quint32 universe, quint32 output, const QByteAr
     return true;
 }
 
-
 void DMXUSBOpenRx::stop()
 {
     if (isRunning() == true)
@@ -186,18 +187,23 @@ void DMXUSBOpenRx::compareAndEmit(const QByteArray& last_payload, const QByteArr
     int max_bound = qMax(last_payload.length(), current_payload.length());
 
     // bytes 0 and 1 are not in use
-    for (int i = 2; i < max_bound; i++) {
-        if (i < last_payload.length() && i < current_payload.length()) {
+    for (int i = 2; i < max_bound; i++)
+    {
+        if (i < last_payload.length() && i < current_payload.length())
+        {
             // value exists in both, just compare
-            if (last_payload[i] != current_payload[i]) {
+            if (last_payload[i] != current_payload[i])
+            {
                 emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, current_payload[i]);
                 qDebug() << "Channel" << i - 2 << "changed to" << QString::number((uchar) current_payload[i], 10);
             }
-        } else if (i < last_payload.length() && i >= current_payload.length()) {
+        } else if (i < last_payload.length() && i >= current_payload.length())
+        {
             // This frame is shorter. So put a 0 instead.
             emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, 0);
             qDebug() << "Channel" << i - 2 << "changed to \"0\"";
-        } else if (i < current_payload.length() && i >= last_payload.length()) {
+        } else if (i < current_payload.length() && i >= last_payload.length())
+        {
             // Last frame was shorter, just put the current value
             emit valueChanged(UINT_MAX, m_inputBaseLine, i - 2, current_payload[i]);
             qDebug() << "Channel" << i - 2 << "changed to" << QString::number((uchar) current_payload[i], 10);
@@ -243,22 +249,25 @@ void DMXUSBOpenRx::run()
 
     m_frameTimeUs = 0;
 
-
     while (m_running == true)
     {
         payload = interface()->read(520);
 
-        if (payload.length() == 0) {
+        if (payload.length() == 0)
+        {
             usleep(1000); // nothing to read, don't waste CPU
             missed_frames += 1;
-        } else if (payload.length() == 1) {
+        } else if (payload.length() == 1)
+        {
             // a new frame has begun, the chip returns us the first byte
             current_payload.append(payload);
             usleep(500); // wait a little for the other bytes to be read
-        } else {
+        } else
+        {
             current_payload.append(payload);
 
-            if (current_payload.length() != last_payload.length() && erroneous_frames < 5) {
+            if (current_payload.length() != last_payload.length() && erroneous_frames < 5)
+            {
                 qDebug() << "Bogus frame" << current_payload.length() << "bytes instead of" << last_payload.length();
                 current_payload.clear();
                 erroneous_frames += 1;
@@ -266,8 +275,8 @@ void DMXUSBOpenRx::run()
             }
 
             // a frame has been received
-
-            if (missed_frames > 300) {
+            if (missed_frames > 300) // only to emit the debug message once, not at each frame
+            {
                 qDebug() << "Receiving";
             }
 
@@ -285,13 +294,14 @@ void DMXUSBOpenRx::run()
             current_payload.clear();
         }
 
-        if (missed_frames == 300) {
+        if (missed_frames == 300)
+        {
             m_reader_state = Idling;
             qDebug() << "Idling";
-        } else if (missed_frames == UINT_MAX) {
+        } else if (missed_frames == UINT_MAX)
+        {
             missed_frames = 300;
         }
-
     }
     qDebug() << "Requested to stop";
 }

--- a/plugins/dmxusb/src/dmxusbopenrx.h
+++ b/plugins/dmxusb/src/dmxusbopenrx.h
@@ -1,0 +1,100 @@
+/*
+  Q Light Controller
+  dmxusbopenrx.h
+
+  Copyright (C) Heikki Junnila
+                Christopher Staite
+                Emmanuel Coirier
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef DMXUSBOPENRX_H
+#define DMXUSBOPENRX_H
+
+#include <QByteArray>
+#include <QThread>
+#include <QMutex>
+
+#include "dmxusbwidget.h"
+
+class DMXUSBOpenRx : public QThread, public DMXUSBWidget
+{
+    Q_OBJECT
+
+    /************************************************************************
+     * Initialization
+     ************************************************************************/
+public:
+    /**
+     * @param interface dmx interface
+     * @param outputline line number
+     * @param parent The owner of this object
+     */
+    DMXUSBOpenRx(DMXInterface *interface,
+                     quint32 inputLine, QObject* parent = 0);
+
+    /** Destructor */
+    virtual ~DMXUSBOpenRx();
+
+    /** @reimp */
+    DMXUSBWidget::Type type() const;
+
+    /************************************************************************
+     * Open & Close
+     ************************************************************************/
+public:
+    /** @reimp */
+    bool open(quint32 line = 0, bool input = false);
+
+    /** @reimp */
+    bool close(quint32 line = 0, bool input = false);
+
+    /************************************************************************
+     * Name & Serial
+     ************************************************************************/
+public:
+    /** @reimp */
+    QString additionalInfo() const;
+
+    /************************************************************************
+     * Thread
+     ************************************************************************/
+public:
+    /** @reimp */
+    bool writeUniverse(quint32 universe, quint32 output, const QByteArray& data);
+
+protected:
+    enum TimerGranularity { Unknown, Good, Bad };
+    enum ReaderState { Idling, Receiving };
+
+    /** Stop the writer thread */
+    void stop();
+
+    /** DMX writer thread worker method */
+    void run();
+
+    /** Compare frame and only emit differences */
+    void compareAndEmit(const QByteArray& last_payload, const QByteArray& current_payload);
+
+protected:
+    bool m_running;
+    TimerGranularity m_granularity;
+    ReaderState m_reader_state;
+
+signals:
+    /** Tells that the value of a received DMX channel has changed */
+    void valueChanged(quint32 universe, quint32 input, quint32 channel, uchar value);
+};
+
+#endif

--- a/plugins/dmxusb/src/dmxusbopenrx.h
+++ b/plugins/dmxusb/src/dmxusbopenrx.h
@@ -75,7 +75,7 @@ public:
 
 protected:
     enum TimerGranularity { Unknown, Good, Bad };
-    enum ReaderState { Idling, Receiving };
+    enum ReaderState { Calibrating, Idling, Receiving };
 
     /** Stop the writer thread */
     void stop();

--- a/plugins/dmxusb/src/dmxusbopenrx.h
+++ b/plugins/dmxusb/src/dmxusbopenrx.h
@@ -1,9 +1,8 @@
 /*
-  Q Light Controller
+  Q Light Controller Plus
   dmxusbopenrx.h
 
-  Copyright (C) Heikki Junnila
-                Christopher Staite
+  Copyright (C) Massimo Callegari
                 Emmanuel Coirier
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/plugins/dmxusb/src/dmxusbwidget.cpp
+++ b/plugins/dmxusb/src/dmxusbwidget.cpp
@@ -24,6 +24,7 @@
 #include "dmxusbwidget.h"
 #include "enttecdmxusbpro.h"
 #include "enttecdmxusbopen.h"
+#include "dmxusbopenrx.h"
 #if defined(Q_WS_X11) || defined(Q_OS_LINUX) || defined(Q_OS_OSX)
   #include "nanodmx.h"
   #include "euroliteusbdmxpro.h"
@@ -97,6 +98,9 @@ QList<DMXUSBWidget *> DMXUSBWidget::widgets()
             {
                 case DMXUSBWidget::OpenTX:
                     widgetList << new EnttecDMXUSBOpen(iface, output_id++);
+                break;
+                case DMXUSBWidget::OpenRX:
+                    widgetList << new DMXUSBOpenRx(iface, input_id++);
                 break;
                 case DMXUSBWidget::ProMk2:
                 {

--- a/plugins/dmxusb/src/dmxusbwidget.h
+++ b/plugins/dmxusb/src/dmxusbwidget.h
@@ -182,7 +182,7 @@ protected:
     /** The QLC+ input line number where this widget inputs start */
     quint32 m_inputBaseLine;
 
-    /** Array of output lines supported by the device. This is resized on setOutputsNumber */
+    /** Array of input lines supported by the device. This is resized on setInputsNumber */
     QVector<DMXUSBLineInfo> m_inputLines;
 
     /********************************************************************

--- a/plugins/dmxusb/src/dmxusbwidget.h
+++ b/plugins/dmxusb/src/dmxusbwidget.h
@@ -68,6 +68,7 @@ public:
     {
         ProRXTX,    //! Enttec Pro widget using the TX/RX features of the dongle
         OpenTX,     //! Enttec Open widget (only TX)
+        OpenRX,     //! FTDI DMX widget with RX capabilities (only RX, use OpenTX for TX)
         ProMk2,     //! Enttec Pro Mk2 widget using 2 TX, 1 RX, 1 MIDI TX and 1 MIDI RX ports
         UltraPro,   //! DMXKing Ultra Pro widget using 2 TX and 1RX ports
         DMX4ALL,    //! DMX4ALL widget (only TX)

--- a/plugins/dmxusb/src/libftdi-interface.cpp
+++ b/plugins/dmxusb/src/libftdi-interface.cpp
@@ -260,8 +260,7 @@ bool LibFTDIInterface::openByPID(const int PID)
     {
         qWarning() << Q_FUNC_INFO << name() << ftdi_get_error_string(&m_handle);
         return false;
-    }
-    else
+    } else
     {
         return true;
     }

--- a/plugins/dmxusb/src/libftdi-interface.cpp
+++ b/plugins/dmxusb/src/libftdi-interface.cpp
@@ -242,6 +242,10 @@ bool LibFTDIInterface::open()
     }
     else
     {
+        if (ftdi_set_latency_timer(&m_handle, 1)) {
+            qWarning() << Q_FUNC_INFO << name() << "latency" <<ftdi_get_error_string(&m_handle);
+            return false;
+        }
         return true;
     }
 }

--- a/plugins/dmxusb/src/libftdi-interface.cpp
+++ b/plugins/dmxusb/src/libftdi-interface.cpp
@@ -242,10 +242,6 @@ bool LibFTDIInterface::open()
     }
     else
     {
-        if (ftdi_set_latency_timer(&m_handle, 1)) {
-            qWarning() << Q_FUNC_INFO << name() << "latency" <<ftdi_get_error_string(&m_handle);
-            return false;
-        }
         return true;
     }
 }
@@ -429,3 +425,12 @@ uchar LibFTDIInterface::readByte(bool* ok)
     return 0;
 }
 
+bool LibFTDIInterface::setLowLatency(bool lowLatency)
+{
+    if (ftdi_set_latency_timer(&m_handle, 1)) {
+        qWarning() << Q_FUNC_INFO << name() << ftdi_get_error_string(&m_handle);
+        return false;
+    }
+
+    return true;
+}

--- a/plugins/dmxusb/src/libftdi-interface.h
+++ b/plugins/dmxusb/src/libftdi-interface.h
@@ -97,6 +97,9 @@ public:
     /** @reimpl */
     uchar readByte(bool* ok = NULL);
 
+    /** @reimpl */
+    bool setLowLatency(bool lowLatency);
+
 private:
     struct ftdi_context m_handle;
     quint8 m_busLocation;

--- a/plugins/dmxusb/src/libftdi-interface.h
+++ b/plugins/dmxusb/src/libftdi-interface.h
@@ -103,6 +103,7 @@ public:
 private:
     struct ftdi_context m_handle;
     quint8 m_busLocation;
+    unsigned char m_defaultLatency;
 };
 
 #endif

--- a/plugins/dmxusb/src/src.pro
+++ b/plugins/dmxusb/src/src.pro
@@ -92,6 +92,7 @@ HEADERS += dmxusb.h \
            dmxusbconfig.h \
            enttecdmxusbpro.h \
            enttecdmxusbopen.h \
+           dmxusbopenrx.h \
            stageprofi.h \
            vinceusbdmx512.h \
            dmxinterface.h
@@ -105,6 +106,7 @@ SOURCES += dmxinterface.cpp \
            dmxusbconfig.cpp \
            enttecdmxusbpro.cpp \
            enttecdmxusbopen.cpp \
+           dmxusbopenrx.cpp \
            stageprofi.cpp \
            vinceusbdmx512.cpp
 


### PR DESCRIPTION
This pull request adds another plugin designed for Enttec like USB DMX adapter based on FTDI RS232R chips.

Called "Open RX", it is based on the Enttec Open TX plugin code, but reads data and emits them in the software instead of writing them.

FTDI RS232 chips can send and receive signals. As a DMX widget, they are usually built with a female DMX socket, since it's the main usage.
    
Using a male/male adaptator and plugging in the widget in a DMX source, it can receive the signal (instead of transmitting it) and forward it to the host computer.
    
It has been tested with another DMX Open TX FTDI device ran by QLC. It works well and is very stable (if the computer hardware is too).
    
It has also been tested with a Stairville DDC-6 LCD very cheap ligthing controller. This controller vaguely speaks DMX, with 250 Hz frame rate frequency (!) and frames of 29 channels. This plugin handles this case, trying to manage bogus frames.
    
As a result, a user can drive 6 sliders (or other virtual widgets) with a cheap DMX Controller using only another cheap DMX USB device.

I didn't have enough devices to test more configuration, but given the fact that the plugin is an optionnal feature, I hope this requests will be accepted.

Please feel free to comment and suggest.