### PR TITLE
Remove SYSFS from udev rules

### DIFF
--- a/plugins/peperoni/unix/z65-peperoni.rules
+++ b/plugins/peperoni/unix/z65-peperoni.rules
@@ -4,4 +4,3 @@
 # and sets their device nodes' permissions so that ALL users can read and write
 # to/from them. The device nodes are found under /dev/bus/usb/xxx/yyy.
 SUBSYSTEM=="usb*", ACTION=="add|change", ATTRS{idVendor}=="0ce1", MODE="0666"
-SUBSYSTEM=="usb*", ACTION=="add|change", SYSFS{idVendor}=="0ce1", MODE="0666"

--- a/plugins/udmx/src/z65-anyma-udmx.rules
+++ b/plugins/udmx/src/z65-anyma-udmx.rules
@@ -4,7 +4,4 @@
 # set their device nodes' permissions so that ALL users can read and write to
 # them. The devices nodes are found under /dev/bus/usb/xxx/yyy.
 SUBSYSTEM=="usb*", ACTION=="add|change", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", MODE="0666"
-SUBSYSTEM=="usb*", ACTION=="add|change", SYSFS{idVendor}=="16c0", SYSFS{idProduct}=="05dc", MODE="0666"
-
 SUBSYSTEM=="usb*", ACTION=="add|change", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="8888", MODE="0666"
-SUBSYSTEM=="usb*", ACTION=="add|change", SYSFS{idVendor}=="03eb", SYSFS{idProduct}=="8888", MODE="0666"


### PR DESCRIPTION
SYSFS key has been removed a long time ago from udev (in v174), and those rules generate errors that we could get rid of.