### PR TITLE
Fix broken fixtures

### DIFF
--- a/resources/fixtures/Martin/Martin-MAC-401-Dual-CT.qxf
+++ b/resources/fixtures/Martin/Martin-MAC-401-Dual-CT.qxf
@@ -3,7 +3,7 @@
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
   <Name>Q Light Controller Plus</Name>
-  <Version>4.12.1 GIT</Version>
+  <Version>4.12.4</Version>
   <Author>Tim Cullingworth</Author>
  </Creator>
  <Manufacturer>Martin</Manufacturer>
@@ -361,6 +361,18 @@
   <Channel Number="23">Group D Cold White</Channel>
   <Channel Number="24">Group D CTC</Channel>
   <Head>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
+  </Head>
+  <Head>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+  </Head>
+  <Head>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>19</Channel>
@@ -371,18 +383,6 @@
    <Channel>22</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
-  </Head>
-  <Head>
-   <Channel>25</Channel>
-   <Channel>26</Channel>
-   <Channel>27</Channel>
-   <Channel>28</Channel>
-  </Head>
-  <Head>
-   <Channel>29</Channel>
-   <Channel>30</Channel>
-   <Channel>31</Channel>
-   <Channel>32</Channel>
   </Head>
  </Mode>
  <Mode Name="HSV 2V">
@@ -404,16 +404,16 @@
   <Channel Number="15">Group B Cold White</Channel>
   <Channel Number="16">Group B CTC</Channel>
   <Head>
-   <Channel>17</Channel>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
-   <Channel>20</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
-   <Channel>23</Channel>
-   <Channel>24</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="HSV 2H">
@@ -435,16 +435,16 @@
   <Channel Number="15">Group B Cold White</Channel>
   <Channel Number="16">Group B CTC</Channel>
   <Head>
-   <Channel>17</Channel>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
-   <Channel>20</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
-   <Channel>23</Channel>
-   <Channel>24</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="HSV All">

--- a/resources/fixtures/Martin/Martin-MAC-401-Dual-RGB.qxf
+++ b/resources/fixtures/Martin/Martin-MAC-401-Dual-RGB.qxf
@@ -3,7 +3,7 @@
 <FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
  <Creator>
   <Name>Q Light Controller Plus</Name>
-  <Version>4.12.1 GIT</Version>
+  <Version>4.12.4</Version>
   <Author>Tim Cullingworth</Author>
  </Creator>
  <Manufacturer>Martin</Manufacturer>
@@ -622,6 +622,18 @@
   <Channel Number="23">Group D Blue</Channel>
   <Channel Number="24">Group D CTC</Channel>
   <Head>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
+  </Head>
+  <Head>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>16</Channel>
+   <Channel>15</Channel>
+  </Head>
+  <Head>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>19</Channel>
@@ -632,18 +644,6 @@
    <Channel>22</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
-  </Head>
-  <Head>
-   <Channel>25</Channel>
-   <Channel>26</Channel>
-   <Channel>27</Channel>
-   <Channel>28</Channel>
-  </Head>
-  <Head>
-   <Channel>29</Channel>
-   <Channel>31</Channel>
-   <Channel>30</Channel>
-   <Channel>32</Channel>
   </Head>
  </Mode>
  <Mode Name="HSV 1">
@@ -673,6 +673,18 @@
   <Channel Number="23">Group D Value</Channel>
   <Channel Number="24">Group D CTC</Channel>
   <Head>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
+  </Head>
+  <Head>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+  </Head>
+  <Head>
    <Channel>17</Channel>
    <Channel>18</Channel>
    <Channel>19</Channel>
@@ -683,18 +695,6 @@
    <Channel>22</Channel>
    <Channel>23</Channel>
    <Channel>24</Channel>
-  </Head>
-  <Head>
-   <Channel>25</Channel>
-   <Channel>26</Channel>
-   <Channel>27</Channel>
-   <Channel>28</Channel>
-  </Head>
-  <Head>
-   <Channel>29</Channel>
-   <Channel>30</Channel>
-   <Channel>31</Channel>
-   <Channel>32</Channel>
   </Head>
  </Mode>
  <Mode Name="RGB 2V">
@@ -716,16 +716,16 @@
   <Channel Number="15">Group B Blue</Channel>
   <Channel Number="16">Group B CTC</Channel>
   <Head>
-   <Channel>17</Channel>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
-   <Channel>20</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
-   <Channel>23</Channel>
-   <Channel>24</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="HSV 2V">
@@ -747,16 +747,16 @@
   <Channel Number="15">Group B Value</Channel>
   <Channel Number="16">Group B CTC</Channel>
   <Head>
-   <Channel>17</Channel>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
-   <Channel>20</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
-   <Channel>23</Channel>
-   <Channel>24</Channel>
+   <Channel>14</Channel>
+   <Channel>13</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="RGB 2H">
@@ -778,16 +778,16 @@
   <Channel Number="15">Group B Blue</Channel>
   <Channel Number="16">Group B CTC</Channel>
   <Head>
-   <Channel>17</Channel>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
-   <Channel>20</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
-   <Channel>23</Channel>
-   <Channel>24</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="HSV 2H">
@@ -809,16 +809,16 @@
   <Channel Number="15">Group B Value</Channel>
   <Channel Number="16">Group B CTC</Channel>
   <Head>
-   <Channel>17</Channel>
-   <Channel>18</Channel>
-   <Channel>19</Channel>
-   <Channel>20</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
   </Head>
   <Head>
-   <Channel>21</Channel>
-   <Channel>22</Channel>
-   <Channel>23</Channel>
-   <Channel>24</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
   </Head>
  </Mode>
  <Mode Name="RGB All">

--- a/resources/fixtures/Stairville/StairVille-MH-z720.qxf
+++ b/resources/fixtures/Stairville/StairVille-MH-z720.qxf
@@ -225,7 +225,6 @@
    <Channel>7</Channel>
    <Channel>6</Channel>
    <Channel>5</Channel>
-   <Channel>24</Channel>
    <Channel>8</Channel>
   </Head>
   <Head>
@@ -233,12 +232,10 @@
    <Channel>11</Channel>
    <Channel>10</Channel>
    <Channel>9</Channel>
-   <Channel>24</Channel>
   </Head>
   <Head>
    <Channel>13</Channel>
    <Channel>16</Channel>
-   <Channel>24</Channel>
    <Channel>15</Channel>
    <Channel>14</Channel>
   </Head>
@@ -247,7 +244,6 @@
    <Channel>18</Channel>
    <Channel>17</Channel>
    <Channel>20</Channel>
-   <Channel>24</Channel>
   </Head>
  </Mode>
  <Physical>

--- a/resources/fixtures/UKing/UKing-7x10W-Mini-Moving-Head.qxf
+++ b/resources/fixtures/UKing/UKing-7x10W-Mini-Moving-Head.qxf
@@ -6,7 +6,7 @@
   <Version>4.12.4</Version>
   <Author>Peter Crowther</Author>
  </Creator>
- <Manufacturer>U'King</Manufacturer>
+ <Manufacturer>UKing</Manufacturer>
  <Model>7x10W Mini Moving Head</Model>
  <Type>Moving Head</Type>
  <Channel Name="Pan" Preset="PositionPan"/>


### PR DESCRIPTION
We found 4 broken fixtures in the library and we fixed it. Generally, it was a problem with indexes and dimmer share across multiple heads.