### PR TITLE
Do not load RGBscript files which are not script files

### DIFF
--- a/engine/src/rgbscriptscache.cpp
+++ b/engine/src/rgbscriptscache.cpp
@@ -69,6 +69,11 @@ bool RGBScriptsCache::load(const QDir& dir)
 
     foreach (QString file, dir.entryList())
     {
+        if (!file.toLower().endsWith(".js") || file.endsWith("devtool.js"))
+        {
+            qDebug() << "    " << file << " skipped (special file or does not end on *.js)";
+            continue;
+        }
         if (!m_scriptsMap.contains(file))
         {
             RGBScript* script = new RGBScript(m_doc);

--- a/engine/src/rgbscriptscache.cpp
+++ b/engine/src/rgbscriptscache.cpp
@@ -69,7 +69,7 @@ bool RGBScriptsCache::load(const QDir& dir)
 
     foreach (QString file, dir.entryList())
     {
-        if (!file.toLower().endsWith(".js") || file.endsWith("devtool.js"))
+        if (!file.toLower().endsWith(".js"))
         {
             qDebug() << "    " << file << " skipped (special file or does not end on *.js)";
             continue;

--- a/engine/test/rgbscript/rgbscript_test.cpp
+++ b/engine/test/rgbscript/rgbscript_test.cpp
@@ -204,6 +204,9 @@ void RGBScript_Test::rgbMap()
 void RGBScript_Test::runScripts()
 {
     QSize mapSize = QSize(7, 11); // Use different numbers for x and y for the test
+    // QColor(Qt::red).rgb() is 0xffff0000 due to the alpha channel
+    // This test also wants to test that there is no color space overrun.
+    int red = 0xff0000;
 
     // Iterate the list of scripts
     QStringList names = m_doc->rgbScriptsCache()->names();
@@ -253,14 +256,20 @@ void RGBScript_Test::runScripts()
         for (int step = 0; step < realsteps; step++)
         {
             RGBMap map;
-            s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+            s.rgbMap(mapSize, red, step, map);
             QVERIFY(map.isEmpty() == false);
             // Check that the color values are limited to a valid range
-            for (int y = 0; y < 5; y++)
+            for (int y = 0; y < mapSize.height(); y++)
             {
-                for (int x = 0; x < 5; x++)
+                for (int x = 0; x < mapSize.width(); x++)
                 {
-                    QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                    //if (map[y][x] > 0x00ffffff) {
+                    //    uint pxr = (map[y][x] >> 16 & 0x000000ff);
+                    //    uint pxg = (map[y][x] >> 8 & 0x000000ff);
+                    //    uint pxb = (map[y][x] & 0x000000ff);
+                    //    qDebug() << "C:" << Qt::hex << pxr << ":" << Qt::hex << pxg << ":" << Qt::hex << pxb << " (" << Qt::hex << map[y][x]<< ")";
+                    //}
+                    QVERIFY(map[y][x] <= 0xffffff);
                 }
             }
         }
@@ -305,14 +314,14 @@ void RGBScript_Test::runScripts()
                         for (int step = 0; step < realsteps; step++)
                         {
                             RGBMap map;
-                            s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                            s.rgbMap(mapSize, red, step, map);
                             QVERIFY(map.isEmpty() == false);
                             // Check that the color values are limited to a valid range
-                            for (int y = 0; y < 5; y++)
+                            for (int y = 0; y < mapSize.height(); y++)
                             {
-                                for (int x = 0; x < 5; x++)
+                                for (int x = 0; x < mapSize.width(); x++)
                                 {
-                                    QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                                    QVERIFY(map[y][x] <= 0xffffff);
                                 }
                             }
                         }
@@ -334,14 +343,14 @@ void RGBScript_Test::runScripts()
                     for (int step = 0; step < realsteps; step++)
                     {
                         RGBMap map;
-                        s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                        s.rgbMap(mapSize, red, step, map);
                         QVERIFY(map.isEmpty() == false);
                         // Check that the color values are limited to a valid range
-                        for (int y = 0; y < 5; y++)
+                        for (int y = 0; y < mapSize.height(); y++)
                         {
-                            for (int x = 0; x < 5; x++)
+                            for (int x = 0; x < mapSize.width(); x++)
                             {
-                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                                QVERIFY(map[y][x] <= 0xffffff);
                             }
                         }
                     }
@@ -352,14 +361,14 @@ void RGBScript_Test::runScripts()
                     for (int step = 0; step < realsteps; step++)
                     {
                         RGBMap map;
-                        s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                        s.rgbMap(mapSize, red, step, map);
                         QVERIFY(map.isEmpty() == false);
                         // Check that the color values are limited to a valid range
-                        for (int y = 0; y < 5; y++)
+                        for (int y = 0; y < mapSize.height(); y++)
                         {
-                            for (int x = 0; x < 5; x++)
+                            for (int x = 0; x < mapSize.width(); x++)
                             {
-                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                                QVERIFY(map[y][x] <= 0xffffff);
                             }
                         }
                     }
@@ -372,14 +381,14 @@ void RGBScript_Test::runScripts()
                     for (int step = 0; step < realsteps; step++)
                     {
                         RGBMap map;
-                        s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                        s.rgbMap(mapSize, red, step, map);
                         QVERIFY(map.isEmpty() == false);
                         // Check that the color values are limited to a valid range
-                        for (int y = 0; y < 5; y++)
+                        for (int y = 0; y < mapSize.height(); y++)
                         {
-                            for (int x = 0; x < 5; x++)
+                            for (int x = 0; x < mapSize.width(); x++)
                             {
-                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                                QVERIFY(map[y][x] <= 0xffffff);
                             }
                         }
                     }
@@ -392,14 +401,14 @@ void RGBScript_Test::runScripts()
                     for (int step = 0; step < realsteps; step++)
                     {
                         RGBMap map;
-                        s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                        s.rgbMap(mapSize, red, step, map);
                         QVERIFY(map.isEmpty() == false);
                         // Check that the color values are limited to a valid range
-                        for (int y = 0; y < 5; y++)
+                        for (int y = 0; y < mapSize.height(); y++)
                         {
-                            for (int x = 0; x < 5; x++)
+                            for (int x = 0; x < mapSize.width(); x++)
                             {
-                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                                QVERIFY(map[y][x] <= 0xffffff);
                             }
                         }
                     }

--- a/engine/test/rgbscript/rgbscript_test.cpp
+++ b/engine/test/rgbscript/rgbscript_test.cpp
@@ -240,6 +240,7 @@ void RGBScript_Test::runScripts()
 
         QVERIFY(s.apiVersion() >= 1 && s.apiVersion() <= 2);
         QVERIFY(!s.author().isEmpty());
+        QVERIFY(!s.name().isEmpty());
         QVERIFY(s.type() == RGBAlgorithm::Script);
         QVERIFY(s.acceptColors() >= 0 && s.acceptColors() <= 2);
 

--- a/engine/test/rgbscript/rgbscript_test.cpp
+++ b/engine/test/rgbscript/rgbscript_test.cpp
@@ -282,11 +282,18 @@ void RGBScript_Test::runScripts()
                 switch (property.m_type)
                 {
                 case RGBScriptProperty::List:
+                    // Verify the list is valid
+                    QVERIFY(property.m_listValues.size() > 1);
+                    QVERIFY(property.m_listValues.removeDuplicates() == 0);
+                    // Verify the default value is valid
+                    QVERIFY(property.m_listValues.contains(s.property(property.m_name)));
                     foreach (QString value, property.m_listValues)
                     {
                         // Test with all values from the list
                         qDebug() << property.m_name << value;
                         s.setProperty(property.m_name, value);
+                        qDebug() << "  Readback" << s.property(property.m_name);
+                        QVERIFY(s.property(property.m_name) == value);
                         for (int step = 0; step < realsteps; step++)
                         {
                             RGBMap map;
@@ -297,9 +304,17 @@ void RGBScript_Test::runScripts()
                     break;
                 case RGBScriptProperty::Range:
                     QVERIFY(property.m_rangeMinValue < property.m_rangeMaxValue);
+                    // Verify the default value is in the valid range
+                    qDebug() << "  Default: " << s.property(property.m_name).toInt()
+                           << " Min: " << property.m_rangeMinValue << " Max: " << property.m_rangeMaxValue;
+                    QVERIFY(s.property(property.m_name).toInt() >= property.m_rangeMinValue);
+                    QVERIFY(s.property(property.m_name).toInt() <= property.m_rangeMaxValue);
                     // test with min and max value from the list
                     qDebug() << property.m_name << QString::number(property.m_rangeMinValue);
+
                     s.setProperty(property.m_name, QString::number(property.m_rangeMinValue));
+                    qDebug() << "  Readback" << s.property(property.m_name);
+                    QVERIFY(s.property(property.m_name) == QString::number(property.m_rangeMinValue));
                     for (int step = 0; step < realsteps; step++)
                     {
                         RGBMap map;
@@ -308,6 +323,8 @@ void RGBScript_Test::runScripts()
                     }
                     qDebug() << property.m_name << QString::number(property.m_rangeMaxValue);
                     s.setProperty(property.m_name, QString::number(property.m_rangeMaxValue));
+                    qDebug() << "  Readback: " << s.property(property.m_name);
+                    QVERIFY(s.property(property.m_name) == QString::number(property.m_rangeMaxValue));
                     for (int step = 0; step < realsteps; step++)
                     {
                         RGBMap map;
@@ -316,8 +333,28 @@ void RGBScript_Test::runScripts()
                     }
                     break;
                 case RGBScriptProperty::Integer:
+                    // Test with an integer value
+                    s.setProperty(property.m_name, QString::number(-1024));
+                    qDebug() << "  Readback: " << s.property(property.m_name);
+                    QVERIFY(s.property(property.m_name) == QString::number(-1024));
+                    for (int step = 0; step < realsteps; step++)
+                    {
+                        RGBMap map;
+                        s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                        QVERIFY(map.isEmpty() == false);
+                    }
                     break;
                 case RGBScriptProperty::String:
+                    // Test with an integer value
+                    s.setProperty(property.m_name, QString("QLC+"));
+                    qDebug() << "  Readback: " << s.property(property.m_name);
+                    QVERIFY(s.property(property.m_name) == QString("QLC+"));
+                    for (int step = 0; step < realsteps; step++)
+                    {
+                        RGBMap map;
+                        s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
+                        QVERIFY(map.isEmpty() == false);
+                    }
                     break;
                 default:
                     qDebug() << "Untested property: " << property.m_name;

--- a/engine/test/rgbscript/rgbscript_test.cpp
+++ b/engine/test/rgbscript/rgbscript_test.cpp
@@ -255,6 +255,14 @@ void RGBScript_Test::runScripts()
             RGBMap map;
             s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
             QVERIFY(map.isEmpty() == false);
+            // Check that the color values are limited to a valid range
+            for (int y = 0; y < 5; y++)
+            {
+                for (int x = 0; x < 5; x++)
+                {
+                    QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                }
+            }
         }
 
         // Validate the parameters
@@ -299,6 +307,14 @@ void RGBScript_Test::runScripts()
                             RGBMap map;
                             s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
                             QVERIFY(map.isEmpty() == false);
+                            // Check that the color values are limited to a valid range
+                            for (int y = 0; y < 5; y++)
+                            {
+                                for (int x = 0; x < 5; x++)
+                                {
+                                    QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                                }
+                            }
                         }
                     }
                     break;
@@ -320,6 +336,14 @@ void RGBScript_Test::runScripts()
                         RGBMap map;
                         s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
                         QVERIFY(map.isEmpty() == false);
+                        // Check that the color values are limited to a valid range
+                        for (int y = 0; y < 5; y++)
+                        {
+                            for (int x = 0; x < 5; x++)
+                            {
+                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                            }
+                        }
                     }
                     qDebug() << property.m_name << QString::number(property.m_rangeMaxValue);
                     s.setProperty(property.m_name, QString::number(property.m_rangeMaxValue));
@@ -330,6 +354,14 @@ void RGBScript_Test::runScripts()
                         RGBMap map;
                         s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
                         QVERIFY(map.isEmpty() == false);
+                        // Check that the color values are limited to a valid range
+                        for (int y = 0; y < 5; y++)
+                        {
+                            for (int x = 0; x < 5; x++)
+                            {
+                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                            }
+                        }
                     }
                     break;
                 case RGBScriptProperty::Integer:
@@ -342,6 +374,14 @@ void RGBScript_Test::runScripts()
                         RGBMap map;
                         s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
                         QVERIFY(map.isEmpty() == false);
+                        // Check that the color values are limited to a valid range
+                        for (int y = 0; y < 5; y++)
+                        {
+                            for (int x = 0; x < 5; x++)
+                            {
+                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                            }
+                        }
                     }
                     break;
                 case RGBScriptProperty::String:
@@ -354,6 +394,14 @@ void RGBScript_Test::runScripts()
                         RGBMap map;
                         s.rgbMap(mapSize, QColor(Qt::red).rgb(), step, map);
                         QVERIFY(map.isEmpty() == false);
+                        // Check that the color values are limited to a valid range
+                        for (int y = 0; y < 5; y++)
+                        {
+                            for (int x = 0; x < 5; x++)
+                            {
+                                QVERIFY(map[y][x] <= QColor(Qt::white).rgb());
+                            }
+                        }
                     }
                     break;
                 default:

--- a/engine/test/rgbscript/rgbscript_test.h
+++ b/engine/test/rgbscript/rgbscript_test.h
@@ -41,6 +41,7 @@ private slots:
     void evaluateInvalidApiVersion();
     void rgbMapStepCount();
     void rgbMap();
+    void runScripts();
 
 private:
     Doc * m_doc;

--- a/resources/rgbscripts/alternate.js
+++ b/resources/rgbscripts/alternate.js
@@ -148,7 +148,7 @@ var testAlgo;
 	};
 	algo.getAlign = function() {
 		if (algo.align === 1) {
-			return "Center";
+			return "Centered";
 		} else {
 			return "Left";
 		}

--- a/resources/rgbscripts/circles.js
+++ b/resources/rgbscripts/circles.js
@@ -100,7 +100,7 @@ var testAlgo;
     };
 
     algo.getFill = function () {
-      if (algo.fadeMode === 1) {
+      if (algo.fillCircles === 1) {
         return "Yes";
       } else {
         return "No";

--- a/resources/rgbscripts/devtool.html
+++ b/resources/rgbscripts/devtool.html
@@ -40,7 +40,7 @@
 </style>
 <script type="text/javascript" src="devtool.js"></script>
 </head>
-<body onLoad="loadAlgoFile()">
+<body onLoad="devtool.loadAlgoFile()">
 
 <h1>Q Light Controller Plus - RGB Script Development Tool</h1>
 
@@ -78,7 +78,7 @@ Google Chrome has one as well, that you can access with F12 or with <i>More Tool
 <table id="definitions">
  <tr>
   <td>filename</td>
-  <td><input type="text" size="12" id="filename" value="Enter filename here." onChange="onFilenameUpdated(this.value)"/></td>
+  <td><input type="text" size="12" id="filename" value="Enter filename here." onChange="devtool.onFilenameUpdated(this.value)"/></td>
  </tr>
  <tr>
   <td>apiVersion</td>
@@ -109,11 +109,11 @@ Google Chrome has one as well, that you can access with F12 or with <i>More Tool
 <table>
  <tr>
   <td>Width</td>
-  <td><input type="number" min="1" id="width" value="15" size="4" style="width: 8em;" required onChange="onGridSizeUpdated()"/></td>
+  <td><input type="number" min="1" id="width" value="15" size="4" style="width: 8em;" required onChange="devtool.onGridSizeUpdated()"/></td>
  </tr>
  <tr>
   <td>Height</td>
-  <td><input type="number" min="1" id="height" value="15" size="4" style="width: 8em;" required onChange="onGridSizeUpdated()"/></td>
+  <td><input type="number" min="1" id="height" value="15" size="4" style="width: 8em;" required onChange="devtool.onGridSizeUpdated()"/></td>
  </tr>
 </table>
 </form>
@@ -126,11 +126,11 @@ Google Chrome has one as well, that you can access with F12 or with <i>More Tool
 <table>
  <tr>
   <td>Primary color (rrggbb)</td>
-  <td><input type="text" id="primaryColor" value="FF0000" pattern="[0-9A-Fa-f]{6}" size="6" onChange="onColorChange()" required /></td>
+  <td><input type="text" id="primaryColor" value="FF0000" pattern="[0-9A-Fa-f]{6}" size="6" onChange="devtool.onColorChange()" required /></td>
  </tr>
  <tr id="secondaryColorChooser">
   <td>Secondary color (rrggbb, leave empty to disable)</td>
-  <td><INPUT TYPE="text" id="secondaryColor" value="" pattern="[0-9A-Fa-f]{6}" size="6" onChange="onColorChange()"/></td>
+  <td><INPUT TYPE="text" id="secondaryColor" value="" pattern="[0-9A-Fa-f]{6}" size="6" onChange="devtool.onColorChange()"/></td>
  </tr>
 </table>
 </form>
@@ -155,24 +155,24 @@ Google Chrome has one as well, that you can access with F12 or with <i>More Tool
 <table>
  <tr>
   <td>rgbMap(width, height, rgb, <b>step</b>)
-   <input type="number" min="0" id="currentStep" onChange="writeCurrentStep()"/>
+   <input type="number" min="0" id="currentStep" onChange="devtool.writeCurrentStep()"/>
   </td>
  </tr>
  <tr>
   <td>
    <span>
-    <input type="button" value="Previous" onClick="previousStep()"/>
-    <input type="button" value="Next" onClick="nextStep()"/>
+    <input type="button" value="Previous" onClick="devtool.previousStep()"/>
+    <input type="button" value="Next" onClick="devtool.nextStep()"/>
    </span>
    <span>
-    <input type="button" value="Start test" onClick="startTest()"/>
-    <input type="button" value="Stop test" onClick="stopTest()"/>
+    <input type="button" value="Start test" onClick="devtool.startTest()"/>
+    <input type="button" value="Stop test" onClick="devtool.stopTest()"/>
    </span>
   </td>
  </tr>
  <tr>
   <td>
-   Speed (ms): <input type="number" min="1" id="speed" value="500" size="4" style="width: 8em;" onChange="onSpeedChanged()"/>
+   Speed (ms): <input type="number" min="1" id="speed" value="500" size="4" style="width: 8em;" onChange="devtool.onSpeedChanged()"/>
   </td>
  </tr>
 </table>

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -440,36 +440,3 @@ devtool.previousStep = function()
         devtool.setStep(devtool.stepCount() - 1); // last step
     }
 }
-
-// Standard template
-//var testAlgo;
-(
-    function () {
-      var algo = {};
-      algo.apiVersion = 2;
-      algo.name = "DEVTOOL";
-      algo.author = "Heikki Junnila";
-      algo.properties = [];
-      algo.acceptColors = 1;
-      algo.rgbMap = function (width, height, rgb, step)
-      {
-        var map = new Array();
-        for (var y = 0; y < height; y++)
-        {
-          var _map = new Array();
-          for (var x = 0; x < width; x++)
-          {
-            _map.push(0);
-          }
-          map.push(_map);
-        }
-        return map;
-      };
-      algo.rgbMapStepCount = function (width, height)
-      {
-        return 1;
-      };
-//      testAlgo = algo;
-      return algo;
-    }
-)();

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -17,14 +17,13 @@
   limitations under the License.
 */
 
-var width;
-var height;
-var stepCount;
-var currentStep;
-var testTimer;
-var timerRunning;
+var devtool = Object;
+devtool.width = null;
+devtool.height = null;
+devtool.currentStep = 0;
+devtool.testTimer = null;
 
-function initDefinitions()
+devtool.initDefinitions = function()
 {
     document.getElementById("apiversion").value = testAlgo.apiVersion;
     document.getElementById("name").value = testAlgo.name;
@@ -36,11 +35,11 @@ function initDefinitions()
     }
 }
 
-function writeSelectOptions(item)
+devtool.writeSelectOptions = function(item)
 {
     var opt = document.createElement("option");
     var t = document.createTextNode(item);
-    if (window.testAlgo[this.readFunction]() === item) {
+    if (this.currentValue === item) {
         opt.selected = "selected";
     }
     opt.setAttribute("value", item);
@@ -48,7 +47,7 @@ function writeSelectOptions(item)
     this.inputElement.appendChild(opt);
 }
 
-function addPropertyTableEntry(property)
+devtool.addPropertyTableEntry = function(property)
 {
     var table = document.getElementById("properties");
     var row = table.insertRow(-1);
@@ -80,68 +79,65 @@ function addPropertyTableEntry(property)
     if (keys.indexOf("values") >= 0) {
         values = property[keys.indexOf("values")][1].split(",");
     }
-    var writeFunction = "";
-    if (keys.indexOf("write") >= 0) {
-        writeFunction = property[keys.indexOf("write")][1];
-        if (name !== "") {
-            var storedValue = localStorage.getItem(name);
-            if (storedValue !== null) {
-                window.testAlgo[writeFunction](storedValue);
-            }
+    var writeFunction = property[keys.indexOf("write")][1];
+    if (name !== "") {
+        var storedValue = localStorage.getItem(name);
+        if (storedValue !== null) {
+            window.testAlgo[writeFunction](storedValue);
         }
     }
-    var readFunction = "";
-    if (keys.indexOf("read") >= 0) {
-        readFunction = property[keys.indexOf("read")][1];
-    }
+    var readFunction = property[keys.indexOf("read")][1];
 
     var nameCell = row.insertCell(-1);
     var t = document.createTextNode(displayName);
     nameCell.appendChild(t);
+
+    var currentValue = window.testAlgo[readFunction]();
 
     var formCell = row.insertCell(-1);
     if (typeProperty === "list") {
         input = document.createElement("select");
         input.name = name;
         input.id = name;
-        input.setAttribute("onChange", "writeFunction('" + writeFunction + "', '" + name + "', this.value); setStep(0); writeCurrentStep()");
+        input.setAttribute("onChange", "devtool.writeFunction('" + writeFunction + "', '" + name + "', this.value); devtool.setStep(0); devtool.writeCurrentStep()");
         var selectOption = new Object();
+        selectOption.currentValue = currentValue;
         selectOption.readFunction = readFunction;
         selectOption.inputElement = input;
-        values.forEach(writeSelectOptions, selectOption);
+        values.forEach(devtool.writeSelectOptions, selectOption);
         formCell.appendChild(input);
     } else if (typeProperty === "range") {
         input = document.createElement("input");
         input.type = "number";
         input.required = "required";
         input.name = name;
-        input.setAttribute("value", window.testAlgo[name]);
+        input.setAttribute("value", currentValue);
         input.id = name;
         input.min = values[0];
         input.max = values[1];
-        input.setAttribute("onChange", "writeFunction('" + writeFunction + "', '" + name + "', this.value); setStep(0); writeCurrentStep()");
+        input.setAttribute("onChange", "devtool.writeFunction('" + writeFunction + "', '" + name + "', this.value); devtool.setStep(0); devtool.writeCurrentStep()");
         formCell.appendChild(input);
     } else if (typeProperty === "integer") {
         input = document.createElement("input");
         input.type = "number";
         input.required = "required";
         input.name = name;
-        input.setAttribute("value", window.testAlgo[name]);
+        input.setAttribute("value", currentValue);
         input.id = name;
-        input.setAttribute("onChange", "writeFunction('" + writeFunction + "', '" + name + "', this.value); setStep(0); writeCurrentStep()");
+        input.setAttribute("onChange", "devtool.writeFunction('" + writeFunction + "', '" + name + "', this.value); devtool.setStep(0); devtool.writeCurrentStep()");
         formCell.appendChild(input);
     } else { // string
         input = document.createElement("input");
         input.type = "text";
         input.name = name;
-        input.setAttribute("value", window.testAlgo[name]);
+        input.setAttribute("value", currentValue);
         input.id = name;
-        input.setAttribute("onChange", "writeFunction('" + writeFunction + "', '" + name + "', this.value); setStep(0); writeCurrentStep()");
+        input.setAttribute("onChange", "devtool.writeFunction('" + writeFunction + "', '" + name + "', this.value); devtool.setStep(0); devtool.writeCurrentStep()");
         formCell.appendChild(input);
     }
 }
 
-function initProperties()
+devtool.initProperties = function()
 {
     var table = document.getElementById("properties");
     var properties = Array();
@@ -175,10 +171,10 @@ function initProperties()
         properties.push(property);
     }
     // Write the properties
-    properties.forEach(addPropertyTableEntry);
+    properties.forEach(devtool.addPropertyTableEntry);
 }
 
-function initPixelColors()
+devtool.initPixelColors = function()
 {
     var pixelColorChooser = document.getElementById("pixelColorChooser");
     pixelColorChooser.hidden = testAlgo.acceptColors === 0;
@@ -187,7 +183,7 @@ function initPixelColors()
     secondaryColorChooser.hidden = testAlgo.acceptColors === 1;
 }
 
-function initSpeedValue()
+devtool.initSpeedValue = function()
 {
     var speed = localStorage.getItem("speed");
     if (speed === null) {
@@ -196,7 +192,7 @@ function initSpeedValue()
     document.getElementById("speed").value = speed;
 }
 
-function initColorValues()
+devtool.initColorValues = function()
 {
     var primary = localStorage.getItem("primaryColor");
     if (primary === null || Number.isNaN(parseInt("0x" + primary, 16))) {
@@ -211,21 +207,21 @@ function initColorValues()
     }
 }
 
-function initGridSize()
+devtool.initGridSize = function()
 {
-    var width = localStorage.getItem("width");
-    if (width === null) {
-        width = 15;
+    devtool.width = localStorage.getItem("width");
+    if (devtool.width === null) {
+        devtool.width = 15;
     }
-    document.getElementById("width").value = width;
-    var height = localStorage.getItem("height");
-    if (height === null) {
-        height = 15;
+    document.getElementById("width").value = devtool.width;
+    devtool.height = localStorage.getItem("height");
+    if (devtool.height === null) {
+        devtool.height = 15;
     }
-    document.getElementById("height").value = height;
+    document.getElementById("height").value = devtool.height;
 }
 
-function getRgbFromColorInt(color)
+devtool.getRgbFromColorInt = function(color)
 {
     var red = color >> 16;
     var green = (color >> 8) - red * 256;
@@ -233,7 +229,7 @@ function getRgbFromColorInt(color)
     return [red, green, blue];
 }
 
-function getCurrentColorInt()
+devtool.getCurrentColorInt = function()
 {
     var primaryColorInput = document.getElementById("primaryColor");
     var primaryColor = parseInt(primaryColorInput.value, 16);
@@ -244,15 +240,15 @@ function getCurrentColorInt()
         return null;
     }
 
-    if (testAlgo.acceptColors === 1 || Number.isNaN(secondaryColor) || stepCount <= 1) {
+    if (testAlgo.acceptColors === 1 || Number.isNaN(secondaryColor) || devtool.stepCount() <= 1) {
         return primaryColor;
     }
 
-    var primaryColorRgb = getRgbFromColorInt(primaryColor);
-    var secondaryColorRgb = getRgbFromColorInt(secondaryColor);
+    var primaryColorRgb = devtool.getRgbFromColorInt(primaryColor);
+    var secondaryColorRgb = devtool.getRgbFromColorInt(secondaryColor);
 
-    var primaryFactor = (stepCount - currentStep - 1) / (stepCount - 1);
-    var secondaryFactor = currentStep / (stepCount - 1);
+    var primaryFactor = (devtool.stepCount() - devtool.currentStep - 1) / (devtool.stepCount() - 1);
+    var secondaryFactor = devtool.currentStep / (devtool.stepCount() - 1);
 
     var red = Math.round(primaryColorRgb[0] * primaryFactor + secondaryColorRgb[0] * secondaryFactor);
     var green = Math.round(primaryColorRgb[1] * primaryFactor + secondaryColorRgb[1] * secondaryFactor);
@@ -261,21 +257,21 @@ function getCurrentColorInt()
     return red * 256 * 256 + green * 256 + blue;
 }
 
-function writeCurrentStep()
+devtool.writeCurrentStep = function()
 {
-    currentStep = parseInt(document.getElementById("currentStep").value); // currentStep may have been changed manually
+    devtool.currentStep = parseInt(document.getElementById("currentStep").value); // currentStep may have been changed manually
 
     var map = document.getElementById("map");
     for (var i = map.rows.length - 1; i >= 0; i--) {
         map.deleteRow(i);
     }
-    var rgb = testAlgo.rgbMap(width, height, getCurrentColorInt(), currentStep);
+    var rgb = testAlgo.rgbMap(devtool.width, devtool.height, devtool.getCurrentColorInt(), devtool.currentStep);
 
-    for (var y = 0; y < height; y++)
+    for (var y = 0; y < devtool.height; y++)
     {
         var row = map.insertRow(y);
 
-        for (var x = 0; x < width; x++)
+        for (var x = 0; x < devtool.width; x++)
         {
             var cell = row.insertCell(x);
             var rgbStr = rgb[y][x].toString(16);
@@ -291,27 +287,39 @@ function writeCurrentStep()
     }
 }
 
-function setStep(step) {
-    currentStep = step;
-    document.getElementById("currentStep").value = currentStep;
-    writeCurrentStep();
-}
-
-function onGridSizeUpdated()
+devtool.setStep = function(step)
 {
-    width = parseInt(document.getElementById("width").value);
-    height = parseInt(document.getElementById("height").value);
-    localStorage.setItem("width", width);
-    localStorage.setItem("height", height);
-
-    stepCount = testAlgo.rgbMapStepCount(width, height);
-    document.getElementById("stepCount").value = stepCount;
-    document.getElementById("currentStep").max = stepCount - 1;
-
-    writeCurrentStep();
+    devtool.currentStep = step;
+    document.getElementById("currentStep").value = devtool.currentStep;
+    devtool.writeCurrentStep();
 }
 
-function onColorChange()
+// Do not cache this value - the program also doesn't
+// and there are scripts changing this number on any parameter change
+devtool.stepCount = function()
+{
+	return testAlgo.rgbMapStepCount(devtool.width, devtool.height);
+}
+
+devtool.updateStepCount = function()
+{
+    document.getElementById("stepCount").value = devtool.stepCount();
+    document.getElementById("currentStep").max = devtool.stepCount() - 1;
+}
+
+devtool.onGridSizeUpdated = function()
+{
+    devtool.width = parseInt(document.getElementById("width").value);
+    devtool.height = parseInt(document.getElementById("height").value);
+    localStorage.setItem("width", devtool.width);
+    localStorage.setItem("height", devtool.height);
+
+    devtool.updateStepCount();
+
+    devtool.writeCurrentStep();
+}
+
+devtool.onColorChange = function()
 {
     var primary = parseInt("0x" + document.getElementById("primaryColor").value).toString(16);
     localStorage.setItem("primaryColor", primary);
@@ -321,54 +329,54 @@ function onColorChange()
     } else {
       localStorage.setItem("secondaryColor", secondary);
     }
-    writeCurrentStep();
+    devtool.writeCurrentStep();
 }
 
-function startTest()
+devtool.startTest = function()
 {
     var speed = document.getElementById("speed").value;
-    window.clearInterval(testTimer); // avoid multiple timers running simultaneously
-    testTimer = window.setInterval("nextStep()", speed);
+    window.clearInterval(devtool.testTimer); // avoid multiple timers running simultaneously
+    devtool.testTimer = window.setInterval("devtool.nextStep()", speed);
     localStorage.setItem("timerRunning", 1);
 }
 
-function stopTest()
+devtool.stopTest = function()
 {
-    window.clearInterval(testTimer);
+    window.clearInterval(devtool.testTimer);
     localStorage.setItem("timerRunning", 0);
 }
 
-function initTestStatus()
+devtool.initTestStatus = function()
 {
     var timerStatus = localStorage.getItem("timerRunning");
     if (timerStatus === null || parseInt(timerStatus) === 1) {
-        startTest();
+        devtool.startTest();
     }
 }
 
-function init()
+devtool.init = function()
 {
     if (typeof testAlgo === "undefined") {
         return;
     }
-    setStep(0);
-    initDefinitions();
-    initSpeedValue();
-    initColorValues();
-    initGridSize();
-    initProperties();
-    initPixelColors();
-    onGridSizeUpdated();
-    writeCurrentStep();
-    initTestStatus();
+    devtool.initDefinitions();
+    devtool.initGridSize();
+    devtool.setStep(0);
+    devtool.initSpeedValue();
+    devtool.initColorValues();
+    devtool.initProperties();
+    devtool.initPixelColors();
+    devtool.onGridSizeUpdated();
+    devtool.writeCurrentStep();
+    devtool.initTestStatus();
 }
 
-function handleLoadError()
+devtool.handleLoadError = function()
 {
     return;
 }
 
-function onFilenameUpdated(filename)
+devtool.onFilenameUpdated = function(filename)
 {
     if (filename === "") {
         return;
@@ -380,55 +388,88 @@ function onFilenameUpdated(filename)
     if (script === null) {
         script = document.createElement("script");
         script.id = "algoScript";
-        script.addEventListener("load", () => init(), false);
-        script.addEventListener("error", () => handleLoadError(), false);
+        script.addEventListener("load", () => devtool.init(), false);
+        script.addEventListener("error", () => devtool.handleLoadError(), false);
         script.type = "text/javascript";
         script.src = filename;
         document.head.appendChild(script);
     } else {
         script.src = filename;
     }
-    // init(); // is called onload.
+    // devtool.init(); // is called onload.
 }
 
-function loadAlgoFile()
+devtool.loadAlgoFile = function()
 {
     var storedValue = localStorage.getItem("filename");
     if (storedValue === null) {
         storedValue = "evenodd.js";
     }
     document.getElementById("filename").value = storedValue;
-    onFilenameUpdated(storedValue);
+    devtool.onFilenameUpdated(storedValue);
 }
 
-function writeFunction(functionName, propertyName, value)
+devtool.writeFunction = function(functionName, propertyName, value)
 {
     window.testAlgo[functionName](value);
     localStorage.setItem(propertyName, value);
+    devtool.updateStepCount();
 }
 
-function onSpeedChanged()
+devtool.onSpeedChanged = function()
 {
     var speed = document.getElementById("speed").value;
     localStorage.setItem("speed", speed);
-    initTestStatus();
+    devtool.initTestStatus();
 }
 
-function nextStep()
+devtool.nextStep = function()
 {
-    if (currentStep + 1 < stepCount) {
-        setStep(currentStep + 1);
-    }
-    else {
-        setStep(0);
-    }
-}
-
-function previousStep()
-{
-    if (currentStep > 0) {
-        setStep(currentStep - 1);
+    if (devtool.currentStep + 1 < devtool.stepCount()) {
+        devtool.setStep(devtool.currentStep + 1);
     } else {
-        setStep(stepCount - 1); // last step
+        devtool.setStep(0);
     }
 }
+
+devtool.previousStep = function()
+{
+    if (devtool.currentStep > 0 && (devtool.currentStep - 1) < devtool.stepCount()) {
+        devtool.setStep(devtool.currentStep - 1);
+    } else {
+        devtool.setStep(devtool.stepCount() - 1); // last step
+    }
+}
+
+// Standard template
+var testAlgo;
+(
+    function () {
+      var algo = {};
+      algo.apiVersion = 2;
+      algo.name = "DEVTOOL";
+      algo.author = "Heikki Junnila";
+      algo.properties = [];
+      algo.acceptColors = 1;
+      algo.rgbMap = function (width, height, rgb, step)
+      {
+        var map = new Array();
+        for (var y = 0; y < height; y++)
+        {
+          var _map = new Array();
+          for (var x = 0; x < width; x++)
+          {
+            _map.push(0);
+          }
+          map.push(_map);
+        }
+        return map;
+      };
+      algo.rgbMapStepCount = function (width, height)
+      {
+        return 1;
+      };
+//      testAlgo = algo;
+      return algo;
+    }
+)();

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -442,7 +442,7 @@ devtool.previousStep = function()
 }
 
 // Standard template
-var testAlgo;
+//var testAlgo;
 (
     function () {
       var algo = {};

--- a/resources/rgbscripts/flyingobjects.js
+++ b/resources/rgbscripts/flyingobjects.js
@@ -141,7 +141,6 @@ var testAlgo;
         // The bottom:
         // offx remains the same.
         // offy is 0
-        let realOffy = offy - candleAlgo.cache.bottomHeight;
         distance = Math.sqrt((offx * offx) + 1);
         factor = Math.max(factor, 1 - (distance / candleAlgo.cache.bottomWidth));
       }
@@ -231,7 +230,6 @@ var testAlgo;
       if (eyeAlgo.cache.presetRadius != algo.presetRadius) {
         eyeAlgo.updateCache();
       }
-      let tips = 0;
       // calculate the offset difference of algo.map location to the float
       // location of the object
       let offx = rx - algo.obj[i].x;
@@ -723,7 +721,6 @@ var testAlgo;
       let offy = ry - algo.obj[i].y;
       let distance = Math.sqrt(offx * offx + offy * offy);
       let angle = geometryCalc.getAngle(offx, offy);
-      let baseIntensity = 0;
       let percent = 0;
       let factor = 0;
       

--- a/resources/rgbscripts/lines.js
+++ b/resources/rgbscripts/lines.js
@@ -33,7 +33,7 @@ var testAlgo;
     algo.linesAmount = 3;
     algo.properties.push("name:linesAmount|type:range|display:Amount|values:1,200|write:setAmount|read:getAmount");
     algo.linesSize = 10;
-    algo.properties.push("name:linesSize|type:range|display:Size|values:1,32|write:setSize|read:getSize");
+    algo.properties.push("name:linesSize|type:range|display:Size|values:1,32|write:setLinesSize|read:getLinesSize");
     algo.linesVariablity = 0;
     algo.properties.push("name:linesVariablity|type:range|display:Size Variablity|values:0,100|write:setVariability|read:getVariability");
     algo.linesType = 0;
@@ -59,28 +59,34 @@ var testAlgo;
       this.xCenter = x;
       this.yCenter = y;
       this.step = step;
-    }
-
-    algo.setSize = function(_size)
-    {
-      algo.linesSize = _size;
-      util.initialized = false;
     };
 
-    algo.getSize = function()
+    algo.setLinesSize = function(_size)
+    {
+	  // Only set if the input is valid.
+      if (!(parseInt(_size) === NaN) && parseInt(_size) > 0) {
+        algo.linesSize = parseInt(_size);
+        util.initialized = false;
+      }
+    };
+
+    algo.getLinesSize = function()
     {
       return algo.linesSize;
     };
 
     algo.setVariability = function(_var)
     {
-      algo.linesVariability = _var;
-      util.initialized = false;
+	  // Only set if the input is valid.
+      if (!(parseInt(_var) === NaN) && parseInt(_var) > 0) {
+        algo.linesVariablity = _var;
+        util.initialized = false;
+      }
     };
 
     algo.getVariability = function()
     {
-      return algo.linesVariability;
+      return algo.linesVariablity;
     };
 
     algo.setAmount = function(_amount)
@@ -229,9 +235,11 @@ var testAlgo;
         if (algo.fadeMode === 2) {
           fadeStep = stepCount - step;
         }
-        var newR = (r / stepCount) * fadeStep;
-        var newG = (g / stepCount) * fadeStep;
-        var newB = (b / stepCount) * fadeStep;
+        var factor = fadeStep / stepCount;
+        var newR = Math.round(r * factor);
+        var newG = Math.round(g * factor);
+        var newB = Math.round(b * factor);
+
         var newRGB = (newR << 16) + (newG << 8) + newB;
         return newRGB;
       }
@@ -239,8 +247,6 @@ var testAlgo;
 
     util.drawPixel = function(cx, cy, color, width, height)
     {
-      //cx = cx.toFixed(0);
-      //cy = cy.toFixed(0);
       cx = Math.round(cx);
       cy = Math.round(cy);
       if (cx >= 0 && cx < width && cy >= 0 && cy < height) {
@@ -269,24 +275,40 @@ var testAlgo;
 
         if (lines[i].xCenter === -1)
         {
-          var seed = Math.floor(Math.random()*100);
-          if (seed > 50) { continue; }
-
-          lines[i].xCenter = Math.floor(Math.random() * width);
-          lines[i].yCenter = Math.floor(Math.random() * height);
+          // Randomize the initialization of a new line.
+          var seed = Math.floor(Math.random() * 100);
+          if (seed > 50)
+            continue;
 
           // if biased .. move the start points to the cardinal ends of the space
-          if ( algo.linesBias == 1 || algo.linesBias == 5 || algo.linesBias == 6 ) { lines[i].yCenter = Math.floor(Math.random() * height/5); } 
-          if ( algo.linesBias == 2 || algo.linesBias == 7 || algo.linesBias == 8 ) { lines[i].yCenter = height - Math.floor(Math.random() * height/5); } 
-          if ( algo.linesBias == 3 || algo.linesBias == 5 || algo.linesBias == 7 ) { lines[i].xCenter = Math.floor(Math.random() * width/5); }
-          if ( algo.linesBias == 4 || algo.linesBias == 6 || algo.linesBias == 8 ) { lines[i].xCenter = width - Math.floor(Math.random() * width/5); } 
+          if (algo.linesBias == 1 || algo.linesBias == 5 || algo.linesBias == 6)
+          {
+            lines[i].yCenter = Math.round(Math.random() * height / 5);
+          } 
+          else if (algo.linesBias == 2 || algo.linesBias == 7 || algo.linesBias == 8)
+          {
+            lines[i].yCenter = (height - 1) - Math.round(Math.random() * height	 / 5);
+          } 
+          else
+          {
+            lines[i].yCenter = Math.round(Math.random() * (height - 1));
+          }
 
-          //if ( algo.linesBias != 0 ) { alert("Line " + i + " xCenter: " + lines[i].xCenter + " color: " + color.toString(16)); }
+          if (algo.linesBias == 3 || algo.linesBias == 5 || algo.linesBias == 7)
+          {
+            lines[i].xCenter = Math.round(Math.random() * width / 5);
+          }
+          else if (algo.linesBias == 4 || algo.linesBias == 6 || algo.linesBias == 8)
+          {
+            lines[i].xCenter = (width - 1) - Math.round(Math.random() * width / 5);
+          } 
+          else
+          {
+            lines[i].xCenter = Math.round(Math.random() * (width - 1));
+          }
 
           util.pixelMap[lines[i].yCenter][lines[i].xCenter] = color;
-
         } else {
-         
           var l = lines[i].step * Math.cos(Math.PI / 4);
           var radius2 = lines[i].step * lines[i].step;
           l = l.toFixed(0);
@@ -320,7 +342,6 @@ var testAlgo;
             if (algo.linesType == 3 || algo.linesType == 4 || algo.linesType == 12) {
               util.drawPixel(lines[i].xCenter - x, lines[i].yCenter + x, color, width, height);
             } 
-
           }
         }
 

--- a/resources/rgbscripts/lines.js
+++ b/resources/rgbscripts/lines.js
@@ -34,8 +34,8 @@ var testAlgo;
     algo.properties.push("name:linesAmount|type:range|display:Amount|values:1,200|write:setAmount|read:getAmount");
     algo.linesSize = 10;
     algo.properties.push("name:linesSize|type:range|display:Size|values:1,32|write:setLinesSize|read:getLinesSize");
-    algo.linesVariablity = 0;
-    algo.properties.push("name:linesVariablity|type:range|display:Size Variablity|values:0,100|write:setVariability|read:getVariability");
+    algo.linesVariability = 0;
+    algo.properties.push("name:linesVariability|type:range|display:Size Variablity|values:0,100|write:setVariability|read:getVariability");
     algo.linesType = 0;
     algo.properties.push("name:linesType|type:list|display:Type|values:Horizontal,Vertical,Plus,X,Star,Left,Right,Up,Down,UpRight,UpLeft,DownRight,DownLeft|write:setType|read:getType");
     algo.linesBias = 0;
@@ -79,14 +79,14 @@ var testAlgo;
     {
 	  // Only set if the input is valid.
       if (!(parseInt(_var) === NaN) && parseInt(_var) > 0) {
-        algo.linesVariablity = _var;
+        algo.linesVariability = _var;
         util.initialized = false;
       }
     };
 
     algo.getVariability = function()
     {
-      return algo.linesVariablity;
+      return algo.linesVariability;
     };
 
     algo.setAmount = function(_amount)

--- a/resources/rgbscripts/strobe.js
+++ b/resources/rgbscripts/strobe.js
@@ -28,7 +28,7 @@ var testAlgo;
       algo.author = "Rob Nieuwenhuizen";
       algo.properties = [];
       algo.acceptColors = 1;
-      algo.properties.push("name:freq|type:range|display:Frequency|values:2,10|write:setFreq|read:getFreq");
+      algo.properties.push("name:frequency|type:range|display:Frequency|values:2,10|write:setFreq|read:getFreq");
       algo.frequency = 2;
       algo.setFreq = function(_freq){
         algo.frequency = parseInt(_freq);


### PR DESCRIPTION
While searching through the logs for the JS execution problem and errors, I would like to add the following lines to avoid the errors while loading files which are not meant to be rgbscripts:
Do not load RGBscript files which are not script files (Makefiles, backup files, directories, etc.)