### PR TITLE
ui: fix wrong feedback on vccuelist in stepmode

### DIFF
--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -1264,7 +1264,10 @@ void VCCueList::slotKeyPressed(const QKeySequence& keySequence)
 
 void VCCueList::updateFeedback()
 {
-    int fbv = (int)SCALE(float(m_sideFader->value()), float(0), float(100), float(0), float(UCHAR_MAX));
+    int fbv = int(SCALE(float(m_sideFader->value()), 
+                        float(m_sideFader->minimum()),
+                        float(m_sideFader->maximum()), 
+                        float(0), float(UCHAR_MAX)));
     sendFeedback(fbv, sideFaderInputSourceId);
 
     Chaser *ch = chaser();


### PR DESCRIPTION
The vccuelist feedback (Side Fader) works fine in Crossfade-Mode but in Steps-Mode the feedback values goes crazy. 