### PR TITLE
Add Vari-Lite VL4000 Spot fixture definition

### DIFF
--- a/resources/fixtures/Vari-Lite/Vari-Lite-VL4000-Spot.qxf
+++ b/resources/fixtures/Vari-Lite/Vari-Lite-VL4000-Spot.qxf
@@ -1,0 +1,1104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.12.5</Version>
+  <Author>Håvard Ose Nordstrand</Author>
+ </Creator>
+ <Manufacturer>Vari-Lite</Manufacturer>
+ <Model>VL4000 Spot</Model>
+ <Type>Moving Head</Type>
+ <Channel Name="Intensity" Preset="IntensityDimmer"/>
+ <Channel Name="Pan" Default="127" Preset="PositionPan"/>
+ <Channel Name="Pan Fine" Default="255" Preset="PositionPanFine"/>
+ <Channel Name="Tilt" Default="127" Preset="PositionTilt"/>
+ <Channel Name="Tilt Fine" Default="255" Preset="PositionTiltFine"/>
+ <Channel Name="Edge" Preset="BeamFocusNearFar"/>
+ <Channel Name="Zoom" Preset="BeamZoomSmallBig"/>
+ <Channel Name="CTO" Preset="ColorCTOMixer"/>
+ <Channel Name="Cyan" Preset="IntensityCyan"/>
+ <Channel Name="Yellow" Preset="IntensityYellow"/>
+ <Channel Name="Magenta" Preset="IntensityMagenta"/>
+ <Channel Name="Color Wheel 1">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="23" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
+  <Capability Min="24" Max="45" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff0000">Open/Red</Capability>
+  <Capability Min="46" Max="69" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="70" Max="92" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#9d0759">Red/Dark Fuchsia</Capability>
+  <Capability Min="93" Max="116" Preset="ColorMacro" Res1="#9d0759">Dark Fuchsia</Capability>
+  <Capability Min="117" Max="138" Preset="ColorDoubleMacro" Res1="#9d0759" Res2="#ffa500">Dark Fuchsia/Orange</Capability>
+  <Capability Min="139" Max="162" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="163" Max="185" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#4cbb17">Orange/Kelly Green</Capability>
+  <Capability Min="186" Max="209" Preset="ColorMacro" Res1="#4cbb17">Kelly Green</Capability>
+  <Capability Min="210" Max="231" Preset="ColorDoubleMacro" Res1="#4cbb17" Res2="#007fff">Kelly Green/Congo Blue</Capability>
+  <Capability Min="232" Max="243" Preset="ColorMacro" Res1="#007fff">Congo Blue</Capability>
+  <Capability Min="244" Max="255" Preset="ColorDoubleMacro" Res1="#007fff" Res2="#ffffff">Congo Blue/Open</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 1">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="5" Preset="GoboMacro" Res1="Others/open.svg">Open</Capability>
+  <Capability Min="6" Max="10" Preset="GoboMacro">Gobo 1 (Alpha Waves) Index</Capability>
+  <Capability Min="11" Max="15" Preset="GoboMacro">Gobo 2 (Leafy Breakup) Index</Capability>
+  <Capability Min="16" Max="20" Preset="GoboMacro">Gobo 3 (Neurons V2) Index</Capability>
+  <Capability Min="21" Max="25" Preset="GoboMacro">Gobo 4 (Night Sky) Index</Capability>
+  <Capability Min="26" Max="30" Preset="GoboMacro">Gobo 5 (Bricked Out) Index</Capability>
+  <Capability Min="31" Max="35" Preset="GoboMacro">Gobo 6 (On The Rocks) Index</Capability>
+  <Capability Min="36" Max="40" Preset="GoboMacro">Gobo 7 (Droplets) Index</Capability>
+  <Capability Min="41" Max="45" Preset="GoboMacro">Open</Capability>
+  <Capability Min="46" Max="50" Preset="GoboMacro">Gobo 1 (Alpha Waves) Rotate</Capability>
+  <Capability Min="51" Max="55" Preset="GoboMacro">Gobo 2 (Leafy Breakup) Rotate</Capability>
+  <Capability Min="56" Max="60" Preset="GoboMacro">Gobo 3 (Neurons V2) Rotate</Capability>
+  <Capability Min="61" Max="65" Preset="GoboMacro">Gobo 4 (Night Sky) Rotate</Capability>
+  <Capability Min="66" Max="70" Preset="GoboMacro">Gobo 5 (Bricked Out) Rotate</Capability>
+  <Capability Min="71" Max="75" Preset="GoboMacro">Gobo 6 (On The Rocks) Rotate</Capability>
+  <Capability Min="76" Max="80" Preset="GoboMacro">Gobo 7 (Droplets) Rotate</Capability>
+  <Capability Min="81" Max="85" Preset="GoboMacro">Open</Capability>
+  <Capability Min="86" Max="90" Preset="GoboMacro">Gobo 1 (Alpha Waves) Rotate with Mega Stepping</Capability>
+  <Capability Min="91" Max="95" Preset="GoboMacro">Gobo 2 (Leafy Breakup) Rotate with Mega Stepping</Capability>
+  <Capability Min="96" Max="100" Preset="GoboMacro">Gobo 3 (Neurons V2) Rotate with Mega Stepping</Capability>
+  <Capability Min="101" Max="105" Preset="GoboMacro">Gobo 4 (Night Sky) Rotate with Mega Stepping</Capability>
+  <Capability Min="106" Max="110" Preset="GoboMacro">Gobo 5 (Bricked Out) Rotate with Mega Stepping</Capability>
+  <Capability Min="111" Max="115" Preset="GoboMacro">Gobo 6 (On The Rocks) Rotate with Mega Stepping</Capability>
+  <Capability Min="116" Max="120" Preset="GoboMacro">Gobo 7 (Droplets) Rotate with Mega Stepping</Capability>
+ </Channel>
+ <Channel Name="Shutter Frame 1A" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 1B" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 2A" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 2B" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 3A" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 3B" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 4A" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame 4B" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Shutter Frame Rotation" Default="128">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="127" Preset="RotationCounterClockwise">-50°</Capability>
+  <Capability Min="128" Max="128" Preset="RotationStop">0°</Capability>
+  <Capability Min="129" Max="255" Preset="RotationClockwise">+50°</Capability>
+ </Channel>
+ <Channel Name="Focus Timing" Default="255">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="0">Full Speed</Capability>
+  <Capability Min="1" Max="1">0.2s</Capability>
+  <Capability Min="2" Max="2">0.4s</Capability>
+  <Capability Min="3" Max="3">0.6s</Capability>
+  <Capability Min="4" Max="4">0.8s</Capability>
+  <Capability Min="5" Max="5">1.0s</Capability>
+  <Capability Min="6" Max="6">1.2s</Capability>
+  <Capability Min="7" Max="7">1.4s</Capability>
+  <Capability Min="8" Max="8">1.6s</Capability>
+  <Capability Min="9" Max="9">1.8s</Capability>
+  <Capability Min="10" Max="10">2.0s</Capability>
+  <Capability Min="11" Max="11">2.2s</Capability>
+  <Capability Min="12" Max="12">2.4s</Capability>
+  <Capability Min="13" Max="13">2.6s</Capability>
+  <Capability Min="14" Max="14">2.8s</Capability>
+  <Capability Min="15" Max="15">3.0s</Capability>
+  <Capability Min="16" Max="16">3.2s</Capability>
+  <Capability Min="17" Max="17">3.4s</Capability>
+  <Capability Min="18" Max="18">3.6s</Capability>
+  <Capability Min="19" Max="19">3.8s</Capability>
+  <Capability Min="20" Max="20">4.0s</Capability>
+  <Capability Min="21" Max="21">4.2s</Capability>
+  <Capability Min="22" Max="22">4.4s</Capability>
+  <Capability Min="23" Max="23">4.6s</Capability>
+  <Capability Min="24" Max="24">4.8s</Capability>
+  <Capability Min="25" Max="25">5.0s</Capability>
+  <Capability Min="26" Max="26">5.2s</Capability>
+  <Capability Min="27" Max="27">5.4s</Capability>
+  <Capability Min="28" Max="28">5.6s</Capability>
+  <Capability Min="29" Max="29">5.8s</Capability>
+  <Capability Min="30" Max="30">6.0s</Capability>
+  <Capability Min="31" Max="31">6.2s</Capability>
+  <Capability Min="32" Max="32">6.4s</Capability>
+  <Capability Min="33" Max="33">6.6s</Capability>
+  <Capability Min="34" Max="34">6.8s</Capability>
+  <Capability Min="35" Max="35">7.0s</Capability>
+  <Capability Min="36" Max="36">7.2s</Capability>
+  <Capability Min="37" Max="37">7.4s</Capability>
+  <Capability Min="38" Max="38">7.6s</Capability>
+  <Capability Min="39" Max="39">7.8s</Capability>
+  <Capability Min="40" Max="40">8.0s</Capability>
+  <Capability Min="41" Max="41">8.2s</Capability>
+  <Capability Min="42" Max="42">8.4s</Capability>
+  <Capability Min="43" Max="43">8.6s</Capability>
+  <Capability Min="44" Max="44">8.8s</Capability>
+  <Capability Min="45" Max="45">9.0s</Capability>
+  <Capability Min="46" Max="46">9.2s</Capability>
+  <Capability Min="47" Max="47">9.4s</Capability>
+  <Capability Min="48" Max="48">9.6s</Capability>
+  <Capability Min="49" Max="49">9.8s</Capability>
+  <Capability Min="50" Max="50">10.0s</Capability>
+  <Capability Min="51" Max="51">10.2s</Capability>
+  <Capability Min="52" Max="52">10.4s</Capability>
+  <Capability Min="53" Max="53">10.6s</Capability>
+  <Capability Min="54" Max="55">11s</Capability>
+  <Capability Min="56" Max="57">12s</Capability>
+  <Capability Min="58" Max="59">13s</Capability>
+  <Capability Min="60" Max="62">14s</Capability>
+  <Capability Min="63" Max="64">15s</Capability>
+  <Capability Min="65" Max="67">16s</Capability>
+  <Capability Min="68" Max="69">17s</Capability>
+  <Capability Min="70" Max="72">18s</Capability>
+  <Capability Min="73" Max="74">19s</Capability>
+  <Capability Min="75" Max="77">20s</Capability>
+  <Capability Min="78" Max="80">21s</Capability>
+  <Capability Min="81" Max="82">22s</Capability>
+  <Capability Min="83" Max="85">23s</Capability>
+  <Capability Min="86" Max="87">24s</Capability>
+  <Capability Min="88" Max="90">25s</Capability>
+  <Capability Min="91" Max="92">26s</Capability>
+  <Capability Min="93" Max="95">27s</Capability>
+  <Capability Min="96" Max="97">28s</Capability>
+  <Capability Min="98" Max="100">29s</Capability>
+  <Capability Min="101" Max="103">30s</Capability>
+  <Capability Min="104" Max="105">31s</Capability>
+  <Capability Min="106" Max="108">32s</Capability>
+  <Capability Min="109" Max="110">33s</Capability>
+  <Capability Min="111" Max="113">34s</Capability>
+  <Capability Min="114" Max="115">35s</Capability>
+  <Capability Min="116" Max="118">36s</Capability>
+  <Capability Min="119" Max="120">37s</Capability>
+  <Capability Min="121" Max="123">38s</Capability>
+  <Capability Min="124" Max="126">39s</Capability>
+  <Capability Min="127" Max="128">40s</Capability>
+  <Capability Min="129" Max="131">41s</Capability>
+  <Capability Min="132" Max="133">42s</Capability>
+  <Capability Min="134" Max="136">43s</Capability>
+  <Capability Min="137" Max="138">44s</Capability>
+  <Capability Min="139" Max="141">45s</Capability>
+  <Capability Min="142" Max="143">46s</Capability>
+  <Capability Min="144" Max="146">47s</Capability>
+  <Capability Min="147" Max="148">48s</Capability>
+  <Capability Min="149" Max="151">49s</Capability>
+  <Capability Min="152" Max="154">50s</Capability>
+  <Capability Min="155" Max="156">51s</Capability>
+  <Capability Min="157" Max="158">52s</Capability>
+  <Capability Min="160" Max="161">53s</Capability>
+  <Capability Min="162" Max="164">54s</Capability>
+  <Capability Min="165" Max="166">55s</Capability>
+  <Capability Min="167" Max="169">56s</Capability>
+  <Capability Min="170" Max="171">57s</Capability>
+  <Capability Min="172" Max="174">58s</Capability>
+  <Capability Min="175" Max="177">59s</Capability>
+  <Capability Min="178" Max="179">60s</Capability>
+  <Capability Min="180" Max="182">65s</Capability>
+  <Capability Min="183" Max="184">70s</Capability>
+  <Capability Min="185" Max="187">75s</Capability>
+  <Capability Min="188" Max="189">80s</Capability>
+  <Capability Min="190" Max="192">85s</Capability>
+  <Capability Min="193" Max="194">90s</Capability>
+  <Capability Min="195" Max="197">95s</Capability>
+  <Capability Min="198" Max="199">100s</Capability>
+  <Capability Min="200" Max="202">110s</Capability>
+  <Capability Min="203" Max="205">120s</Capability>
+  <Capability Min="206" Max="207">130s</Capability>
+  <Capability Min="208" Max="210">140s</Capability>
+  <Capability Min="211" Max="212">150s</Capability>
+  <Capability Min="213" Max="215">160s</Capability>
+  <Capability Min="216" Max="217">170s</Capability>
+  <Capability Min="218" Max="220">180s</Capability>
+  <Capability Min="221" Max="222">190s</Capability>
+  <Capability Min="223" Max="224">200s</Capability>
+  <Capability Min="226" Max="228">210s</Capability>
+  <Capability Min="229" Max="230">220s</Capability>
+  <Capability Min="231" Max="233">230s</Capability>
+  <Capability Min="234" Max="235">240s</Capability>
+  <Capability Min="236" Max="238">250s</Capability>
+  <Capability Min="239" Max="240">260s</Capability>
+  <Capability Min="241" Max="243">270s</Capability>
+  <Capability Min="244" Max="245">280s</Capability>
+  <Capability Min="246" Max="248">290s</Capability>
+  <Capability Min="249" Max="250">300s</Capability>
+  <Capability Min="251" Max="254">310s</Capability>
+  <Capability Min="255" Max="255">Follows Cue Data</Capability>
+ </Channel>
+ <Channel Name="Control">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="5">Idle</Capability>
+  <Capability Min="6" Max="10">Full Recalibration</Capability>
+  <Capability Min="11" Max="15">Lamp On</Capability>
+  <Capability Min="16" Max="20">Lamp Off</Capability>
+  <Capability Min="21" Max="25">Fixture Shutdown</Capability>
+  <Capability Min="26" Max="30">Display On</Capability>
+  <Capability Min="31" Max="35">Display Off</Capability>
+  <Capability Min="36" Max="40">Recalibrate Position</Capability>
+  <Capability Min="41" Max="45">Recalibrate Color</Capability>
+  <Capability Min="46" Max="50">Recalibrate Gobo</Capability>
+  <Capability Min="51" Max="55">Recalibrate Beam</Capability>
+  <Capability Min="56" Max="60">Recalibrate Optics</Capability>
+  <Capability Min="61" Max="65">Recalibrate Dimmer/Strobe</Capability>
+  <Capability Min="66" Max="70">Reset Fixture to Defaults</Capability>
+  <Capability Min="71" Max="75">Full Reboot</Capability>
+  <Capability Min="76" Max="80">Display Status Toggle</Capability>
+  <Capability Min="81" Max="85">Standard Mode</Capability>
+  <Capability Min="86" Max="90">Studio Mode</Capability>
+ </Channel>
+ <Channel Name="Edge Fine" Preset="BeamFocusFine"/>
+ <Channel Name="Zoom Fine" Preset="BeamZoomFine"/>
+ <Channel Name="Programming Control">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="2">Idle</Capability>
+  <Capability Min="3" Max="15">Dimmer Snap OFF</Capability>
+  <Capability Min="16" Max="20">Dimmer Snap ON (Fixture Default)</Capability>
+ </Channel>
+ <Channel Name="Color Wheel 2">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="23" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
+  <Capability Min="24" Max="45" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#0000ff">Open/Blue</Capability>
+  <Capability Min="46" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
+  <Capability Min="70" Max="92" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#00ff00">Blue/Green</Capability>
+  <Capability Min="93" Max="116" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="117" Max="138" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff00ff">Green/Minus Green</Capability>
+  <Capability Min="139" Max="162" Preset="ColorMacro" Res1="#ff00ff">Minus Green</Capability>
+  <Capability Min="163" Max="185" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#e6e6fa">Minus Green/Lavender</Capability>
+  <Capability Min="186" Max="209" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
+  <Capability Min="210" Max="231" Preset="ColorDoubleMacro" Res1="#e6e6fa" Res2="#ffbf00">Lavender/Amber</Capability>
+  <Capability Min="232" Max="243" Preset="ColorMacro" Res1="#ffbf00">Amber</Capability>
+  <Capability Min="244" Max="255" Preset="ColorDoubleMacro" Res1="#ffbf00" Res2="#ffffff">Amber/Open</Capability>
+ </Channel>
+ <Channel Name="Color Wheen 1 Control">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="5">Linear Movement Quickest Path</Capability>
+  <Capability Min="6" Max="10">Linear Movement Normal Path</Capability>
+  <Capability Min="11" Max="15">Wheel Spin Forward (Fast to Slow)</Capability>
+  <Capability Min="16" Max="20">Wheel Spin STOP</Capability>
+  <Capability Min="21" Max="25">Wheel Spin Reverse (Slow to Fast)</Capability>
+  <Capability Min="26" Max="56">Color Shake Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="57" Max="87">Color Shake Normal Path (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Color Wheen 2 Control">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="5">Linear Movement Quickest Path</Capability>
+  <Capability Min="6" Max="10">Linear Movement Normal Path</Capability>
+  <Capability Min="11" Max="15">Wheel Spin Forward (Fast to Slow)</Capability>
+  <Capability Min="16" Max="20">Wheel Spin STOP</Capability>
+  <Capability Min="21" Max="25">Wheel Spin Reverse (Slow to Fast)</Capability>
+  <Capability Min="26" Max="56">Color Shake Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="57" Max="87">Color Shake Normal Path (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 2">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="5" Preset="GoboMacro" Res1="Others/open.svg">Open</Capability>
+  <Capability Min="6" Max="10" Preset="GoboMacro">Gobo 1 (Circle of Eights) Index</Capability>
+  <Capability Min="11" Max="15" Preset="GoboMacro">Gobo 2 (Punch Card) Index</Capability>
+  <Capability Min="16" Max="20" Preset="GoboMacro">Gobo 3 (Vertical Bars) Index</Capability>
+  <Capability Min="21" Max="25" Preset="GoboMacro">Gobo 4 (Lattice) Index</Capability>
+  <Capability Min="26" Max="30" Preset="GoboMacro">Gobo 5 (Wavy Triangle) Index</Capability>
+  <Capability Min="31" Max="35" Preset="GoboMacro">Gobo 6 (Dot Buffet) Index</Capability>
+  <Capability Min="36" Max="40" Preset="GoboMacro">Gobo 7 (Quadcone Red) Index</Capability>
+  <Capability Min="41" Max="45" Preset="GoboMacro">Open</Capability>
+  <Capability Min="46" Max="50" Preset="GoboMacro">Gobo 1 (Circle of Eights) Rotate</Capability>
+  <Capability Min="51" Max="55" Preset="GoboMacro">Gobo 2 (Punch Card) Rotate</Capability>
+  <Capability Min="56" Max="60" Preset="GoboMacro">Gobo 3 (Vertical Bars) Rotate</Capability>
+  <Capability Min="61" Max="65" Preset="GoboMacro">Gobo 4 (Lattice) Rotate</Capability>
+  <Capability Min="66" Max="70" Preset="GoboMacro">Gobo 5 (Wavy Triangle) Rotate</Capability>
+  <Capability Min="71" Max="75" Preset="GoboMacro">Gobo 6 (Dot Buffet) Rotate</Capability>
+  <Capability Min="76" Max="80" Preset="GoboMacro">Gobo 7 (Quadcone Red) Rotate</Capability>
+  <Capability Min="81" Max="85" Preset="GoboMacro">Open</Capability>
+  <Capability Min="86" Max="90" Preset="GoboMacro">Gobo 1 (Circle of Eights) Rotate with Mega Stepping</Capability>
+  <Capability Min="91" Max="95" Preset="GoboMacro">Gobo 2 (Punch Card) Rotate with Mega Stepping</Capability>
+  <Capability Min="96" Max="100" Preset="GoboMacro">Gobo 3 (Vertical Bars) Rotate with Mega Stepping</Capability>
+  <Capability Min="101" Max="105" Preset="GoboMacro">Gobo 4 (Lattice) Rotate with Mega Stepping</Capability>
+  <Capability Min="106" Max="110" Preset="GoboMacro">Gobo 5 (Wavy Triangle) Rotate with Mega Stepping</Capability>
+  <Capability Min="111" Max="115" Preset="GoboMacro">Gobo 6 (Dot Buffet) Rotate with Mega Stepping</Capability>
+  <Capability Min="116" Max="120" Preset="GoboMacro">Gobo 7 (Quadcone Red) Rotate with Mega Stepping</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 1 Index/Rotate" Default="127">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="126" Preset="RotationCounterClockwiseFastToSlow">Rotate Fast to Slow</Capability>
+  <Capability Min="127" Max="127" Preset="RotationStop">Rotate Stop</Capability>
+  <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Rotate Slow to Fast</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 1 Index/Rotate Fine" Default="255">
+  <Group Byte="1">Gobo</Group>
+  <Capability Min="0" Max="255">Index/Rotate Fine</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 2 Index/Rotate" Default="127">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="126" Preset="RotationCounterClockwiseFastToSlow">Rotate Fast to Slow</Capability>
+  <Capability Min="127" Max="127" Preset="RotationStop">Rotate Stop</Capability>
+  <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Rotate Slow to Fast</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 2 Index/Rotate Fine" Default="255">
+  <Group Byte="1">Gobo</Group>
+  <Capability Min="0" Max="255">Index/Rotate Fine</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 1 Control">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="5">Gobo Selection Quickest Path</Capability>
+  <Capability Min="6" Max="10">Gobo Selection Normal Path</Capability>
+  <Capability Min="11" Max="20">Reserved</Capability>
+  <Capability Min="21" Max="50" Preset="RotationClockwiseFastToSlow">Wheel Spin Forward (Fast to Slow)</Capability>
+  <Capability Min="51" Max="60" Preset="RotationStop">Wheel Spin Stop</Capability>
+  <Capability Min="61" Max="90" Preset="RotationCounterClockwiseSlowToFast">Wheel Spin Reverse (Slow to Fast)</Capability>
+  <Capability Min="91" Max="120" Preset="SlowToFast">Gobo Shake Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="121" Max="150" Preset="SlowToFast">Gobo Shake Normal Path (Slow to Fast)</Capability>
+  <Capability Min="151" Max="180" Preset="SlowToFast">Gobo Twist Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="181" Max="210" Preset="SlowToFast">Gobo Twist Normal Path (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Gobo Wheel 2 Control">
+  <Group Byte="0">Gobo</Group>
+  <Capability Min="0" Max="5">Gobo Selection Quickest Path</Capability>
+  <Capability Min="6" Max="10">Gobo Selection Normal Path</Capability>
+  <Capability Min="11" Max="20">Reserved</Capability>
+  <Capability Min="21" Max="50" Preset="RotationClockwiseFastToSlow">Wheel Spin Forward (Fast to Slow)</Capability>
+  <Capability Min="51" Max="60" Preset="RotationStop">Wheel Spin Stop</Capability>
+  <Capability Min="61" Max="90" Preset="RotationCounterClockwiseSlowToFast">Wheel Spin Reverse (Slow to Fast)</Capability>
+  <Capability Min="91" Max="120" Preset="SlowToFast">Gobo Shake Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="121" Max="150" Preset="SlowToFast">Gobo Shake Normal Path (Slow to Fast)</Capability>
+  <Capability Min="151" Max="180" Preset="SlowToFast">Gobo Twist Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="181" Max="210" Preset="SlowToFast">Gobo Twist Normal Path (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 1 (Dichro*Fusion)">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="255">Animation Wheel</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 2 (Wicked Waves)">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="255">Animation Wheel</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 1 (Dichro*Fusion) Index/Rotate" Default="127">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="126" Preset="RotationCounterClockwiseFastToSlow">Rotate Fast to Slow</Capability>
+  <Capability Min="127" Max="127" Preset="RotationStop">Rotate Stop</Capability>
+  <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Rotate Slow to Fast</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 1 (Dichro*Fusion) Index/Rotate Fine" Default="255">
+  <Group Byte="1">Effect</Group>
+  <Capability Min="0" Max="255">Index/Rotate Fine</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 2 (Wicked Waves) Index/Rotate" Default="127">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="126" Preset="RotationCounterClockwiseFastToSlow">Rotate Fast to Slow</Capability>
+  <Capability Min="127" Max="127" Preset="RotationStop">Rotate Stop</Capability>
+  <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Rotate Slow to Fast</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 2 (Wicked Waves) Index/Rotate Fine" Default="255">
+  <Group Byte="1">Effect</Group>
+  <Capability Min="0" Max="255">Index/Rotate Fine</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 1 (Dichro*Fusion) Control">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="5">Gobo Selection Quickest Path</Capability>
+  <Capability Min="6" Max="10">Gobo Selection Normal Path</Capability>
+  <Capability Min="11" Max="15">Rotate Normal</Capability>
+  <Capability Min="16" Max="20">Rotate with Mega Stepping</Capability>
+  <Capability Min="21" Max="25">Reserved</Capability>
+  <Capability Min="26" Max="56" Preset="SlowToFast">Image Shake Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="57" Max="87" Preset="SlowToFast">Image Shake Normal Path (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Animation Wheel 2 (Wicked Waves) Control">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="5">Gobo Selection Quickest Path</Capability>
+  <Capability Min="6" Max="10">Gobo Selection Normal Path</Capability>
+  <Capability Min="11" Max="15">Rotate Normal</Capability>
+  <Capability Min="16" Max="20">Rotate with Mega Stepping</Capability>
+  <Capability Min="21" Max="25">Reserved</Capability>
+  <Capability Min="26" Max="56" Preset="SlowToFast">Image Shake Quickest Path (Slow to Fast)</Capability>
+  <Capability Min="57" Max="87" Preset="SlowToFast">Image Shake Normal Path (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Beam Iris" Preset="ShutterIrisMaxToMin"/>
+ <Channel Name="Prism">
+  <Group Byte="0">Prism</Group>
+  <Capability Min="0" Max="5">Open</Capability>
+  <Capability Min="6" Max="10">Index</Capability>
+  <Capability Min="11" Max="15">Rotate Normal</Capability>
+  <Capability Min="16" Max="20">Rotate with Mega Stepping</Capability>
+ </Channel>
+ <Channel Name="Prism Index/Rotate" Default="127">
+  <Group Byte="0">Prism</Group>
+  <Capability Min="0" Max="126" Preset="RotationCounterClockwiseFastToSlow">Rotate (Fast to Slow)</Capability>
+  <Capability Min="127" Max="127">Rotate Stop</Capability>
+  <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Rotate (Slow to Fast)</Capability>
+ </Channel>
+ <Channel Name="Prism Index/Rotate Fine" Default="255">
+  <Group Byte="1">Prism</Group>
+  <Capability Min="0" Max="255">Index/Rotate Fine</Capability>
+ </Channel>
+ <Channel Name="Prism Diverge">
+  <Group Byte="0">Prism</Group>
+  <Capability Min="0" Max="255" Preset="SmallToBig">Spread (Small to Big)</Capability>
+ </Channel>
+ <Channel Name="Frost">
+  <Group Byte="0">Beam</Group>
+  <Capability Min="0" Max="255" Preset="SmallToBig">Frost (Small to Big)</Capability>
+ </Channel>
+ <Channel Name="Strobe Speed" Preset="ShutterStrobeSlowFast"/>
+ <Channel Name="Strobe Control">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="5">Open</Capability>
+  <Capability Min="6" Max="10">Closed</Capability>
+  <Capability Min="11" Max="15">Normal Strobe</Capability>
+  <Capability Min="16" Max="20">Random Strobe</Capability>
+  <Capability Min="21" Max="25">Random Sync</Capability>
+ </Channel>
+ <Channel Name="Optics Timing" Default="255">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="0">Full Speed</Capability>
+  <Capability Min="1" Max="1">0.2s</Capability>
+  <Capability Min="2" Max="2">0.4s</Capability>
+  <Capability Min="3" Max="3">0.6s</Capability>
+  <Capability Min="4" Max="4">0.8s</Capability>
+  <Capability Min="5" Max="5">1.0s</Capability>
+  <Capability Min="6" Max="6">1.2s</Capability>
+  <Capability Min="7" Max="7">1.4s</Capability>
+  <Capability Min="8" Max="8">1.6s</Capability>
+  <Capability Min="9" Max="9">1.8s</Capability>
+  <Capability Min="10" Max="10">2.0s</Capability>
+  <Capability Min="11" Max="11">2.2s</Capability>
+  <Capability Min="12" Max="12">2.4s</Capability>
+  <Capability Min="13" Max="13">2.6s</Capability>
+  <Capability Min="14" Max="14">2.8s</Capability>
+  <Capability Min="15" Max="15">3.0s</Capability>
+  <Capability Min="16" Max="16">3.2s</Capability>
+  <Capability Min="17" Max="17">3.4s</Capability>
+  <Capability Min="18" Max="18">3.6s</Capability>
+  <Capability Min="19" Max="19">3.8s</Capability>
+  <Capability Min="20" Max="20">4.0s</Capability>
+  <Capability Min="21" Max="21">4.2s</Capability>
+  <Capability Min="22" Max="22">4.4s</Capability>
+  <Capability Min="23" Max="23">4.6s</Capability>
+  <Capability Min="24" Max="24">4.8s</Capability>
+  <Capability Min="25" Max="25">5.0s</Capability>
+  <Capability Min="26" Max="26">5.2s</Capability>
+  <Capability Min="27" Max="27">5.4s</Capability>
+  <Capability Min="28" Max="28">5.6s</Capability>
+  <Capability Min="29" Max="29">5.8s</Capability>
+  <Capability Min="30" Max="30">6.0s</Capability>
+  <Capability Min="31" Max="31">6.2s</Capability>
+  <Capability Min="32" Max="32">6.4s</Capability>
+  <Capability Min="33" Max="33">6.6s</Capability>
+  <Capability Min="34" Max="34">6.8s</Capability>
+  <Capability Min="35" Max="35">7.0s</Capability>
+  <Capability Min="36" Max="36">7.2s</Capability>
+  <Capability Min="37" Max="37">7.4s</Capability>
+  <Capability Min="38" Max="38">7.6s</Capability>
+  <Capability Min="39" Max="39">7.8s</Capability>
+  <Capability Min="40" Max="40">8.0s</Capability>
+  <Capability Min="41" Max="41">8.2s</Capability>
+  <Capability Min="42" Max="42">8.4s</Capability>
+  <Capability Min="43" Max="43">8.6s</Capability>
+  <Capability Min="44" Max="44">8.8s</Capability>
+  <Capability Min="45" Max="45">9.0s</Capability>
+  <Capability Min="46" Max="46">9.2s</Capability>
+  <Capability Min="47" Max="47">9.4s</Capability>
+  <Capability Min="48" Max="48">9.6s</Capability>
+  <Capability Min="49" Max="49">9.8s</Capability>
+  <Capability Min="50" Max="50">10.0s</Capability>
+  <Capability Min="51" Max="51">10.2s</Capability>
+  <Capability Min="52" Max="52">10.4s</Capability>
+  <Capability Min="53" Max="53">10.6s</Capability>
+  <Capability Min="54" Max="55">11s</Capability>
+  <Capability Min="56" Max="57">12s</Capability>
+  <Capability Min="58" Max="59">13s</Capability>
+  <Capability Min="60" Max="62">14s</Capability>
+  <Capability Min="63" Max="64">15s</Capability>
+  <Capability Min="65" Max="67">16s</Capability>
+  <Capability Min="68" Max="69">17s</Capability>
+  <Capability Min="70" Max="72">18s</Capability>
+  <Capability Min="73" Max="74">19s</Capability>
+  <Capability Min="75" Max="77">20s</Capability>
+  <Capability Min="78" Max="80">21s</Capability>
+  <Capability Min="81" Max="82">22s</Capability>
+  <Capability Min="83" Max="85">23s</Capability>
+  <Capability Min="86" Max="87">24s</Capability>
+  <Capability Min="88" Max="90">25s</Capability>
+  <Capability Min="91" Max="92">26s</Capability>
+  <Capability Min="93" Max="95">27s</Capability>
+  <Capability Min="96" Max="97">28s</Capability>
+  <Capability Min="98" Max="100">29s</Capability>
+  <Capability Min="101" Max="103">30s</Capability>
+  <Capability Min="104" Max="105">31s</Capability>
+  <Capability Min="106" Max="108">32s</Capability>
+  <Capability Min="109" Max="110">33s</Capability>
+  <Capability Min="111" Max="113">34s</Capability>
+  <Capability Min="114" Max="115">35s</Capability>
+  <Capability Min="116" Max="118">36s</Capability>
+  <Capability Min="119" Max="120">37s</Capability>
+  <Capability Min="121" Max="123">38s</Capability>
+  <Capability Min="124" Max="126">39s</Capability>
+  <Capability Min="127" Max="128">40s</Capability>
+  <Capability Min="129" Max="131">41s</Capability>
+  <Capability Min="132" Max="133">42s</Capability>
+  <Capability Min="134" Max="136">43s</Capability>
+  <Capability Min="137" Max="138">44s</Capability>
+  <Capability Min="139" Max="141">45s</Capability>
+  <Capability Min="142" Max="143">46s</Capability>
+  <Capability Min="144" Max="146">47s</Capability>
+  <Capability Min="147" Max="148">48s</Capability>
+  <Capability Min="149" Max="151">49s</Capability>
+  <Capability Min="152" Max="154">50s</Capability>
+  <Capability Min="155" Max="156">51s</Capability>
+  <Capability Min="157" Max="158">52s</Capability>
+  <Capability Min="160" Max="161">53s</Capability>
+  <Capability Min="162" Max="164">54s</Capability>
+  <Capability Min="165" Max="166">55s</Capability>
+  <Capability Min="167" Max="169">56s</Capability>
+  <Capability Min="170" Max="171">57s</Capability>
+  <Capability Min="172" Max="174">58s</Capability>
+  <Capability Min="175" Max="177">59s</Capability>
+  <Capability Min="178" Max="179">60s</Capability>
+  <Capability Min="180" Max="182">65s</Capability>
+  <Capability Min="183" Max="184">70s</Capability>
+  <Capability Min="185" Max="187">75s</Capability>
+  <Capability Min="188" Max="189">80s</Capability>
+  <Capability Min="190" Max="192">85s</Capability>
+  <Capability Min="193" Max="194">90s</Capability>
+  <Capability Min="195" Max="197">95s</Capability>
+  <Capability Min="198" Max="199">100s</Capability>
+  <Capability Min="200" Max="202">110s</Capability>
+  <Capability Min="203" Max="205">120s</Capability>
+  <Capability Min="206" Max="207">130s</Capability>
+  <Capability Min="208" Max="210">140s</Capability>
+  <Capability Min="211" Max="212">150s</Capability>
+  <Capability Min="213" Max="215">160s</Capability>
+  <Capability Min="216" Max="217">170s</Capability>
+  <Capability Min="218" Max="220">180s</Capability>
+  <Capability Min="221" Max="222">190s</Capability>
+  <Capability Min="223" Max="224">200s</Capability>
+  <Capability Min="226" Max="228">210s</Capability>
+  <Capability Min="229" Max="230">220s</Capability>
+  <Capability Min="231" Max="233">230s</Capability>
+  <Capability Min="234" Max="235">240s</Capability>
+  <Capability Min="236" Max="238">250s</Capability>
+  <Capability Min="239" Max="240">260s</Capability>
+  <Capability Min="241" Max="243">270s</Capability>
+  <Capability Min="244" Max="245">280s</Capability>
+  <Capability Min="246" Max="248">290s</Capability>
+  <Capability Min="249" Max="250">300s</Capability>
+  <Capability Min="251" Max="254">310s</Capability>
+  <Capability Min="255" Max="255">Follows Cue Data</Capability>
+ </Channel>
+ <Channel Name="Color Timing" Default="255">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="0">Full Speed</Capability>
+  <Capability Min="1" Max="1">0.2s</Capability>
+  <Capability Min="2" Max="2">0.4s</Capability>
+  <Capability Min="3" Max="3">0.6s</Capability>
+  <Capability Min="4" Max="4">0.8s</Capability>
+  <Capability Min="5" Max="5">1.0s</Capability>
+  <Capability Min="6" Max="6">1.2s</Capability>
+  <Capability Min="7" Max="7">1.4s</Capability>
+  <Capability Min="8" Max="8">1.6s</Capability>
+  <Capability Min="9" Max="9">1.8s</Capability>
+  <Capability Min="10" Max="10">2.0s</Capability>
+  <Capability Min="11" Max="11">2.2s</Capability>
+  <Capability Min="12" Max="12">2.4s</Capability>
+  <Capability Min="13" Max="13">2.6s</Capability>
+  <Capability Min="14" Max="14">2.8s</Capability>
+  <Capability Min="15" Max="15">3.0s</Capability>
+  <Capability Min="16" Max="16">3.2s</Capability>
+  <Capability Min="17" Max="17">3.4s</Capability>
+  <Capability Min="18" Max="18">3.6s</Capability>
+  <Capability Min="19" Max="19">3.8s</Capability>
+  <Capability Min="20" Max="20">4.0s</Capability>
+  <Capability Min="21" Max="21">4.2s</Capability>
+  <Capability Min="22" Max="22">4.4s</Capability>
+  <Capability Min="23" Max="23">4.6s</Capability>
+  <Capability Min="24" Max="24">4.8s</Capability>
+  <Capability Min="25" Max="25">5.0s</Capability>
+  <Capability Min="26" Max="26">5.2s</Capability>
+  <Capability Min="27" Max="27">5.4s</Capability>
+  <Capability Min="28" Max="28">5.6s</Capability>
+  <Capability Min="29" Max="29">5.8s</Capability>
+  <Capability Min="30" Max="30">6.0s</Capability>
+  <Capability Min="31" Max="31">6.2s</Capability>
+  <Capability Min="32" Max="32">6.4s</Capability>
+  <Capability Min="33" Max="33">6.6s</Capability>
+  <Capability Min="34" Max="34">6.8s</Capability>
+  <Capability Min="35" Max="35">7.0s</Capability>
+  <Capability Min="36" Max="36">7.2s</Capability>
+  <Capability Min="37" Max="37">7.4s</Capability>
+  <Capability Min="38" Max="38">7.6s</Capability>
+  <Capability Min="39" Max="39">7.8s</Capability>
+  <Capability Min="40" Max="40">8.0s</Capability>
+  <Capability Min="41" Max="41">8.2s</Capability>
+  <Capability Min="42" Max="42">8.4s</Capability>
+  <Capability Min="43" Max="43">8.6s</Capability>
+  <Capability Min="44" Max="44">8.8s</Capability>
+  <Capability Min="45" Max="45">9.0s</Capability>
+  <Capability Min="46" Max="46">9.2s</Capability>
+  <Capability Min="47" Max="47">9.4s</Capability>
+  <Capability Min="48" Max="48">9.6s</Capability>
+  <Capability Min="49" Max="49">9.8s</Capability>
+  <Capability Min="50" Max="50">10.0s</Capability>
+  <Capability Min="51" Max="51">10.2s</Capability>
+  <Capability Min="52" Max="52">10.4s</Capability>
+  <Capability Min="53" Max="53">10.6s</Capability>
+  <Capability Min="54" Max="55">11s</Capability>
+  <Capability Min="56" Max="57">12s</Capability>
+  <Capability Min="58" Max="59">13s</Capability>
+  <Capability Min="60" Max="62">14s</Capability>
+  <Capability Min="63" Max="64">15s</Capability>
+  <Capability Min="65" Max="67">16s</Capability>
+  <Capability Min="68" Max="69">17s</Capability>
+  <Capability Min="70" Max="72">18s</Capability>
+  <Capability Min="73" Max="74">19s</Capability>
+  <Capability Min="75" Max="77">20s</Capability>
+  <Capability Min="78" Max="80">21s</Capability>
+  <Capability Min="81" Max="82">22s</Capability>
+  <Capability Min="83" Max="85">23s</Capability>
+  <Capability Min="86" Max="87">24s</Capability>
+  <Capability Min="88" Max="90">25s</Capability>
+  <Capability Min="91" Max="92">26s</Capability>
+  <Capability Min="93" Max="95">27s</Capability>
+  <Capability Min="96" Max="97">28s</Capability>
+  <Capability Min="98" Max="100">29s</Capability>
+  <Capability Min="101" Max="103">30s</Capability>
+  <Capability Min="104" Max="105">31s</Capability>
+  <Capability Min="106" Max="108">32s</Capability>
+  <Capability Min="109" Max="110">33s</Capability>
+  <Capability Min="111" Max="113">34s</Capability>
+  <Capability Min="114" Max="115">35s</Capability>
+  <Capability Min="116" Max="118">36s</Capability>
+  <Capability Min="119" Max="120">37s</Capability>
+  <Capability Min="121" Max="123">38s</Capability>
+  <Capability Min="124" Max="126">39s</Capability>
+  <Capability Min="127" Max="128">40s</Capability>
+  <Capability Min="129" Max="131">41s</Capability>
+  <Capability Min="132" Max="133">42s</Capability>
+  <Capability Min="134" Max="136">43s</Capability>
+  <Capability Min="137" Max="138">44s</Capability>
+  <Capability Min="139" Max="141">45s</Capability>
+  <Capability Min="142" Max="143">46s</Capability>
+  <Capability Min="144" Max="146">47s</Capability>
+  <Capability Min="147" Max="148">48s</Capability>
+  <Capability Min="149" Max="151">49s</Capability>
+  <Capability Min="152" Max="154">50s</Capability>
+  <Capability Min="155" Max="156">51s</Capability>
+  <Capability Min="157" Max="158">52s</Capability>
+  <Capability Min="160" Max="161">53s</Capability>
+  <Capability Min="162" Max="164">54s</Capability>
+  <Capability Min="165" Max="166">55s</Capability>
+  <Capability Min="167" Max="169">56s</Capability>
+  <Capability Min="170" Max="171">57s</Capability>
+  <Capability Min="172" Max="174">58s</Capability>
+  <Capability Min="175" Max="177">59s</Capability>
+  <Capability Min="178" Max="179">60s</Capability>
+  <Capability Min="180" Max="182">65s</Capability>
+  <Capability Min="183" Max="184">70s</Capability>
+  <Capability Min="185" Max="187">75s</Capability>
+  <Capability Min="188" Max="189">80s</Capability>
+  <Capability Min="190" Max="192">85s</Capability>
+  <Capability Min="193" Max="194">90s</Capability>
+  <Capability Min="195" Max="197">95s</Capability>
+  <Capability Min="198" Max="199">100s</Capability>
+  <Capability Min="200" Max="202">110s</Capability>
+  <Capability Min="203" Max="205">120s</Capability>
+  <Capability Min="206" Max="207">130s</Capability>
+  <Capability Min="208" Max="210">140s</Capability>
+  <Capability Min="211" Max="212">150s</Capability>
+  <Capability Min="213" Max="215">160s</Capability>
+  <Capability Min="216" Max="217">170s</Capability>
+  <Capability Min="218" Max="220">180s</Capability>
+  <Capability Min="221" Max="222">190s</Capability>
+  <Capability Min="223" Max="224">200s</Capability>
+  <Capability Min="226" Max="228">210s</Capability>
+  <Capability Min="229" Max="230">220s</Capability>
+  <Capability Min="231" Max="233">230s</Capability>
+  <Capability Min="234" Max="235">240s</Capability>
+  <Capability Min="236" Max="238">250s</Capability>
+  <Capability Min="239" Max="240">260s</Capability>
+  <Capability Min="241" Max="243">270s</Capability>
+  <Capability Min="244" Max="245">280s</Capability>
+  <Capability Min="246" Max="248">290s</Capability>
+  <Capability Min="249" Max="250">300s</Capability>
+  <Capability Min="251" Max="254">310s</Capability>
+  <Capability Min="255" Max="255">Follows Cue Data</Capability>
+ </Channel>
+ <Channel Name="Beam Timing" Default="255">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="0">Full Speed</Capability>
+  <Capability Min="1" Max="1">0.2s</Capability>
+  <Capability Min="2" Max="2">0.4s</Capability>
+  <Capability Min="3" Max="3">0.6s</Capability>
+  <Capability Min="4" Max="4">0.8s</Capability>
+  <Capability Min="5" Max="5">1.0s</Capability>
+  <Capability Min="6" Max="6">1.2s</Capability>
+  <Capability Min="7" Max="7">1.4s</Capability>
+  <Capability Min="8" Max="8">1.6s</Capability>
+  <Capability Min="9" Max="9">1.8s</Capability>
+  <Capability Min="10" Max="10">2.0s</Capability>
+  <Capability Min="11" Max="11">2.2s</Capability>
+  <Capability Min="12" Max="12">2.4s</Capability>
+  <Capability Min="13" Max="13">2.6s</Capability>
+  <Capability Min="14" Max="14">2.8s</Capability>
+  <Capability Min="15" Max="15">3.0s</Capability>
+  <Capability Min="16" Max="16">3.2s</Capability>
+  <Capability Min="17" Max="17">3.4s</Capability>
+  <Capability Min="18" Max="18">3.6s</Capability>
+  <Capability Min="19" Max="19">3.8s</Capability>
+  <Capability Min="20" Max="20">4.0s</Capability>
+  <Capability Min="21" Max="21">4.2s</Capability>
+  <Capability Min="22" Max="22">4.4s</Capability>
+  <Capability Min="23" Max="23">4.6s</Capability>
+  <Capability Min="24" Max="24">4.8s</Capability>
+  <Capability Min="25" Max="25">5.0s</Capability>
+  <Capability Min="26" Max="26">5.2s</Capability>
+  <Capability Min="27" Max="27">5.4s</Capability>
+  <Capability Min="28" Max="28">5.6s</Capability>
+  <Capability Min="29" Max="29">5.8s</Capability>
+  <Capability Min="30" Max="30">6.0s</Capability>
+  <Capability Min="31" Max="31">6.2s</Capability>
+  <Capability Min="32" Max="32">6.4s</Capability>
+  <Capability Min="33" Max="33">6.6s</Capability>
+  <Capability Min="34" Max="34">6.8s</Capability>
+  <Capability Min="35" Max="35">7.0s</Capability>
+  <Capability Min="36" Max="36">7.2s</Capability>
+  <Capability Min="37" Max="37">7.4s</Capability>
+  <Capability Min="38" Max="38">7.6s</Capability>
+  <Capability Min="39" Max="39">7.8s</Capability>
+  <Capability Min="40" Max="40">8.0s</Capability>
+  <Capability Min="41" Max="41">8.2s</Capability>
+  <Capability Min="42" Max="42">8.4s</Capability>
+  <Capability Min="43" Max="43">8.6s</Capability>
+  <Capability Min="44" Max="44">8.8s</Capability>
+  <Capability Min="45" Max="45">9.0s</Capability>
+  <Capability Min="46" Max="46">9.2s</Capability>
+  <Capability Min="47" Max="47">9.4s</Capability>
+  <Capability Min="48" Max="48">9.6s</Capability>
+  <Capability Min="49" Max="49">9.8s</Capability>
+  <Capability Min="50" Max="50">10.0s</Capability>
+  <Capability Min="51" Max="51">10.2s</Capability>
+  <Capability Min="52" Max="52">10.4s</Capability>
+  <Capability Min="53" Max="53">10.6s</Capability>
+  <Capability Min="54" Max="55">11s</Capability>
+  <Capability Min="56" Max="57">12s</Capability>
+  <Capability Min="58" Max="59">13s</Capability>
+  <Capability Min="60" Max="62">14s</Capability>
+  <Capability Min="63" Max="64">15s</Capability>
+  <Capability Min="65" Max="67">16s</Capability>
+  <Capability Min="68" Max="69">17s</Capability>
+  <Capability Min="70" Max="72">18s</Capability>
+  <Capability Min="73" Max="74">19s</Capability>
+  <Capability Min="75" Max="77">20s</Capability>
+  <Capability Min="78" Max="80">21s</Capability>
+  <Capability Min="81" Max="82">22s</Capability>
+  <Capability Min="83" Max="85">23s</Capability>
+  <Capability Min="86" Max="87">24s</Capability>
+  <Capability Min="88" Max="90">25s</Capability>
+  <Capability Min="91" Max="92">26s</Capability>
+  <Capability Min="93" Max="95">27s</Capability>
+  <Capability Min="96" Max="97">28s</Capability>
+  <Capability Min="98" Max="100">29s</Capability>
+  <Capability Min="101" Max="103">30s</Capability>
+  <Capability Min="104" Max="105">31s</Capability>
+  <Capability Min="106" Max="108">32s</Capability>
+  <Capability Min="109" Max="110">33s</Capability>
+  <Capability Min="111" Max="113">34s</Capability>
+  <Capability Min="114" Max="115">35s</Capability>
+  <Capability Min="116" Max="118">36s</Capability>
+  <Capability Min="119" Max="120">37s</Capability>
+  <Capability Min="121" Max="123">38s</Capability>
+  <Capability Min="124" Max="126">39s</Capability>
+  <Capability Min="127" Max="128">40s</Capability>
+  <Capability Min="129" Max="131">41s</Capability>
+  <Capability Min="132" Max="133">42s</Capability>
+  <Capability Min="134" Max="136">43s</Capability>
+  <Capability Min="137" Max="138">44s</Capability>
+  <Capability Min="139" Max="141">45s</Capability>
+  <Capability Min="142" Max="143">46s</Capability>
+  <Capability Min="144" Max="146">47s</Capability>
+  <Capability Min="147" Max="148">48s</Capability>
+  <Capability Min="149" Max="151">49s</Capability>
+  <Capability Min="152" Max="154">50s</Capability>
+  <Capability Min="155" Max="156">51s</Capability>
+  <Capability Min="157" Max="158">52s</Capability>
+  <Capability Min="160" Max="161">53s</Capability>
+  <Capability Min="162" Max="164">54s</Capability>
+  <Capability Min="165" Max="166">55s</Capability>
+  <Capability Min="167" Max="169">56s</Capability>
+  <Capability Min="170" Max="171">57s</Capability>
+  <Capability Min="172" Max="174">58s</Capability>
+  <Capability Min="175" Max="177">59s</Capability>
+  <Capability Min="178" Max="179">60s</Capability>
+  <Capability Min="180" Max="182">65s</Capability>
+  <Capability Min="183" Max="184">70s</Capability>
+  <Capability Min="185" Max="187">75s</Capability>
+  <Capability Min="188" Max="189">80s</Capability>
+  <Capability Min="190" Max="192">85s</Capability>
+  <Capability Min="193" Max="194">90s</Capability>
+  <Capability Min="195" Max="197">95s</Capability>
+  <Capability Min="198" Max="199">100s</Capability>
+  <Capability Min="200" Max="202">110s</Capability>
+  <Capability Min="203" Max="205">120s</Capability>
+  <Capability Min="206" Max="207">130s</Capability>
+  <Capability Min="208" Max="210">140s</Capability>
+  <Capability Min="211" Max="212">150s</Capability>
+  <Capability Min="213" Max="215">160s</Capability>
+  <Capability Min="216" Max="217">170s</Capability>
+  <Capability Min="218" Max="220">180s</Capability>
+  <Capability Min="221" Max="222">190s</Capability>
+  <Capability Min="223" Max="224">200s</Capability>
+  <Capability Min="226" Max="228">210s</Capability>
+  <Capability Min="229" Max="230">220s</Capability>
+  <Capability Min="231" Max="233">230s</Capability>
+  <Capability Min="234" Max="235">240s</Capability>
+  <Capability Min="236" Max="238">250s</Capability>
+  <Capability Min="239" Max="240">260s</Capability>
+  <Capability Min="241" Max="243">270s</Capability>
+  <Capability Min="244" Max="245">280s</Capability>
+  <Capability Min="246" Max="248">290s</Capability>
+  <Capability Min="249" Max="250">300s</Capability>
+  <Capability Min="251" Max="254">310s</Capability>
+  <Capability Min="255" Max="255">Follows Cue Data</Capability>
+ </Channel>
+ <Channel Name="Gobo Timing" Default="255">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="0">Full Speed</Capability>
+  <Capability Min="1" Max="1">0.2s</Capability>
+  <Capability Min="2" Max="2">0.4s</Capability>
+  <Capability Min="3" Max="3">0.6s</Capability>
+  <Capability Min="4" Max="4">0.8s</Capability>
+  <Capability Min="5" Max="5">1.0s</Capability>
+  <Capability Min="6" Max="6">1.2s</Capability>
+  <Capability Min="7" Max="7">1.4s</Capability>
+  <Capability Min="8" Max="8">1.6s</Capability>
+  <Capability Min="9" Max="9">1.8s</Capability>
+  <Capability Min="10" Max="10">2.0s</Capability>
+  <Capability Min="11" Max="11">2.2s</Capability>
+  <Capability Min="12" Max="12">2.4s</Capability>
+  <Capability Min="13" Max="13">2.6s</Capability>
+  <Capability Min="14" Max="14">2.8s</Capability>
+  <Capability Min="15" Max="15">3.0s</Capability>
+  <Capability Min="16" Max="16">3.2s</Capability>
+  <Capability Min="17" Max="17">3.4s</Capability>
+  <Capability Min="18" Max="18">3.6s</Capability>
+  <Capability Min="19" Max="19">3.8s</Capability>
+  <Capability Min="20" Max="20">4.0s</Capability>
+  <Capability Min="21" Max="21">4.2s</Capability>
+  <Capability Min="22" Max="22">4.4s</Capability>
+  <Capability Min="23" Max="23">4.6s</Capability>
+  <Capability Min="24" Max="24">4.8s</Capability>
+  <Capability Min="25" Max="25">5.0s</Capability>
+  <Capability Min="26" Max="26">5.2s</Capability>
+  <Capability Min="27" Max="27">5.4s</Capability>
+  <Capability Min="28" Max="28">5.6s</Capability>
+  <Capability Min="29" Max="29">5.8s</Capability>
+  <Capability Min="30" Max="30">6.0s</Capability>
+  <Capability Min="31" Max="31">6.2s</Capability>
+  <Capability Min="32" Max="32">6.4s</Capability>
+  <Capability Min="33" Max="33">6.6s</Capability>
+  <Capability Min="34" Max="34">6.8s</Capability>
+  <Capability Min="35" Max="35">7.0s</Capability>
+  <Capability Min="36" Max="36">7.2s</Capability>
+  <Capability Min="37" Max="37">7.4s</Capability>
+  <Capability Min="38" Max="38">7.6s</Capability>
+  <Capability Min="39" Max="39">7.8s</Capability>
+  <Capability Min="40" Max="40">8.0s</Capability>
+  <Capability Min="41" Max="41">8.2s</Capability>
+  <Capability Min="42" Max="42">8.4s</Capability>
+  <Capability Min="43" Max="43">8.6s</Capability>
+  <Capability Min="44" Max="44">8.8s</Capability>
+  <Capability Min="45" Max="45">9.0s</Capability>
+  <Capability Min="46" Max="46">9.2s</Capability>
+  <Capability Min="47" Max="47">9.4s</Capability>
+  <Capability Min="48" Max="48">9.6s</Capability>
+  <Capability Min="49" Max="49">9.8s</Capability>
+  <Capability Min="50" Max="50">10.0s</Capability>
+  <Capability Min="51" Max="51">10.2s</Capability>
+  <Capability Min="52" Max="52">10.4s</Capability>
+  <Capability Min="53" Max="53">10.6s</Capability>
+  <Capability Min="54" Max="55">11s</Capability>
+  <Capability Min="56" Max="57">12s</Capability>
+  <Capability Min="58" Max="59">13s</Capability>
+  <Capability Min="60" Max="62">14s</Capability>
+  <Capability Min="63" Max="64">15s</Capability>
+  <Capability Min="65" Max="67">16s</Capability>
+  <Capability Min="68" Max="69">17s</Capability>
+  <Capability Min="70" Max="72">18s</Capability>
+  <Capability Min="73" Max="74">19s</Capability>
+  <Capability Min="75" Max="77">20s</Capability>
+  <Capability Min="78" Max="80">21s</Capability>
+  <Capability Min="81" Max="82">22s</Capability>
+  <Capability Min="83" Max="85">23s</Capability>
+  <Capability Min="86" Max="87">24s</Capability>
+  <Capability Min="88" Max="90">25s</Capability>
+  <Capability Min="91" Max="92">26s</Capability>
+  <Capability Min="93" Max="95">27s</Capability>
+  <Capability Min="96" Max="97">28s</Capability>
+  <Capability Min="98" Max="100">29s</Capability>
+  <Capability Min="101" Max="103">30s</Capability>
+  <Capability Min="104" Max="105">31s</Capability>
+  <Capability Min="106" Max="108">32s</Capability>
+  <Capability Min="109" Max="110">33s</Capability>
+  <Capability Min="111" Max="113">34s</Capability>
+  <Capability Min="114" Max="115">35s</Capability>
+  <Capability Min="116" Max="118">36s</Capability>
+  <Capability Min="119" Max="120">37s</Capability>
+  <Capability Min="121" Max="123">38s</Capability>
+  <Capability Min="124" Max="126">39s</Capability>
+  <Capability Min="127" Max="128">40s</Capability>
+  <Capability Min="129" Max="131">41s</Capability>
+  <Capability Min="132" Max="133">42s</Capability>
+  <Capability Min="134" Max="136">43s</Capability>
+  <Capability Min="137" Max="138">44s</Capability>
+  <Capability Min="139" Max="141">45s</Capability>
+  <Capability Min="142" Max="143">46s</Capability>
+  <Capability Min="144" Max="146">47s</Capability>
+  <Capability Min="147" Max="148">48s</Capability>
+  <Capability Min="149" Max="151">49s</Capability>
+  <Capability Min="152" Max="154">50s</Capability>
+  <Capability Min="155" Max="156">51s</Capability>
+  <Capability Min="157" Max="158">52s</Capability>
+  <Capability Min="160" Max="161">53s</Capability>
+  <Capability Min="162" Max="164">54s</Capability>
+  <Capability Min="165" Max="166">55s</Capability>
+  <Capability Min="167" Max="169">56s</Capability>
+  <Capability Min="170" Max="171">57s</Capability>
+  <Capability Min="172" Max="174">58s</Capability>
+  <Capability Min="175" Max="177">59s</Capability>
+  <Capability Min="178" Max="179">60s</Capability>
+  <Capability Min="180" Max="182">65s</Capability>
+  <Capability Min="183" Max="184">70s</Capability>
+  <Capability Min="185" Max="187">75s</Capability>
+  <Capability Min="188" Max="189">80s</Capability>
+  <Capability Min="190" Max="192">85s</Capability>
+  <Capability Min="193" Max="194">90s</Capability>
+  <Capability Min="195" Max="197">95s</Capability>
+  <Capability Min="198" Max="199">100s</Capability>
+  <Capability Min="200" Max="202">110s</Capability>
+  <Capability Min="203" Max="205">120s</Capability>
+  <Capability Min="206" Max="207">130s</Capability>
+  <Capability Min="208" Max="210">140s</Capability>
+  <Capability Min="211" Max="212">150s</Capability>
+  <Capability Min="213" Max="215">160s</Capability>
+  <Capability Min="216" Max="217">170s</Capability>
+  <Capability Min="218" Max="220">180s</Capability>
+  <Capability Min="221" Max="222">190s</Capability>
+  <Capability Min="223" Max="224">200s</Capability>
+  <Capability Min="226" Max="228">210s</Capability>
+  <Capability Min="229" Max="230">220s</Capability>
+  <Capability Min="231" Max="233">230s</Capability>
+  <Capability Min="234" Max="235">240s</Capability>
+  <Capability Min="236" Max="238">250s</Capability>
+  <Capability Min="239" Max="240">260s</Capability>
+  <Capability Min="241" Max="243">270s</Capability>
+  <Capability Min="244" Max="245">280s</Capability>
+  <Capability Min="246" Max="248">290s</Capability>
+  <Capability Min="249" Max="250">300s</Capability>
+  <Capability Min="251" Max="254">310s</Capability>
+  <Capability Min="255" Max="255">Follows Cue Data</Capability>
+ </Channel>
+ <Mode Name="Standard 16-Bit">
+  <Channel Number="0">Intensity</Channel>
+  <Channel Number="1">Pan</Channel>
+  <Channel Number="2">Pan Fine</Channel>
+  <Channel Number="3">Tilt</Channel>
+  <Channel Number="4">Tilt Fine</Channel>
+  <Channel Number="5">Edge</Channel>
+  <Channel Number="6">Edge Fine</Channel>
+  <Channel Number="7">Zoom</Channel>
+  <Channel Number="8">Zoom Fine</Channel>
+  <Channel Number="9">Programming Control</Channel>
+  <Channel Number="10">Cyan</Channel>
+  <Channel Number="11">Yellow</Channel>
+  <Channel Number="12">Magenta</Channel>
+  <Channel Number="13">CTO</Channel>
+  <Channel Number="14">Color Wheel 1</Channel>
+  <Channel Number="15">Color Wheen 1 Control</Channel>
+  <Channel Number="16">Color Wheel 2</Channel>
+  <Channel Number="17">Color Wheen 2 Control</Channel>
+  <Channel Number="18">Gobo Wheel 1</Channel>
+  <Channel Number="19">Gobo Wheel 1 Index/Rotate</Channel>
+  <Channel Number="20">Gobo Wheel 1 Index/Rotate Fine</Channel>
+  <Channel Number="21">Gobo Wheel 1 Control</Channel>
+  <Channel Number="22">Gobo Wheel 2</Channel>
+  <Channel Number="23">Gobo Wheel 2 Index/Rotate</Channel>
+  <Channel Number="24">Gobo Wheel 2 Index/Rotate Fine</Channel>
+  <Channel Number="25">Gobo Wheel 2 Control</Channel>
+  <Channel Number="26">Animation Wheel 1 (Dichro*Fusion)</Channel>
+  <Channel Number="27">Animation Wheel 1 (Dichro*Fusion) Index/Rotate</Channel>
+  <Channel Number="28">Animation Wheel 1 (Dichro*Fusion) Index/Rotate Fine</Channel>
+  <Channel Number="29">Animation Wheel 1 (Dichro*Fusion) Control</Channel>
+  <Channel Number="30">Animation Wheel 2 (Wicked Waves)</Channel>
+  <Channel Number="31">Animation Wheel 2 (Wicked Waves) Index/Rotate</Channel>
+  <Channel Number="32">Animation Wheel 2 (Wicked Waves) Index/Rotate Fine</Channel>
+  <Channel Number="33">Animation Wheel 2 (Wicked Waves) Control</Channel>
+  <Channel Number="34">Beam Iris</Channel>
+  <Channel Number="35">Shutter Frame 1A</Channel>
+  <Channel Number="36">Shutter Frame 1B</Channel>
+  <Channel Number="37">Shutter Frame 2A</Channel>
+  <Channel Number="38">Shutter Frame 2B</Channel>
+  <Channel Number="39">Shutter Frame 3A</Channel>
+  <Channel Number="40">Shutter Frame 3B</Channel>
+  <Channel Number="41">Shutter Frame 4A</Channel>
+  <Channel Number="42">Shutter Frame 4B</Channel>
+  <Channel Number="43">Shutter Frame Rotation</Channel>
+  <Channel Number="44">Prism</Channel>
+  <Channel Number="45">Prism Index/Rotate</Channel>
+  <Channel Number="46">Prism Index/Rotate Fine</Channel>
+  <Channel Number="47">Prism Diverge</Channel>
+  <Channel Number="48">Frost</Channel>
+  <Channel Number="49">Strobe Speed</Channel>
+  <Channel Number="50">Strobe Control</Channel>
+  <Channel Number="51">Control</Channel>
+ </Mode>
+ <Mode Name="Enhanced 16-Bit">
+  <Channel Number="0">Intensity</Channel>
+  <Channel Number="1">Pan</Channel>
+  <Channel Number="2">Pan Fine</Channel>
+  <Channel Number="3">Tilt</Channel>
+  <Channel Number="4">Tilt Fine</Channel>
+  <Channel Number="5">Edge</Channel>
+  <Channel Number="6">Edge Fine</Channel>
+  <Channel Number="7">Zoom</Channel>
+  <Channel Number="8">Zoom Fine</Channel>
+  <Channel Number="9">Programming Control</Channel>
+  <Channel Number="10">Cyan</Channel>
+  <Channel Number="11">Yellow</Channel>
+  <Channel Number="12">Magenta</Channel>
+  <Channel Number="13">CTO</Channel>
+  <Channel Number="14">Color Wheel 1</Channel>
+  <Channel Number="15">Color Wheen 1 Control</Channel>
+  <Channel Number="16">Color Wheel 2</Channel>
+  <Channel Number="17">Color Wheen 2 Control</Channel>
+  <Channel Number="18">Gobo Wheel 1</Channel>
+  <Channel Number="19">Gobo Wheel 1 Index/Rotate</Channel>
+  <Channel Number="20">Gobo Wheel 1 Index/Rotate Fine</Channel>
+  <Channel Number="21">Gobo Wheel 1 Control</Channel>
+  <Channel Number="22">Gobo Wheel 2</Channel>
+  <Channel Number="23">Gobo Wheel 2 Index/Rotate</Channel>
+  <Channel Number="24">Gobo Wheel 2 Index/Rotate Fine</Channel>
+  <Channel Number="25">Gobo Wheel 2 Control</Channel>
+  <Channel Number="26">Animation Wheel 1 (Dichro*Fusion)</Channel>
+  <Channel Number="27">Animation Wheel 1 (Dichro*Fusion) Index/Rotate</Channel>
+  <Channel Number="28">Animation Wheel 1 (Dichro*Fusion) Index/Rotate Fine</Channel>
+  <Channel Number="29">Animation Wheel 1 (Dichro*Fusion) Control</Channel>
+  <Channel Number="30">Animation Wheel 2 (Wicked Waves)</Channel>
+  <Channel Number="31">Animation Wheel 2 (Wicked Waves) Index/Rotate</Channel>
+  <Channel Number="32">Animation Wheel 2 (Wicked Waves) Index/Rotate Fine</Channel>
+  <Channel Number="33">Animation Wheel 2 (Wicked Waves) Control</Channel>
+  <Channel Number="34">Beam Iris</Channel>
+  <Channel Number="35">Shutter Frame 1A</Channel>
+  <Channel Number="36">Shutter Frame 1B</Channel>
+  <Channel Number="37">Shutter Frame 2A</Channel>
+  <Channel Number="38">Shutter Frame 2B</Channel>
+  <Channel Number="39">Shutter Frame 3A</Channel>
+  <Channel Number="40">Shutter Frame 3B</Channel>
+  <Channel Number="41">Shutter Frame 4A</Channel>
+  <Channel Number="42">Shutter Frame 4B</Channel>
+  <Channel Number="43">Shutter Frame Rotation</Channel>
+  <Channel Number="44">Prism</Channel>
+  <Channel Number="45">Prism Index/Rotate</Channel>
+  <Channel Number="46">Prism Index/Rotate Fine</Channel>
+  <Channel Number="47">Prism Diverge</Channel>
+  <Channel Number="48">Frost</Channel>
+  <Channel Number="49">Strobe Speed</Channel>
+  <Channel Number="50">Strobe Control</Channel>
+  <Channel Number="51">Focus Timing</Channel>
+  <Channel Number="52">Optics Timing</Channel>
+  <Channel Number="53">Color Timing</Channel>
+  <Channel Number="54">Beam Timing</Channel>
+  <Channel Number="55">Gobo Timing</Channel>
+  <Channel Number="56">Control</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="Philips MSR 1200W Gold FastFit" Lumens="33000" ColourTemperature="6000"/>
+  <Dimensions Weight="41" Width="571" Height="808" Depth="624"/>
+  <Lens Name="" DegreesMin="9" DegreesMax="47"/>
+  <Focus Type="Head" PanMax="540" TiltMax="270"/>
+  <Technical PowerConsumption="1850" DmxConnector="5-pin"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION
This is the first fixture definition I'm attempting to add, I'm happy to fix any functional or quality problems with it. It follows the official DMX tables for the fixture, minus the color wheel "mid-positions" (between two colors) which aren't described by the tables, but which were also used by the other Vari-Lite fixtures.