### PR TITLE
Improve the tempo detection algorithm

### DIFF
--- a/ui/src/speeddial.h
+++ b/ui/src/speeddial.h
@@ -149,6 +149,7 @@ private:
     int m_previousDialValue;
     bool m_preventSignals;
     int m_value;
+    QList<int> m_tapHistory;
 
     bool m_tapTick;
     QElapsedTimer* m_tapTime;


### PR DESCRIPTION
The Speed Dial widget features a "Tap" button that allows users to tap along with a beat, when choosing a duration.

Currently, this tap button only computes the time since the last tap. The computed value can be off by +-20ms. When tapping to music, this is enough to put the beat completely out-of-phase with the music in 10 seconds.

This patch records the most recent 20 taps, and computes the tempo that best passes through all of them. Within 10 taps it can compute a tempo that's correct +- 2ms. It's even robust against occasional missed taps.

The first tap uses the old (current) behavior, as does waiting more than 1.5 seconds in between a tap.