### PR TITLE
Scene editor: Immediately update tabs in when fixture selection changes

### DIFF
--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -334,6 +334,8 @@ void SceneEditor::init(bool applyValues)
     }
     connect(m_channelGroupsTree, SIGNAL(itemChanged(QTreeWidgetItem*,int)),
             this, SLOT(slotChannelGroupsChanged(QTreeWidgetItem*,int)));
+    connect(m_tree, SIGNAL(itemSelectionChanged()),
+            this, SLOT(selectedFixturesChanged()));
     connect(m_enableChannelsButton, SIGNAL(clicked()),
             this, SLOT(slotEnableAll()));
     connect(m_disableChannelsButton, SIGNAL(clicked()),
@@ -902,6 +904,11 @@ void SceneEditor::slotModeChanged(Doc::Mode mode)
         slotBlindToggled(false);
     }
 
+}
+
+void SceneEditor::selectedFixturesChanged()
+{
+    slotViewModeChanged(m_tabViewAction->isChecked(), true);
 }
 
 void SceneEditor::slotViewModeChanged(bool tabbed, bool applyValues)

--- a/ui/src/sceneeditor.h
+++ b/ui/src/sceneeditor.h
@@ -176,6 +176,7 @@ public slots:
 
 private slots:
     /** called when the user check/uncheck a group of m_channelGroupsTree */
+    void selectedFixturesChanged();
     void slotChannelGroupsChanged(QTreeWidgetItem*item, int column);
 
     /** Called when the user moves a fader of the ChannelGroup console */


### PR DESCRIPTION
Currently, when the view is changed between the Tab View and the All Fixtures View, only the fixtures selected in the General tab are populated. This is somewhat confusing. The purpose appears to be so I can highlight a subset of fixtures, and "Copy current values to all fixtures" will only copy to the _selected_ fixtures.

This adds a signal to update the tabs and consoles immediately when the selection changes.

---

This is submitted as a draft because populating all of the tabs when the selection changes is a little sluggish, there's a few optimizations I'd like to work on.

Alternatively, if this feature was supposed to be removed, let's remove the code for that in the Tab/All channels toggle as well.