### PR TITLE
Rgbscrips fix acceptColors attributes, formatting, removing unused variables

### DIFF
--- a/resources/rgbscripts/alternate.js
+++ b/resources/rgbscripts/alternate.js
@@ -85,13 +85,13 @@ var testAlgo;
   };
 
   algo.color1Index = algo.getColorIndex("Red");
-  algo.properties.push("name:color1Index|type:list|display:Color 1|"
-    + "values:" + colorPalette.names.toString() + "|"
-    + "write:setColor1Index|read:getColor1Name");
+  algo.properties.push("name:color1Index|type:list|display:Color 1|" +
+    "values:" + colorPalette.names.toString() + "|" +
+    "write:setColor1Index|read:getColor1Name");
   algo.color2Index = algo.getColorIndex("Green");
-  algo.properties.push("name:color2Index|type:list|display:Color 2|"
-    + "values:" + colorPalette.names.toString() + "|"
-    + "write:setColor2Index|read:getColor2Name");
+  algo.properties.push("name:color2Index|type:list|display:Color 2|" +
+    "values:" + colorPalette.names.toString() + "|" +
+    "write:setColor2Index|read:getColor2Name");
 
   algo.getColorName = function(_index) {
     if (_index < 0) {
@@ -133,9 +133,9 @@ var testAlgo;
   };
 
   algo.align = 0;
-  algo.properties.push("name:align|type:list|"
-    + "display:Align (for even width)|values:Left,Centered|"
-    + "write:setAlign|read:getAlign");
+  algo.properties.push("name:align|type:list|" +
+    "display:Align (for even width)|values:Left,Centered|" +
+    "write:setAlign|read:getAlign");
   // Left aligned is default.
   algo.setAlign = function(_align) {
     if (_align === "Centered") {
@@ -153,9 +153,9 @@ var testAlgo;
   };
 
   algo.orientation = 0;
-  algo.properties.push("name:orientation|type:list|"
-    + "display:Orientation|values:Horizontal,Vertical,Interleaved|"
-    + "write:setOrientation|read:getOrientation");
+  algo.properties.push("name:orientation|type:list|" +
+    "display:Orientation|values:Horizontal,Vertical,Interleaved|" +
+    "write:setOrientation|read:getOrientation");
   algo.setOrientation = function(_orientation) {
     if (_orientation === "Vertical") {
       algo.orientation = 1;

--- a/resources/rgbscripts/alternate.js
+++ b/resources/rgbscripts/alternate.js
@@ -21,255 +21,254 @@
 var testAlgo;
 
 (function() {
-	var colorPalette = new Object;
-	colorPalette.collection = new Array(
-	[ "White", 0xFFFFFF ], // 0
-	[ "Cream", 0xFFFF7F ], // 1
-	[ "Pink", 0xFF7F7F ], // 2
-	[ "Rose", 0x7F3F3F ], // 3
-	[ "Coral", 0x7F3F1F ], // 4
-	[ "Dim Red", 0x7F0000 ], // 5
-	[ "Red", 0xFF0000 ], // 6
-	[ "Orange", 0xFF3F00 ], // 7
-	[ "Dim Orange", 0x7F1F00 ], // 8
-	[ "Goldenrod", 0x7F3F00 ], // 9
-	[ "Gold", 0xFF7F00 ], // 10
-	[ "Yellow", 0xFFFF00 ], // 11
-	[ "Dim Yellow", 0x7F7F00 ], // 12
-	[ "Lime", 0x7FFF00 ], // 13
-	[ "Pale Green", 0x3F7F00 ], // 14
-	[ "Dim Green", 0x007F00 ], // 15
-	[ "Green", 0x00FF00 ], // 16
-	[ "Seafoam", 0x00FF3F ], // 17
-	[ "Turquoise", 0x007F3F ], // 18
-	[ "Teal", 0x007F7F ], // 19
-	[ "Cyan", 0x00FFFF ], // 20
-	[ "Electric Blue", 0x007FFF ], // 21
-	[ "Blue", 0x0000FF ], // 22
-	[ "Dim Blue", 0x00007F ], // 23
-	[ "Pale Blue", 0x1F1F7F ], // 24
-	[ "Indigo", 0x1F00BF ], // 25
-	[ "Purple", 0x3F00BF ], // 26
-	[ "Violet", 0x7F007F ], // 27
-	[ "Magenta", 0xFF00FF ], // 28
-	[ "Hot Pink", 0xFF003F ], // 29
-	[ "Deep Pink", 0x7F001F ], // 30
-	[ "OFF", 0x000000 ]); // 31
+  var colorPalette = new Object;
+  colorPalette.collection = new Array(
+    ["White", 0xFFFFFF], // 0
+    ["Cream", 0xFFFF7F], // 1
+    ["Pink", 0xFF7F7F], // 2
+    ["Rose", 0x7F3F3F], // 3
+    ["Coral", 0x7F3F1F], // 4
+    ["Dim Red", 0x7F0000], // 5
+    ["Red", 0xFF0000], // 6
+    ["Orange", 0xFF3F00], // 7
+    ["Dim Orange", 0x7F1F00], // 8
+    ["Goldenrod", 0x7F3F00], // 9
+    ["Gold", 0xFF7F00], // 10
+    ["Yellow", 0xFFFF00], // 11
+    ["Dim Yellow", 0x7F7F00], // 12
+    ["Lime", 0x7FFF00], // 13
+    ["Pale Green", 0x3F7F00], // 14
+    ["Dim Green", 0x007F00], // 15
+    ["Green", 0x00FF00], // 16
+    ["Seafoam", 0x00FF3F], // 17
+    ["Turquoise", 0x007F3F], // 18
+    ["Teal", 0x007F7F], // 19
+    ["Cyan", 0x00FFFF], // 20
+    ["Electric Blue", 0x007FFF], // 21
+    ["Blue", 0x0000FF], // 22
+    ["Dim Blue", 0x00007F], // 23
+    ["Pale Blue", 0x1F1F7F], // 24
+    ["Indigo", 0x1F00BF], // 25
+    ["Purple", 0x3F00BF], // 26
+    ["Violet", 0x7F007F], // 27
+    ["Magenta", 0xFF00FF], // 28
+    ["Hot Pink", 0xFF003F], // 29
+    ["Deep Pink", 0x7F001F], // 30
+    ["OFF", 0x000000]); // 31
 
-	colorPalette.makeSubArray = function(_index) {
-		var _array = new Array();
-		for (var i = 0; i < colorPalette.collection.length; i++) {
-			_array.push(colorPalette.collection[parseInt(i)][parseInt(_index)]);
-		}
-		return _array;
-	};
-	colorPalette.names = colorPalette.makeSubArray(0);
+  colorPalette.makeSubArray = function(_index) {
+    var _array = new Array();
+    for (var i = 0; i < colorPalette.collection.length; i++) {
+      _array.push(colorPalette.collection[parseInt(i)][parseInt(_index)]);
+    }
+    return _array;
+  };
+  colorPalette.names = colorPalette.makeSubArray(0);
 
-	var algo = new Object;
-	algo.apiVersion = 2;
-	algo.name = "Alternate";
-	algo.author = "Hans-Jürgen Tappe";
-	
-	var x = 0;
-	var y = 0;
+  var algo = new Object;
+  algo.apiVersion = 2;
+  algo.name = "Alternate";
+  algo.author = "Hans-Jürgen Tappe";
 
-	algo.acceptColors = 0;
-	// Only two steps; one for even pixels and another for odd pixels
-	algo.maxSteps = 2;
-	algo.properties = new Array();
+  var x = 0;
+  var y = 0;
 
-	algo.getColorIndex = function(_name) {
-		var idx = colorPalette.names.indexOf(_name);
-		if (idx === -1) {
-			idx = (colorPalette.collection.length - 1);
-		}
-		return idx;
-	};
+  algo.acceptColors = 0;
+  algo.properties = new Array();
 
-	algo.color1Index = algo.getColorIndex("Red");
-	algo.properties.push("name:color1Index|type:list|display:Color 1|"
-			+ "values:" + colorPalette.names.toString() + "|"
-			+ "write:setColor1Index|read:getColor1Name");
-	algo.color2Index = algo.getColorIndex("Green");
-	algo.properties.push("name:color2Index|type:list|display:Color 2|"
-			+ "values:" + colorPalette.names.toString() + "|"
-			+ "write:setColor2Index|read:getColor2Name");
+  algo.getColorIndex = function(_name) {
+    var idx = colorPalette.names.indexOf(_name);
+    if (idx === -1) {
+      idx = (colorPalette.collection.length - 1);
+    }
+    return idx;
+  };
 
-	algo.getColorName = function(_index) {
-		if (_index < 0) {
-			_index = 0;
-		}
-		if (_index >= colorPalette.collection.length) {
-			_index = (colorPalette.collection.length - 1);
-		}
-		return colorPalette.collection[parseInt(_index)][0];
-	};
-	algo.getColorValue = function(_index) {
-		if (_index < 0) {
-			_index = 0;
-		}
-		if (_index >= colorPalette.collection.length) {
-			_index = (colorPalette.collection.length - 1);
-		}
-		return colorPalette.collection[parseInt(_index)][1];
-	};
+  algo.color1Index = algo.getColorIndex("Red");
+  algo.properties.push("name:color1Index|type:list|display:Color 1|"
+    + "values:" + colorPalette.names.toString() + "|"
+    + "write:setColor1Index|read:getColor1Name");
+  algo.color2Index = algo.getColorIndex("Green");
+  algo.properties.push("name:color2Index|type:list|display:Color 2|"
+    + "values:" + colorPalette.names.toString() + "|"
+    + "write:setColor2Index|read:getColor2Name");
 
-	algo.setColor1Index = function(_name) {
-		algo.color1Index = algo.getColorIndex(_name);
-	};
-	algo.getColor1Name = function() {
-		return algo.getColorName(algo.color1Index);
-	};
-	algo.getColor1Value = function() {
-		return algo.getColorValue(algo.color1Index);
-	};
+  algo.getColorName = function(_index) {
+    if (_index < 0) {
+      _index = 0;
+    }
+    if (_index >= colorPalette.collection.length) {
+      _index = (colorPalette.collection.length - 1);
+    }
+    return colorPalette.collection[parseInt(_index)][0];
+  };
+  algo.getColorValue = function(_index) {
+    if (_index < 0) {
+      _index = 0;
+    }
+    if (_index >= colorPalette.collection.length) {
+      _index = (colorPalette.collection.length - 1);
+    }
+    return colorPalette.collection[parseInt(_index)][1];
+  };
 
-	algo.setColor2Index = function(_name) {
-		algo.color2Index = algo.getColorIndex(_name);
-	};
-	algo.getColor2Name = function() {
-		return algo.getColorName(algo.color2Index);
-	};
-	algo.getColor2Value = function() {
-		return algo.getColorValue(algo.color2Index);
-	};
+  algo.setColor1Index = function(_name) {
+    algo.color1Index = algo.getColorIndex(_name);
+  };
+  algo.getColor1Name = function() {
+    return algo.getColorName(algo.color1Index);
+  };
+  algo.getColor1Value = function() {
+    return algo.getColorValue(algo.color1Index);
+  };
 
-	algo.align = 0;
-	algo.properties.push("name:align|type:list|"
-			+ "display:Align (for even width)|values:Left,Centered|"
-			+ "write:setAlign|read:getAlign");
-	// Left aligned is default.
-	algo.setAlign = function(_align) {
-		if (_align === "Centered") {
-			algo.align = 1;
-		} else {
-			algo.align = 0;
-		}
-	};
-	algo.getAlign = function() {
-		if (algo.align === 1) {
-			return "Centered";
-		} else {
-			return "Left";
-		}
-	};
+  algo.setColor2Index = function(_name) {
+    algo.color2Index = algo.getColorIndex(_name);
+  };
+  algo.getColor2Name = function() {
+    return algo.getColorName(algo.color2Index);
+  };
+  algo.getColor2Value = function() {
+    return algo.getColorValue(algo.color2Index);
+  };
 
-	algo.orientation = 0;
-	algo.properties.push("name:orientation|type:list|"
-			+ "display:Orientation|values:Horizontal,Vertical,Interleaved|"
-			+ "write:setOrientation|read:getOrientation");
-	algo.setOrientation = function(_orientation) {
-		if (_orientation === "Vertical") {
-			algo.orientation = 1;
-		} else if (_orientation === "Interleaved") {
-			algo.orientation = 2;
-		} else {
-			algo.orientation = 0;
-		}
-	};
-	algo.getOrientation = function() {
-		if (parseInt(algo.orientation) === 1) {
-			return "Vertical";
-		} else if (algo.orientation === 2) {
-			return "Interleaved";
-		} else {
-			return "Horizontal";
-		}
-	};
+  algo.align = 0;
+  algo.properties.push("name:align|type:list|"
+    + "display:Align (for even width)|values:Left,Centered|"
+    + "write:setAlign|read:getAlign");
+  // Left aligned is default.
+  algo.setAlign = function(_align) {
+    if (_align === "Centered") {
+      algo.align = 1;
+    } else {
+      algo.align = 0;
+    }
+  };
+  algo.getAlign = function() {
+    if (algo.align === 1) {
+      return "Centered";
+    } else {
+      return "Left";
+    }
+  };
 
-	algo.blockSize = 1;
-	algo.properties.push("name:blockSize|type:range|"
-			+ "display:Block Size (1-16)|"
-			+ "values:1,16|"
-			+ "write:setBlockSize|read:getBlockSize");
-	algo.setBlockSize = function(_size) {
-		algo.blockSize = parseInt(_size);
-	};
-	algo.getBlockSize = function() {
-		return algo.blockSize;
-	};
+  algo.orientation = 0;
+  algo.properties.push("name:orientation|type:list|"
+    + "display:Orientation|values:Horizontal,Vertical,Interleaved|"
+    + "write:setOrientation|read:getOrientation");
+  algo.setOrientation = function(_orientation) {
+    if (_orientation === "Vertical") {
+      algo.orientation = 1;
+    } else if (_orientation === "Interleaved") {
+      algo.orientation = 2;
+    } else {
+      algo.orientation = 0;
+    }
+  };
+  algo.getOrientation = function() {
+    if (parseInt(algo.orientation) === 1) {
+      return "Vertical";
+    } else if (algo.orientation === 2) {
+      return "Interleaved";
+    } else {
+      return "Horizontal";
+    }
+  };
 
-	algo.offset = 0;
-	algo.properties.push("name:offset|type:range|"
-			+ "display:Offset (0-16)|"
-			+ "values:0,16|"
-			+ "write:setOffset|read:getOffset");
-	algo.setOffset = function(_size) {
-		algo.offset = parseInt(_size);
-	};
-	algo.getOffset = function() {
-		return algo.offset;
-	};
+  algo.blockSize = 1;
+  algo.properties.push("name:blockSize|type:range|"
+    + "display:Block Size (1-16)|"
+    + "values:1,16|"
+    + "write:setBlockSize|read:getBlockSize");
+  algo.setBlockSize = function(_size) {
+    algo.blockSize = parseInt(_size);
+  };
+  algo.getBlockSize = function() {
+    return algo.blockSize;
+  };
 
-	algo.rgbMap = function(width, height, rgb, step) {
-		var map = new Array(height);
-		var effectiveStep = step;
-		var colorSelectOne = (step === 1) ? false : true;
-		var rowColorOne = colorSelectOne;
+  algo.offset = 0;
+  algo.properties.push("name:offset|type:range|"
+    + "display:Offset (0-16)|"
+    + "values:0,16|"
+    + "write:setOffset|read:getOffset");
+  algo.setOffset = function(_size) {
+    algo.offset = parseInt(_size);
+  };
+  algo.getOffset = function() {
+    return algo.offset;
+  };
 
-		var xMax = width;
-		if (algo.align === 1 && width % 2 === 0) {
-			xMax = width / 2 + width % 2;
-		}
-		for (y = 0; y < height; y++) {
-			if (algo.orientation === 0 ) {
-				// Initialize vertical bars, each column the same
-				colorSelectOne = (step === 1) ? false : true;
-			} else if (algo.orientation === 1) {
-				// Horizontal Bars, count steps by row
-				effectiveStep = y + step * algo.blockSize + algo.offset;
-				// Initialize start color for each row.
-				if (effectiveStep % algo.blockSize === 0) {
-					colorSelectOne = ! colorSelectOne;
-				}
-			} else if (algo.orientation === 2) {
-				var effectiveY = y + step * algo.blockSize + algo.offset;
-				if (effectiveY % (algo.blockSize) === 0) {
-					rowColorOne = ! rowColorOne;
-				}
-				colorSelectOne = rowColorOne;
-			}
-			map[parseInt(y)] = new Array();
-			for (x = 0; x < width; x++) {
-				if (algo.orientation === 0) {
-					// Vertical bars, count steps by column
-					effectiveStep = x + algo.offset;
-					if (effectiveStep % algo.blockSize === 0) {
-						colorSelectOne = ! colorSelectOne;
-					}
-				} else if (algo.orientation === 2) {
-					// Horizontal Bars, count steps by row and column
-					var effectiveX = x + step * algo.blockSize + algo.offset;
-					// Change color each step.
-					if (effectiveX % algo.blockSize === 0) {
-						colorSelectOne = ! colorSelectOne;
-					}
-				}
-				if (colorSelectOne) {
-					map[parseInt(y)][parseInt(x)] = algo.getColor1Value();
-				} else {
-					map[parseInt(y)][parseInt(x)] = algo.getColor2Value();
-				}
-			}
-		}
-		// Align centered
-		if (algo.align === 1 && width % 2 === 0) {
-			for (y = 0; y < height; y++) {
-				for (x = 0; x < xMax; x++) {
-					map[parseInt(y)][parseInt(x)] = map[parseInt(y)][parseInt(width - x - 1)];
-				}
-			}
-		}
+  algo.rgbMap = function(width, height, rgb, step) {
+    var map = new Array(height);
+    var effectiveStep = step;
+    var colorSelectOne = (step === 1) ? false : true;
+    var rowColorOne = colorSelectOne;
 
-		return map;
-	};
+    var xMax = width;
+    if (algo.align === 1 && width % 2 === 0) {
+      xMax = width / 2 + width % 2;
+    }
+    for (y = 0; y < height; y++) {
+      if (algo.orientation === 0) {
+        // Initialize vertical bars, each column the same
+        colorSelectOne = (step === 1) ? false : true;
+      } else if (algo.orientation === 1) {
+        // Horizontal Bars, count steps by row
+        effectiveStep = y + step * algo.blockSize + algo.offset;
+        // Initialize start color for each row.
+        if (effectiveStep % algo.blockSize === 0) {
+          colorSelectOne = !colorSelectOne;
+        }
+      } else if (algo.orientation === 2) {
+        var effectiveY = y + step * algo.blockSize + algo.offset;
+        if (effectiveY % (algo.blockSize) === 0) {
+          rowColorOne = !rowColorOne;
+        }
+        colorSelectOne = rowColorOne;
+      }
+      map[parseInt(y)] = new Array();
+      for (x = 0; x < width; x++) {
+        if (algo.orientation === 0) {
+          // Vertical bars, count steps by column
+          effectiveStep = x + algo.offset;
+          if (effectiveStep % algo.blockSize === 0) {
+            colorSelectOne = !colorSelectOne;
+          }
+        } else if (algo.orientation === 2) {
+          // Horizontal Bars, count steps by row and column
+          var effectiveX = x + step * algo.blockSize + algo.offset;
+          // Change color each step.
+          if (effectiveX % algo.blockSize === 0) {
+            colorSelectOne = !colorSelectOne;
+          }
+        }
+        if (colorSelectOne) {
+          map[parseInt(y)][parseInt(x)] = algo.getColor1Value();
+        } else {
+          map[parseInt(y)][parseInt(x)] = algo.getColor2Value();
+        }
+      }
+    }
+    // Align centered
+    if (algo.align === 1 && width % 2 === 0) {
+      for (y = 0; y < height; y++) {
+        for (x = 0; x < xMax; x++) {
+          map[parseInt(y)][parseInt(x)] = map[parseInt(y)][parseInt(width - x - 1)];
+        }
+      }
+    }
 
-	algo.rgbMapStepCount = function(width, height) {
-		return algo.maxSteps;
-	};
+    return map;
+  };
 
-	// Development tool access
-	testAlgo = algo;
+  algo.rgbMapStepCount = function(width, height) {
+    // Only two steps; one for even pixels and another for odd pixels
+    return 2;
+  };
 
-	return algo;
+  // Development tool access
+  testAlgo = algo;
+
+  return algo;
 })();

--- a/resources/rgbscripts/balls.js
+++ b/resources/rgbscripts/balls.js
@@ -27,7 +27,7 @@ var testAlgo;
     algo.apiVersion = 2;
     algo.name = "Balls";
     algo.author = "Tim Cullingworth";
-    algo.acceptColors = 2;
+    algo.acceptColors = 1;
     algo.properties = new Array();
     algo.rstepcount = 0;
     algo.gstepcount = 50;
@@ -218,7 +218,7 @@ var testAlgo;
 
     algo.rgbMapStepCount = function(width, height)
     {
-      return width * height;  // This make no diferance to the script ;-)
+      return 2;  // This make no difference to the script ;-)
     };
 
     // Development tool access

--- a/resources/rgbscripts/balls.js
+++ b/resources/rgbscripts/balls.js
@@ -218,7 +218,8 @@ var testAlgo;
 
     algo.rgbMapStepCount = function(width, height)
     {
-      return 2;  // This make no difference to the script ;-)
+      // This make no difference to the script ;-)
+      return 2;
     };
 
     // Development tool access

--- a/resources/rgbscripts/ballscolors.js
+++ b/resources/rgbscripts/ballscolors.js
@@ -70,7 +70,7 @@ var testAlgo;
     algo.apiVersion = 2;
     algo.name = "Balls (Colors)";
     algo.author = "Rob Nieuwenhuizen";
-    // algo.acceptColors = 2;
+    algo.acceptColors = 0;
     algo.properties = new Array();
     algo.presetSize = 1;
     algo.properties.push("name:presetSize|type:range|display:Size|values:1,20|write:setSize|read:getSize");

--- a/resources/rgbscripts/ballscolors.js
+++ b/resources/rgbscripts/ballscolors.js
@@ -305,7 +305,8 @@ var testAlgo;
     };
 
     algo.rgbMapStepCount = function (width, height) {
-      return width * height;  // This make no diferance to the script ;-)
+      // This make no difference to the script ;-)
+      return 2;
     };
 
     // Development tool access

--- a/resources/rgbscripts/circles.js
+++ b/resources/rgbscripts/circles.js
@@ -46,12 +46,14 @@ var testAlgo;
 
     var circles = new Array();
 
-    function Circle(x, y, step)
-    {
-      this.xCenter = x;
-      this.yCenter = y;
-      this.step = step;
-    }
+    class Circle {
+          constructor(x, y, step, rgb) {
+              this.xCenter = x;
+              this.yCenter = y;
+              this.step = step;
+              this.rgb = rgb;
+          }
+      }
 
     algo.setAmount = function(_amount)
     {
@@ -107,7 +109,7 @@ var testAlgo;
       }
     };
 
-    util.initialize = function(size)
+    util.initialize = function(size, rgb)
     {
       if (size > 0) {
         util.circlesMaxSize = size;
@@ -115,7 +117,7 @@ var testAlgo;
 
       circles = new Array();
       for (var i = 0; i < algo.circlesAmount; i++) {
-        circles[i] = new Circle(-1, -1, 0);
+        circles[i] = new Circle(-1, -1, 0, rgb);
       }
 
       util.initialized = true;
@@ -196,7 +198,11 @@ var testAlgo;
 
       for (var i = 0; i < algo.circlesAmount; i++)
       {
-        var color = util.getColor(circles[i].step, rgb);
+        if (circles[i].xCenter === -1)
+        {
+          circles[i].rgb = rgb;
+        }
+        var color = util.getColor(circles[i].step, circles[i].rgb);
         //alert("Circle " + i + " xCenter: " + circles[i].xCenter + " color: " + color.toString(16));
         if (circles[i].xCenter === -1)
         {
@@ -249,11 +255,11 @@ var testAlgo;
       if (util.initialized === false)
       {
         if ( algo.circlesSize > 0 ) {
-          util.initialize(algo.circlesSize);
+          util.initialize(algo.circlesSize, rgb);
         } else if (height < width) {
-          util.initialize(height);
+          util.initialize(height, rgb);
         } else {
-          util.initialize(width);
+          util.initialize(width, rgb);
         }
       }
 
@@ -262,7 +268,7 @@ var testAlgo;
 
     algo.rgbMapStepCount = function(width, height)
     {
-      return width;
+      return 2;
     };
 
     // Development tool access

--- a/resources/rgbscripts/circles.js
+++ b/resources/rgbscripts/circles.js
@@ -47,13 +47,13 @@ var testAlgo;
     var circles = new Array();
 
     class Circle {
-          constructor(x, y, step, rgb) {
-              this.xCenter = x;
-              this.yCenter = y;
-              this.step = step;
-              this.rgb = rgb;
-          }
+      constructor(x, y, step, rgb) {
+        this.xCenter = x;
+        this.yCenter = y;
+        this.step = step;
+        this.rgb = rgb;
       }
+    }
 
     algo.setAmount = function(_amount)
     {
@@ -185,7 +185,7 @@ var testAlgo;
 
     util.getNextStep = function(width, height, rgb)
     {
-      var x, y;
+      let x, y;
       // create an empty, black pixelMap
       util.pixelMap = new Array(height);
       for (y = 0; y < height; y++)
@@ -196,17 +196,17 @@ var testAlgo;
         }
       }
 
-      for (var i = 0; i < algo.circlesAmount; i++)
+      for (let i = 0; i < algo.circlesAmount; i++)
       {
         if (circles[i].xCenter === -1)
         {
           circles[i].rgb = rgb;
         }
-        var color = util.getColor(circles[i].step, circles[i].rgb);
+        let color = util.getColor(circles[i].step, circles[i].rgb);
         //alert("Circle " + i + " xCenter: " + circles[i].xCenter + " color: " + color.toString(16));
         if (circles[i].xCenter === -1)
         {
-          var seed = Math.floor(Math.random()*100);
+          let seed = Math.floor(Math.random()*100);
           if (seed > 50) { continue; }
           circles[i].xCenter = Math.floor(Math.random() * width);
           circles[i].yCenter = Math.floor(Math.random() * height);
@@ -214,8 +214,8 @@ var testAlgo;
         }
         else
         {
-          var l = circles[i].step * Math.cos(Math.PI / 4);
-          var radius2 = circles[i].step * circles[i].step;
+          let l = circles[i].step * Math.cos(Math.PI / 4);
+          let radius2 = circles[i].step * circles[i].step;
           l = l.toFixed(0);
 
           if ( algo.fillCircles == 0 ) {

--- a/resources/rgbscripts/devtool.html
+++ b/resources/rgbscripts/devtool.html
@@ -177,6 +177,11 @@ Google Chrome has one as well, that you can access with F12 or with <i>More Tool
  </tr>
  <tr>
   <td>
+   Alternate: <input type="checkbox" id="alternate" onChange="devtool.onAlternateChanged()"/>
+  </td>
+ </tr>
+ <tr>
+  <td>
    Speed (ms): <input type="number" min="1" id="speed" value="500" size="4" style="width: 8em;" onChange="devtool.onSpeedChanged()"/>
   </td>
  </tr>

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -197,12 +197,12 @@ devtool.initSpeedValue = function()
 devtool.initAlternateValue = function()
 {
     var alternate = localStorage.getItem("devtool.alternate");
-    if (alternate === 1) {
+    if (alternate === true) {
       alternate = true;
     } else {
       alternate = false;
     }
-    document.getElementById("alternate").value = alternate;
+    document.getElementById("alternate").checked = alternate;
 }
 
 devtool.initColorValues = function()
@@ -444,9 +444,9 @@ devtool.writeFunction = function(functionName, propertyName, value)
 
 devtool.onAlternateChanged = function()
 {
-    var alternate = document.getElementById("alternate").value;
+    var alternate = document.getElementById("alternate").checked;
     localStorage.setItem("devtool.alternate", alternate);
-    devtool.alternate = (alternate === 0);
+    devtool.alternate = alternate;
 }
 
 devtool.onSpeedChanged = function()
@@ -462,8 +462,8 @@ devtool.nextStep = function()
         devtool.setStep(devtool.currentStep + 1);
     } else {
         let timerStatus = localStorage.getItem("devtool.timerRunning");
-        let alternate = document.getElementById("alternate").value;
-        if (timerStatus == "1" && alternate === "on") {
+        let alternate = document.getElementById("alternate").checked;
+        if (timerStatus == "1" && alternate) {
             devtool.startTest(-1);
         } else {
             devtool.setStep(0);
@@ -477,8 +477,8 @@ devtool.previousStep = function()
         devtool.setStep(devtool.currentStep - 1);
     } else {
         let timerStatus = localStorage.getItem("devtool.timerRunning");
-        let alternate = document.getElementById("alternate").value;
-        if (timerStatus == "1" && alternate == "on") {
+        let alternate = document.getElementById("alternate").checked;
+        if (timerStatus == "1" && alternate) {
             devtool.startTest(1);
         } else {
             devtool.setStep(devtool.stepCount() - 1); // last step

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -374,7 +374,7 @@ devtool.stopTest = function()
 
 devtool.initTestStatus = function()
 {
-    var timerStatus = localStorage.getItem("devtool.timerRunning");
+    let timerStatus = localStorage.getItem("devtool.timerRunning");
     if (timerStatus === null || parseInt(timerStatus) === 1) {
         devtool.startTest();
     }
@@ -461,8 +461,10 @@ devtool.nextStep = function()
     if (devtool.currentStep + 1 < devtool.stepCount()) {
         devtool.setStep(devtool.currentStep + 1);
     } else {
-        if (document.getElementById("alternate").value) {
-          devtool.startTest(-1);
+        let timerStatus = localStorage.getItem("devtool.timerRunning");
+        let alternate = document.getElementById("alternate").value;
+        if (timerStatus == "1" && alternate === "on") {
+            devtool.startTest(-1);
         } else {
             devtool.setStep(0);
         }
@@ -474,10 +476,12 @@ devtool.previousStep = function()
     if (devtool.currentStep > 0 && (devtool.currentStep - 1) < devtool.stepCount()) {
         devtool.setStep(devtool.currentStep - 1);
     } else {
-        if (document.getElementById("alternate").value) {
-          devtool.startTest(1);
+        let timerStatus = localStorage.getItem("devtool.timerRunning");
+        let alternate = document.getElementById("alternate").value;
+        if (timerStatus == "1" && alternate == "on") {
+            devtool.startTest(1);
         } else {
-          devtool.setStep(devtool.stepCount() - 1); // last step
+            devtool.setStep(devtool.stepCount() - 1); // last step
         }
     }
 }

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -23,6 +23,7 @@ devtool.gridheight = null;
 devtool.gridsize = null;
 devtool.currentStep = 0;
 devtool.testTimer = null;
+devtool.alternate = false;
 
 devtool.initDefinitions = function()
 {
@@ -191,6 +192,17 @@ devtool.initSpeedValue = function()
         speed = 500;
     }
     document.getElementById("speed").value = speed;
+}
+
+devtool.initAlternateValue = function()
+{
+    var alternate = localStorage.getItem("devtool.alternate");
+    if (alternate === 1) {
+      alternate = true;
+    } else {
+      alternate = false;
+    }
+    document.getElementById("alternate").value = alternate;
 }
 
 devtool.initColorValues = function()
@@ -430,6 +442,13 @@ devtool.writeFunction = function(functionName, propertyName, value)
     devtool.updateStepCount();
 }
 
+devtool.onAlternateChanged = function()
+{
+    var alternate = document.getElementById("alternate").value;
+    localStorage.setItem("devtool.alternate", alternate);
+    devtool.alternate = (alternate == 0);
+}
+
 devtool.onSpeedChanged = function()
 {
     var speed = document.getElementById("speed").value;
@@ -442,7 +461,11 @@ devtool.nextStep = function()
     if (devtool.currentStep + 1 < devtool.stepCount()) {
         devtool.setStep(devtool.currentStep + 1);
     } else {
-        devtool.setStep(0);
+        if (document.getElementById("alternate").value) {
+          devtool.startTest(-1);
+        } else {
+            devtool.setStep(0);
+        }
     }
 }
 
@@ -451,6 +474,10 @@ devtool.previousStep = function()
     if (devtool.currentStep > 0 && (devtool.currentStep - 1) < devtool.stepCount()) {
         devtool.setStep(devtool.currentStep - 1);
     } else {
-        devtool.setStep(devtool.stepCount() - 1); // last step
+        if (document.getElementById("alternate").value) {
+          devtool.startTest(1);
+        } else {
+          devtool.setStep(devtool.stepCount() - 1); // last step
+        }
     }
 }

--- a/resources/rgbscripts/devtool.js
+++ b/resources/rgbscripts/devtool.js
@@ -446,7 +446,7 @@ devtool.onAlternateChanged = function()
 {
     var alternate = document.getElementById("alternate").value;
     localStorage.setItem("devtool.alternate", alternate);
-    devtool.alternate = (alternate == 0);
+    devtool.alternate = (alternate === 0);
 }
 
 devtool.onSpeedChanged = function()

--- a/resources/rgbscripts/fireworks.js
+++ b/resources/rgbscripts/fireworks.js
@@ -27,7 +27,7 @@ var testAlgo;
     algo.apiVersion = 2;
     algo.name = "Fireworks";
     algo.author = "Hans-Jürgen Tappe";
-    algo.acceptColors = 2;
+    algo.acceptColors = 1;
     algo.properties = new Array();
     algo.initialized = false;
 

--- a/resources/rgbscripts/fireworks.js
+++ b/resources/rgbscripts/fireworks.js
@@ -23,6 +23,8 @@ var testAlgo;
 (
   function()
   {
+    var util = new Object;
+
     var algo = new Object;
     algo.apiVersion = 2;
     algo.name = "Fireworks";
@@ -215,7 +217,6 @@ var testAlgo;
 
     // --------------------------------
     // Helper Utilities & Functions
-    var util = new Object;
 
     util.gravity = 0.4;
     util.acceleration = 1.05;

--- a/resources/rgbscripts/flyingobjects.js
+++ b/resources/rgbscripts/flyingobjects.js
@@ -27,7 +27,7 @@ var testAlgo;
     algo.apiVersion = 2;
     algo.name = "Flying Objects";
     algo.author = "Hans-Jürgen Tappe";
-    algo.acceptColors = 2;
+    algo.acceptColors = 1;
     algo.properties = new Array();
 
     // Algorithms ----------------------------

--- a/resources/rgbscripts/flyingobjects.js
+++ b/resources/rgbscripts/flyingobjects.js
@@ -23,6 +23,10 @@ var testAlgo;
 
 (function()
   {
+    var util = new Object;
+
+    let geometryCalc = new Object;
+
     var algo = new Object;
     algo.apiVersion = 2;
     algo.name = "Flying Objects";
@@ -1081,7 +1085,6 @@ var testAlgo;
 
     // General Purpose Functions ------------------
 
-    let geometryCalc = new Object;
     geometryCalc.cache = {
       presetRadius: 0,
     };
@@ -1144,7 +1147,6 @@ var testAlgo;
     }
     
     // Utility functions --------------------------
-    var util = new Object;
 
     util.initialize = function(width, height)
     {

--- a/resources/rgbscripts/lines.js
+++ b/resources/rgbscripts/lines.js
@@ -59,6 +59,7 @@ var testAlgo;
               this.xCenter = x;
               this.yCenter = y;
               this.step = step;
+              this.color = 0;
           }
       };
 
@@ -270,16 +271,15 @@ var testAlgo;
 
       for (var i = 0; i < algo.linesAmount; i++)
       {
-        var color = util.getColor(lines[i].step, rgb);
-        //alert("Line " + i + " xCenter: " + lines[i].xCenter + " color: " + color.toString(16));
-        //move center if set
-
         if (lines[i].xCenter === -1)
         {
           // Randomize the initialization of a new line.
           var seed = Math.floor(Math.random() * 100);
           if (seed > 50)
             continue;
+
+          // apply the current step color
+          lines[i].color = rgb;
 
           // if biased .. move the start points to the cardinal ends of the space
           if (algo.linesBias == 1 || algo.linesBias == 5 || algo.linesBias == 6)
@@ -308,8 +308,11 @@ var testAlgo;
             lines[i].xCenter = Math.round(Math.random() * (width - 1));
           }
 
-          util.pixelMap[lines[i].yCenter][lines[i].xCenter] = color;
+          util.pixelMap[lines[i].yCenter][lines[i].xCenter] = lines[i].color;
         } else {
+          var color = util.getColor(lines[i].step, lines[i].color);
+          //alert("Line " + i + " xCenter: " + lines[i].xCenter + " color: " + color.toString(16));
+
           var l = lines[i].step * Math.cos(Math.PI / 4);
           var radius2 = lines[i].step * lines[i].step;
           l = l.toFixed(0);
@@ -383,7 +386,7 @@ var testAlgo;
 
     algo.rgbMapStepCount = function(width, height)
     {
-      return algo.linesSize;
+      return 2;
     };
 
     // Development tool access

--- a/resources/rgbscripts/lines.js
+++ b/resources/rgbscripts/lines.js
@@ -54,12 +54,13 @@ var testAlgo;
 
     var lines = new Array();
 
-    function Line(x, y, step)
-    {
-      this.xCenter = x;
-      this.yCenter = y;
-      this.step = step;
-    };
+    class Line {
+          constructor(x, y, step) {
+              this.xCenter = x;
+              this.yCenter = y;
+              this.step = step;
+          }
+      };
 
     algo.setLinesSize = function(_size)
     {

--- a/resources/rgbscripts/lines.js
+++ b/resources/rgbscripts/lines.js
@@ -55,13 +55,13 @@ var testAlgo;
     var lines = new Array();
 
     class Line {
-          constructor(x, y, step) {
-              this.xCenter = x;
-              this.yCenter = y;
-              this.step = step;
-              this.color = 0;
-          }
-      };
+      constructor(x, y, step) {
+        this.xCenter = x;
+        this.yCenter = y;
+        this.step = step;
+        this.color = 0;
+      }
+    };
 
     algo.setLinesSize = function(_size)
     {

--- a/resources/rgbscripts/randomcolumn.js
+++ b/resources/rgbscripts/randomcolumn.js
@@ -101,7 +101,7 @@ var testAlgo;
 
         algo.rgbMapStepCount = function(width, height)
         {
-            return width;
+            return 2;
         };
 
         // Development tool access

--- a/resources/rgbscripts/randomrow.js
+++ b/resources/rgbscripts/randomrow.js
@@ -101,7 +101,7 @@ var testAlgo;
 
         algo.rgbMapStepCount = function(width, height)
         {
-            return height;
+            return 2;
         };
 
         // Development tool access

--- a/resources/rgbscripts/randomsingle.js
+++ b/resources/rgbscripts/randomsingle.js
@@ -157,7 +157,7 @@ var testAlgo;
             // All pixels in the map must be used exactly once, each one separately
             // at a time. Therefore, the maximum number of steps produced by this
             // script on a 5 * 5 grid is 25.
-            return width * height;
+            return 2;
         };
 
         // Development tool access

--- a/resources/rgbscripts/snowbubbles.js
+++ b/resources/rgbscripts/snowbubbles.js
@@ -28,7 +28,7 @@ var testAlgo;
     algo.name = "Snow or Bubbles";
     algo.author = "Hans-Jürgen Tappe";
     algo.properties = [];
-    algo.acceptColors = 2;
+    algo.acceptColors = 1;
     algo.presetColor = 0x000000;
     // number of flakes on screen at one time (default)
     algo.presetflakes = 20;

--- a/resources/rgbscripts/snowbubbles.js
+++ b/resources/rgbscripts/snowbubbles.js
@@ -44,8 +44,6 @@ var testAlgo;
     var depth = 5;
     // main flake position array
     var flakes = new Array(255);
-    // set flake color to user chosen color at the start
-    var zcolor = algo.presetColor;
     algo.speedX = 0;
 
     algo.setAmount = function (_amount) {
@@ -271,7 +269,7 @@ var testAlgo;
     };
 
     algo.rgbMapStepCount = function (width, height) {
-      return width * height;
+      return 2;
     };
 
   // Development tool access

--- a/resources/rgbscripts/squares.js
+++ b/resources/rgbscripts/squares.js
@@ -47,6 +47,7 @@ var testAlgo;
         this.xCenter = x;
         this.yCenter = y;
         this.step = step;
+        this.color = 0;
       }
     }
 
@@ -125,6 +126,29 @@ var testAlgo;
         return newRGB;
       }
     };
+    
+    util.mergeRgb = function(rgb1, rgb2)
+    {
+      if (rgb1 === 0) {
+        return rgb2;
+      } else if (rgb2 === 0) {
+        return rgb1;
+      }
+      // split rgb in to components
+      let r1 = (rgb1 >> 16) & 0x00FF;
+      let g1 = (rgb1 >> 8) & 0x00FF;
+      let b1 = rgb1 & 0x00FF;
+
+      let r2 = (rgb2 >> 16) & 0x00FF;
+      let g2 = (rgb2 >> 8) & 0x00FF;
+      let b2 = rgb2 & 0x00FF;
+      
+      let r = Math.max(r1, r2);
+      let g = Math.max(g1, g2);
+      let b = Math.max(b1, b2);
+      
+      return ((r << 16) + (g << 8) + b);
+    }
 
     util.getNextStep = function(width, height, rgb)
     {
@@ -142,7 +166,6 @@ var testAlgo;
 
       for (var i = 0; i < algo.squaresAmount; i++)
       {
-        var color = util.getColor(squares[i].step, rgb);
         //alert("Square " + i + " xCenter: " + squares[i].xCenter + " color: " + color.toString(16));
         if (squares[i].xCenter === -1)
         {
@@ -150,10 +173,13 @@ var testAlgo;
           if (seed > 50) { continue; }
           squares[i].xCenter = Math.floor(Math.random() * width);
           squares[i].yCenter = Math.floor(Math.random() * height);
-          map[squares[i].yCenter][squares[i].xCenter] = color;
+          squares[i].color = rgb;
+          map[squares[i].yCenter][squares[i].xCenter] =
+              util.mergeRgb(map[squares[i].yCenter][squares[i].xCenter], squares[i].color);
         }
         else
         {
+          var color = util.getColor(squares[i].step, squares[i].color);
           var firstY = squares[i].yCenter - squares[i].step;
           var side = (squares[i].step * 2) + 1;
           for (var sy = firstY; sy <= (firstY + side); sy++)
@@ -167,12 +193,12 @@ var testAlgo;
               if (sx < 0 || sx >= width) { continue; }
               if (sy === firstY || sy === firstY + side || algo.fillSquares === 1)
               {
-                map[sy][sx] = color;
+                map[sy][sx] = util.mergeRgb(map[sy][sx], color);
               }
               else
               {
                 if (sx === firstX || sx === firstX + side) {
-                  map[sy][sx] = color;
+                  map[sy][sx] = util.mergeRgb(map[sy][sx], color);
                 }
               }
             }
@@ -207,11 +233,7 @@ var testAlgo;
 
     algo.rgbMapStepCount = function(width, height)
     {
-      if (height < width) {
-        return height;
-      } else {
-        return width;
-      }
+      return 2;
     };
 
     // Development tool access

--- a/resources/rgbscripts/squares.js
+++ b/resources/rgbscripts/squares.js
@@ -42,11 +42,12 @@ var testAlgo;
 
     var squares = new Array();
 
-    function Square(x, y, step)
-    {
-      this.xCenter = x;
-      this.yCenter = y;
-      this.step = step;
+    class Square {
+      constructor(x, y, step) {
+        this.xCenter = x;
+        this.yCenter = y;
+        this.step = step;
+      }
     }
 
     algo.setAmount = function(_amount)

--- a/resources/rgbscripts/starfield.js
+++ b/resources/rgbscripts/starfield.js
@@ -22,193 +22,191 @@
 var testAlgo;
 
 (
-    function () {
-        var algo = {};
-        algo.apiVersion = 2;
-        algo.name = "3D Starfield";
-        algo.author = "Doug Puckett+Branson Matheson";
-        algo.properties = [];
-        algo.acceptColors = 1;
-        algo.presetColor = 0x000000;
-        algo.properties.push("name:StarsAmount|type:range|display:Number of Stars (10-255)|values:10,255|write:setAmount|read:getAmount");
-        algo.presetStars = 50;          // 50 stars on screen at one time (default)
-        algo.properties.push("name:MultiColor|type:list|display:MultiColored Stars?|values:No,Yes|write:setMulti|read:getMulti");
-        algo.multiColor = 0;            // Multicolor stars off defaultly (1 = stars will be randomly colored)
-        algo.properties.push("name:InvertBrightness|type:list|display:Invert Brightness|values:Dim->Bright,Bright->Dim|write:setInvert|read:getInvert");
-        algo.invertColor = 0;           // Reverse Brightness
-        var depth = 128;                // depth - best not to change
-        var stars = new Array(255);     // main star position array
+  function() {
+    var algo = {};
+    algo.apiVersion = 2;
+    algo.name = "3D Starfield";
+    algo.author = "Doug Puckett+Branson Matheson";
+    algo.properties = [];
+    algo.acceptColors = 1;
+    algo.presetColor = 0x000000;
+    algo.properties.push("name:StarsAmount|type:range|display:Number of Stars (10-255)|values:10,255|write:setAmount|read:getAmount");
+    algo.presetStars = 50;          // 50 stars on screen at one time (default)
+    algo.properties.push("name:MultiColor|type:list|display:MultiColored Stars?|values:No,Yes|write:setMulti|read:getMulti");
+    algo.multiColor = 0;            // Multicolor stars off defaultly (1 = stars will be randomly colored)
+    algo.properties.push("name:InvertBrightness|type:list|display:Invert Brightness|values:Dim->Bright,Bright->Dim|write:setInvert|read:getInvert");
+    algo.invertColor = 0;           // Reverse Brightness
+    var depth = 128;                // depth - best not to change
+    var stars = new Array(255);     // main star position array
 
-        algo.setAmount = function(_amount) {
-            algo.presetStars = _amount;
+    algo.setAmount = function(_amount) {
+      algo.presetStars = _amount;
+    };
+
+    algo.getAmount = function() {
+      return algo.presetStars;
+    };
+
+    algo.setMulti = function(_multic) {
+      if (_multic === "Yes") {
+        algo.multiColor = 1;    // Random Colored Stars
+      } else {
+        algo.multiColor = 0;    // Stars are chosen color
+      }
+    };
+
+    algo.getMulti = function() {
+      if (algo.multiColor === 1) {
+        return "Yes";
+      } else {
+        return "No";
+      }
+    };
+
+    algo.setInvert = function(_invert) {
+      if (_invert === "Bright->Dim") {
+        algo.invertColor = 1;    // Start Bright -> Dim
+      } else {
+        algo.invertColor = 0;    // Start Dim -> Bright
+      }
+    };
+
+    algo.getInvert = function() {
+      if (algo.invertColor === 1) {
+        return "Bright->Dim";
+      } else {
+        return "Dim->Bright";
+      }
+    };
+
+
+    var util = new Object;
+    algo.initialized = false;
+
+    //random position function for new star
+    function getNewNumberRange(minVal, maxVal) {
+      minVal = Math.random() * minVal;
+      maxVal = Math.random() * maxVal;
+      return Math.floor(Math.random() * (maxVal - minVal + 1)) + minVal;
+    }
+
+    //set color of star - if multicolor, choose random color. If not random, return user chosen color
+    function getNewColor(isMultiColor, zColor) {
+      if (isMultiColor === 1) {
+        var tr = Math.floor(Math.random() * 255);   // random red level
+        var tg = Math.floor(Math.random() * 255);   // random green level
+        var tb = Math.floor(Math.random() * 255);   // random blue level
+        return (tr << 16) + (tg << 8) + tb;         // returned combined color
+      } else {
+        // If not multicolor, return chosen color
+        return zColor;
+      }
+    }
+
+    // initialize the stars and load random positions
+    util.initialize = function(width, height) {
+      for (var i = 0; i < stars.length; i++) {
+        stars[i] = {
+          x: getNewNumberRange(-10, 10),
+          y: getNewNumberRange(-10, 10),
+          z: depth,
+          c: getNewColor(algo.multiColor, algo.presetColor)
         };
+      }
 
-        algo.getAmount = function() {
-            return algo.presetStars;
-        };
+      algo.initialized = true;
+      return;
+    };
 
-        algo.setMulti = function(_multic)
-        {
-            if (_multic === "Yes") {
-                algo.multiColor = 1;    // Random Colored Stars
-            } else {
-                algo.multiColor = 0;    // Stars are chosen color
-            }
-        };
+    // main QLC+ routine where the work is done
+    algo.rgbMap = function(width, height, rgb, step) {
+      if (algo.initialized === false) {
+        util.initialize(width, height);
+      }
 
-        algo.getMulti = function() {
-            if (algo.multiColor === 1) {
-                return "Yes";
-            } else {
-                return "No";
-            }
-        };
+      // Clear map data for a blank map
+      var map = new Array(height);
 
-        algo.setInvert = function(_invert) {
-            if (_invert === "Bright->Dim") {
-                algo.invertColor = 1;    // Start Bright -> Dim
-            } else {
-                algo.invertColor = 0;    // Start Dim -> Bright
-            }
-        };
+      for (var y = 0; y < height; y++) {
+        map[y] = new Array();
+        for (var x = 0; x < width; x++) {
+          map[y][x] = 0;
+        }
+      }
 
-        algo.getInvert = function() {
-            if (algo.invertColor === 1) {
-                return "Bright->Dim";
-            } else {
-                return "Dim->Bright";
-            }
-        };
+      // find center of display
+      var halfWidth = width / 2;
+      var halfHeight = height / 2;
 
+      // start moving the stars by looping through this routine, addressing each star individually (i is the star number)
+      for (var i = 0; i < algo.presetStars - 1; i++) {
 
-        var util = new Object;
-        algo.initialized = false;
+        // decrease depth on each pass through 
+        if (height >= width) { stars[i].z -= height / (height / 4); }
+        else { stars[i].z -= width / (width / 4); }
 
-        //random position function for new star
-        function getNewNumberRange(minVal,maxVal) {
-            minVal = Math.random() * minVal;
-            maxVal = Math.random() * maxVal;
-            return Math.floor(Math.random() * (maxVal - minVal + 1)) + minVal;
+        // if star is off screen (depth is zero or less) then create a new star near the center of the display
+        if (stars[i].z <= 0) {
+          stars[i].x = getNewNumberRange(-10, 10);
+          stars[i].y = getNewNumberRange(-10, 10);
+          stars[i].z = depth;
+          stars[i].c = getNewColor(algo.multiColor, rgb);
         }
 
-        //set color of star - if multicolor, choose random color. If not random, return user chosen color
-        function getNewColor(isMultiColor,zColor) {
-            if (isMultiColor === 1) {
-                var tr = Math.floor(Math.random() * 255);   // random red level
-                var tg = Math.floor(Math.random() * 255);   // random green level
-                var tb = Math.floor(Math.random() * 255);   // random blue level
-                return (tr << 16) + (tg << 8) + tb;         // returned combined color
-            }
-            else {
-                return zColor;  // If not multicolor, return chosen color
-            }
+        // calculate the stars next position
+        var k = 200 / stars[i].z;                           // how far away the star is
+        var px = Math.floor(stars[i].x * k + halfWidth);    // x position of star
+        var py = Math.floor(stars[i].y * k + halfHeight);   // y position of star
+
+        if (px > 0 && px < width && py > 0 && py < height) {
+          // if star is in the center, then it should be darker (farther away)
+          // and lighten as it moves "closer" (out to the edges)
+          if (algo.invertColor == 1) {
+            var colorLevel = (stars[i].z * 2);
+          } else {
+            var colorLevel = (255 - (stars[i].z * 2));
+          }
+
+          // parse out individual colors of current star color
+          var r = (stars[i].c >> 16) & 0x00FF;
+          var g = (stars[i].c >> 8) & 0x00FF;
+          var b = stars[i].c & 0x00FF;
+
+          // Adjust star brightness level based on how far away it is and by chosen star color
+          var rr = r - (255 - colorLevel);
+          var gg = g - (255 - colorLevel);
+          var bb = b - (255 - colorLevel);
+
+          // Limit each color element to the maximum for chosen color or make 0 if below 0
+          if (rr > r) { rr = r; }
+          if (rr < 0) { rr = 0; }
+          if (gg > g) { gg = g; }
+          if (gg < 0) { gg = 0; }
+          if (bb > b) { bb = b; }
+          if (bb < 0) { bb = 0; }
+
+          // put all the individual rgb colors back together
+          var pRGB = (rr << 16) + (gg << 8) + bb;
+          px = Math.floor(px); // get rid of x and y position fractions
+          py = Math.floor(py);
+          map[py][px] = pRGB; // store the star's combined color in the map
+          // console.log("i: " + i + " px: " + px + " py: " + py + " pz: " + stars[i].z + " color: " + r+g+b);
+        } else {
+          // console.log("i: " + i + " k: " + k + " px: " + px + " width: " + width + " py: " + py + " height: " + height);
+          stars[i].z = 0;     // if here, the star was outside screen for some reason so force a new star
         }
+      }
+      return map; // return the map back to QLC+
 
-        // initialize the stars and load random positions
-        util.initialize = function (width, height) {
-           for (var i = 0; i < stars.length; i++) {
-                stars[i] = {
-                    x: getNewNumberRange(-10,10),
-                    y: getNewNumberRange(-10,10),
-                    z: depth,
-                    c: getNewColor(algo.multiColor, algo.presetColor)
-                };
-            }
+    };
 
-            algo.initialized = true;
-            return;
-        };
-
-        // main QLC+ routine where the work is done
-        algo.rgbMap = function (width, height, rgb, step) {
-
-            if (algo.initialized === false) {
-                util.initialize(width, height);
-            }
-
-            // Clear map data for a blank map
-            var map = new Array(height);
-
-            for (var y = 0; y < height; y++) {
-                map[y] = new Array();
-                for (var x = 0; x < width; x++) {
-                    map[y][x] = 0;
-                }
-            }
-
-            // find center of display
-            var halfWidth = width / 2;
-            var halfHeight = height / 2;
-
-            // start moving the stars by looping through this routine, addressing each star individually (i is the star number)
-            for (var i = 0; i < algo.presetStars-1; i++) {
-
-                // decrease depth on each pass through 
-                if (height >= width) { stars[i].z -= height/(height/4); }
-                else { stars[i].z -= width/(width/4); }
-
-                // if star is off screen (depth is zero or less) then create a new star near the center of the display
-                if (stars[i].z <= 0) {
-                    stars[i].x = getNewNumberRange(-10,10);
-                    stars[i].y = getNewNumberRange(-10,10);
-                    stars[i].z = depth;
-                    stars[i].c = getNewColor(algo.multiColor,rgb);
-                }
-
-                // calculate the stars next position
-                var k = 200 / stars[i].z;                           // how far away the star is
-                var px = Math.floor(stars[i].x * k + halfWidth);    // x position of star
-                var py = Math.floor(stars[i].y * k + halfHeight);   // y position of star
-
-                if ( px > 0 && px < width && py > 0 && py < height) {
-                  // if star is in the center, then it should be darker (farther away)
-                  // and lighten as it moves "closer" (out to the edges)
-                  if (algo.invertColor == 1) {
-                    var colorLevel = (stars[i].z * 2);
-                  } else {
-                    var colorLevel = (255 - (stars[i].z * 2));
-                  }
-
-                  // parse out individual colors of current star color
-                  var r = (stars[i].c >> 16) & 0x00FF;
-                  var g = (stars[i].c >> 8) & 0x00FF;
-                  var b = stars[i].c & 0x00FF;
-
-                  // Adjust star brightness level based on how far away it is and by chosen star color
-                  var rr = r - (255 - colorLevel);
-                  var gg = g - (255 - colorLevel);
-                  var bb = b - (255 - colorLevel);
-
-                  // Limit each color element to the maximum for chosen color or make 0 if below 0
-                  if (rr > r) { rr = r; }
-                  if (rr < 0) { rr = 0; }
-                  if (gg > g) { gg = g; }
-                  if (gg < 0) { gg = 0; }
-                  if (bb > b) { bb = b; }
-                  if (bb < 0) { bb = 0; }
-
-                  // put all the individual rgb colors back together
-                  var pRGB = (rr << 16) + (gg << 8) + bb;
-                  px = Math.floor(px); // get rid of x and y position fractions
-                  py = Math.floor(py);
-                  map[py][px] = pRGB; // store the star's combined color in the map
-                  // console.log("i: " + i + " px: " + px + " py: " + py + " pz: " + stars[i].z + " color: " + r+g+b);
-                } else {
-                    // console.log("i: " + i + " k: " + k + " px: " + px + " width: " + width + " py: " + py + " height: " + height);
-                    stars[i].z = 0;     // if here, the star was outside screen for some reason so force a new star
-                }
-            }
-            return map; // return the map back to QLC+
-            
-        };
-
-        algo.rgbMapStepCount = function (width, height) {
-            return 2;
-        };
+    algo.rgbMapStepCount = function(width, height) {
+      return 2;
+    };
 
     // Development tool access
     testAlgo = algo;
 
     return algo;
-}
+  }
 )();

--- a/resources/rgbscripts/starfield.js
+++ b/resources/rgbscripts/starfield.js
@@ -38,7 +38,6 @@ var testAlgo;
         algo.invertColor = 0;           // Reverse Brightness
         var depth = 128;                // depth - best not to change
         var stars = new Array(255);     // main star position array
-        var zcolor = algo.presetColor;  // set star color to user chosen color at the start
 
         algo.setAmount = function(_amount) {
             algo.presetStars = _amount;
@@ -204,7 +203,7 @@ var testAlgo;
         };
 
         algo.rgbMapStepCount = function (width, height) {
-            return width * height;
+            return 2;
         };
 
     // Development tool access

--- a/resources/rgbscripts/waves.js
+++ b/resources/rgbscripts/waves.js
@@ -192,7 +192,6 @@ function()
       var isEven = (span % 2 === 0);
       var tailSteps = Math.round(span * algo.taillength/100);
       if (tailSteps === 0) { tailSteps = 1; }
-      var mult = (1 + (algo.taillength/100));
       if ((algo.direction === 0) || (algo.direction === 1)) {
         return (span + tailSteps - (isEven ? 0 : 1));
       } else if ((algo.direction === 2) || (algo.direction === 3)) {

--- a/resources/rgbscripts/waves.js
+++ b/resources/rgbscripts/waves.js
@@ -22,6 +22,9 @@ var testAlgo;
 (
 function()
 {
+    var util = new Object;
+    util.initialized = false;
+
     var algo = new Object;
     algo.apiVersion = 2;
     algo.name = "Waves";
@@ -87,9 +90,6 @@ function()
       if (algo.orientation === 1) { return "Vertical"; }
       else if (algo.orientation === 0) { return "Horizontal"; }
     };
-
-    var util = new Object;
-    util.initialized = false;
 
     util.initialize = function()
     {


### PR DESCRIPTION
Hello @mcallegari,

I took some in-depth time to review the attributes, usage and code of the RGB matrix scripts and have corrected the places which raised my attention. Please review if you agree with my findings.

- Set the acceptColors to a value as used in the script. Some scripts had no value set, which defaults to 2, but never used the second color.
- Set the acceptColors to 1 if the second color can neither be used in matrix object initalization and if the script does not evaluate the current progStep to always apply the same color in the same point in sequence of steps (i.e. it does not distinguish between forward / backward increments / decrements). Color change on the stage must be managed otherwise, e.g. through the virtual console to achieve a synchronous color change.
- Set the rgbMapStepCount to 2 if it is not relevant for the proceedings of the effect, especially to make the acceptColors=2 usable as the second color in instanciating matrix objects (apply the first / second color on an even / uneven step)
- Fix tabs to spaces
- Use the ECMAscript 2015 form and replace Class Functions by a Class with constructor.