### PR TITLE
ui: do not focus function name text when function is selected

### DIFF
--- a/ui/src/audioeditor.cpp
+++ b/ui/src/audioeditor.cpp
@@ -43,7 +43,6 @@ AudioEditor::AudioEditor(QWidget* parent, Audio *audio, Doc* doc)
     setupUi(this);
 
     m_nameEdit->setText(m_audio->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
 
     m_fadeInEdit->setText(Function::speedToString(audio->fadeInSpeed()));
     m_fadeOutEdit->setText(Function::speedToString(audio->fadeOutSpeed()));
@@ -117,9 +116,6 @@ AudioEditor::AudioEditor(QWidget* parent, Audio *audio, Doc* doc)
             this, SLOT(slotLoopCheckClicked()));
     connect(m_singleCheck, SIGNAL(clicked()),
             this, SLOT(slotSingleShotCheckClicked()));
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 AudioEditor::~AudioEditor()

--- a/ui/src/chasereditor.cpp
+++ b/ui/src/chasereditor.cpp
@@ -89,7 +89,6 @@ ChaserEditor::ChaserEditor(QWidget* parent, Chaser* chaser, Doc* doc, bool liveM
 
     /* Name edit */
     m_nameEdit->setText(m_chaser->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
 
     /* Fade In Mode */
     switch (m_chaser->fadeInMode())
@@ -235,9 +234,6 @@ ChaserEditor::ChaserEditor(QWidget* parent, Chaser* chaser, Doc* doc, bool liveM
     updateSpeedDials();
 
     slotModeChanged(m_doc->mode());
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 
     m_testPreviousButton->setEnabled(false);
     m_testNextButton->setEnabled(false);

--- a/ui/src/collectioneditor.cpp
+++ b/ui/src/collectioneditor.cpp
@@ -56,12 +56,8 @@ CollectionEditor::CollectionEditor(QWidget* parent, Collection* fc, Doc* doc)
             this, SLOT(slotTestClicked()));
 
     m_nameEdit->setText(m_collection->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
 
     updateFunctionList();
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 CollectionEditor::~CollectionEditor()

--- a/ui/src/efxeditor.cpp
+++ b/ui/src/efxeditor.cpp
@@ -103,9 +103,6 @@ EFXEditor::EFXEditor(QWidget* parent, EFX* efx, Doc* doc)
     QVariant showDial = efx->uiStateValue(UI_STATE_SHOW_DIAL);
     if (showDial.isNull() == false && showDial.toBool() == true)
         m_speedDial->setChecked(true);
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 EFXEditor::~EFXEditor()
@@ -142,7 +139,6 @@ void EFXEditor::initGeneralPage()
 
     /* Set the EFX's name to the name field */
     m_nameEdit->setText(m_efx->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
 
     /* Put all of the EFX's fixtures to the tree view */
     updateFixtureTree();

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -86,9 +86,6 @@ RGBMatrixEditor::RGBMatrixEditor(QWidget* parent, RGBMatrix* mtx, Doc* doc)
     init();
 
     slotModeChanged(m_doc->mode());
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 RGBMatrixEditor::~RGBMatrixEditor()
@@ -126,7 +123,6 @@ void RGBMatrixEditor::init()
 {
     /* Name */
     m_nameEdit->setText(m_matrix->name());
-    m_nameEdit->setSelection(0, m_matrix->name().length());
 
     /* Running order */
     switch (m_matrix->runOrder())

--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -108,9 +108,6 @@ SceneEditor::SceneEditor(QWidget* parent, Scene* scene, Doc* doc, bool applyValu
     connect(m_doc, SIGNAL(fixtureRemoved(quint32)), this, SLOT(slotFixtureRemoved(quint32)));
 
     m_initFinished = true;
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 SceneEditor::~SceneEditor()
@@ -312,7 +309,6 @@ void SceneEditor::init(bool applyValues)
             this, SLOT(slotRemoveFixtureClicked()));
 
     m_nameEdit->setText(m_scene->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
     connect(m_nameEdit, SIGNAL(textEdited(const QString&)),
             this, SLOT(slotNameEdited(const QString&)));
 

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -49,7 +49,6 @@ ScriptEditor::ScriptEditor(QWidget* parent, Script* script, Doc* doc)
 
     /* Name */
     m_nameEdit->setText(m_script->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
     connect(m_nameEdit, SIGNAL(textEdited(const QString&)),
             this, SLOT(slotNameEdited(const QString&)));
 
@@ -73,9 +72,6 @@ ScriptEditor::ScriptEditor(QWidget* parent, Script* script, Doc* doc)
     connect(m_checkButton, SIGNAL(clicked()), this, SLOT(slotCheckSyntax()));
 
     connect(m_script, SIGNAL(stopped(quint32)), this, SLOT(slotFunctionStopped(quint32)));
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 ScriptEditor::~ScriptEditor()

--- a/ui/src/videoeditor.cpp
+++ b/ui/src/videoeditor.cpp
@@ -38,7 +38,6 @@ VideoEditor::VideoEditor(QWidget* parent, Video *video, Doc* doc)
     setupUi(this);
 
     m_nameEdit->setText(m_video->name());
-    m_nameEdit->setSelection(0, m_nameEdit->text().length());
 
     connect(m_video, SIGNAL(totalTimeChanged(qint64)),
             this, SLOT(slotDurationChanged(qint64)));
@@ -93,9 +92,6 @@ VideoEditor::VideoEditor(QWidget* parent, Video *video, Doc* doc)
             this, SLOT(slotLoopCheckClicked()));
     connect(m_singleCheck, SIGNAL(clicked()),
             this, SLOT(slotSingleShotCheckClicked()));
-
-    // Set focus to the editor
-    m_nameEdit->setFocus();
 }
 
 VideoEditor::~VideoEditor()


### PR DESCRIPTION
This modifies the behavior in the function manager when a function is selected.
Currently, the nameEdit widget in the function editor is explicitly focused and the text is selected.
Because focus changes to the text, it breaks keyboard navigation and shortcuts (clone, delete...) in the FunctionsTreeWidget.

This pull request does not set the focus, this allows the expected interaction with the tree view, for example:
- traversing the function tree with the arrow keys
- clicking on functions, then using the clone or delete key shortcut

If the function name should be selected for immediate editing for newly created functions, the old behavior could be kept for this special case.

If you agree, I can follow this pull request with an adjustment of the tab order in the function editors, so the selected treeview item leads to the function name and then the function parameters.