### PR TITLE
Fix script bracket parsing and add line number to usage list.

### DIFF
--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -1158,6 +1158,10 @@ QList<quint32> Doc::getUsage(quint32 fid)
                 {
                     if (l.at(i) == fid)
                     {
+                        if (i + 1 >= l.count()) {
+                            qDebug() << "Doc::getUsage: Index entry missing on " << f->name();
+                            break;
+                        }
                         usageList.append(s->id());
                         usageList.append(l.at(i + 1)); // line number
                     }

--- a/engine/src/scriptv4.cpp
+++ b/engine/src/scriptv4.cpp
@@ -33,13 +33,18 @@
 #define KXMLQLCScriptCommand "Command"
 #define KXMLQLCScriptVersion "Version"
 
-const QString Script::startFunctionCmd = QString("startfunction");
-const QString Script::stopFunctionCmd = QString("stopfunction");
-const QString Script::blackoutCmd = QString("blackout");
-const QString Script::waitCmd = QString("wait");
-const QString Script::setFixtureCmd = QString("setfixture");
-const QString Script::systemCmd = QString("systemcommand");
-
+const QString Script::startFunctionLegacy = QString("startfunction");
+const QString Script::startFunctionCmd = QString("Engine.startFunction");
+const QString Script::stopFunctionLegacy = QString("stopfunction");
+const QString Script::stopFunctionCmd = QString("Engine.stopFunction");
+const QString Script::blackoutLegacy = QString("blackout");
+const QString Script::blackoutCmd = QString("Engine.setBlackout");
+const QString Script::waitLegacy = QString("wait");
+const QString Script::waitCmd = QString("Engine.waitTime");
+const QString Script::setFixtureLegacy = QString("setfixture");
+const QString Script::setFixtureCmd = QString("Engine.setFixture");
+const QString Script::systemLegacy = QString("systemcommand");
+const QString Script::systemCmd = QString("Engine.systemCommand");
 const QStringList knownKeywords(QStringList() << "ch" << "val" << "arg");
 
 /****************************************************************************
@@ -149,22 +154,32 @@ QStringList Script::dataLines() const
 QList<quint32> Script::functionList() const
 {
     QList<quint32> list;
+    int count = 0;
 
     foreach (QString line, dataLines())
     {
-        if (line.contains("startFunction") || line.contains("stopFunction"))
+        count ++;
+        if (line.startsWith(startFunctionCmd + "(") ||
+                line.startsWith(stopFunctionCmd + "("))
         {
             QStringList tokens = line.split("(");
             if (tokens.isEmpty() || tokens.count() < 2)
                 continue;
 
-            QStringList params = tokens[1].split(",");
+            tokens = tokens[1].split(")");
+            if (tokens.isEmpty() || tokens.count() < 2)
+                continue;
+
+            QStringList params = tokens[0].split(",");
             if (tokens.isEmpty())
                 continue;
 
             quint32 funcID = params[0].toUInt();
             if (list.contains(funcID) == false)
+            {
                 list.append(funcID);
+                list.append(count - 1);
+            }
         }
     }
 
@@ -405,7 +420,7 @@ QString Script::convertLine(const QString& str, bool *ok)
         int right = line.indexOf(":", left);
         if (right == -1)
         {
-            qDebug() << "Syntax error:" << line.mid(left);
+            qDebug() << "Syntax error (colon missing after keyword):" << line.mid(left);
             if (ok != NULL)
                 *ok = false;
             break;
@@ -435,7 +450,7 @@ QString Script::convertLine(const QString& str, bool *ok)
             }
             else
             {
-                qDebug() << "Syntax error:" << line.mid(quoteleft);
+                qDebug() << "Syntax error (unbalanced quotes):" << line.mid(quoteleft);
                 if (ok != NULL)
                     *ok = false;
                 break;
@@ -447,7 +462,7 @@ QString Script::convertLine(const QString& str, bool *ok)
             right = line.indexOf(QRegExp("\\s"), left);
             if (right == -1)
             {
-                qDebug() << "Syntax error:" << line.mid(left);
+                qDebug() << "Syntax error (whitespace before value missing):" << line.mid(left);
                 if (ok != NULL)
                     *ok = false;
                 break;
@@ -487,7 +502,7 @@ QString Script::convertLine(const QString& str, bool *ok)
 
                 value = QString("Engine.random(%1,%2)").arg(min).arg(max);
             }
-            else if (command == waitCmd)
+            else if (command == waitLegacy)
             {
                 if (value.contains("s") || value.contains("m") || value.contains("h"))
                 {
@@ -500,7 +515,7 @@ QString Script::convertLine(const QString& str, bool *ok)
         }
     }
 
-    if (command == systemCmd)
+    if (command == systemLegacy)
     {
         QString cmd = values.join(" ");
         cmd.prepend("\"");
@@ -530,12 +545,12 @@ QString Script::convertLine(const QString& str, bool *ok)
 
 QString Script::convertLegacyMethod(QString method)
 {
-    if (method == startFunctionCmd) return "Engine.startFunction";
-    else if (method == stopFunctionCmd) return "Engine.stopFunction";
-    else if (method == blackoutCmd) return "Engine.setBlackout";
-    else if (method == waitCmd) return "Engine.waitTime";
-    else if (method == setFixtureCmd) return "Engine.setFixture";
-    else if (method == systemCmd) return "Engine.systemCommand";
+    if (method == startFunctionLegacy) return startFunctionCmd;
+    else if (method == stopFunctionLegacy) return stopFunctionCmd;
+    else if (method == blackoutLegacy) return blackoutCmd;
+    else if (method == waitLegacy) return waitCmd;
+    else if (method == setFixtureLegacy) return setFixtureCmd;
+    else if (method == systemLegacy) return systemCmd;
     else return "";
 }
 

--- a/engine/src/scriptv4.h
+++ b/engine/src/scriptv4.h
@@ -43,17 +43,20 @@ class Script : public Function
      * Script keywords
      ************************************************************************/
 public:
+    static const QString startFunctionLegacy;
     static const QString startFunctionCmd;
+    static const QString stopFunctionLegacy;
     static const QString stopFunctionCmd;
+    static const QString blackoutLegacy;
     static const QString blackoutCmd;
 
+    static const QString waitLegacy;
     static const QString waitCmd;
 
+    static const QString setFixtureLegacy;
     static const QString setFixtureCmd;
+    static const QString systemLegacy;
     static const QString systemCmd;
-
-    static const QString blackoutOn;
-    static const QString blackoutOff;
 
     /************************************************************************
      * Initialization

--- a/engine/test/doc/doc_test.cpp
+++ b/engine/test/doc/doc_test.cpp
@@ -866,64 +866,77 @@ void Doc_Test::usage()
 
     Scene *s5 = new Scene(m_doc);
     m_doc->addFunction(s5);
+    QVERIFY(m_doc->functions().count() == 5);
 
     Chaser *c1 = new Chaser(m_doc);
     ChaserStep cs1(s1->id());
     ChaserStep cs2(s5->id());
     c1->addStep(cs1);
     c1->addStep(cs2);
+    QVERIFY(c1->stepsCount() == 2);
     m_doc->addFunction(c1);
+    QVERIFY(m_doc->functions().count() == 6);
+
 
     Collection *col1 = new Collection(m_doc);
     col1->addFunction(s2->id());
     col1->addFunction(s5->id());
+    QVERIFY(col1->functions().count() == 2);
     m_doc->addFunction(col1);
+    QVERIFY(m_doc->functions().count() == 7);
 
     Sequence *seq1 = new Sequence(m_doc);
     seq1->setBoundSceneID(s4->id());
     m_doc->addFunction(seq1);
+    QVERIFY(m_doc->functions().count() == 8);
 
     Script *sc1 = new Script(m_doc);
     sc1->appendData(QString("startfunction:%1").arg(c1->id()));
     m_doc->addFunction(sc1);
-
     QVERIFY(m_doc->functions().count() == 9);
 
     QList<quint32> usage;
 
     /* check the usage of an invalid ID */
+    qDebug() << "Check the usage of an invalid ID";
     usage = m_doc->getUsage(100);
     QVERIFY(usage.count() == 0);
 
     /* check the usage of an unused function */
+    qDebug() << "Check the usage of an unused function";
     usage = m_doc->getUsage(s3->id());
     QVERIFY(usage.count() == 0);
 
     /* check usage of a Scene used by a Chaser */
+    qDebug() << "Check usage of a Scene used by a Chaser";
     usage = m_doc->getUsage(s1->id());
     QVERIFY(usage.count() == 2);
     QVERIFY(usage.at(0) == c1->id());
     QVERIFY(usage.at(1) == 0); // step 0
 
     /* check usage of a Scene used by a Sequence */
+    qDebug() << "Check usage of a Scene used by a Sequence";
     usage = m_doc->getUsage(s4->id());
     QVERIFY(usage.count() == 2);
     QVERIFY(usage.at(0) == seq1->id());
     QVERIFY(usage.at(1) == 0); // no info
 
     /* check usage of a Scene used by a Collection */
+    qDebug() << "Check usage of a Scene used by a Collection";
     usage = m_doc->getUsage(s2->id());
     QVERIFY(usage.count() == 2);
     QVERIFY(usage.at(0) == col1->id());
     QVERIFY(usage.at(1) == 0); // index 0
 
     /* check usage of a Chaser used by a Script */
+    qDebug() << "Check usage of a Chaser used by a Script";
     usage = m_doc->getUsage(c1->id());
     QVERIFY(usage.count() == 2);
     QVERIFY(usage.at(0) == sc1->id());
     QVERIFY(usage.at(1) == 0); // line 1
 
     /* check usage of shared function */
+    qDebug() << "Check usage of shared function";
     usage = m_doc->getUsage(s5->id());
     QVERIFY(usage.count() == 4);
     QVERIFY(usage.at(0) == c1->id());
@@ -932,6 +945,7 @@ void Doc_Test::usage()
     QVERIFY(usage.at(3) == 1); // index 1
 
     /* test also the function by type method */
+    qDebug() << "Test also the function by type method";
     QList<Function *> byType = m_doc->functionsByType(Function::SceneType);
     QVERIFY(byType.count() == 5);
     QVERIFY(byType.at(0) == s1);


### PR DESCRIPTION
Hi, this is part two of the CPP files patches to fix problems when running the unittests in a QMLUI environment under Linux.
This patch addresses the new scriptv4 "functionlist" handling which lacked the second information in the list, which is the line number. The doc.cpp failed with an index out of bound error, which is now leading to a debug message. The keywords and translation from legacy to v4 is now more explicit between the versions.