### PR TITLE
Add a way to hide the disclaimer in order to ease development

### DIFF
--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -58,6 +58,7 @@
 
 #define SETTINGS_WORKINGPATH "workspace/workingpath"
 #define SETTINGS_RECENTFILE "workspace/recent"
+#define SETTINGS_NODISCLAIMER "workspace/nodisclaimer"
 #define KXMLQLCWorkspaceWindow "CurrentWindow"
 
 #define MAX_RECENT_FILES    10
@@ -75,6 +76,7 @@ App::App()
     , m_printItem(nullptr)
     , m_fileName(QString())
     , m_importManager(nullptr)
+    , m_noDisclaimer(false)
 {
     QSettings settings;
 
@@ -83,6 +85,8 @@ App::App()
     QVariant dir = settings.value(SETTINGS_WORKINGPATH);
     if (dir.isValid() == true)
         m_workingPath = dir.toString();
+
+    m_noDisclaimer = settings.value(SETTINGS_NODISCLAIMER).toBool();
 
     setAccessMask(defaultMask());
 
@@ -230,6 +234,11 @@ qreal App::pixelDensity() const
 int App::accessMask() const
 {
     return m_accessMask;
+}
+
+bool App::noDisclaimer() const
+{
+    return m_noDisclaimer;
 }
 
 bool App::is3DSupported() const

--- a/qmlui/app.h
+++ b/qmlui/app.h
@@ -56,6 +56,7 @@ class App : public QQuickView
 
     Q_PROPERTY(QString appName READ appName CONSTANT)
     Q_PROPERTY(QString appVersion READ appVersion CONSTANT)
+    Q_PROPERTY(bool noDisclaimer READ noDisclaimer CONSTANT)
     Q_PROPERTY(bool is3DSupported READ is3DSupported CONSTANT)
 
 public:
@@ -138,6 +139,9 @@ public:
     /** Get/Set the UI access mask */
     int defaultMask() const;
     int accessMask() const;
+
+    /** Get the flag to hide the disclaimer */
+    bool noDisclaimer() const;
 
     bool is3DSupported() const;
 
@@ -297,5 +301,6 @@ private:
     QStringList m_recentFiles;
     QString m_workingPath;
     ImportManager *m_importManager;
+    bool m_noDisclaimer;
 };
 #endif // APP_H

--- a/qmlui/qml/MainView.qml
+++ b/qmlui/qml/MainView.qml
@@ -318,5 +318,8 @@ Rectangle
         color: Qt.rgba(0, 0, 0, 0.5)
     }
 
-    PopupDisclaimer { }
+    PopupDisclaimer
+    {
+        visible: !qlcplus.noDisclaimer
+    }
 }


### PR DESCRIPTION
With this change, the disclaimer can be hidden. This should only be done by developers in order to not have to click the disclaimer away when testing out code changes.
I wouldn't document this feature much, developers who want to use this feature will know how to activate it. All others will have to live with the disclaimer ;)