### PR TITLE
velleman_mock: Include stdint.h in any case since it's required by more than just Windows (musl for example)

### DIFF
--- a/plugins/velleman/src/velleman_mock.cpp
+++ b/plugins/velleman/src/velleman_mock.cpp
@@ -18,9 +18,7 @@
 */
 
 #include <stdlib.h>
-#if defined(WIN32) || defined(Q_OS_WIN)
-#       include <stdint.h> // int32_t
-#endif
+#include <stdint.h> // int32_t
 
 extern "C"
 {


### PR DESCRIPTION
File `plugins/velleman/src/velleman_mock.cpp` included the header file `stdint.h` (used for data type `int32_t` in this case) only if `WIN32` or `Q_OS_WIN` was defined. This is perfectly fine for most Linux and macOS systems. However, it can fail if another libc-implementation other than glibc is used.
For [musl libc](https://musl.libc.org/) on Gentoo Linux, the build fails since `int32_t` is not defined: https://bugs.gentoo.org/830558

This PR fixes the problem by including `stdint.h` in any case. This still compiles fine with glibc on Gentoo Linux and is probably more correct anyways.

I honestly didn't to much testing since I don't have a velleman device but since the compilation worked fine and the PR doesn't touch any logic, I wouldn't expect any runtime problems.