### PR TITLE
Choose an common test entry point for script.cpp and scriptv4.cpp

### DIFF
--- a/engine/test/script/script_test.cpp
+++ b/engine/test/script/script_test.cpp
@@ -61,11 +61,9 @@ void Script_Test::initial()
 
     Script scr(&doc);
     scr.setData(script0);
+    scr.start(doc.masterTimer(), FunctionParent::master());
 
-    for (int i = 0; i < 11; i++)
-    {
-        scr.executeCommand(i, doc.masterTimer(), ua);
-    }
+    scr.write(doc.masterTimer(), ua);
 }
 
 QTEST_APPLESS_MAIN(Script_Test)

--- a/engine/test/script/script_test.cpp
+++ b/engine/test/script/script_test.cpp
@@ -62,8 +62,11 @@ void Script_Test::initial()
     Script scr(&doc);
     scr.setData(script0);
     scr.start(doc.masterTimer(), FunctionParent::master());
+    scr.preRun(doc.masterTimer());
 
     scr.write(doc.masterTimer(), ua);
+
+    scr.postRun(doc.masterTimer(), ua);
 }
 
 QTEST_APPLESS_MAIN(Script_Test)


### PR DESCRIPTION
Hello Massimo,

The original Script::executeCommand is not part of scriptv4, so the test needs to use another entry point in order to also work for scriptv4.

Nevertheless, please check the test as it does not seem to implement any useful outcome (it seeds a script with syntax errors, but does not even check the reaction on these), but at least now it compiles.