### PR TITLE
Prevent color tool being covered up in fullscreen

### DIFF
--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -577,7 +577,7 @@ void SceneEditor::slotColorTool()
 {
     QColor color = slotColorSelectorChanged(QColor());
 
-    QColorDialog dialog(color);
+    QColorDialog dialog(color, this);
     connect(&dialog, SIGNAL(currentColorChanged(const QColor&)),
             this, SLOT(slotColorSelectorChanged(const QColor&)));
 


### PR DESCRIPTION
Specify the parent of the QColorDialog when creating it for the
color tool.  This ensures that the dialog remains on top of the
main window.  Without this fix, the dialog can get covered up in
fullscreen mode under Ubuntu MATE and probably other Linux distributions.
Once the dialog is buried, recovery is impossible and the application
must be killed from a terminal window.