### PR TITLE
Read a local plugin configuration from plugins.config

### DIFF
--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -27,3 +27,9 @@ SUBDIRS              += artnet
 SUBDIRS              += E1.31
 SUBDIRS              += loopback
 SUBDIRS              += osc
+
+# Allow a local configuration file (not checked in) to override
+# or add to the defaults specified here
+exists(plugins.config) {
+  include(plugins.config)
+}


### PR DESCRIPTION
When I have several different branches checked out, changes to the plugins/plugins.pro file become difficult to manage because you can't rebase unless the working tree is completely clean. And using "git stash" causes conflicts. Moving local configuration to a separate, untracked file resolves this.

For example, my "plugins.config" file looks like:

```
SUBDIRS = artnet loopback osc
```