### PR TITLE
Sorting of ArtNet interfaces implemented.

### DIFF
--- a/plugins/E1.31/e131plugin.cpp
+++ b/plugins/E1.31/e131plugin.cpp
@@ -25,6 +25,12 @@
 
 #define MAX_INIT_RETRY  10
 
+
+bool addressCompare(const E131IO &v1, const E131IO &v2)
+{
+    return v1.address.ip().toString() < v2.address.ip().toString();
+}
+
 E131Plugin::~E131Plugin()
 {
 }
@@ -59,6 +65,7 @@ void E131Plugin::init()
             }
         }
     }
+    std::sort(m_IOmapping.begin(), m_IOmapping.end(), addressCompare);
 }
 
 QString E131Plugin::name()

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -27,7 +27,7 @@
 
 bool addressCompare(const ArtNetIO &v1, const ArtNetIO &v2)
 {
-	return v2.address.ip().toString() < v1.address.ip().toString();
+	return v1.address.ip().toString() < v2.address.ip().toString();
 }
 
 

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -24,6 +24,13 @@
 
 #define MAX_INIT_RETRY  10
 
+
+bool addressCompare(const ArtNetIO &v1, const ArtNetIO &v2)
+{
+	return v2.address.ip().toString() < v1.address.ip().toString();
+}
+
+
 ArtNetPlugin::~ArtNetPlugin()
 {
 }
@@ -58,6 +65,7 @@ void ArtNetPlugin::init()
             }
         }
     }
+    std::sort(m_IOmapping.begin(), m_IOmapping.end(), addressCompare);
 }
 
 QString ArtNetPlugin::name()

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -27,7 +27,7 @@
 
 bool addressCompare(const ArtNetIO &v1, const ArtNetIO &v2)
 {
-	return v1.address.ip().toString() < v2.address.ip().toString();
+    return v1.address.ip().toString() < v2.address.ip().toString();
 }
 
 

--- a/plugins/osc/oscplugin.cpp
+++ b/plugins/osc/oscplugin.cpp
@@ -25,6 +25,11 @@
 
 #define MAX_INIT_RETRY  10
 
+bool addressCompare(const OSCIO &v1, const OSCIO &v2)
+{
+    return v1.IPAddress < v2.IPAddress;
+}
+
 OSCPlugin::~OSCPlugin()
 {
 }
@@ -58,6 +63,7 @@ void OSCPlugin::init()
             }
         }
     }
+    std::sort(m_IOmapping.begin(), m_IOmapping.end(), addressCompare);
 }
 
 QString OSCPlugin::name()


### PR DESCRIPTION
QNetworkInterfaces::allInterfaces() does not guarantee the order of interfaces, which can cause problems if you have many interfaces. QXW file specifies only the "line number" of the selected interface, so sometimes it can be some other interface selected different from what you set up.
For example, I have a Raspberry Pi with 6 interfaces: localhost, ethernet, wlan (hostapd, so that the customer can connect and change the scene), 2 interfaces for 3G connection, and tun (OpenVPN connection). ArtNet device is on ethernet. But, sometimes, if I restart the RPi some other interface can be selected. If that happens with wlan or 3g QLCplus floods that interface with ArtNet packet rendering that interface completely unable to respond (no 3g connection or customer not able to connect to WiFi AP). Yes, flooding of the interface can be prevented with iptables, but the problem of not sending ArtNet packets to proper interface stays.