### PR TITLE
avoid sending duplicate MIDI notes

### DIFF
--- a/plugins/midi/src/alsa/alsamidioutputdevice.cpp
+++ b/plugins/midi/src/alsa/alsamidioutputdevice.cpp
@@ -153,7 +153,6 @@ void AlsaMidiOutputDevice::writeUniverse(const QByteArray& universe)
                 snd_seq_ev_set_noteoff(&ev, midiChannel(), channel, scaled);
             else
                 snd_seq_ev_set_noteon(&ev, midiChannel(), channel, scaled);
-            snd_seq_event_output(m_alsa, &ev);
         }
         else if (mode() == ProgramChange)
         {

--- a/plugins/midi/src/common/midiprotocol.h
+++ b/plugins/midi/src/common/midiprotocol.h
@@ -91,7 +91,7 @@ namespace QLCMIDIProtocol
 #define MIDI2DMX(x) uchar((x == 127U) ? 255U : x << 1)
 
 /** Convert DMX value to MIDI value */
-#define DMX2MIDI(x) uchar(x >> 1)
+#define DMX2MIDI(x) (uchar(x >> 1) & 0x7F)
 
 /****************************************************************************
  * MIDI channels


### PR DESCRIPTION
When using MIDI plugin in Note mode to output channel data from QLC, notes are sent twice.
This patch removes a superfluous call of snd_seq_event_output(m_alsa, &ev); that causes this misbehaviour.