### PR TITLE
Bug Fixture Remapping VCWidgets

### DIFF
--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -579,6 +579,8 @@ bool Doc::replaceFixtures(QList<Fixture*> newFixturesList)
         }
 
         newFixture->setExcludeFadeChannels(fixture->excludeFadeChannels());
+        newFixture->setForcedHTPChannels(fixture->forcedHTPChannels());
+        newFixture->setForcedLTPChannels(fixture->forcedLTPChannels());
         m_fixtures.insert(id, newFixture);
         m_fixturesListCacheUpToDate = false;
 

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -579,6 +579,9 @@ bool Doc::replaceFixtures(QList<Fixture*> newFixturesList)
         }
 
         newFixture->setExcludeFadeChannels(fixture->excludeFadeChannels());
+        newFixture->setForcedHTPChannels(fixture->forcedHTPChannels());
+        newFixture->setForcedLTPChannels(fixture->forcedLTPChannels());
+
         m_fixtures.insert(id, newFixture);
         m_fixturesListCacheUpToDate = false;
 

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -619,9 +619,9 @@ QList<SceneValue> FixtureRemap::remapSceneValues(QList<SceneValue> funcList,
     return newValuesList;
 }
 
-QList<VCWidget *> FixtureRemap::getVCChildren(VCWidget *obj)
+QSet<VCWidget *> FixtureRemap::getVCChildren(VCWidget *obj)
 {
-    QList<VCWidget *> list;
+    QSet<VCWidget *> list;
     if (obj == NULL)
         return list;
     QListIterator <VCWidget*> it(obj->findChildren<VCWidget*>());
@@ -631,9 +631,9 @@ QList<VCWidget *> FixtureRemap::getVCChildren(VCWidget *obj)
         if (list.contains(child) == false)
         {
             qDebug() << Q_FUNC_INFO << "append: " << child->caption();
-            list.append(child);
+            list.insert(child);
         }
-        list.append(getVCChildren(child));
+        list.unite(getVCChildren(child));
     }
     return list;
 }
@@ -814,7 +814,7 @@ void FixtureRemap::accept()
      * 6 - remap Virtual Console widgets
      * ********************************************************************** */
     VCFrame* contents = VirtualConsole::instance()->contents();
-    QList<VCWidget *> widgetsList = getVCChildren((VCWidget *)contents).toSet().toList();
+    QSet<VCWidget *> widgetsList = getVCChildren((VCWidget *)contents);
 
     foreach (QObject *object, widgetsList)
     {

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -479,6 +479,12 @@ void FixtureRemap::slotAddRemap()
                  srcFxiMode == NULL && tgtFxiMode == NULL)
                     oneToOneRemap = true;
 
+        if (oneToOneRemap == true)
+        {
+            tgtFxi->setForcedHTPChannels(srcFxi->forcedHTPChannels());
+            tgtFxi->setForcedLTPChannels(srcFxi->forcedLTPChannels());
+        }
+
         for (quint32 s = 0; s < srcFxi->channels(); s++)
         {
             if (oneToOneRemap == true)

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -814,7 +814,7 @@ void FixtureRemap::accept()
      * 6 - remap Virtual Console widgets
      * ********************************************************************** */
     VCFrame* contents = VirtualConsole::instance()->contents();
-    QList<VCWidget *> widgetsList = getVCChildren((VCWidget *)contents);
+    QList<VCWidget *> widgetsList = getVCChildren((VCWidget *)contents).toSet().toList();
 
     foreach (QObject *object, widgetsList)
     {

--- a/ui/src/fixtureremap.h
+++ b/ui/src/fixtureremap.h
@@ -22,6 +22,7 @@
 
 #include <QDialog>
 #include <QList>
+#include <QSet>
 
 #include "ui_fixtureremap.h"
 
@@ -64,7 +65,7 @@ protected:
                                        QList<SceneValue> &srcList,
                                        QList<SceneValue> &tgtList);
 
-    QList<VCWidget *> getVCChildren(VCWidget *obj);
+    QSet<VCWidget *> getVCChildren(VCWidget *obj);
 
 protected slots:
     void slotAddTargetFixture();


### PR DESCRIPTION
Related to this forum post : https://www.qlcplus.org/forum/viewtopic.php?f=20&t=15864
Somehow some VCWidgets are listed twice (or more ?) with getVCChildren. The remapping happens then more than once, making confusion in fixture IDs at the second remapping.
Just removing duplicate VCWidget from the list using a Set.