### PR TITLE
Mac OS audio permissions

### DIFF
--- a/platforms/macos/Info.plist
+++ b/platforms/macos/Info.plist
@@ -25,6 +25,9 @@
 
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Process incoming audio</string>
 
 	<key>CFBundleDocumentTypes</key>
 	<array>

--- a/platforms/macos/Info.plist.qmlui
+++ b/platforms/macos/Info.plist.qmlui
@@ -27,7 +27,7 @@
 	<string>True</string>
 	
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Process incomming audio</string>
+	<string>Process incoming audio</string>
 
 	<key>CFBundleDocumentTypes</key>
 	<array>

--- a/platforms/macos/Info.plist.qmlui
+++ b/platforms/macos/Info.plist.qmlui
@@ -25,6 +25,9 @@
 
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Process incomming audio</string>
 
 	<key>CFBundleDocumentTypes</key>
 	<array>


### PR DESCRIPTION
The .plist need to be changed to allow the application to access microphones or soundcards.