### PR TITLE
Add support for FTDI USB-COM485-PLUS2 for DMX USB Interface

### DIFF
--- a/plugins/dmxusb/src/dmxinterface.cpp
+++ b/plugins/dmxusb/src/dmxinterface.cpp
@@ -78,6 +78,7 @@ bool DMXInterface::validInterface(quint16 vendor, quint16 product)
             return false;
 
     if (product != DMXInterface::FTDIPID &&
+        product != DMXInterface::FTDI2PID &&
         product != DMXInterface::DMX4ALLPID &&
         product != DMXInterface::NANODMXPID &&
         product != DMXInterface::EUROLITEPID &&

--- a/plugins/dmxusb/src/dmxinterface.h
+++ b/plugins/dmxusb/src/dmxinterface.h
@@ -89,6 +89,7 @@ public:
     static const int ATMELVID = 0x03EB;     //! Atmel Vendor ID
     static const int MICROCHIPVID = 0x04D8; //! Microchip Vendor ID
     static const int FTDIPID = 0x6001;      //! FTDI Product ID
+    static const int FTDI2PID = 0x6010;     //! FTDI COM485-PLUS2 Product ID
     static const int DMX4ALLPID = 0xC850;   //! DMX4ALL FTDI Product ID
     static const int NANODMXPID = 0x2018;   //! DMX4ALL Nano DMX Product ID
     static const int EUROLITEPID = 0xFA63;  //! Eurolite USB DMX Product ID


### PR DESCRIPTION
This has been tested and works fine using port #0 on the unit i.e.
port closest to the USB connector.