### PR TITLE
Qt5 5.15.0 deprecation fixes

### DIFF
--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -20,6 +20,9 @@
 */
 
 #include <QElapsedTimer>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#include <QRandomGenerator>
+#endif
 #include <QDebug>
 
 #include "chaserrunner.h"
@@ -380,7 +383,11 @@ void ChaserRunner::shuffle(QVector<int> & data)
    int n = data.size();
    for (int i = n - 1; i > 0; --i)
    {
-       qSwap(data[i], data[qrand() % (i + 1)]);
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
+      qSwap(data[i], data[qrand() % (i + 1)]);
+#else
+      qSwap(data[i], data[QRandomGenerator::global()->generate() % (i + 1)]);
+#endif
    }
 }
 

--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -20,7 +20,7 @@
 */
 
 #include <QElapsedTimer>
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QRandomGenerator>
 #endif
 #include <QDebug>
@@ -383,7 +383,7 @@ void ChaserRunner::shuffle(QVector<int> & data)
    int n = data.size();
    for (int i = n - 1; i > 0; --i)
    {
-#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
       qSwap(data[i], data[qrand() % (i + 1)]);
 #else
       qSwap(data[i], data[QRandomGenerator::global()->generate() % (i + 1)]);

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -26,7 +26,7 @@
 #include <QList>
 #include <QTime>
 #include <QDir>
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QRandomGenerator>
 #endif
 
@@ -88,7 +88,7 @@ Doc::Doc(QObject* parent, int universes)
 {
     Bus::init(this);
     resetModified();
-#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     qsrand(QTime::currentTime().msec());
 #endif
     

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -26,6 +26,7 @@
 #include <QList>
 #include <QTime>
 #include <QDir>
+#include <QRandomGenerator>
 
 #include "qlcfixturemode.h"
 #include "qlcfixturedef.h"
@@ -85,7 +86,10 @@ Doc::Doc(QObject* parent, int universes)
 {
     Bus::init(this);
     resetModified();
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
     qsrand(QTime::currentTime().msec());
+#endif
+    
 }
 
 Doc::~Doc()

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -26,7 +26,9 @@
 #include <QList>
 #include <QTime>
 #include <QDir>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
 #include <QRandomGenerator>
+#endif
 
 #include "qlcfixturemode.h"
 #include "qlcfixturedef.h"

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -143,11 +143,7 @@ bool Script::setData(const QString& str)
     if (m_data.isEmpty() == false)
     {
         int i = 1;
-#if QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 )
-        QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
-#else
-        QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
-#endif
+        QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"));
         foreach (QString line, lines)
         {
             bool ok = false;
@@ -191,11 +187,7 @@ QString Script::data() const
 
 QStringList Script::dataLines() const
 {
-#if QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 )
-    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
-#else
-    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
-#endif
+    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"));
     while (result.count() && result.last().isEmpty())
         result.takeLast();
 

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -143,7 +143,7 @@ bool Script::setData(const QString& str)
     if (m_data.isEmpty() == false)
     {
         int i = 1;
-#if QT_VERSION <= QT_VERSION_CHECK( 5, 14, 0 )
+#if QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 )
         QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
 #else
         QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
@@ -191,7 +191,7 @@ QString Script::data() const
 
 QStringList Script::dataLines() const
 {
-#if QT_VERSION <= QT_VERSION_CHECK( 5, 14, 0 )
+#if QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 )
     QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
 #else
     QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -25,7 +25,10 @@
 #endif
 #include <QDebug>
 #include <QUrl>
-
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#include <QRandomGenerator>
+#endif
+ 
 #include "genericfader.h"
 #include "fadechannel.h"
 #include "mastertimer.h"
@@ -140,7 +143,7 @@ bool Script::setData(const QString& str)
     if (m_data.isEmpty() == false)
     {
         int i = 1;
-        QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+        QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
         foreach (QString line, lines)
         {
             bool ok = false;
@@ -184,7 +187,7 @@ QString Script::data() const
 
 QStringList Script::dataLines() const
 {
-    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
 
     while (result.count() && result.last().isEmpty())
         result.takeLast();
@@ -405,7 +408,11 @@ quint32 Script::getValueFromString(QString str, bool *ok)
     int max = Function::stringToSpeed(valList.at(1));
 
     *ok = true;
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
     return qrand() % ((max + 1) - min) + min;
+#else
+      return QRandomGenerator::global()->generate() % ((max + 1) - min) + min;
+#endif
 }
 
 bool Script::executeCommand(int index, MasterTimer* timer, QList<Universe *> universes)

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -143,7 +143,11 @@ bool Script::setData(const QString& str)
     if (m_data.isEmpty() == false)
     {
         int i = 1;
+#if QT_VERSION <= QT_VERSION_CHECK( 5, 14, 0 )
+        QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+#else
         QStringList lines = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
+#endif
         foreach (QString line, lines)
         {
             bool ok = false;
@@ -187,8 +191,11 @@ QString Script::data() const
 
 QStringList Script::dataLines() const
 {
+#if QT_VERSION <= QT_VERSION_CHECK( 5, 14, 0 )
+    QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+#else
     QStringList result = m_data.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
-
+#endif
     while (result.count() && result.last().isEmpty())
         result.takeLast();
 

--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -25,7 +25,7 @@
 #endif
 #include <QDebug>
 #include <QUrl>
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QRandomGenerator>
 #endif
  
@@ -407,7 +407,7 @@ quint32 Script::getValueFromString(QString str, bool *ok)
     int max = Function::stringToSpeed(valList.at(1));
 
     *ok = true;
-#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     return qrand() % ((max + 1) - min) + min;
 #else
       return QRandomGenerator::global()->generate() % ((max + 1) - min) + min;

--- a/engine/test/qlcinputprofile/qlcinputprofile_test.cpp
+++ b/engine/test/qlcinputprofile/qlcinputprofile_test.cpp
@@ -386,7 +386,7 @@ void QLCInputProfile_Test::save()
 
 #if !defined(WIN32) && !defined(Q_OS_WIN)
     QFile::Permissions perm = QFile::permissions(path);
-    QFile::setPermissions(path, 0);
+    QFile::setPermissions(path, QFileDevice::WriteOwner);
     QVERIFY(ip.saveXML(path) == false);
     QFile::setPermissions(path, perm);
 #endif

--- a/engine/test/qlcinputprofile/qlcinputprofile_test.cpp
+++ b/engine/test/qlcinputprofile/qlcinputprofile_test.cpp
@@ -386,7 +386,7 @@ void QLCInputProfile_Test::save()
 
 #if !defined(WIN32) && !defined(Q_OS_WIN)
     QFile::Permissions perm = QFile::permissions(path);
-    QFile::setPermissions(path, QFileDevice::WriteOwner);
+    QFile::setPermissions(path, QFileDevice::WriteOther);
     QVERIFY(ip.saveXML(path) == false);
     QFile::setPermissions(path, perm);
 #endif

--- a/fixtureeditor/capabilitywizard.cpp
+++ b/fixtureeditor/capabilitywizard.cpp
@@ -113,7 +113,7 @@ void CapabilityWizard::slotCreateCapabilities()
                 m_channel->searchCapability(cap->max()) != NULL)
         {
             /* Disable the item to indicate overlapping */
-            item->setFlags(0);
+            item->setFlags(Qt::NoItemFlags);
         }
     }
 }

--- a/fixtureeditor/edithead.cpp
+++ b/fixtureeditor/edithead.cpp
@@ -69,7 +69,7 @@ void EditHead::fillChannelTree(const QLCFixtureMode* mode)
         if (ch->group() == QLCChannel::Intensity && ch->colour() == QLCChannel::NoColour)
             item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         else if (m_head.channels().contains(i) == false && mode->headForChannel(i) != -1)
-            item->setFlags(0);
+            item->setFlags(Qt::NoItemFlags);
         else
             item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 

--- a/fixtureeditor/editmode.cpp
+++ b/fixtureeditor/editmode.cpp
@@ -377,7 +377,7 @@ void EditMode::refreshHeadList()
                 chitem->setText(0, QString("%1: %2").arg(chnum + 1).arg(ch->name()));
             else
                 chitem->setText(0, QString("%1: INVALID!"));
-            chitem->setFlags(0); // Disable channel selection inside heads
+            chitem->setFlags(Qt::NoItemFlags); // Disable channel selection inside heads
 
             summary += QString::number(chnum + 1);
             if (it.hasNext() == true)

--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -644,7 +644,7 @@ void QLCFixtureEditor::updateChannelItem(const QLCChannel *channel, QTreeWidgetI
         capitem->setText(CH_COL_NAME,
                          QString("[%1-%2]: %3").arg(cap->min())
                          .arg(cap->max()).arg(cap->name()));
-        capitem->setFlags(0); /* No selection etc. */
+        capitem->setFlags(Qt::NoItemFlags); /* No selection etc. */
     }
 }
 
@@ -988,7 +988,7 @@ void QLCFixtureEditor::updateModeItem(const QLCFixtureMode *mode,
         chitem->setText(MODE_COL_NAME, ch->name());
         chitem->setIcon(MODE_COL_NAME, ch->getIcon());
         chitem->setText(MODE_COL_CHS, QString("%1").arg(i + 1));
-        chitem->setFlags(0); /* No selection etc. */
+        chitem->setFlags(Qt::NoItemFlags); /* No selection etc. */
     }
 }
 

--- a/fixtureeditor/main.cpp
+++ b/fixtureeditor/main.cpp
@@ -52,13 +52,13 @@ void printVersion()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
-    cout << endl;
-    cout << App::longName() << " " << App::version() << endl;
+    cout << Qt::endl;
+    cout << App::longName() << " " << App::version() << Qt::endl;
     cout << "This program is licensed under the terms of the ";
-    cout << "Apache 2.0 license." << endl;
-    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)." << endl;
-    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)." << endl;
-    cout << endl;
+    cout << "Apache 2.0 license." << Qt::endl;
+    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)." << Qt::endl;
+    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)." << Qt::endl;
+    cout << Qt::endl;
 }
 
 /**
@@ -69,13 +69,13 @@ void printUsage()
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
     cout << "Usage:";
-    cout << "  qlcplus-fixtureeditor [options]" << endl;
-    cout << "Options:" << endl;
-    cout << "  -o or --open <file>\t\tOpen the specified fixture definition file" << endl;
-    cout << "  -l or --locale <locale>\tForce a locale for translation" << endl;
-    cout << "  -h or --help\t\t\tPrint this help" << endl;
-    cout << "  -v or --version\t\tPrint version information" << endl;
-    cout << endl;
+    cout << "  qlcplus-fixtureeditor [options]" << Qt::endl;
+    cout << "Options:" << Qt::endl;
+    cout << "  -o or --open <file>\t\tOpen the specified fixture definition file" << Qt::endl;
+    cout << "  -l or --locale <locale>\tForce a locale for translation" << Qt::endl;
+    cout << "  -h or --help\t\t\tPrint this help" << Qt::endl;
+    cout << "  -v or --version\t\tPrint version information" << Qt::endl;
+    cout << Qt::endl;
 }
 
 /**

--- a/fixtureeditor/main.cpp
+++ b/fixtureeditor/main.cpp
@@ -45,6 +45,10 @@ QString fixture;
 QString locale;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#define endl Qt::endl
+#endif
+
 /**
  * Prints the application version
  */
@@ -52,15 +56,6 @@ void printVersion()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-    cout << Qt::endl;
-    cout << App::longName() << " " << App::version() << Qt::endl;
-    cout << "This program is licensed under the terms of the ";
-    cout << "Apache 2.0 license." << Qt::endl;
-    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)." << Qt::endl;
-    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)." << Qt::endl;
-    cout << Qt::endl;
-#else
     cout << endl;
     cout << App::longName() << " " << App::version() << endl;
     cout << "This program is licensed under the terms of the ";
@@ -68,7 +63,6 @@ void printVersion()
     cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)." << endl;
     cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)." << endl;
     cout << endl;
-#endif
 }
 
 /**
@@ -78,16 +72,6 @@ void printUsage()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-    cout << "Usage:";
-    cout << "  qlcplus-fixtureeditor [options]" << Qt::endl;
-    cout << "Options:" << Qt::endl;
-    cout << "  -o or --open <file>\t\tOpen the specified fixture definition file" << Qt::endl;
-    cout << "  -l or --locale <locale>\tForce a locale for translation" << Qt::endl;
-    cout << "  -h or --help\t\t\tPrint this help" << Qt::endl;
-    cout << "  -v or --version\t\tPrint version information" << Qt::endl;
-    cout << Qt::endl;
-#else
     cout << "Usage:";
     cout << "  qlcplus-fixtureeditor [options]" << endl;
     cout << "Options:" << endl;
@@ -96,7 +80,6 @@ void printUsage()
     cout << "  -h or --help\t\t\tPrint this help" << endl;
     cout << "  -v or --version\t\tPrint version information" << endl;
     cout << endl;
-#endif
 }
 
 /**

--- a/fixtureeditor/main.cpp
+++ b/fixtureeditor/main.cpp
@@ -52,6 +52,7 @@ void printVersion()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
     cout << Qt::endl;
     cout << App::longName() << " " << App::version() << Qt::endl;
     cout << "This program is licensed under the terms of the ";
@@ -59,6 +60,15 @@ void printVersion()
     cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)." << Qt::endl;
     cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)." << Qt::endl;
     cout << Qt::endl;
+#else
+    cout << endl;
+    cout << App::longName() << " " << App::version() << endl;
+    cout << "This program is licensed under the terms of the ";
+    cout << "Apache 2.0 license." << endl;
+    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)." << endl;
+    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)." << endl;
+    cout << endl;
+#endif
 }
 
 /**
@@ -68,6 +78,7 @@ void printUsage()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
     cout << "Usage:";
     cout << "  qlcplus-fixtureeditor [options]" << Qt::endl;
     cout << "Options:" << Qt::endl;
@@ -76,6 +87,16 @@ void printUsage()
     cout << "  -h or --help\t\t\tPrint this help" << Qt::endl;
     cout << "  -v or --version\t\tPrint version information" << Qt::endl;
     cout << Qt::endl;
+#else
+    cout << "Usage:";
+    cout << "  qlcplus-fixtureeditor [options]" << endl;
+    cout << "Options:" << endl;
+    cout << "  -o or --open <file>\t\tOpen the specified fixture definition file" << endl;
+    cout << "  -l or --locale <locale>\tForce a locale for translation" << endl;
+    cout << "  -h or --help\t\t\tPrint this help" << endl;
+    cout << "  -v or --version\t\tPrint version information" << endl;
+    cout << endl;
+#endif
 }
 
 /**

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -149,6 +149,10 @@ void qlcMessageHandler(QtMsgType type, const QMessageLogContext &context, const 
 }
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#define endl Qt::endl
+#endif
+
 /**
  * Prints the application version
  */
@@ -156,15 +160,6 @@ void printVersion()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-    cout << Qt::endl;
-    cout << APPNAME << " " << "version " << APPVERSION << Qt::endl;
-    cout << "This program is licensed under the terms of the ";
-    cout << "Apache 2.0 license." << Qt::endl;
-    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)" << Qt::endl;
-    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)" << Qt::endl;
-    cout << Qt::endl;
-#else
     cout << endl;
     cout << APPNAME << " " << "version " << APPVERSION << endl;
     cout << "This program is licensed under the terms of the ";
@@ -172,7 +167,6 @@ void printVersion()
     cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)" << endl;
     cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)" << endl;
     cout << endl;
-#endif
 }
 
 /**
@@ -182,27 +176,6 @@ void printUsage()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-    cout << "Usage:";
-    cout << "  qlcplus [options]" << Qt::endl;
-    cout << "Options:" << Qt::endl;
-    cout << "  -c or --closebutton <x,y,w,h>\tPlace a close button in virtual console (only when -k is specified)" << Qt::endl;
-    cout << "  -d or --debug <level>\t\tSet debug output level (0-3, see QtMsgType)" << Qt::endl;
-    cout << "  -f or --fullscreen <method>\tStart the application in fullscreen mode (method is either 'normal' or 'resize')" << Qt::endl;
-    cout << "  -g or --log\t\t\tLog debug messages to a file" << Qt::endl;
-    cout << "  -h or --help\t\t\tPrint this help" << Qt::endl;
-    cout << "  -k or --kiosk\t\t\tEnable kiosk mode (only virtual console in forced operate mode)" << Qt::endl;
-    cout << "  -l or --locale <locale>\tForce a locale for translation" << Qt::endl;
-    cout << "  -m or --nowm\t\t\tInform the application that the system doesn't provide a window manager" << Qt::endl;
-    cout << "  -n or --nogui\t\t\tStart the application with the GUI hidden (requires --nowm)" << Qt::endl;
-    cout << "  -o or --open <file>\t\tOpen the specified workspace file" << Qt::endl;
-    cout << "  -p or --operate\t\tStart in operate mode" << Qt::endl;
-    cout << "  -v or --version\t\tPrint version information" << Qt::endl;
-    cout << "  -w or --web\t\t\tEnable remote web access" << Qt::endl;
-    cout << "  -wa or --web-auth\t\tEnable remote web access with users authentication" << Qt::endl;
-    cout << "  -a or --web-auth-file <file>\tSpecify a file where to store web access basic authentication credentials" << Qt::endl;
-    cout << Qt::endl;
-#else
     cout << "Usage:";
     cout << "  qlcplus [options]" << endl;
     cout << "Options:" << endl;
@@ -222,7 +195,6 @@ void printUsage()
     cout << "  -wa or --web-auth\t\tEnable remote web access with users authentication" << endl;
     cout << "  -a or --web-auth-file <file>\tSpecify a file where to store web access basic authentication credentials" << endl;
     cout << endl;
-#endif
 }
 
 /**

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -156,13 +156,13 @@ void printVersion()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
-    cout << endl;
-    cout << APPNAME << " " << "version " << APPVERSION << endl;
+    cout << Qt::endl;
+    cout << APPNAME << " " << "version " << APPVERSION << Qt::endl;
     cout << "This program is licensed under the terms of the ";
-    cout << "Apache 2.0 license." << endl;
-    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)" << endl;
-    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)" << endl;
-    cout << endl;
+    cout << "Apache 2.0 license." << Qt::endl;
+    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)" << Qt::endl;
+    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)" << Qt::endl;
+    cout << Qt::endl;
 }
 
 /**
@@ -173,24 +173,24 @@ void printUsage()
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
     cout << "Usage:";
-    cout << "  qlcplus [options]" << endl;
-    cout << "Options:" << endl;
-    cout << "  -c or --closebutton <x,y,w,h>\tPlace a close button in virtual console (only when -k is specified)" << endl;
-    cout << "  -d or --debug <level>\t\tSet debug output level (0-3, see QtMsgType)" << endl;
-    cout << "  -f or --fullscreen <method>\tStart the application in fullscreen mode (method is either 'normal' or 'resize')" << endl;
-    cout << "  -g or --log\t\t\tLog debug messages to a file" << endl;
-    cout << "  -h or --help\t\t\tPrint this help" << endl;
-    cout << "  -k or --kiosk\t\t\tEnable kiosk mode (only virtual console in forced operate mode)" << endl;
-    cout << "  -l or --locale <locale>\tForce a locale for translation" << endl;
-    cout << "  -m or --nowm\t\t\tInform the application that the system doesn't provide a window manager" << endl;
-    cout << "  -n or --nogui\t\t\tStart the application with the GUI hidden (requires --nowm)" << endl;
-    cout << "  -o or --open <file>\t\tOpen the specified workspace file" << endl;
-    cout << "  -p or --operate\t\tStart in operate mode" << endl;
-    cout << "  -v or --version\t\tPrint version information" << endl;
-    cout << "  -w or --web\t\t\tEnable remote web access" << endl;
-    cout << "  -wa or --web-auth\t\tEnable remote web access with users authentication" << endl;
-    cout << "  -a or --web-auth-file <file>\tSpecify a file where to store web access basic authentication credentials" << endl;
-    cout << endl;
+    cout << "  qlcplus [options]" << Qt::endl;
+    cout << "Options:" << Qt::endl;
+    cout << "  -c or --closebutton <x,y,w,h>\tPlace a close button in virtual console (only when -k is specified)" << Qt::endl;
+    cout << "  -d or --debug <level>\t\tSet debug output level (0-3, see QtMsgType)" << Qt::endl;
+    cout << "  -f or --fullscreen <method>\tStart the application in fullscreen mode (method is either 'normal' or 'resize')" << Qt::endl;
+    cout << "  -g or --log\t\t\tLog debug messages to a file" << Qt::endl;
+    cout << "  -h or --help\t\t\tPrint this help" << Qt::endl;
+    cout << "  -k or --kiosk\t\t\tEnable kiosk mode (only virtual console in forced operate mode)" << Qt::endl;
+    cout << "  -l or --locale <locale>\tForce a locale for translation" << Qt::endl;
+    cout << "  -m or --nowm\t\t\tInform the application that the system doesn't provide a window manager" << Qt::endl;
+    cout << "  -n or --nogui\t\t\tStart the application with the GUI hidden (requires --nowm)" << Qt::endl;
+    cout << "  -o or --open <file>\t\tOpen the specified workspace file" << Qt::endl;
+    cout << "  -p or --operate\t\tStart in operate mode" << Qt::endl;
+    cout << "  -v or --version\t\tPrint version information" << Qt::endl;
+    cout << "  -w or --web\t\t\tEnable remote web access" << Qt::endl;
+    cout << "  -wa or --web-auth\t\tEnable remote web access with users authentication" << Qt::endl;
+    cout << "  -a or --web-auth-file <file>\tSpecify a file where to store web access basic authentication credentials" << Qt::endl;
+    cout << Qt::endl;
 }
 
 /**

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -156,6 +156,7 @@ void printVersion()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
     cout << Qt::endl;
     cout << APPNAME << " " << "version " << APPVERSION << Qt::endl;
     cout << "This program is licensed under the terms of the ";
@@ -163,6 +164,15 @@ void printVersion()
     cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)" << Qt::endl;
     cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)" << Qt::endl;
     cout << Qt::endl;
+#else
+    cout << endl;
+    cout << APPNAME << " " << "version " << APPVERSION << endl;
+    cout << "This program is licensed under the terms of the ";
+    cout << "Apache 2.0 license." << endl;
+    cout << "Copyright (c) Heikki Junnila (hjunnila@users.sf.net)" << endl;
+    cout << "Copyright (c) Massimo Callegari (massimocallegari@yahoo.it)" << endl;
+    cout << endl;
+#endif
 }
 
 /**
@@ -172,6 +182,7 @@ void printUsage()
 {
     QTextStream cout(stdout, QIODevice::WriteOnly);
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
     cout << "Usage:";
     cout << "  qlcplus [options]" << Qt::endl;
     cout << "Options:" << Qt::endl;
@@ -191,6 +202,27 @@ void printUsage()
     cout << "  -wa or --web-auth\t\tEnable remote web access with users authentication" << Qt::endl;
     cout << "  -a or --web-auth-file <file>\tSpecify a file where to store web access basic authentication credentials" << Qt::endl;
     cout << Qt::endl;
+#else
+    cout << "Usage:";
+    cout << "  qlcplus [options]" << endl;
+    cout << "Options:" << endl;
+    cout << "  -c or --closebutton <x,y,w,h>\tPlace a close button in virtual console (only when -k is specified)" << endl;
+    cout << "  -d or --debug <level>\t\tSet debug output level (0-3, see QtMsgType)" << endl;
+    cout << "  -f or --fullscreen <method>\tStart the application in fullscreen mode (method is either 'normal' or 'resize')" << endl;
+    cout << "  -g or --log\t\t\tLog debug messages to a file" << endl;
+    cout << "  -h or --help\t\t\tPrint this help" << endl;
+    cout << "  -k or --kiosk\t\t\tEnable kiosk mode (only virtual console in forced operate mode)" << endl;
+    cout << "  -l or --locale <locale>\tForce a locale for translation" << endl;
+    cout << "  -m or --nowm\t\t\tInform the application that the system doesn't provide a window manager" << endl;
+    cout << "  -n or --nogui\t\t\tStart the application with the GUI hidden (requires --nowm)" << endl;
+    cout << "  -o or --open <file>\t\tOpen the specified workspace file" << endl;
+    cout << "  -p or --operate\t\tStart in operate mode" << endl;
+    cout << "  -v or --version\t\tPrint version information" << endl;
+    cout << "  -w or --web\t\t\tEnable remote web access" << endl;
+    cout << "  -wa or --web-auth\t\tEnable remote web access with users authentication" << endl;
+    cout << "  -a or --web-auth-file <file>\tSpecify a file where to store web access basic authentication credentials" << endl;
+    cout << endl;
+#endif
 }
 
 /**

--- a/ui/src/ctkrangeslider.cpp
+++ b/ui/src/ctkrangeslider.cpp
@@ -111,7 +111,7 @@ ctkRangeSliderPrivate::ctkRangeSliderPrivate(ctkRangeSlider& object)
   this->m_SubclassClickOffset = 0;
   this->m_SubclassPosition = 0;
   this->m_SubclassWidth = 0;
-  this->m_SelectedHandles = 0;
+  this->m_SelectedHandles = NoHandle;
   this->m_SymmetricMoves = false;
 }
 
@@ -769,7 +769,7 @@ void ctkRangeSlider::mouseReleaseEvent(QMouseEvent* mouseEvent)
   this->QSlider::mouseReleaseEvent(mouseEvent);
 
   setSliderDown(false);
-  d->m_SelectedHandles = 0;
+  d->m_SelectedHandles = ctkRangeSliderPrivate::NoHandle;
 
   this->update();
 }

--- a/ui/src/fixturetreewidget.cpp
+++ b/ui/src/fixturetreewidget.cpp
@@ -182,7 +182,7 @@ void FixtureTreeWidget::updateFixtureItem(QTreeWidgetItem* item, Fixture* fixtur
     if (m_disabledFixtures.contains(fixture->id()) == true)
     {
         // Disable selection
-        item->setFlags(0);
+        item->setFlags(Qt::NoItemFlags);
     }
 
     if (m_uniColumn > 0)
@@ -235,14 +235,14 @@ void FixtureTreeWidget::updateFixtureItem(QTreeWidgetItem* item, Fixture* fixtur
             headItem->setData(KColumnName, PROP_HEAD, i);
             if (m_disabledHeads.contains(GroupHead(fixture->id(), i)) == true)
             {
-                headItem->setFlags(0); // Disable selection
+                headItem->setFlags(Qt::NoItemFlags); // Disable selection
                 disabled++;
             }
         }
 
         // Disable the whole fixture if all heads are disabled
         if (disabled == fixture->heads())
-            item->setFlags(0);
+            item->setFlags(Qt::NoItemFlags);
     }
 
     if (m_channelSelection == true)

--- a/ui/src/flowlayout.cpp
+++ b/ui/src/flowlayout.cpp
@@ -114,7 +114,7 @@ QLayoutItem *FlowLayout::takeAt(int index)
 //! [6]
 Qt::Orientations FlowLayout::expandingDirections() const
 {
-    return 0;
+    return Qt::Vertical;
 }
 //! [6]
 

--- a/ui/src/functionselection.cpp
+++ b/ui/src/functionselection.cpp
@@ -339,7 +339,7 @@ void FunctionSelection::refillTree()
         {
             QTreeWidgetItem* item = m_funcTree->addFunction(function->id());
             if (disabledFunctions().contains(function->id()))
-                item->setFlags(0); // Disable the item
+                item->setFlags(Qt::NoItemFlags); // Disable the item
             else
                 item->setSelected(selection.contains(function->id()));
         }

--- a/ui/src/monitor/monitor.h
+++ b/ui/src/monitor/monitor.h
@@ -91,7 +91,7 @@ protected:
     void saveSettings();
 
     /** Protected constructor to prevent multiple instances. */
-    Monitor(QWidget* parent, Doc* doc, Qt::WindowFlags f = 0);
+    Monitor(QWidget* parent, Doc* doc, Qt::WindowFlags f = Qt::Widget);
 
 protected:
     /** The singleton Monitor instance */

--- a/ui/src/monitor/monitorlayout.cpp
+++ b/ui/src/monitor/monitorlayout.cpp
@@ -117,7 +117,7 @@ void MonitorLayout::sort()
 
 Qt::Orientations MonitorLayout::expandingDirections() const
 {
-    return 0;
+    return Qt::Vertical;
 }
 
 bool MonitorLayout::hasHeightForWidth() const

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -475,7 +475,7 @@ void ScriptEditor::slotCheckSyntax()
     }
     else
     {
-        QStringList lines = scriptText.split(QRegExp("(\r\n|\n\r|\r|\n)"), QString::KeepEmptyParts);
+        QStringList lines = scriptText.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
         foreach(int line, errLines)
         {
             errResult.append(tr("Syntax error at line %1:\n%2\n\n").arg(line).arg(lines.at(line - 1)));

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -475,7 +475,7 @@ void ScriptEditor::slotCheckSyntax()
     }
     else
     {
-        QStringList lines = scriptText.split(QRegExp("(\r\n|\n\r|\r|\n)"), Qt::KeepEmptyParts);
+        QStringList lines = scriptText.split(QRegExp("(\r\n|\n\r|\r|\n)"));
         foreach(int line, errLines)
         {
             errResult.append(tr("Syntax error at line %1:\n%2\n\n").arg(line).arg(lines.at(line - 1)));

--- a/ui/test/vcbutton/vcbutton_test.cpp
+++ b/ui/test/vcbutton/vcbutton_test.cpp
@@ -517,10 +517,10 @@ void VCButton_Test::toggle()
 
     // Mouse button press in design mode doesn't toggle the function
     QCOMPARE(m_doc->mode(), Doc::Design);
-    QMouseEvent ev(QEvent::MouseButtonPress, QPoint(0, 0), Qt::LeftButton, 0, 0);
+    QMouseEvent ev(QEvent::MouseButtonPress, QPoint(0, 0), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
     btn.mousePressEvent(&ev);
     QCOMPARE(m_doc->masterTimer()->m_functionList.size(), 0);
-    ev = QMouseEvent(QEvent::MouseButtonRelease, QPoint(0, 0), Qt::LeftButton, 0, 0);
+    ev = QMouseEvent(QEvent::MouseButtonRelease, QPoint(0, 0), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
     btn.mouseReleaseEvent(&ev);
     QCOMPARE(m_doc->masterTimer()->m_functionList.size(), 0);
 
@@ -537,7 +537,7 @@ void VCButton_Test::toggle()
     QCOMPARE(sc->stopped(), false);
     QCOMPARE(btn.state(), VCButton::Active);
 
-    ev = QMouseEvent(QEvent::MouseButtonPress, QPoint(0, 0), Qt::LeftButton, 0, 0);
+    ev = QMouseEvent(QEvent::MouseButtonPress, QPoint(0, 0), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
     btn.mousePressEvent(&ev);
     QCOMPARE(sc->m_stop, true);
     QCOMPARE(btn.state(), VCButton::Active);
@@ -549,7 +549,7 @@ void VCButton_Test::toggle()
     QTest::qWait(500);
     QVERIFY(btn.palette().color(QPalette::Button) == another.palette().color(QPalette::Button));
 
-    ev = QMouseEvent(QEvent::MouseButtonRelease, QPoint(0, 0), Qt::LeftButton, 0, 0);
+    ev = QMouseEvent(QEvent::MouseButtonRelease, QPoint(0, 0), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
     btn.mouseReleaseEvent(&ev);
 }
 

--- a/ui/test/vcwidget/vcwidget_test.cpp
+++ b/ui/test/vcwidget/vcwidget_test.cpp
@@ -937,7 +937,7 @@ void VCWidget_Test::mousePress()
     stub->resize(QSize(20, 20));
     QCOMPARE(stub->pos(), QPoint(0, 0));
 
-    QMouseEvent e(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, 0, 0);
+    QMouseEvent e(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
 
     stub->mousePressEvent(&e);
     QCOMPARE(vc->selectedWidgets().size(), 1);
@@ -945,7 +945,7 @@ void VCWidget_Test::mousePress()
     QCOMPARE(stub->lastClickPoint(), QPoint(10, 10));
     QTest::qWait(10);
 
-    e = QMouseEvent(QEvent::MouseMove, QPoint(20, 20), Qt::NoButton, Qt::LeftButton, 0);
+    e = QMouseEvent(QEvent::MouseMove, QPoint(20, 20), Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
     stub->mouseMoveEvent(&e);
     QTest::qWait(10);
     QCOMPARE(stub->pos(), QPoint(10, 10));

--- a/ui/test/vcxypadarea/vcxypadarea_test.cpp
+++ b/ui/test/vcxypadarea/vcxypadarea_test.cpp
@@ -106,7 +106,7 @@ void VCXYPadArea_Test::mouseEvents()
     VCXYPadArea area(NULL);
     area.resize(QSize(256, 256));
 
-    QMouseEvent e(QEvent::MouseButtonPress, QPoint(20, 30), Qt::LeftButton, 0, 0);
+    QMouseEvent e(QEvent::MouseButtonPress, QPoint(20, 30), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
     area.mousePressEvent(&e);
     QCOMPARE(area.m_dmxPos, QPointF(0, 0));
     QVERIFY(area.cursor().shape() != Qt::CrossCursor);
@@ -116,7 +116,7 @@ void VCXYPadArea_Test::mouseEvents()
     QCOMPARE(area.m_dmxPos, QPointF(20, 30));
     QCOMPARE(area.cursor().shape(), Qt::CrossCursor);
 
-    QMouseEvent e2(QEvent::MouseButtonPress, QPoint(320, 330), Qt::LeftButton, 0, 0);
+    QMouseEvent e2(QEvent::MouseButtonPress, QPoint(320, 330), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
     area.mouseMoveEvent(&e2);
     QCOMPARE(area.m_dmxPos, QPointF(255.0 + 255.0/256, 255.0 + 255.0/256));
     QCOMPARE(area.cursor().shape(), Qt::CrossCursor);

--- a/webaccess/src/webaccessauth.cpp
+++ b/webaccess/src/webaccessauth.cpp
@@ -23,6 +23,9 @@
 #include <QTextStream>
 #include <QStringList>
 #include <QCryptographicHash>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#include <QRandomGenerator>
+#endif
 
 #include "webaccessauth.h"
 #include "qlcconfig.h"
@@ -107,7 +110,7 @@ bool WebAccessAuth::savePasswordsFile() const
             << user.passwordHash << ':'
             << (int)user.level << ':'
             << user.hashType << ':'
-            << user.passwordSalt << endl;
+            << user.passwordSalt << Qt::endl;
     }
 
     return true;
@@ -208,7 +211,11 @@ QString WebAccessAuth::generateSalt() const
 
     for(int i = 0; i < SALT_LENGTH; i++)
     {
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
         int halfByte = qrand() % 16;
+#else
+        int halfByte = QRandomGenerator::global()->generate() % 16;
+#endif
         salt.append(QString::number(halfByte, 16));
     }
 

--- a/webaccess/src/webaccessauth.cpp
+++ b/webaccess/src/webaccessauth.cpp
@@ -110,7 +110,11 @@ bool WebAccessAuth::savePasswordsFile() const
             << user.passwordHash << ':'
             << (int)user.level << ':'
             << user.hashType << ':'
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
             << user.passwordSalt << Qt::endl;
+#else
+            << user.passwordSalt << endl;
+#endif
     }
 
     return true;

--- a/webaccess/src/webaccessauth.cpp
+++ b/webaccess/src/webaccessauth.cpp
@@ -23,7 +23,7 @@
 #include <QTextStream>
 #include <QStringList>
 #include <QCryptographicHash>
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QRandomGenerator>
 #endif
 
@@ -110,7 +110,7 @@ bool WebAccessAuth::savePasswordsFile() const
             << user.passwordHash << ':'
             << (int)user.level << ':'
             << user.hashType << ':'
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             << user.passwordSalt << Qt::endl;
 #else
             << user.passwordSalt << endl;
@@ -215,7 +215,7 @@ QString WebAccessAuth::generateSalt() const
 
     for(int i = 0; i < SALT_LENGTH; i++)
     {
-#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
         int halfByte = qrand() % 16;
 #else
         int halfByte = QRandomGenerator::global()->generate() % 16;


### PR DESCRIPTION
Everything inside Qt5 version checks, so this shouldn't break backwards compatibility.
I hope I'm right assuming (from reading similar fixes I found on the net) that with the the new generator seeding isn't needed anymore in doc.cpp. Otherwise please instruct me regarding a proper way to handle that. 