### PR TITLE
Midi feedback for motorized faders

### DIFF
--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -1271,6 +1271,11 @@ void VCSlider::setSliderValue(uchar value, bool scale, bool external)
     if (m_slider->isSliderDown() == false && val != m_slider->value())
        emit requestSliderUpdate(val);
 
+    /* Send Feedback for motorized faders */
+    if (external) {
+        sendFeedback(val);
+    }
+
     switch (sliderMode())
     {
         case Level:


### PR DESCRIPTION
I have a midi control surface with motorized faders.
When moved, those faders get back in their original positions.
These forum topics are describing the issue:

https://www.qlcplus.org/forum/viewtopic.php?f=29&p=66484
https://www.qlcplus.org/forum/viewtopic.php?t=14190

With the help a of midi sniffer, I found that qlcplus don't send any midi feedback. It is needed to keep the sliders in place.
Here is a flow for a simple project with only one slider and its external input mapped to a pitchweel message : 

- fader moves
- midi controller sends a pitchwheel message to qlcplus
- VCSlider changes its value

To make the fader stay in place, this extra step is needed : 

- VCSlider sends feedback (pitchwheel) to the controller


I added a sendFeedback call in vcslider.cpp and it works great (at least for my Icon Platform M+).