### PR TITLE
Update license header of hidapi library

### DIFF
--- a/plugins/hid/hidapi.h
+++ b/plugins/hid/hidapi.h
@@ -1,15 +1,24 @@
-/*
- * HIDAPI - Multi-Platform library for
- * communication with HID devices.
- *
- * Copyright (c) 2010 Alan Ott - Signal 11 Software
- *
- * 2010-07-03
- *
- * This software may be used by anyone for any reason so
- * long as the copyright notice in the source files
- * remains intact.
- */
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 8/22/2009
+
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
 
 /** @file
  * @defgroup API hidapi API
@@ -284,22 +293,26 @@ extern "C" {
 
 		/** @brief Get a feature report from a HID device.
 
-			Make sure to set the first byte of @p data[] to the Report
-			ID of the report to be read.  Make sure to allow space for
-			this extra byte in @p data[].
+			Set the first byte of @p data[] to the Report ID of the
+			report to be read.  Make sure to allow space for this
+			extra byte in @p data[]. Upon return, the first byte will
+			still contain the Report ID, and the report data will
+			start in data[1].
 
 			@ingroup API
 			@param device A device handle returned from hid_open().
 			@param data A buffer to put the read data into, including
 				the Report ID. Set the first byte of @p data[] to the
-				Report ID of the report to be read.
+				Report ID of the report to be read, or set it to zero
+				if your device does not use numbered reports.
 			@param length The number of bytes to read, including an
 				extra byte for the report ID. The buffer can be longer
 				than the actual report.
 
 			@returns
-				This function returns the number of bytes read and
-				-1 on error.
+				This function returns the number of bytes read plus
+				one for the report ID (which is still in the first
+				byte), or -1 on error.
 		*/
 		int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *device, unsigned char *data, size_t length);
 

--- a/plugins/hid/linux/hidapi.cpp
+++ b/plugins/hid/linux/hidapi.cpp
@@ -1,16 +1,25 @@
-/*
-  HIDAPI - Multi-Platform library for
-  communication with HID devices.
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
 
-  Copyright (c) 2009 Alan Ott - Signal 11 Software
+ Alan Ott
+ Signal 11 Software
 
-  8/22/2009
-  Linux Version - 6/2/2009
+ 8/22/2009
+ Linux Version - 6/2/2009
 
-  This software may be used by anyone for any reason so
-  long as the copyright notice in the source files
-  remains intact.
-*/
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
 
 /* C */
 #include <stdio.h>

--- a/plugins/hid/macx/hidapi.cpp
+++ b/plugins/hid/macx/hidapi.cpp
@@ -1,15 +1,24 @@
-/*
-  HIDAPI - Multi-Platform library for
-  communication with HID devices.
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
 
-  Copyright (c) 2010 Alan Ott - Signal 11 Software
+ Alan Ott
+ Signal 11 Software
 
-  2010-07-03
+ 2010-07-03
 
-  This software may be used by anyone for any reason so
-  long as the copyright notice in the source files
-  remains intact.
-*/
+ Copyright 2010, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
 
 /* See Apple Technical Note TN2187 for details on IOHidManager. */
 

--- a/plugins/hid/win32/hidapi.cpp
+++ b/plugins/hid/win32/hidapi.cpp
@@ -1,15 +1,24 @@
-/*
-  HIDAPI - Multi-Platform library for
-  communication with HID devices.
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
 
-  Copyright (c) 2009 Alan Ott - Signal 11 Software
+ Alan Ott
+ Signal 11 Software
 
-  8/22/2009
+ 8/22/2009
 
-  This software may be used by anyone for any reason so
-  long as the copyright notice in the source files
-  remains intact.
-*/
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
 
 #include <windows.h>
 


### PR DESCRIPTION
This update the license header of the hidapi library from upstream which is much clearer. It is needed for the upcoming Debian package (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=694077). Thanks in advance!