### PR TITLE
Add Keywords entry for .desktop files

### DIFF
--- a/platforms/linux/qlcplus-fixtureeditor.desktop
+++ b/platforms/linux/qlcplus-fixtureeditor.desktop
@@ -11,6 +11,7 @@ GenericName[it]=Editor di Fixture
 GenericName[nl]=Bewerker voor armaturen
 GenericName[es]=Editor de Fixtures
 GenericName[ca]=Editor de Fixtures
+Keywords=qlc;light;controller;fixture;
 Exec=qlcplus-fixtureeditor --open %f
 Icon=qlcplus-fixtureeditor
 MimeType=application/x-qlc-fixture;

--- a/platforms/linux/qlcplus.desktop
+++ b/platforms/linux/qlcplus.desktop
@@ -11,6 +11,7 @@ GenericName[it]=Controllore di luci
 GenericName[nl]=Lichtregeling
 GenericName[es]=Controlador de iluminación
 GenericName[ca]=Controlador d'iluminació
+Keywords=qlc;light;controller;dmx;analog;midi;artnet;e131;osc;
 Exec=qlcplus --open %f
 Icon=qlcplus
 MimeType=application/x-qlc-workspace;

--- a/platforms/linux/qlcplus.desktop
+++ b/platforms/linux/qlcplus.desktop
@@ -1,7 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=Q Light Controller Plus
-Name[fr]=Contrôleur de luminaires QLC+
 GenericName=Lighting control
 GenericName[cz]=Řízení světel
 GenericName[de]=Lichtsteuerung


### PR DESCRIPTION
At least GNOME ask to add keywords to application desktop files - see [here](https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords). It is also reported by lintian with the *desktop-entry-lacks-keywords-entry* information tag. I just add some basic ones, do you see others?

I have also removed the French translation of the Name as it doesn't make sense to me to translate the software name.