### PR TITLE
bugfix: Rework WebSocket library to be stateful

### DIFF
--- a/webaccess/src/qhttpserver/qhttpconnection.cpp
+++ b/webaccess/src/qhttpserver/qhttpconnection.cpp
@@ -31,8 +31,6 @@
 #include "qhttprequest.h"
 #include "qhttpresponse.h"
 
-#define WS_CLOSE_CODE(n) (char[]{(n/0x100, n & 0xff})
-
 /// @cond nodoc
 
 QHttpConnection::QHttpConnection(QTcpSocket *socket, QObject *parent)
@@ -365,27 +363,14 @@ void QHttpConnection::webSocketWrite(WebSocketOpCode opCode, QByteArray data)
     header.append(0x80 + quint8(opCode));
 
     qDebug() << "[webSocketWrite] data size:" << data.size();
-    // qDebug() << "[webSocketWrite] opCode:" << QString("0x%1").arg(m_websocket_opCode, 2, 16, QChar('0')) << data.toHex();
     if (data.size() < 126)
     {
         header.append(quint8(data.size()));
     }
-    else if(data.size() < 65536)
+    else
     {
         header.append(0x7E);
         header.append(quint8(data.size() >> 8));
-        header.append(quint8(data.size() & 0xFF));
-    }
-    else
-    {
-        header.append(0x7F);
-        header.append(quint8(0));
-        header.append(quint8(0));
-        header.append(quint8(0));
-        header.append(quint8(0));
-        header.append(quint8((data.size() >> 24) & 0xFF));
-        header.append(quint8((data.size() >> 16) & 0xFF));
-        header.append(quint8((data.size() >> 8) & 0xFF));
         header.append(quint8(data.size() & 0xFF));
     }
 

--- a/webaccess/src/qhttpserver/qhttpconnection.h
+++ b/webaccess/src/qhttpserver/qhttpconnection.h
@@ -111,23 +111,28 @@ private Q_SLOTS:
 private:
     void webSocketRead(QByteArray &data);
     void webSocketParsePayload();
+    void webSocketClose(quint16 error_code);
 
 private:
     bool m_isWebSocket;
     enum WebSocketState {
         init,
         length,
-        length_extra,
+        length_extended,
         mask,
         payload,
+        closed,
         sink,
     } m_websocket_state;
+    bool m_websocket_closing;
+    uint m_websocket_state_param;
+    bool m_websocket_fin;
+    int m_websocket_opCode;
     bool m_websocket_masked;
     quint8 m_websocket_mask[4];
-    int m_websocket_opCode;
     uint m_websocket_dataLen;
-    uint m_websocket_state_param;
     QByteArray m_websocket_payload;
+    QByteArray m_websocket_payload_buffer;
     QTimer *m_pollTimer;
 
 public:

--- a/webaccess/src/qhttpserver/qhttpconnection.h
+++ b/webaccess/src/qhttpserver/qhttpconnection.h
@@ -109,10 +109,25 @@ private Q_SLOTS:
     void slotWebSocketPollTimeout();
 
 private:
-    void webSocketRead(QByteArray data);
+    void webSocketRead(QByteArray &data);
+    void webSocketParsePayload();
 
 private:
     bool m_isWebSocket;
+    enum WebSocketState {
+        init,
+        length,
+        length_extra,
+        mask,
+        payload,
+        sink,
+    } m_websocket_state;
+    bool m_websocket_masked;
+    quint8 m_websocket_mask[4];
+    int m_websocket_opCode;
+    uint m_websocket_dataLen;
+    uint m_websocket_state_param;
+    QByteArray m_websocket_payload;
     QTimer *m_pollTimer;
 
 public:


### PR DESCRIPTION
This avoids bugs when the IP or TCP packets arrive fragmented.

---


This needs a lot more work, but making the parser stateful seems to be what's necessary to prevent #1308.