### PR TITLE
Change the FlowLayout from vertical to horizontal.

### DIFF
--- a/ui/src/flowlayout.cpp
+++ b/ui/src/flowlayout.cpp
@@ -114,7 +114,7 @@ QLayoutItem *FlowLayout::takeAt(int index)
 //! [6]
 Qt::Orientations FlowLayout::expandingDirections() const
 {
-    return Qt::Vertical;
+    return Qt::Horizontal;
 }
 //! [6]
 


### PR DESCRIPTION
This fixes #1284 - [ui] XY Pad doesn't scale correctly.

Between 4052a1b (10.06.2020) and 8e24317 (13.06.2020) the value was set
from zero to Qt::Vertical, which caused the xy pad to display incorrectly.

The original return value was zero, the enumeration is:
    enum Orientation {
        Horizontal = 0x1,
        Vertical = 0x2
    };