### PR TITLE
Set E1.31 multicast address from universe number

### DIFF
--- a/plugins/E1.31/configuree131.h
+++ b/plugins/E1.31/configuree131.h
@@ -43,11 +43,11 @@ public slots:
 
 private:
     void fillMappingTree();
-    QWidget *createMcastIPWidget(QString ip);
     void showIPAlert(QString ip);
 
 private slots:
     void slotMulticastCheckboxClicked();
+    void slotUniverseSpinChanged();
 
 private:
     E131Plugin* m_plugin;

--- a/plugins/E1.31/e131controller.h
+++ b/plugins/E1.31/e131controller.h
@@ -36,6 +36,7 @@
 
 #define E131_DEFAULT_PORT     5568
 
+
 typedef struct
 {
     bool inputMulticast;
@@ -54,6 +55,8 @@ typedef struct
 
     int type;
 } UniverseInfo;
+
+QHostAddress e131UniverseToMcastAddress(quint16 universe);
 
 class E131Controller : public QObject
 {
@@ -88,9 +91,6 @@ public:
     /** Set input as multicast for the givin QLC+ universe */
     void setInputMulticast(quint32 universe, bool multicast);
 
-    /** Set input as multicast for the givin QLC+ universe */
-    void setInputMCastAddress(quint32 universe, QString address);
-
     /** Set a specific port for the given QLC+ universe */
     void setInputUCastPort(quint32 universe, quint16 port);
 
@@ -99,9 +99,6 @@ public:
 
     /** Set output as multicast for the given QLC+ universe */
     void setOutputMulticast(quint32 universe, bool multicast);
-
-    /** Set a specific multicast IP address for the given QLC+ universe */
-    void setOutputMCastAddress(quint32 universe, QString address);
 
     /** Set a specific unicast IP address for the given QLC+ universe */
     void setOutputUCastAddress(quint32 universe, QString address);

--- a/plugins/E1.31/e131plugin.cpp
+++ b/plugins/E1.31/e131plugin.cpp
@@ -324,8 +324,6 @@ void E131Plugin::setParameter(quint32 universe, quint32 line, Capability type,
     {
         if (name == E131_MULTICAST)
             controller->setInputMulticast(universe, value.toInt());
-        else if (name == E131_MCASTIP)
-            controller->setInputMCastAddress(universe, value.toString());
         else if (name == E131_UCASTPORT)
             controller->setInputUCastPort(universe, value.toUInt());
         else if (name == E131_UNIVERSE)
@@ -340,8 +338,6 @@ void E131Plugin::setParameter(quint32 universe, quint32 line, Capability type,
     {
         if (name == E131_MULTICAST)
             controller->setOutputMulticast(universe, value.toInt());
-        else if (name == E131_MCASTIP)
-            controller->setOutputMCastAddress(universe, value.toString());
         else if (name == E131_UCASTIP)
             controller->setOutputUCastAddress(universe, value.toString());
         else if (name == E131_UCASTPORT)

--- a/plugins/E1.31/e131plugin.h
+++ b/plugins/E1.31/e131plugin.h
@@ -38,7 +38,6 @@ typedef struct
 } E131IO;
 
 #define E131_MULTICAST "multicast"
-#define E131_MCASTIP "mcastIP"
 #define E131_UCASTIP "ucastIP"
 #define E131_UCASTPORT "ucastPort"
 #define E131_UNIVERSE "universe"


### PR DESCRIPTION
Right now when you set an E1.31 output to multicast, it only lets you edit the last octet of the multicast address. The E1.31 multicast address is supposed to match the universe number. By only allowing editing of the last octet, this limits QLC+ to using only the first 255 E1.31 universes, and not universes 256-63999. Also, by requiring the multicast address to be entered manually, it requires type the universe number twice to have it correctly match the universe number, and allows likely erroneous mismatches of the address and universe number. This patch makes the multicast address uneditable and sets it automatically to make the universe number, correctly handling all 64,000 universes.