### PR TITLE
fix handling of two deprecated Qt5 enum value names

### DIFF
--- a/ui/src/addfixture.ui
+++ b/ui/src/addfixture.ui
@@ -89,11 +89,8 @@
       </item>
       <item row="3" column="2">
        <widget class="QComboBox" name="m_universeCombo">
-        <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-        </property>
-        <property name="minimumContentsLength">
-         <number>16</number>
+        <property name="toolTip">
+         <string>Add fixture to this universe</string>
         </property>
        </widget>
       </item>

--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -1292,7 +1292,7 @@ void VCWidget::mousePressEvent(QMouseEvent* e)
     }
 
     /* Move, resize or context menu invocation */
-    if (e->button() & Qt::LeftButton || e->button() & Qt::MidButton)
+    if (e->button() & Qt::LeftButton || e->button() & Qt::MiddleButton)
     {
         /* Start moving or resizing based on where the click landed */
         if (e->x() > rect().width() - 10 && e->y() > rect().height() - 10 && allowResize())
@@ -1384,7 +1384,7 @@ void VCWidget::mouseMoveEvent(QMouseEvent* e)
             resize(QSize(p.x() - x(), p.y() - y()));
             m_doc->setModified();
         }
-        else if (e->buttons() & Qt::LeftButton || e->buttons() & Qt::MidButton)
+        else if (e->buttons() & Qt::LeftButton || e->buttons() & Qt::MiddleButton)
         {
             QPoint p = mapToParent(e->pos());
             p.setX(p.x() - m_mousePressPoint.x());


### PR DESCRIPTION
Once again I'm getting warnings (treated as errors) breaking compilation for Tumbleweed in OBS, so I've removed the QComboBox::AdjustToMinimumContentsLength property as it seems unnecessary (the QComboBox above it doesn't have this either), and instead added a tooltip even if the meaning of that choice should be totally clear.

The second change of 2 instances from now deprecated Qt::MidButton to Qt::MiddleButton, which seems to be around already since Qt 4.6.0.