### PR TITLE
FFT: Fixed mono and stereo audio capture triggers based on frequency spectrum

### DIFF
--- a/engine/audio/src/audiocapture.cpp
+++ b/engine/audio/src/audiocapture.cpp
@@ -30,9 +30,7 @@
 
 #define USE_HANNING
 #define CLEAR_FFT_NOISE
-
 #define M_2PI       6.28318530718           /* 2*pi */
-#define SQRT_32768  181.0193
 
 AudioCapture::AudioCapture (QObject* parent)
     : QThread (parent)
@@ -162,7 +160,7 @@ double AudioCapture::fillBandsData(int number)
 
     for (int b = 0; b < number; b++)
     {
-        quint64 magnitudeSum = 0;
+        double magnitudeSum = 0.;
         for (int s = 0; s < subBandWidth; s++, i++)
         {
             if (i == bufferSize)
@@ -170,7 +168,7 @@ double AudioCapture::fillBandsData(int number)
             magnitudeSum += qSqrt((((fftw_complex*)m_fftOutputBuffer)[i][0] * ((fftw_complex*)m_fftOutputBuffer)[i][0]) +
                                   (((fftw_complex*)m_fftOutputBuffer)[i][1] * ((fftw_complex*)m_fftOutputBuffer)[i][1]));
         }
-        double bandMagnitude = (magnitudeSum / subBandWidth) * SQRT_32768;
+        double bandMagnitude = (magnitudeSum / (subBandWidth * M_2PI));
         m_fftMagnitudeMap[number].m_fftMagnitudeBuffer[b] = bandMagnitude;
         if (maxMagnitude < bandMagnitude)
             maxMagnitude = bandMagnitude;
@@ -245,7 +243,7 @@ void AudioCapture::processData()
         {
             pwrSum += m_fftMagnitudeMap[barsNumber].m_fftMagnitudeBuffer[n];
         }
-        m_signalPower = pwrSum * qSqrt(M_2PI) * SQRT_32768 / barsNumber;
+        m_signalPower = 32768 * pwrSum * qSqrt(M_2PI) / (double)barsNumber;
         emit dataProcessed(m_fftMagnitudeMap[barsNumber].m_fftMagnitudeBuffer.data(),
                            m_fftMagnitudeMap[barsNumber].m_fftMagnitudeBuffer.size(),
                            maxMagnitude, m_signalPower);

--- a/engine/audio/src/audiocapture.h
+++ b/engine/audio/src/audiocapture.h
@@ -145,10 +145,11 @@ protected:
 
     QMutex m_mutex;
 
-    unsigned int m_captureSize, m_sampleRate, m_channels;
+    unsigned int bufferSize, m_captureSize, m_sampleRate, m_channels;
 
     /** Data buffer for audio data coming from the sound card */
     int16_t *m_audioBuffer;
+    int16_t *m_audioMixdown;
 
     quint32 m_signalPower;
 


### PR DESCRIPTION
As per this thread https://www.qlcplus.org/forum/viewtopic.php?f=24&t=10301&start=10 

I have also observed an issue with the FFT part that analyses the frequencies and attempts to plot the power of the signal for different bands and trigger various functions based on the audio signal levels.  Indeed the levels are appearing too low, and for good reason.  The key problem I have identified is that the power of the signal overall should be the sum of squares of the frequency spectra magnitudes, but currently the power is estimated by finding the sum of the absolute raw signal values.

I would like to start a conversation about this part of the code, so I have changed the bits that I think are critical, but may have made mistakes regarding the bar graph as I don't yet understand the scaling and how the data is plotted/stored in QT.  Please bear with me and we can fix this problem together.