### PR TITLE
Engine - script - startDetached() enables to delete QProcess object without killing running process

### DIFF
--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -707,7 +707,13 @@ QString Script::handleSystemCommand(const QList<QStringList> &tokens)
         programArgs << tokens[i][1];
 #if !defined(Q_OS_IOS)
     QProcess *newProcess = new QProcess();
-    newProcess->start(programName, programArgs);
+
+    // startDetached() enables to delete QProcess object without killing actual process
+    qint64 pid;
+    newProcess->setProgram(programName);
+    newProcess->setArguments(programArgs);
+    newProcess->startDetached(&pid);
+    delete newProcess;
 #endif
     return QString();
 }


### PR DESCRIPTION
Hello Massimo,

Here is a very simple fix for [#1270](https://github.com/mcallegari/qlcplus/pull/1270) and[ #1339](https://github.com/mcallegari/qlcplus/issues/1339) 

Replacing start() by startDetached() enables to immediately delete the QProcess object, and clean-up all associated pipes and file descriptors, without killing the running process.

This fix has been validated:
- on Linux Raspbian 10 with Qt 5.11.3
- and on Windows 10 with Qt 5.15.3

This fix does not drastically change the current behavior of system commands, unlike the fix on procfix which requires to specify a timeout (wait time) for every command. 

This fix is based on following doc & source code of QProcess::startDetached :
- https://www.qt.io/blog/2017/08/25/a-new-qprocessstartdetached
- https://doc.qt.io/qt-5/qprocess.html#startDetached

- https://github.com/qt/qtbase/blob/5.15/src/corelib/io/qprocess.cpp
- https://github.com/qt/qtbase/blob/5.15/src/corelib/io/qprocess_unix.cpp
- https://github.com/qt/qtbase/blob/5.15/src/corelib/io/qprocess_win.cpp


My test results on Linux & Windows are summarized below:

1) The number of open file descriptors does not increase anymore every time a new systemcommand is executed.

On Linux: ls -l /proc/`pidof qlcplus`/fd | wc -l
28

On Windows: handle -s -p qlcplus | find "File"
  File            : 47

2) The standard input/output/error streams (0, 1, 2) of the sub-processes launched by systemcommand are inherited from qlcplus and redirected to the same devices as qlcplus (no change):

ls -l /proc/1929/fd
total 0
lr-x------ 1 pi pi 64 Aug 20 10:250 -> /dev/null
l-wx------ 1 pi pi 64 Aug 20 10:25 1 -> /home/pi/.cache/lxsession/LXDE-pi/run.log
l-wx------ 1 pi pi 64 Aug 20 10:25 2 -> /home/pi/.cache/lxsession/LXDE-pi/run.log

ls -l /proc/$(pidof qlcplus)/fd
total 0
lr-x------ 1 pi pi 64 Aug 20 10:22 0 -> /dev/null
l-wx------ 1 pi pi 64 Aug 20 10:22 1 -> /home/pi/.cache/lxsession/LXDE-pi/run.log
lrwx------ 1 pi pi 64 Aug 20 10:22 10 -> 'socket:[24384]'
lrwx------ 1 pi pi 64 Aug 20 10:22 11 -> /dev/snd/seq
lrwx------ 1 pi pi 64 Aug 20 10:22 12 -> 'socket:[24386]'
lr-x------ 1 pi pi 64 Aug 20 10:22 13 -> 'pipe:[24387]'
l-wx------ 1 pi pi 64 Aug 20 10:22 14 -> 'pipe:[24387]'
lr-x------ 1 pi pi 64 Aug 20 10:22 15 -> 'pipe:[24388]'
l-wx------ 1 pi pi 64 Aug 20 10:22 16 -> 'pipe:[24388]'
lrwx------ 1 pi pi 64 Aug 20 10:22 17 -> 'anon_inode:[timerfd]'
lr-x------ 1 pi pi 64 Aug 20 10:27 18 -> 'pipe:[24389]'
l-wx------ 1 pi pi 64 Aug 20 10:27 19 -> 'pipe:[24389]'
l-wx------ 1 pi pi 64 Aug 20 10:22 2 -> /home/pi/.cache/lxsession/LXDE-pi/run.log
…

3) All system commands keep running as long as needed, independantly from qlcplus.
