### PR TITLE
update audio preview when a different file is loaded

### DIFF
--- a/ui/src/showmanager/audioitem.cpp
+++ b/ui/src/showmanager/audioitem.cpp
@@ -140,6 +140,11 @@ Audio *AudioItem::getAudio()
 
 void AudioItem::slotAudioChanged(quint32)
 {
+    PreviewThread *waveformThread = new PreviewThread;
+    waveformThread->setAudioItem(this);
+    connect(waveformThread, SIGNAL(finished()), waveformThread, SLOT(deleteLater()));
+    waveformThread->start();
+
     prepareGeometryChange();
     calculateWidth();
     if (m_function)


### PR DESCRIPTION
See this forum [thread]:(https://www.qlcplus.org/forum/viewtopic.php?f=22&t=15924)

This fixes the waveform display at new file load, for me.