### PR TITLE
Don't crash when the RGB script to be parsed is empty. Fixes #1185

### DIFF
--- a/engine/src/rgbscriptv4.cpp
+++ b/engine/src/rgbscriptv4.cpp
@@ -115,10 +115,9 @@ bool RGBScript::evaluate()
     m_rgbMapStepCount = QJSValue();
     m_apiVersion = 0;
 
-    if ((m_fileName == "") || (m_contents == ""))
+    if (m_fileName.isEmpty() || m_contents.isEmpty())
     {
-        QString msg("%1: Script fileName or content is empty, cannot parse");
-        qWarning() << msg.arg(m_fileName);
+        qWarning() << m_fileName << ": Script filename or content is empty, cannot parse";
         return false;
     }
 

--- a/engine/src/rgbscriptv4.cpp
+++ b/engine/src/rgbscriptv4.cpp
@@ -115,6 +115,13 @@ bool RGBScript::evaluate()
     m_rgbMapStepCount = QJSValue();
     m_apiVersion = 0;
 
+    if ((m_fileName == "") || (m_contents == ""))
+    {
+        QString msg("%1: Script fileName or content is empty, cannot parse");
+        qWarning() << msg.arg(m_fileName);
+        return false;
+    }
+
     m_script = s_engine->evaluate(m_contents, m_fileName);
     if (m_script.isError())
     {


### PR DESCRIPTION
See description in #1185 