### PR TITLE
Round values explicitly in FadeChannel and KeyPadParser

### DIFF
--- a/engine/src/fadechannel.cpp
+++ b/engine/src/fadechannel.cpp
@@ -323,14 +323,11 @@ uchar FadeChannel::calculateCurrent(uint fadeTime, uint elapsedTime)
         // 16 bit fading works as long as MSB and LSB channels
         // are targeting the same value. E.g. Red and Red Fine both at 158
         float val = (float(m_target - m_start) * (float(elapsedTime) / float(fadeTime))) + float(m_start);
+        long rval = lrintf(val * 256);
         if (m_flags & Fine)
-        {
-            m_current = ((val - floor(val)) * float(UCHAR_MAX));
-        }
+            m_current = rval & 0xff;
         else
-        {
-            m_current = val;
-        }
+            m_current = rval / 256;
     }
 
     return uchar(m_current);

--- a/engine/src/keypadparser.cpp
+++ b/engine/src/keypadparser.cpp
@@ -17,6 +17,8 @@
   limitations under the License.
 */
 
+#include <cmath>
+
 #include "keypadparser.h"
 #include "qlcmacros.h"
 
@@ -194,9 +196,9 @@ QList<SceneValue> KeyPadParser::parseCommand(Doc *doc, QString command,
         else if (lastCommand == CommandMinus)
             scv.value = CLAMP(uniValue - toValue, 0, 255);
         else if (lastCommand == CommandPlusPercent)
-            scv.value = CLAMP(uniValue * (1.0 + toValue), 0, 255);
+            scv.value = CLAMP(lrintf(uniValue * (1.0 + toValue)), 0, 255);
         else if (lastCommand == CommandMinusPercent)
-            scv.value = CLAMP(uniValue - (float(uniValue) * toValue), 0, 255);
+            scv.value = CLAMP(lrintf(uniValue - (float(uniValue) * toValue)), 0, 255);
         else if (lastCommand == CommandZERO)
             scv.value = 0;
         else if (lastCommand == CommandFULL)


### PR DESCRIPTION
This fixes #1344. Tests on arm64 and i386 pass with this patch as we can see in [Debian buildd status](https://buildd.debian.org/status/package.php?p=qlcplus) with version 4.12.5-2.