### PR TITLE
noop/cosmetic: remove duplicate resource includes in affected .ui files

### DIFF
--- a/ui/src/aboutbox.ui
+++ b/ui/src/aboutbox.ui
@@ -339,7 +339,6 @@ p, li { white-space: pre-wrap; }
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/addfixture.ui
+++ b/ui/src/addfixture.ui
@@ -292,7 +292,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/addrgbpanel.ui
+++ b/ui/src/addrgbpanel.ui
@@ -365,7 +365,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/audioeditor.ui
+++ b/ui/src/audioeditor.ui
@@ -330,7 +330,6 @@
  </tabstops>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/channelmodifiereditor.ui
+++ b/ui/src/channelmodifiereditor.ui
@@ -208,7 +208,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/channelsselection.ui
+++ b/ui/src/channelsselection.ui
@@ -93,7 +93,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/chasereditor.ui
+++ b/ui/src/chasereditor.ui
@@ -770,7 +770,7 @@
     </widget>
    </item>
    <item row="7" column="2">
-    <widget class="Line" name="line">
+    <widget class="Line" name="line_3">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -796,7 +796,6 @@
   </layout>
  </widget>
  <resources>
-  <include location="qlcui.qrc"/>
   <include location="qlcui.qrc"/>
  </resources>
  <connections/>

--- a/ui/src/collectioneditor.ui
+++ b/ui/src/collectioneditor.ui
@@ -201,7 +201,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/dmxdumpfactory.ui
+++ b/ui/src/dmxdumpfactory.ui
@@ -188,7 +188,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/efxeditor.ui
+++ b/ui/src/efxeditor.ui
@@ -729,7 +729,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/fixturegroupeditor.ui
+++ b/ui/src/fixturegroupeditor.ui
@@ -200,7 +200,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/fixtureremap.ui
+++ b/ui/src/fixtureremap.ui
@@ -304,7 +304,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/functionwizard.ui
+++ b/ui/src/functionwizard.ui
@@ -359,7 +359,6 @@ p, li { white-space: pre-wrap; }
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/inputoutputpatcheditor.ui
+++ b/ui/src/inputoutputpatcheditor.ui
@@ -425,7 +425,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
  <slots>

--- a/ui/src/inputprofileeditor.ui
+++ b/ui/src/inputprofileeditor.ui
@@ -408,7 +408,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/inputselectionwidget.ui
+++ b/ui/src/inputselectionwidget.ui
@@ -301,7 +301,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/monitor/monitorbackgroundselection.ui
+++ b/ui/src/monitor/monitorbackgroundselection.ui
@@ -166,7 +166,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/monitor/monitorfixturepropertieseditor.ui
+++ b/ui/src/monitor/monitorfixturepropertieseditor.ui
@@ -200,7 +200,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/scripteditor.ui
+++ b/ui/src/scripteditor.ui
@@ -226,7 +226,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/showmanager/showeditor.ui
+++ b/ui/src/showmanager/showeditor.ui
@@ -154,8 +154,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
+  <include location="../qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/videoeditor.ui
+++ b/ui/src/videoeditor.ui
@@ -303,7 +303,6 @@
  </widget>
  <resources>
   <include location="qlcui.qrc"/>
-  <include location="qlcui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ui/src/virtualconsole/addvcbuttonmatrix.ui
+++ b/ui/src/virtualconsole/addvcbuttonmatrix.ui
@@ -229,7 +229,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vcbuttonproperties.ui
+++ b/ui/src/virtualconsole/vcbuttonproperties.ui
@@ -318,7 +318,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vcclockproperties.ui
+++ b/ui/src/virtualconsole/vcclockproperties.ui
@@ -233,7 +233,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vccuelistproperties.ui
+++ b/ui/src/virtualconsole/vccuelistproperties.ui
@@ -366,7 +366,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vcmatrixpresetselection.ui
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.ui
@@ -102,7 +102,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vcmatrixproperties.ui
+++ b/ui/src/virtualconsole/vcmatrixproperties.ui
@@ -396,7 +396,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vcsliderproperties.ui
+++ b/ui/src/virtualconsole/vcsliderproperties.ui
@@ -602,7 +602,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/ui/src/virtualconsole/vcxypadproperties.ui
+++ b/ui/src/virtualconsole/vcxypadproperties.ui
@@ -470,7 +470,6 @@
  </widget>
  <resources>
   <include location="../qlcui.qrc"/>
-  <include location="../qlcui.qrc"/>
  </resources>
  <connections>
   <connection>


### PR DESCRIPTION
By chance I found out that most .ui files in ui/src and subdirs have a duplicated entry for including the common icon resource...

Obviously this didn't harm in any way, but I thought it's better to tidy this up.