### PR TITLE
Use the full path for comparison to fix a test failure in the qmlui build

### DIFF
--- a/engine/test/inputoutputmap/inputoutputmap_test.cpp
+++ b/engine/test/inputoutputmap/inputoutputmap_test.cpp
@@ -615,9 +615,11 @@ void InputOutputMap_Test::inputSourceNames()
 void InputOutputMap_Test::profileDirectories()
 {
     QDir dir = InputOutputMap::systemProfileDirectory();
+    QDir ipDir;
+    ipDir.setPath(INPUTPROFILEDIR);
     QVERIFY(dir.filter() & QDir::Files);
     QVERIFY(dir.nameFilters().contains(QString("*%1").arg(KExtInputProfile)));
-    QVERIFY(dir.absolutePath().contains(INPUTPROFILEDIR));
+    QCOMPARE(dir.absolutePath(), ipDir.absolutePath());
 
     dir = InputOutputMap::userProfileDirectory();
 #ifndef SKIP_TEST
@@ -626,7 +628,6 @@ void InputOutputMap_Test::profileDirectories()
     QVERIFY(dir.filter() & QDir::Files);
     QVERIFY(dir.nameFilters().contains(QString("*%1").arg(KExtInputProfile)));
     QVERIFY(dir.absolutePath().contains(USERINPUTPROFILEDIR));
-
 }
 
 void InputOutputMap_Test::claimReleaseDumpReset()

--- a/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp
+++ b/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp
@@ -198,9 +198,12 @@ void QLCFixtureDefCache_Test::load()
 void QLCFixtureDefCache_Test::defDirectories()
 {
     QDir dir = QLCFixtureDefCache::systemDefinitionDirectory();
+
     QVERIFY(dir.filter() & QDir::Files);
     QVERIFY(dir.nameFilters().contains(QString("*%1").arg(KExtFixture)));
-    QVERIFY(dir.absolutePath().contains(FIXTUREDIR));
+    QDir fxDir;
+    fxDir.setPath(FIXTUREDIR);
+    QCOMPARE(dir.absolutePath(), fxDir.absolutePath());
 
     dir = QLCFixtureDefCache::userDefinitionDirectory();
 #ifndef SKIP_TEST


### PR DESCRIPTION
Hi, this is part one of the CPP files patches to fix problems when running the unittests in a QMLUI environment under Linux.
This patch addresses the comparison of path names, when done relatively, there is no "contains" match due to the leading "./" in the relative path that is compared.