### PR TITLE
Web interface - Slider - Top level value disappears when changed

### DIFF
--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -1228,7 +1228,7 @@ void VCSlider::setTopLabelText(int value)
 
     if (valueDisplayStyle() == ExactValue)
     {
-        m_topLabel->setText(text.asprintf("%.3d", value));
+        text = text.asprintf("%.3d", value);
     }
     else
     {
@@ -1237,9 +1237,9 @@ void VCSlider::setTopLabelText(int value)
         if (m_slider)
             f = SCALE(float(value), float(m_slider->minimum()),
                       float(m_slider->maximum()), float(0), float(100));
-        m_topLabel->setText(text.asprintf("%.3d%%", static_cast<int> (f)));
+        text = text.asprintf("%.3d%%", static_cast<int> (f));
     }
-
+    m_topLabel->setText(text);
     emit valueChanged(text);
 }
 


### PR DESCRIPTION
Hello Massimo,

This 3 lines change in vcslider.cpp is fixing the issue in the sliders of the web interface "[4.12.3] Slider - Current value disappears when changed" that is reported here:
https://www.qlcplus.org/forum/viewtopic.php?f=34&t=14584

This issue was actually introduced in QLC+ 4.12.3 when QString::sprintf was replaced by QString::asprintf in VCSlider::setTopLabelText:
https://github.com/mcallegari/qlcplus/compare/QLC+_4.12.2...QLC+_4.12.3#diff-16b0bf7edf2376537e0c84b9fd8fe4b1a3d5503253fa4a40ed614bc16e3a7d19

I really appreciate QLC+ and I'm very happy to contribute a little bit to the project.
