### PR TITLE
chore: add websocket reconnect when connection is closed

### DIFF
--- a/webaccess/res/keypad.html
+++ b/webaccess/res/keypad.html
@@ -88,7 +88,7 @@ var channels, c, v, first, last, step, range;
 var reqchan;
 var addval;
 var values=[];
-window.onload = function()
+function connect()
 {
   var url = 'ws://' + window.location.host + '/qlcplusWS';
   websocket = new WebSocket(url);
@@ -96,10 +96,17 @@ window.onload = function()
     isConnected = true;
   };
   websocket.onclose = function(ev) {
-    alert("QLC+ connection lost!");
+    console.log(
+      "QLC+ connection is closed. Reconnect will be attempted in 1 second.",
+      e.reason
+    );
+    setTimeout(function () {
+      connect();
+    }, 1000);
   };
   websocket.onerror = function(ev) {
-    alert("QLC+ connection error!");
+    console.error("QLC+ connection encountered error: ", err.message, "Closing socket");
+    ws.close();
   };
   websocket.onmessage = function(ev) {
     //alert(ev.data);
@@ -120,6 +127,8 @@ window.onload = function()
     }
   };
 };
+
+window.onload = connect();
 
 function composeCommand(cmd)
 {

--- a/webaccess/res/simpledesk.js
+++ b/webaccess/res/simpledesk.js
@@ -25,17 +25,24 @@ function getPage(uni, page) {
  websocket.send(wsMsg);
 }
 
-window.onload = function() {
+function connect() {
    var url = "ws://" + window.location.host + "/qlcplusWS";
    websocket = new WebSocket(url);
    websocket.onopen = function(ev) {
     getPage(1, 1);
    };
    websocket.onclose = function(ev) {
-    alert("QLC+ connection lost!");
+    console.log(
+      "QLC+ connection is closed. Reconnect will be attempted in 1 second.",
+      e.reason
+    );
+    setTimeout(function () {
+      connect();
+    }, 1000);
    };
    websocket.onerror = function(ev) {
-    alert("QLC+ connection error!");
+    console.error("QLC+ connection encountered error: ", err.message, "Closing socket");
+    ws.close();
    };
    websocket.onmessage = function(ev) {
     //alert(ev.data);
@@ -47,6 +54,8 @@ window.onload = function() {
     }
    };
 };
+
+window.onload = connect();
 
 function getGroupIconName(grp) {
    if (grp === 0) { return "intensity.png"; }

--- a/webaccess/res/websocket.js
+++ b/webaccess/res/websocket.js
@@ -22,20 +22,27 @@ function sendCMD(cmd) {
  websocket.send("QLC+CMD|" + cmd);
 }
 
-window.onload = function() {
+function connect() {
  var url = "ws://" + window.location.host + "/qlcplusWS";
  websocket = new WebSocket(url);
  websocket.onopen = function(ev) {
   //alert(\"Websocket open!\");
  };
 
- websocket.onclose = function(ev) {
-  alert("QLC+ connection lost!");
- };
+ websocket.onclose = function (e) {
+  console.log(
+    "QLC+ connection is closed. Reconnect will be attempted in 1 second.",
+    e.reason
+  );
+  setTimeout(function () {
+    connect();
+  }, 1000);
+};
 
- websocket.onerror = function(ev) {
-  alert("QLC+ connection error!");
- };
+websocket.onerror = function (err) {
+  console.error("QLC+ connection encountered error: ", err.message, "Closing socket");
+  ws.close();
+};
 
  websocket.onmessage = function(ev) {
   //console.log(ev.data);
@@ -65,3 +72,5 @@ window.onload = function() {
  };
  initVirtualConsole();
 };
+
+window.onload = connect();


### PR DESCRIPTION
This PR implements an automatic reconnection when the websocket is closed.

When using the webaccess in iOS Safari everytime that the iPhone screen is locked the websocket connection is lost and to workaround that, we are forced to refresh the page.