### PR TITLE
Hide disconnected network interfaces

### DIFF
--- a/plugins/E1.31/configuree131.cpp
+++ b/plugins/E1.31/configuree131.cpp
@@ -125,6 +125,8 @@ void ConfigureE131::fillMappingTree()
                     portSpin->setValue(info->inputUcastPort);
                     m_uniMapTree->setItemWidget(item, KMapColumnPort, portSpin);
                 }
+                if (!controller->canMulticast())
+                    multicastCb->setEnabled(false);
                 connect(multicastCb, SIGNAL(clicked()), this, SLOT(slotMulticastCheckboxClicked()));
                 m_uniMapTree->setItemWidget(item, KMapColumnMulticast, multicastCb);
 
@@ -164,6 +166,8 @@ void ConfigureE131::fillMappingTree()
                     portSpin->setValue(info->outputUcastPort);
                     m_uniMapTree->setItemWidget(item, KMapColumnPort, portSpin);
                 }
+                if (!controller->canMulticast())
+                    multicastCb->setEnabled(false);
                 connect(multicastCb, SIGNAL(clicked()), this, SLOT(slotMulticastCheckboxClicked()));
                 m_uniMapTree->setItemWidget(item, KMapColumnMulticast, multicastCb);
 

--- a/plugins/E1.31/e131controller.cpp
+++ b/plugins/E1.31/e131controller.cpp
@@ -55,6 +55,11 @@ QString E131Controller::getNetworkIP()
     return m_ipAddr.toString();
 }
 
+bool E131Controller::canMulticast()
+{
+    return m_interface.flags().testFlag(QNetworkInterface::CanMulticast);
+}
+
 void E131Controller::addUniverse(quint32 universe, E131Controller::Type type)
 {
     qDebug() << "[E1.31] addUniverse - universe" << universe << ", type" << type;
@@ -65,12 +70,12 @@ void E131Controller::addUniverse(quint32 universe, E131Controller::Type type)
     else
     {
         UniverseInfo info;
-        info.inputMulticast = true;
+        info.inputMulticast = canMulticast();
         info.inputMcastAddress = QHostAddress(QString("239.255.0.%1").arg(universe + 1));
         info.inputUcastPort = E131_DEFAULT_PORT;
         info.inputUniverse = universe + 1;
         info.inputSocket.clear();
-        info.outputMulticast = true;
+        info.outputMulticast = canMulticast();
         info.outputMcastAddress = QHostAddress(QString("239.255.0.%1").arg(universe + 1));
         if (m_ipAddr != QHostAddress::LocalHost)
             info.outputUcastAddress = QHostAddress(quint32((m_ipAddr.toIPv4Address() & 0xFFFFFF00) + (universe + 1)));

--- a/plugins/E1.31/e131controller.h
+++ b/plugins/E1.31/e131controller.h
@@ -79,6 +79,9 @@ public:
     /** Return the controller IP address */
     QString getNetworkIP();
 
+    /** Gets wether the interface supports multicast */
+    bool canMulticast();
+
     /** Add a universe to the map of this controller */
     void addUniverse(quint32 universe, Type type);
 

--- a/plugins/E1.31/e131plugin.cpp
+++ b/plugins/E1.31/e131plugin.cpp
@@ -39,6 +39,11 @@ void E131Plugin::init()
 {
     foreach(QNetworkInterface interface, QNetworkInterface::allInterfaces())
     {
+        //qDebug() << "[E1.31] Interface " << interface.index() << "-" << interface.humanReadableName() << ":" << interface;
+
+        if (!interface.flags().testFlag(QNetworkInterface::IsUp))
+            continue;
+
         foreach (QNetworkAddressEntry entry, interface.addressEntries())
         {
             QHostAddress addr = entry.ip();

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -39,6 +39,11 @@ void ArtNetPlugin::init()
 {
     foreach(QNetworkInterface interface, QNetworkInterface::allInterfaces())
     {
+        //qDebug() << "[ArtNet] Interface " << interface.index() << "-" << interface.humanReadableName() << ":" << interface;
+
+        if (!interface.flags().testFlag(QNetworkInterface::IsUp))
+            continue;
+
         foreach (QNetworkAddressEntry entry, interface.addressEntries())
         {
             QHostAddress addr = entry.ip();

--- a/plugins/osc/oscplugin.cpp
+++ b/plugins/osc/oscplugin.cpp
@@ -38,6 +38,11 @@ void OSCPlugin::init()
 {
     foreach(QNetworkInterface interface, QNetworkInterface::allInterfaces())
     {
+        //qDebug() << "[OSC] Interface " << interface.index() << "-" << interface.humanReadableName() << ":" << interface;
+
+        if (!interface.flags().testFlag(QNetworkInterface::IsUp))
+            continue;
+
         foreach (QNetworkAddressEntry entry, interface.addressEntries())
         {
             QHostAddress addr = entry.ip();


### PR DESCRIPTION
Hides network interfaces that are not connected from the ArtNet, E1.31, and OSC interface choices.
Also disables the E1.31 multicast option for interfaces that don't support multicast.