### PR TITLE
Add extraFeedback option for MIDI input channels

### DIFF
--- a/engine/src/qlcinputchannel.cpp
+++ b/engine/src/qlcinputchannel.cpp
@@ -35,6 +35,7 @@ QLCInputChannel::QLCInputChannel()
     , m_movementType(Absolute)
     , m_movementSensitivity(20)
     , m_sendExtraPress(false)
+    , m_extraFeedback(false)
     , m_lower(0)
     , m_upper(UCHAR_MAX)
 {

--- a/engine/src/qlcinputchannel.cpp
+++ b/engine/src/qlcinputchannel.cpp
@@ -48,6 +48,7 @@ QLCInputChannel *QLCInputChannel::createCopy()
     copy->setMovementType(this->movementType());
     copy->setMovementSensitivity(this->movementSensitivity());
     copy->setSendExtraPress(this->sendExtraPress());
+    copy->setExtraFeedback(this->extraFeedback());
     copy->setRange(this->lowerValue(), this->upperValue());
 
     return copy;
@@ -208,6 +209,16 @@ bool QLCInputChannel::sendExtraPress() const
     return m_sendExtraPress;
 }
 
+void QLCInputChannel::setExtraFeedback(bool enable)
+{
+    m_extraFeedback = enable;
+}
+
+bool QLCInputChannel::extraFeedback() const
+{
+    return m_extraFeedback;
+}
+
 void QLCInputChannel::setRange(uchar lower, uchar upper)
 {
     m_lower = lower;
@@ -250,6 +261,11 @@ bool QLCInputChannel::loadXML(QXmlStreamReader &root)
         {
             root.readElementText();
             setSendExtraPress(true);
+        }
+        else if (root.name() == KXMLQLCInputChannelExtraFeedback)
+        {
+            root.readElementText();
+            setExtraFeedback(true);
         }
         else if (root.name() == KXMLQLCInputChannelMovement)
         {
@@ -294,6 +310,8 @@ bool QLCInputChannel::saveXML(QXmlStreamWriter *doc, quint32 channelNumber) cons
     doc->writeTextElement(KXMLQLCInputChannelType, typeToString(m_type));
     if (sendExtraPress() == true)
         doc->writeTextElement(KXMLQLCInputChannelExtraPress, "True");
+    if (extraFeedback() == true)
+        doc->writeTextElement(KXMLQLCInputChannelExtraFeedback, "True");
 
     /* Save only slider's relative movement */
     if ((type() == Slider || type() == Knob) && movementType() == Relative)

--- a/engine/src/qlcinputchannel.h
+++ b/engine/src/qlcinputchannel.h
@@ -47,6 +47,7 @@ class QString;
 #define KXMLQLCInputChannelRelative "Relative"
 #define KXMLQLCInputChannelSensitivity "Sensitivity"
 #define KXMLQLCInputChannelExtraPress "ExtraPress"
+#define KXMLQLCInputChannelExtraFeedback "ExtraFeedback"
 #define KXMLQLCInputChannelFeedbacks "Feedbacks"
 #define KXMLQLCInputChannelLowerValue "LowerValue"
 #define KXMLQLCInputChannelUpperValue "UpperValue"
@@ -155,13 +156,16 @@ protected:
      *********************************************************************/
 public:
     void setSendExtraPress(bool enable);
+    void setExtraFeedback(bool enable);
     bool sendExtraPress() const;
+    bool extraFeedback() const;
     void setRange(uchar lower, uchar upper);
     uchar lowerValue() const;
     uchar upperValue() const;
 
 protected:
     bool m_sendExtraPress;
+    bool m_extraFeedback;
     uchar m_lower, m_upper;
 
     /********************************************************************

--- a/resources/docs/html_en_EN/howto-input-profiles.html
+++ b/resources/docs/html_en_EN/howto-input-profiles.html
@@ -183,17 +183,22 @@ channel value.
 It is possible to change the behaviour of individual buttons from an input profile, and
 the following properties will be used globally in QLC+.
 <br><br>
+
 <B>Generate an extra Press/Release when toggled</B>: this is a quite specific option used for
 example when dealing with TouchOSC or the Behringer BCF2000.<br>
 QLC+ toggle events are triggered when a high+low sequence is received. This means that QLC+ expects a
 non zero value (typically 255) followed by a zero value to toggle, for example, a button.<br>
 Devices like BCF2000 or softwares like TouchOSC, instead, send just a non zero value when activating
 a button, and a zero value when deactivating it.<br>
+When checking this option, QLC+ will generate the "missing" events to standardize the way some controller
+work. So, for example, the BCF2000 will look like sending 255+0 when pressing a button, and
+another 255+0 when pressing it again.<br><br>
+
 <B>Send extra feedback on release</B>: this is a another specific option, used for
 example for the Behringer X Touch Compact.<br>
 Typically, feedback about the button state is only send to the controller, when the state changes. Unless "Send extra feedback on release" is checked, for a toggle buttons this corresponds to a high value being received. Some controllers (such as the Behringer X Touch Compact) turn off the button LED internally, when a button is released. Thus, after releasing a button, it does not represent the state of the virtual console button anymore.<br>
-When checking this option, an additional feedback message is sent, when a low signal is received (i.e. when the controller button is released). This way, the controller's button state is overridden correctly.<br>
-<br><br>
+When checking this option, an additional feedback message is sent, when a low signal is received (i.e. when the controller button is released). This way, the controller's button state is overridden correctly.<br><br>
+
 <B>Custom feedback</B>: with the "Lower value" and "Upper value" boxes, it is possible to force
 custom values to be sent when the selected button sends a non-zero and a zero value.<br>
 For example, with this option it is possible to set globally how Akai APC devices LEDs should be

--- a/resources/docs/html_en_EN/howto-input-profiles.html
+++ b/resources/docs/html_en_EN/howto-input-profiles.html
@@ -189,9 +189,11 @@ QLC+ toggle events are triggered when a high+low sequence is received. This mean
 non zero value (typically 255) followed by a zero value to toggle, for example, a button.<br>
 Devices like BCF2000 or softwares like TouchOSC, instead, send just a non zero value when activating
 a button, and a zero value when deactivating it.<br>
-When checking this option, QLC+ will generate the "missing" events to standardize the way some controller
-work. So, for example, the BCF2000 will look like sending 255+0 when pressing a button, and
-another 255+0 when pressing it again.<br><br>
+<B>Send extra feedback on release</B>: this is a another specific option, used for
+example for the Behringer X Touch Compact.<br>
+Typically, feedback about the button state is only send to the controller, when the state changes. Unless "Send extra feedback on release" is checked, for a toggle buttons this corresponds to a high value being received. Some controllers (such as the Behringer X Touch Compact) turn off the button LED internally, when a button is released. Thus, after releasing a button, it does not represent the state of the virtual console button anymore.<br>
+When checking this option, an additional feedback message is sent, when a low signal is received (i.e. when the controller button is released). This way, the controller's button state is overridden correctly.<br>
+<br><br>
 <B>Custom feedback</B>: with the "Lower value" and "Upper value" boxes, it is possible to force
 custom values to be sent when the selected button sends a non-zero and a zero value.<br>
 For example, with this option it is possible to set globally how Akai APC devices LEDs should be

--- a/resources/schemas/inputprofile.xsd
+++ b/resources/schemas/inputprofile.xsd
@@ -75,6 +75,7 @@ elementFormDefault="qualified"
         <xs:element name="Name" type="xs:string"/>
         <xs:element name="Type" type="channelTypeEnum"/>
         <xs:element name="ExtraPress" type="qlcBool" minOccurs="0"/>
+        <xs:element name="ExtraFeedback" type="qlcBool" minOccurs="0"/>
         <xs:element name="Movement" type="movementType" minOccurs="0"/>
         <xs:element name="Feedbacks" type="feedbackType" minOccurs="0"/>
     </xs:sequence>

--- a/ui/src/inputprofileeditor.cpp
+++ b/ui/src/inputprofileeditor.cpp
@@ -85,6 +85,8 @@ InputProfileEditor::InputProfileEditor(QWidget* parent, QLCInputProfile* profile
             this, SLOT(slotSensitivitySpinChanged(int)));
     connect(m_extraPressCheck, SIGNAL(toggled(bool)),
             this, SLOT(slotExtraPressChecked(bool)));
+    connect(m_extraFeedback, SIGNAL(toggled(bool)),
+            this, SLOT(slotExtraFeedback(bool)));
     connect(m_lowerSpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotLowerValueSpinChanged(int)));
     connect(m_upperSpin, SIGNAL(valueChanged(int)),
@@ -216,6 +218,7 @@ void InputProfileEditor::setOptionsVisibility(QLCInputChannel::Type type)
     m_sensitivityLabel->setVisible(showSensitivity);
     m_sensitivitySpin->setVisible(showSensitivity);
     m_extraPressCheck->setVisible(showButtonOpts);
+    m_extraFeedback->setVisible(showButtonOpts);
     m_feedbackGroup->setVisible(showButtonOpts);
     m_behaviourBox->setVisible(showBox);
 }
@@ -499,6 +502,7 @@ void InputProfileEditor::slotItemClicked(QTreeWidgetItem *item, int col)
         else if (ich->type() == QLCInputChannel::Button)
         {
             m_extraPressCheck->setChecked(ich->sendExtraPress());
+            m_extraFeedback->setChecked(ich->extraFeedback());
             m_lowerSpin->blockSignals(true);
             m_upperSpin->blockSignals(true);
             m_lowerSpin->setValue(ich->lowerValue());
@@ -550,6 +554,15 @@ void InputProfileEditor::slotExtraPressChecked(bool checked)
     {
         if(channel->type() == QLCInputChannel::Button)
             channel->setSendExtraPress(checked);
+    }
+}
+
+void InputProfileEditor::slotExtraFeedback(bool checked)
+{
+    foreach(QLCInputChannel *channel, selectedChannels())
+    {
+        if(channel->type() == QLCInputChannel::Button)
+            channel->setExtraFeedback(checked);
     }
 }
 

--- a/ui/src/inputprofileeditor.h
+++ b/ui/src/inputprofileeditor.h
@@ -78,6 +78,7 @@ protected slots:
     void slotMovementComboChanged(int index);
     void slotSensitivitySpinChanged(int value);
     void slotExtraPressChecked(bool checked);
+    void slotExtraFeedback(bool checked);
     void slotLowerValueSpinChanged(int value);
     void slotUpperValueSpinChanged(int value);
 

--- a/ui/src/inputprofileeditor.ui
+++ b/ui/src/inputprofileeditor.ui
@@ -190,6 +190,13 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0" colspan="4">
+           <widget class="QCheckBox" name="m_extraFeedback">
+            <property name="text">
+             <string>Send extra feedback on release</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -552,8 +552,14 @@ void VCButton::slotInputValueChanged(quint32 universe, quint32 channel, uchar va
         else if (value > 0)
         {
             // Only toggle when the external button is pressed.
-            // Releasing the button does nothing.
             pressFunction();
+        }
+        else if (m_extraFeedbackOnRelease)
+        {
+            // Releasing the button does nothing. Except when the extraFeedback
+            // option of the input channel is set: In that case, we send an
+            // extra feedback update on release.
+            updateFeedback();
         }
     }
 }

--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -637,6 +637,7 @@ void VCWidget::setInputSource(QSharedPointer<QLCInputSource> const& source, quin
                             connect(source.data(), SIGNAL(inputValueChanged(quint32,quint32,uchar)),
                                     this, SLOT(slotInputValueChanged(quint32,quint32,uchar)));
                         }
+                        m_extraFeedbackOnRelease = ich->extraFeedback();
 
                         // user custom feedbacks have precedence over input profile custom feedbacks
                         source->setRange((source->lowerValue() != 0) ? source->lowerValue() : ich->lowerValue(),

--- a/ui/src/virtualconsole/vcwidget.h
+++ b/ui/src/virtualconsole/vcwidget.h
@@ -472,6 +472,7 @@ protected slots:
 
 protected:
     QHash <quint8, QSharedPointer<QLCInputSource> > m_inputs;
+    bool m_extraFeedbackOnRelease = false;
 
     /*********************************************************************
      * Key sequence handler


### PR DESCRIPTION
This patch introduces a new option for input channels in MIDI input profiles. The option is meant to workaround the behaviour of some MIDI controllers, such as the *Behringer X Touch Compact*:

This controller (and probably others?) updates the state of its button LEDs internally, when the button is pressed or released. In the default configuration (buttons send high value when pressed and low value when rleased), the LED is turned off internally, when the button is released. QLC+ only sends feedback signals, when the state of the assigned virtual button changes, which is (for toggle buttons) only upon a high value from the input. Thus, when using such a button with a button widget in QLC+ in toggle mode, the controller's button reflects the virtual button state correctly while being pressed, but is reset incorrectly when being released. In simpler words: The LED stays off after toggling a virtual button on.

A workaround has been proposed in [this thread in the forum](http://www.qlcplus.org/forum/viewtopic.php?t=10943#p56060): The controller's buttons can be configured to work in "toggle" mode, so they send a high value when pressed and released once and a low value when pressed and released a second time. QLC+ supports this behaviour when using the "extra press" input channel option. However, with this configuration change, the buttons cannot be used for flash buttons anymore, since QLC+ does not receive any event on release of the controller's buttons.

So, this PR introduces the new option "Send extra feedback on release", which allows to update the controller's LED state when releasing a button.

Please let me know if I missed something or if the patch does not comply with the coding guidelines.

In particular, I'm unsure if the new `m_extraFeedbackOnRelease` attribute of the `VCWidget` class is the correct way to store this information for making it available to `VCButton::slotInputValueChanged`.