### PR TITLE
Account for channel value modifed with VC widget page value when using MIDI feedback for OMNI channel.

### DIFF
--- a/plugins/midi/src/common/midiprotocol.cpp
+++ b/plugins/midi/src/common/midiprotocol.cpp
@@ -127,8 +127,9 @@ bool QLCMIDIProtocol::feedbackToMidi(quint32 channel, uchar value,
                                      uchar* data1, uchar* data2)
 {
     // for OMNI mode, retrieve the original MIDI channel where data was sent
+    // account for cases where channel has been modified with VC widget page info
     if (midiChannel == MAX_MIDI_CHANNELS)
-        midiChannel = channel >> 12;
+        midiChannel = (channel >> 12) % MAX_MIDI_CHANNELS;
 
     // Remove the 4 MSB bits to retrieve the QLC+ channel to be processed
     channel = channel & 0x0FFF;

--- a/plugins/midi/test/midi_test.cpp
+++ b/plugins/midi/test/midi_test.cpp
@@ -57,7 +57,7 @@ void Midi_Test::feedbackToMidi()
 
     QLCMIDIProtocol::feedbackToMidi(channel, value, midiChannel, false, &cmd, &data1, &data2);
 
-    QCOMPARE(cmd, MIDI_PROGRAM_CHANGE | midiChannel);
+    QCOMPARE(cmd, uchar(MIDI_PROGRAM_CHANGE | midiChannel));
     QCOMPARE(data1, uchar(2U));
 }
 
@@ -73,7 +73,7 @@ void Midi_Test::feedbackToMidi_omni()
 
     QLCMIDIProtocol::feedbackToMidi(channel, value, midiChannel, false, &cmd, &data1, &data2);
 
-    QCOMPARE(cmd, MIDI_PROGRAM_CHANGE | 0x05);
+    QCOMPARE(cmd, uchar(MIDI_PROGRAM_CHANGE | 0x05));
     QCOMPARE(data1, uchar(127U));
 }
 
@@ -89,7 +89,7 @@ void Midi_Test::feedbackToMidi_omni_paged()
 
     QLCMIDIProtocol::feedbackToMidi(channel, value, midiChannel, false, &cmd, &data1, &data2);
 
-    QCOMPARE(cmd, MIDI_PROGRAM_CHANGE | 0x05);
+    QCOMPARE(cmd, uchar(MIDI_PROGRAM_CHANGE | 0x05));
     QCOMPARE(data1, uchar(127U));
 }
 

--- a/plugins/midi/test/midi_test.cpp
+++ b/plugins/midi/test/midi_test.cpp
@@ -45,4 +45,52 @@ void Midi_Test::midiToInput()
     QCOMPARE(value, uchar(255U));
 }
 
+void Midi_Test::feedbackToMidi()
+{
+    uchar cmd = 0;
+    uchar data1 = 0;
+    uchar data2 = 0;
+
+    quint32 channel = 387;
+    uchar value = 4;
+    uchar midiChannel = 7;
+
+    QLCMIDIProtocol::feedbackToMidi(channel, value, midiChannel, false, &cmd, &data1, &data2);
+
+    QCOMPARE(cmd, MIDI_PROGRAM_CHANGE | midiChannel);
+    QCOMPARE(data1, uchar(2U));
+}
+
+void Midi_Test::feedbackToMidi_omni()
+{
+    uchar cmd = 0;
+    uchar data1 = 0;
+    uchar data2 = 0;
+
+    quint32 channel = 20866;
+    uchar value = 255;
+    uchar midiChannel = MAX_MIDI_CHANNELS;
+
+    QLCMIDIProtocol::feedbackToMidi(channel, value, midiChannel, false, &cmd, &data1, &data2);
+
+    QCOMPARE(cmd, MIDI_PROGRAM_CHANGE | 0x05);
+    QCOMPARE(data1, uchar(127U));
+}
+
+void Midi_Test::feedbackToMidi_omni_paged()
+{
+    uchar cmd = 0;
+    uchar data1 = 0;
+    uchar data2 = 0;
+
+    quint32 channel = 20866 | 17 << 16;
+    uchar value = 255;
+    uchar midiChannel = MAX_MIDI_CHANNELS;
+
+    QLCMIDIProtocol::feedbackToMidi(channel, value, midiChannel, false, &cmd, &data1, &data2);
+
+    QCOMPARE(cmd, MIDI_PROGRAM_CHANGE | 0x05);
+    QCOMPARE(data1, uchar(127U));
+}
+
 QTEST_MAIN(Midi_Test)

--- a/plugins/midi/test/midi_test.h
+++ b/plugins/midi/test/midi_test.h
@@ -28,6 +28,9 @@ class Midi_Test : public QObject
 
 private slots:
     void midiToInput();
+    void feedbackToMidi();
+    void feedbackToMidi_omni();
+    void feedbackToMidi_omni_paged();
 };
 
 #endif


### PR DESCRIPTION
VC frame pages encode their value in the channel value sent to the plugin, when using the MIDI OMNI
channel, this gets embedded in the bits which define the MIDI channel to send a feedback message on.
Take off the embedded page data to get the correct MIDI channel for sending feedback.

Add some simple test cases to validate the change.

[Forum discussion](https://www.qlcplus.org/forum/viewtopic.php?f=33&t=14709)