### PR TITLE
added hardware support zu scene editor

### DIFF
--- a/ui/src/consolechannel.cpp
+++ b/ui/src/consolechannel.cpp
@@ -295,6 +295,11 @@ void ConsoleChannel::setChannelStyleSheet(const QString &styleSheet)
         m_styleSheet = styleSheet;
 }
 
+void ConsoleChannel::setSliderStylesheet(const QString &styleSheet)
+{
+    m_slider->setSliderStyleSheet(styleSheet);
+}
+
 void ConsoleChannel::showResetButton(bool show)
 {
     if (show == true)

--- a/ui/src/consolechannel.h
+++ b/ui/src/consolechannel.h
@@ -127,6 +127,7 @@ public:
     void setChannelStyleSheet(const QString& styleSheet);
     void showResetButton(bool show);
     bool hasResetButton();
+    void setSliderStylesheet(const QString& styleSheet);
 
 private slots:
     void slotResetButtonClicked();

--- a/ui/src/fixtureconsole.cpp
+++ b/ui/src/fixtureconsole.cpp
@@ -203,6 +203,28 @@ void FixtureConsole::setChecked(bool state, quint32 channel)
     }
 }
 
+bool FixtureConsole::check(quint32 channel)
+{
+    QListIterator <ConsoleChannel*> it(m_channels);
+    while (it.hasNext() == true)
+    {
+        ConsoleChannel* cc = it.next();
+        Q_ASSERT(cc != NULL);
+        if (channel == cc->channelIndex()){
+          cc->setChecked(!cc->isChecked());
+          return cc->isChecked();
+        }
+    }
+    return false;
+}
+
+bool FixtureConsole::isChecked(quint32 channel)
+{
+  if((int)channel >= m_channels.count())
+     return false;
+  return m_channels.at(channel)->isChecked();
+}
+
 void FixtureConsole::setOutputDMX(bool state)
 {
     Q_UNUSED(state);
@@ -310,6 +332,13 @@ void FixtureConsole::setChannelStylesheet(quint32 ch, QString ss)
     ConsoleChannel* cc = channel(ch);
     if (cc != NULL)
         cc->setChannelStyleSheet(ss);
+}
+
+void FixtureConsole::setSliderStylesheet(quint32 ch, QString ss)
+{
+    ConsoleChannel* cc = channel(ch);
+    if (cc != NULL)
+        cc->setSliderStylesheet(ss);
 }
 
 void FixtureConsole::resetChannelsStylesheet()

--- a/ui/src/fixtureconsole.h
+++ b/ui/src/fixtureconsole.h
@@ -93,6 +93,10 @@ protected:
 public:
     /** Set channels' check state (UINT_MAX to set all) */
     void setChecked(bool state, quint32 channel = UINT_MAX);
+    /** toggle check state */
+    bool check(quint32 channel);
+    /** get checkstate of channel */
+    bool isChecked(quint32 channel);
 
     /** Enable/disable DMX output when sliders are dragged */
     void setOutputDMX(bool state);
@@ -117,6 +121,8 @@ public:
 
     /** Set the stylesheet of the ConsoleChannel at the given index */
     void setChannelStylesheet(quint32 ch, QString ss);
+    /** set the stylesheet of the slider of the channel at given index */
+    void setSliderStylesheet(quint32 ch, QString ss);
 
     /** Reset all the channels stylesheet to the original value */
     void resetChannelsStylesheet();

--- a/ui/src/sceneeditor.h
+++ b/ui/src/sceneeditor.h
@@ -63,6 +63,14 @@ public:
 public slots:
     void slotFunctionManagerActive(bool active);
     void slotSetSceneValues(QList <SceneValue>&);
+    void onInput(quint32 univ, quint32 chan, uchar val, const QString &key);
+private:
+    bool hw_enable;
+    quint32 m_offset;
+    QList<quint32> channelBanks;
+    QList<quint32> faders;
+    QList<quint32> armButton;
+    QList<quint32> tabs;
 
 protected slots:
     void slotFixtureRemoved(quint32 id);
@@ -105,6 +113,7 @@ private slots:
     void slotChaserComboActivated(int index);
     void slotModeChanged(Doc::Mode mode);
     void slotViewModeChanged(bool tabbed, bool applyValues = true);
+    void slotHardwareAction();
 
 private:
     bool isColorToolAvailable();
@@ -128,6 +137,8 @@ private:
     QAction* m_prevTabAction;
 
     QAction* m_tabViewAction;
+
+    QAction* m_hardwareAction;
 
     QComboBox* m_chaserCombo;
     QLineEdit* m_nameEdit;


### PR DESCRIPTION
this adds hardware support to the scene editor. currently it is possible to use 8 faders with 8 arm/disarm buttons, 8 buttons for channelgroups (1-8, 9-16, ....) and two buttons for next_fixture, previous_fixture. it also gives a visual feedback for the current controlled channelgroup.

currently i use an AKAI MidiMix using the "mute" buttons as channel groups, the "rec" buttons for arm/disarm, faders 1-8 for sceneeditor-faders and "bank left"/"bank right" for fixture switching. 

the patch also contains a configuration dialog to support other devices as well.