### PR TITLE
Make detached contexts apply the Qt style sheet

### DIFF
--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -1162,7 +1162,7 @@ void App::slotDetachContext(int index)
 
     qDebug() << "Detaching context" << context;
 
-    DetachedContext *detachedWindow = new DetachedContext();
+    DetachedContext *detachedWindow = new DetachedContext(this);
     detachedWindow->setCentralWidget(context);
     detachedWindow->resize(800, 600);
     detachedWindow->show();

--- a/ui/src/app.h
+++ b/ui/src/app.h
@@ -57,7 +57,7 @@ class DetachedContext : public QMainWindow
     Q_OBJECT
 
 public:
-    DetachedContext() {}
+    DetachedContext(QWidget *parent) : QMainWindow(parent) {}
 
 protected slots:
     void closeEvent(QCloseEvent *ev)


### PR DESCRIPTION
When detaching a context the Qt style sheet is not applied to the new window. This is because DetachedContext does not call QMainWindow::setStyleSheet() nor set any parent where the style sheet could be inherited from.

Disclaimer: This patch is only tested on Linux (Ubuntu 20.04.2 LTS). I have no idea if setting the main window as parent might have any other unforeseen consequences. Everything seems to work as usual.