### PR TITLE
Fix some issues in AppStream MetaInfo

### DIFF
--- a/platforms/linux/org.qlcplus.QLCPlus.appdata.xml
+++ b/platforms/linux/org.qlcplus.QLCPlus.appdata.xml
@@ -81,6 +81,7 @@
  </screenshots>
  <url type="homepage">https://www.qlcplus.org/</url>
  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues</url>
+ <launchable type="desktop-id">qlcplus.desktop</launchable>
  <provides>
   <binary>qlcplus</binary>
  </provides>

--- a/platforms/linux/org.qlcplus.QLCPlus.appdata.xml
+++ b/platforms/linux/org.qlcplus.QLCPlus.appdata.xml
@@ -79,7 +79,7 @@
    <caption>Show Manager</caption>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.qlcplus.org/</url>
+ <url type="homepage">https://www.qlcplus.org/</url>
  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues</url>
  <provides>
   <binary>qlcplus</binary>

--- a/platforms/linux/org.qlcplus.QLCPlusFixtureEditor.appdata.xml
+++ b/platforms/linux/org.qlcplus.QLCPlusFixtureEditor.appdata.xml
@@ -41,7 +41,7 @@
    <caption>Fixture Definition Editor</caption>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.qlcplus.org/</url>
+ <url type="homepage">https://www.qlcplus.org/</url>
  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues</url>
  <provides>
   <binary>qlcplus-fixtureeditor</binary>

--- a/platforms/linux/org.qlcplus.QLCPlusFixtureEditor.appdata.xml
+++ b/platforms/linux/org.qlcplus.QLCPlusFixtureEditor.appdata.xml
@@ -43,6 +43,7 @@
  </screenshots>
  <url type="homepage">https://www.qlcplus.org/</url>
  <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues</url>
+ <launchable type="desktop-id">qlcplus-fixtureeditor.desktop</launchable>
  <provides>
   <binary>qlcplus-fixtureeditor</binary>
  </provides>

--- a/plugins/E1.31/org.qlcplus.QLCPlus.e131.metainfo.xml
+++ b/plugins/E1.31/org.qlcplus.QLCPlus.e131.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>E1.31</name>
   <summary>E1.31 plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[e1.31]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/artnet/src/org.qlcplus.QLCPlus.artnet.metainfo.xml
+++ b/plugins/artnet/src/org.qlcplus.QLCPlus.artnet.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>Artnet</name>
   <summary>ArtNet plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[artnet]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/dmx4linux/org.qlcplus.QLCPlus.dmx4linux.metainfo.xml
+++ b/plugins/dmx4linux/org.qlcplus.QLCPlus.dmx4linux.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>DMX4Linux</name>
   <summary>DMX4Linux plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[DMX4Linux]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/dmxusb/src/org.qlcplus.QLCPlus.dmxusb.metainfo.xml
+++ b/plugins/dmxusb/src/org.qlcplus.QLCPlus.dmxusb.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>DMXUSB</name>
   <summary>DMX USB plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[DMXUSB]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/enttecwing/src/org.qlcplus.QLCPlus.enttecwing.metainfo.xml
+++ b/plugins/enttecwing/src/org.qlcplus.QLCPlus.enttecwing.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>Enttec Wing</name>
   <summary>Enttec Wing plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[enttecwing]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/hid/linux/org.qlcplus.QLCPlus.hid.metainfo.xml
+++ b/plugins/hid/linux/org.qlcplus.QLCPlus.hid.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>Hid</name>
   <summary>HID plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[hid]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/loopback/src/org.qlcplus.QLCPlus.loopback.metainfo.xml
+++ b/plugins/loopback/src/org.qlcplus.QLCPlus.loopback.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>Loopback</name>
   <summary>Loopback plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[e1.31]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/midi/src/org.qlcplus.QLCPlus.midi.metainfo.xml
+++ b/plugins/midi/src/org.qlcplus.QLCPlus.midi.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>Midi</name>
   <summary>MIDI plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[Midi]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/ola/org.qlcplus.QLCPlus.ola.metainfo.xml
+++ b/plugins/ola/org.qlcplus.QLCPlus.ola.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>OLA</name>
   <summary>OLA plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[OLA]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/os2l/org.qlcplus.QLCPlus.os2l.metainfo.xml
+++ b/plugins/os2l/org.qlcplus.QLCPlus.os2l.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>OS2L</name>
   <summary>OS2L plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[OS2L]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/osc/org.qlcplus.QLCPlus.osc.metainfo.xml
+++ b/plugins/osc/org.qlcplus.QLCPlus.osc.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>OSC</name>
   <summary>OSC plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[OSC]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/peperoni/unix/org.qlcplus.QLCPlus.peperoni.metainfo.xml
+++ b/plugins/peperoni/unix/org.qlcplus.QLCPlus.peperoni.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>Peperoni</name>
   <summary>Peperoni plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[peperoni]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/spi/org.qlcplus.QLCPlus.spi.metainfo.xml
+++ b/plugins/spi/org.qlcplus.QLCPlus.spi.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>SPI</name>
   <summary>SPI plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[SPI]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/plugins/udmx/src/org.qlcplus.QLCPlus.udmx.metainfo.xml
+++ b/plugins/udmx/src/org.qlcplus.QLCPlus.udmx.metainfo.xml
@@ -4,7 +4,7 @@
   <extends>org.qlcplus.QLCPlus</extends>
   <name>uDMX</name>
   <summary>uDMX plugin for QLC+</summary>
-  <url type="homepage">http://www.qlcplus.org/</url>
+  <url type="homepage">https://www.qlcplus.org/</url>
   <url type="bugtracker">https://github.com/mcallegari/qlcplus/issues/new?title=[uDMX]:</url>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>Apache-2.0</project_license>


### PR DESCRIPTION
This tries to fix some issues reported by [AppStream Report for Debian](https://appstream.debian.org/sid/main/issues/qlcplus.html):
* **asv-url-not-secure**: use HTTPS in homepage URL of MetaInfo
* **missing-desktop-file**: define `<launchable>` tag in desktop-application MetaInfo to associate it with the .desktop file
* **metainfo-no-summary**: I guess that it would be fixed with the `<launchable>` tag since it is said that either .desktop file should have a `Comment=` field set or the component MetaInfo file should have a `summary` tag - which is the case.