### PR TITLE
Fixtures colorname to colorcode check

### DIFF
--- a/resources/fixtures/AFX/AFX-Spot-60-LED.qxf
+++ b/resources/fixtures/AFX/AFX-Spot-60-LED.qxf
@@ -22,7 +22,7 @@
   <Capability Min="30" Max="49" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="50" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="70" Max="89" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="90" Max="109" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="90" Max="109" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="110" Max="129">Simple green</Capability>
   <Capability Min="130" Max="149">Simple blue</Capability>
   <Capability Min="150" Max="255">Rainbow</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Auto-Spot-150.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Auto-Spot-150.qxf
@@ -42,9 +42,9 @@
   <Capability Min="41" Max="46" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="47" Max="53" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#aaddff">Green-Lightblue</Capability>
   <Capability Min="54" Max="60" Preset="ColorMacro" Res1="#aaddff">Lightblue</Capability>
-  <Capability Min="61" Max="66" Preset="ColorDoubleMacro" Res1="#aaddff" Res2="#ff7f00">Lightblue-Orange</Capability>
-  <Capability Min="67" Max="73" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="74" Max="80" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#ffaaaa">Orange-Pink</Capability>
+  <Capability Min="61" Max="66" Preset="ColorDoubleMacro" Res1="#aaddff" Res2="#ffa500">Lightblue-Orange</Capability>
+  <Capability Min="67" Max="73" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="74" Max="80" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#ffaaaa">Orange-Pink</Capability>
   <Capability Min="81" Max="87" Preset="ColorMacro" Res1="#ffaaaa">Pink</Capability>
   <Capability Min="88" Max="93" Preset="ColorDoubleMacro" Res1="#ffaaaa" Res2="#ff00ff">Pink-Magenta</Capability>
   <Capability Min="94" Max="100" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
@@ -68,7 +68,7 @@
   <Capability Min="26" Max="38" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="39" Max="51" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="52" Max="63" Preset="ColorMacro" Res1="#aaddff">Lightblue</Capability>
-  <Capability Min="64" Max="76" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="64" Max="76" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="77" Max="89" Preset="ColorMacro" Res1="#ffaaaa">Pink</Capability>
   <Capability Min="90" Max="102" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="103" Max="115" Preset="ColorMacro" Res1="#ffbf00">Amber</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-DJ-Spot-250.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-DJ-Spot-250.qxf
@@ -18,7 +18,7 @@
   <Capability Min="50" Max="74" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="75" Max="99" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="100" Max="124" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="125" Max="149" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="125" Max="149" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="150" Max="174" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="175" Max="199" Preset="ColorMacro" Res1="#ffc0ff">Pink</Capability>
   <Capability Min="200" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow Effect</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-DJ-Spot-250.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-DJ-Spot-250.qxf
@@ -18,7 +18,7 @@
   <Capability Min="50" Max="74" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="75" Max="99" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="100" Max="124" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="125" Max="149" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="125" Max="149" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="150" Max="174" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="175" Max="199" Preset="ColorMacro" Res1="#ffc0ff">Pink</Capability>
   <Capability Min="200" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow Effect</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-DJ-Spot-300.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-DJ-Spot-300.qxf
@@ -21,9 +21,9 @@
   <Capability Min="36" Max="42" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="43" Max="49" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#00ff00">Blue/green</Capability>
   <Capability Min="50" Max="56" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="57" Max="63" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff00ff">Green/purple</Capability>
-  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
-  <Capability Min="72" Max="77" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#ff8000">Purple/orange</Capability>
+  <Capability Min="57" Max="63" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#a020f0">Green/purple</Capability>
+  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
+  <Capability Min="72" Max="77" Preset="ColorDoubleMacro" Res1="#a020f0" Res2="#ff8000">Purple/orange</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="86" Max="92" Preset="ColorDoubleMacro" Res1="#ff8000" Res2="#ffc0ff">Orange/pink</Capability>
   <Capability Min="93" Max="99" Preset="ColorMacro" Res1="#ffc0ff">Pink</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Inno-Pocket-Spot-Twins.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Inno-Pocket-Spot-Twins.qxf
@@ -68,7 +68,7 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="8" Max="14" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="15" Max="21" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="15" Max="21" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="22" Max="28" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="29" Max="35" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="36" Max="42" Preset="ColorMacro" Res1="#1a46ff">Blue</Capability>
@@ -112,7 +112,7 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="8" Max="14" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="15" Max="21" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="15" Max="21" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="22" Max="28" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="29" Max="35" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="36" Max="42" Preset="ColorMacro" Res1="#1a46ff">Blue</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Inno-Pocket-Spot.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Inno-Pocket-Spot.qxf
@@ -21,8 +21,8 @@
   <Capability Min="22" Max="28" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="29" Max="35" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="36" Max="42" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="43" Max="49" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
-  <Capability Min="50" Max="56" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="43" Max="49" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="50" Max="56" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="57" Max="127">Split Colors</Capability>
   <Capability Min="128" Max="189" Preset="GoboMacro" Res1="Others/rainbow.png">Color Scroll Fast to Slow</Capability>
   <Capability Min="190" Max="193">Stop</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Inno-Spot-Elite.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Inno-Spot-Elite.qxf
@@ -21,7 +21,7 @@
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00aaff">Light blue</Capability>
   <Capability Min="64" Max="127">Color mixing</Capability>
   <Capability Min="128" Max="189">CW rotation fast - slow</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Inno-Spot-Pro.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Inno-Spot-Pro.qxf
@@ -23,7 +23,7 @@
   <Capability Min="36" Max="42" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="43" Max="49" Preset="ColorMacro" Res1="#aa557f">Purple</Capability>
   <Capability Min="50" Max="56" Preset="ColorMacro" Res1="#aaffff">Light Blue</Capability>
-  <Capability Min="57" Max="63" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="57" Max="63" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="64" Max="127">Color Mixing</Capability>
   <Capability Min="128" Max="189" Preset="GoboMacro" Res1="Others/rainbow.png">Clockwise Rotation (Fast &gt; Slow)</Capability>
   <Capability Min="190" Max="193">Stop</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Inno-Spot-Pro.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Inno-Spot-Pro.qxf
@@ -23,7 +23,7 @@
   <Capability Min="36" Max="42" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="43" Max="49" Preset="ColorMacro" Res1="#aa557f">Purple</Capability>
   <Capability Min="50" Max="56" Preset="ColorMacro" Res1="#aaffff">Light Blue</Capability>
-  <Capability Min="57" Max="63" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="57" Max="63" Preset="ColorMacro" Res1="#ffc0ff">Pink</Capability>
   <Capability Min="64" Max="127">Color Mixing</Capability>
   <Capability Min="128" Max="189" Preset="GoboMacro" Res1="Others/rainbow.png">Clockwise Rotation (Fast &gt; Slow)</Capability>
   <Capability Min="190" Max="193">Stop</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Mega-QA-Par38.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Mega-QA-Par38.qxf
@@ -48,7 +48,7 @@
  <Channel Name="Dimming/Static Color/Color Change/Color Fade Select">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="51">Dimmer mode</Capability>
-  <Capability Min="52" Max="102" Preset="ColorMacro">Color macro mode</Capability>
+  <Capability Min="52" Max="102">Color macro mode</Capability>
   <Capability Min="103" Max="153">Color change mode</Capability>
   <Capability Min="154" Max="204">Color fade mode</Capability>
   <Capability Min="205" Max="255">Sound active mode</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Mega-Tri-Par.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Mega-Tri-Par.qxf
@@ -42,7 +42,7 @@
   <Capability Min="216" Max="223">Double CTB</Capability>
   <Capability Min="224" Max="231">Full CTB</Capability>
   <Capability Min="232" Max="239">Half CTB</Capability>
-  <Capability Min="240" Max="247" Preset="ColorMacro" Res1="#000080">Dark blue</Capability>
+  <Capability Min="240" Max="247" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="248" Max="255" Preset="ColorMacro" Res1="#ffffff">White</Capability>
  </Channel>
  <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>

--- a/resources/fixtures/American_DJ/American-DJ-Nucleus-LED.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Nucleus-LED.qxf
@@ -69,7 +69,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -115,7 +115,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -151,7 +151,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -187,7 +187,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -223,7 +223,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -259,7 +259,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Nucleus-PRO.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Nucleus-PRO.qxf
@@ -69,7 +69,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -115,7 +115,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -151,7 +151,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -187,7 +187,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -223,7 +223,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>
@@ -259,7 +259,7 @@
   <Capability Min="117" Max="123" Preset="ColorMacro" Res1="#b1c5e0">Hemsley Blue</Capability>
   <Capability Min="124" Max="131" Preset="ColorMacro" Res1="#a8bdff">Tipton Blue</Capability>
   <Capability Min="132" Max="139" Preset="ColorMacro" Res1="#b0c3de">Light Steel Blue</Capability>
-  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#b0c4de">Light Sky Blue</Capability>
+  <Capability Min="140" Max="147" Preset="ColorMacro" Res1="#87cefa">Light Sky Blue</Capability>
   <Capability Min="148" Max="154" Preset="ColorMacro" Res1="#46bff0">Sky Blue</Capability>
   <Capability Min="155" Max="162" Preset="ColorMacro" Res1="#1c7ee7">Brilliant Blue</Capability>
   <Capability Min="163" Max="170" Preset="ColorMacro" Res1="#0eb8e7">Light Breen Blue</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-VBar.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-VBar.qxf
@@ -23,7 +23,7 @@
  <Channel Name="Dimming/Static Color Select/Color Change Select/Color Fade Select">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="51">Dimmer mode</Capability>
-  <Capability Min="52" Max="102" Preset="ColorMacro">Color macro mode</Capability>
+  <Capability Min="52" Max="102">Color macro mode</Capability>
   <Capability Min="103" Max="153">Color change mode</Capability>
   <Capability Min="154" Max="204">Color fade mode</Capability>
   <Capability Min="205" Max="255">Sound active mode</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Vizi-Beam-5R.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Vizi-Beam-5R.qxf
@@ -20,7 +20,7 @@
   <Capability Min="20" Max="29" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="60" Max="69">6</Capability>
   <Capability Min="70" Max="79">7</Capability>
   <Capability Min="80" Max="89">8</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Vizi-Beam-RXONE.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Vizi-Beam-RXONE.qxf
@@ -24,9 +24,9 @@
   <Capability Min="13" Max="14" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="15" Max="16" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffff7f">Green and light yellow</Capability>
   <Capability Min="17" Max="18" Preset="ColorMacro" Res1="#ffff7f">Light yellow</Capability>
-  <Capability Min="19" Max="21" Preset="ColorDoubleMacro" Res1="#ffff7f" Res2="#ff7f00">Light yellow &amp; orange</Capability>
-  <Capability Min="22" Max="23" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="24" Max="25" Preset="ColorDoubleMacro" Res1="#ff7f01" Res2="#ff00ff">Orange &amp; magenta</Capability>
+  <Capability Min="19" Max="21" Preset="ColorDoubleMacro" Res1="#ffff7f" Res2="#ffa500">Light yellow &amp; orange</Capability>
+  <Capability Min="22" Max="23" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="24" Max="25" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#ff00ff">Orange &amp; magenta</Capability>
   <Capability Min="26" Max="27" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="28" Max="29" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#7f7fff">Magenta &amp; light blue</Capability>
   <Capability Min="30" Max="31" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Vizi-Beam-RXONE.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Vizi-Beam-RXONE.qxf
@@ -119,8 +119,8 @@
   <Capability Min="60" Max="69">Pan/tilt normal mode</Capability>
   <Capability Min="70" Max="79">Enable blackout with pan/tilt movement</Capability>
   <Capability Min="80" Max="89">Disable blackout with pan/tilt movement</Capability>
-  <Capability Min="90" Max="99" Preset="ColorMacro">Enable blackout with color change</Capability>
-  <Capability Min="100" Max="109" Preset="ColorMacro">Disable blackout with color change</Capability>
+  <Capability Min="90" Max="99">Enable blackout with color change</Capability>
+  <Capability Min="100" Max="109">Disable blackout with color change</Capability>
   <Capability Min="110" Max="119" Preset="GoboMacro">Enable blackout with gobo change</Capability>
   <Capability Min="120" Max="129" Preset="GoboMacro">Disable blackout with gobo change</Capability>
   <Capability Min="130" Max="139" Preset="LampOn">Lamp on</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Vizi-LED-Spot.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Vizi-LED-Spot.qxf
@@ -98,8 +98,8 @@
  </Channel>
  <Channel Name="Reset &amp; Internal Programs">
   <Group Byte="0">Maintenance</Group>
-  <Capability Min="0" Max="19" Preset="ColorMacro">Color Change Normal</Capability>
-  <Capability Min="20" Max="39" Preset="ColorMacro">Color Change to any Position</Capability>
+  <Capability Min="0" Max="19">Color Change Normal</Capability>
+  <Capability Min="20" Max="39">Color Change to any Position</Capability>
   <Capability Min="40" Max="79">No function</Capability>
   <Capability Min="80" Max="84" Preset="ResetAll">All Motor Reset</Capability>
   <Capability Min="85" Max="87">Scan Motor Reset</Capability>

--- a/resources/fixtures/American_DJ/American-DJ-Vizi-Roller-Beam-2R.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Vizi-Roller-Beam-2R.qxf
@@ -20,7 +20,7 @@
   <Capability Min="18" Max="26" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="27" Max="35" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="36" Max="44" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="45" Max="53" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="45" Max="53" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="54" Max="62">Color 6</Capability>
   <Capability Min="63" Max="71">Color 7</Capability>
   <Capability Min="72" Max="80">Color 8</Capability>

--- a/resources/fixtures/Ayra/Ayra-ALO-Micro-Scan.qxf
+++ b/resources/fixtures/Ayra/Ayra-ALO-Micro-Scan.qxf
@@ -17,18 +17,18 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">Open White</Capability>
   <Capability Min="8" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff0000">SPLC 1</Capability>
-  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ff5500">Red</Capability>
-  <Capability Min="24" Max="31" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#ffaa00">SPLC 2</Capability>
-  <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#ffaa00" Res2="#ffff00">SPLC 3</Capability>
+  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="24" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ffa500">SPLC 2</Capability>
+  <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#ffff00">SPLC 3</Capability>
   <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#00aa00">SPLC 4</Capability>
-  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
-  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#00aa00" Res2="#0000ff">SPLC 5</Capability>
-  <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
-  <Capability Min="88" Max="95" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#55ffff">SPLC 6</Capability>
-  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
-  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ff00ff">SPLC 7</Capability>
+  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#00ff00">SPLC 4</Capability>
+  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#00008b">SPLC 5</Capability>
+  <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
+  <Capability Min="88" Max="95" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#add8e6">SPLC 6</Capability>
+  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ff00ff">SPLC 7</Capability>
   <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="128" Max="255" Preset="SlowToFast">Rainbow effect, slow -&gt; fast</Capability>
  </Channel>

--- a/resources/fixtures/BoomToneDJ/BoomToneDJ-Slim-PAR-7x3W-LED-RGB.qxf
+++ b/resources/fixtures/BoomToneDJ/BoomToneDJ-Slim-PAR-7x3W-LED-RGB.qxf
@@ -42,7 +42,7 @@
  <Channel Name="Function Mode">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="59" Preset="ShutterOpen">Dimmer Mode</Capability>
-  <Capability Min="60" Max="119" Preset="ColorMacro">Static Color Mode</Capability>
+  <Capability Min="60" Max="119">Static Color Mode</Capability>
   <Capability Min="120" Max="179">Hop Change Mode</Capability>
   <Capability Min="180" Max="239">Gradual Change Mode</Capability>
   <Capability Min="240" Max="255" Preset="SilentModeOff">Sound Active Mode</Capability>

--- a/resources/fixtures/Briteq/Briteq-BT-Vintage.qxf
+++ b/resources/fixtures/Briteq/Briteq-BT-Vintage.qxf
@@ -29,7 +29,7 @@
   <Capability Min="68" Max="87" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="88" Max="97" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="98" Max="107" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="108" Max="117" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="108" Max="117" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="118" Max="255">Fade colour change (very slow &gt; fast)</Capability>
  </Channel>
  <Mode Name="5 Channel">

--- a/resources/fixtures/Briteq/Briteq-BTX-Saturn.qxf
+++ b/resources/fixtures/Briteq/Briteq-BTX-Saturn.qxf
@@ -63,41 +63,41 @@
  <Channel Name="Yellow" Preset="IntensityYellow"/>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="9" Preset="ColorMacro">CMY color mixing usind channels 8 to 10</Capability>
-  <Capability Min="10" Max="14" Preset="ColorMacro">LEE 790 - Moroccan pink</Capability>
-  <Capability Min="15" Max="19" Preset="ColorMacro">LEE 157 - Pink</Capability>
-  <Capability Min="20" Max="24" Preset="ColorMacro">LEE 332 - Special rose pink</Capability>
-  <Capability Min="25" Max="29" Preset="ColorMacro">LEE 328 - Follies pink</Capability>
-  <Capability Min="30" Max="34" Preset="ColorMacro">LEE 345 - Fuchsia pink</Capability>
-  <Capability Min="35" Max="39" Preset="ColorMacro">LEE 194 - Surprise pink</Capability>
-  <Capability Min="40" Max="44" Preset="ColorMacro">LEE 181 - Congo Blue</Capability>
-  <Capability Min="45" Max="49" Preset="ColorMacro">LEE 071 - Tokyo Blue</Capability>
-  <Capability Min="50" Max="54" Preset="ColorMacro">LEE 120 - Deep Blue</Capability>
-  <Capability Min="55" Max="59" Preset="ColorMacro">LEE 079 - Just Blue</Capability>
-  <Capability Min="60" Max="64" Preset="ColorMacro">LEE 132 - Medium Blue</Capability>
-  <Capability Min="65" Max="69" Preset="ColorMacro">LEE 200 - Double CT Blue</Capability>
-  <Capability Min="70" Max="74" Preset="ColorMacro">LEE 161 - Slate Blue</Capability>
-  <Capability Min="75" Max="79" Preset="ColorMacro">LEE 201 - Full CT Blue</Capability>
-  <Capability Min="80" Max="84" Preset="ColorMacro">LEE 202 - Half CT Blue</Capability>
-  <Capability Min="85" Max="89" Preset="ColorMacro">LEE 117 - Steel Blue</Capability>
-  <Capability Min="90" Max="94" Preset="ColorMacro">LEE 353 - Lighter Blue</Capability>
-  <Capability Min="95" Max="99" Preset="ColorMacro">LEE 118 - Light Blue</Capability>
-  <Capability Min="100" Max="104" Preset="ColorMacro">LEE 116 - Medium Blue Green</Capability>
-  <Capability Min="105" Max="109" Preset="ColorMacro">LEE 124 - Dark Green</Capability>
-  <Capability Min="110" Max="114" Preset="ColorMacro">LEE 139 - Primary Green</Capability>
-  <Capability Min="115" Max="119" Preset="ColorMacro">LEE 089 - Moss Green</Capability>
-  <Capability Min="120" Max="124" Preset="ColorMacro">LEE 122 - Fern Green</Capability>
-  <Capability Min="125" Max="129" Preset="ColorMacro">LEE 738 - JAS Green</Capability>
-  <Capability Min="130" Max="134" Preset="ColorMacro">LEE 088 - Lime Green</Capability>
-  <Capability Min="135" Max="139" Preset="ColorMacro">LEE 100 - Spring Yellow</Capability>
-  <Capability Min="140" Max="144" Preset="ColorMacro">LEE 104 - Deep Amber</Capability>
-  <Capability Min="145" Max="149" Preset="ColorMacro">LEE 179 - Chrome Orange</Capability>
-  <Capability Min="150" Max="154" Preset="ColorMacro">LEE 105 - Orange</Capability>
-  <Capability Min="155" Max="159" Preset="ColorMacro">LEE 021 - Gold Amber</Capability>
-  <Capability Min="160" Max="164" Preset="ColorMacro">LEE 778 - Millennium Gold</Capability>
-  <Capability Min="165" Max="169" Preset="ColorMacro">LEE 135 - Deep Golden Amber</Capability>
-  <Capability Min="170" Max="174" Preset="ColorMacro">LEE 164 - Flame Red</Capability>
-  <Capability Min="175" Max="179" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
+  <Capability Min="0" Max="9">CMY color mixing usind channels 8 to 10</Capability>
+  <Capability Min="10" Max="14">LEE 790 - Moroccan pink</Capability>
+  <Capability Min="15" Max="19">LEE 157 - Pink</Capability>
+  <Capability Min="20" Max="24">LEE 332 - Special rose pink</Capability>
+  <Capability Min="25" Max="29">LEE 328 - Follies pink</Capability>
+  <Capability Min="30" Max="34">LEE 345 - Fuchsia pink</Capability>
+  <Capability Min="35" Max="39">LEE 194 - Surprise pink</Capability>
+  <Capability Min="40" Max="44">LEE 181 - Congo Blue</Capability>
+  <Capability Min="45" Max="49">LEE 071 - Tokyo Blue</Capability>
+  <Capability Min="50" Max="54">LEE 120 - Deep Blue</Capability>
+  <Capability Min="55" Max="59">LEE 079 - Just Blue</Capability>
+  <Capability Min="60" Max="64">LEE 132 - Medium Blue</Capability>
+  <Capability Min="65" Max="69">LEE 200 - Double CT Blue</Capability>
+  <Capability Min="70" Max="74">LEE 161 - Slate Blue</Capability>
+  <Capability Min="75" Max="79">LEE 201 - Full CT Blue</Capability>
+  <Capability Min="80" Max="84">LEE 202 - Half CT Blue</Capability>
+  <Capability Min="85" Max="89">LEE 117 - Steel Blue</Capability>
+  <Capability Min="90" Max="94">LEE 353 - Lighter Blue</Capability>
+  <Capability Min="95" Max="99">LEE 118 - Light Blue</Capability>
+  <Capability Min="100" Max="104">LEE 116 - Medium Blue Green</Capability>
+  <Capability Min="105" Max="109">LEE 124 - Dark Green</Capability>
+  <Capability Min="110" Max="114">LEE 139 - Primary Green</Capability>
+  <Capability Min="115" Max="119">LEE 089 - Moss Green</Capability>
+  <Capability Min="120" Max="124">LEE 122 - Fern Green</Capability>
+  <Capability Min="125" Max="129">LEE 738 - JAS Green</Capability>
+  <Capability Min="130" Max="134">LEE 088 - Lime Green</Capability>
+  <Capability Min="135" Max="139">LEE 100 - Spring Yellow</Capability>
+  <Capability Min="140" Max="144">LEE 104 - Deep Amber</Capability>
+  <Capability Min="145" Max="149">LEE 179 - Chrome Orange</Capability>
+  <Capability Min="150" Max="154">LEE 105 - Orange</Capability>
+  <Capability Min="155" Max="159">LEE 021 - Gold Amber</Capability>
+  <Capability Min="160" Max="164">LEE 778 - Millennium Gold</Capability>
+  <Capability Min="165" Max="169">LEE 135 - Deep Golden Amber</Capability>
+  <Capability Min="170" Max="174">LEE 164 - Flame Red</Capability>
+  <Capability Min="175" Max="179" Res1="#ffffff">Open</Capability>
   <Capability Min="180" Max="201" Preset="RotationClockwiseFastToSlow">Clockwise color macro rotation (fast -&gt; slow)</Capability>
   <Capability Min="202" Max="207" Preset="RotationStop">Stop (this will stop wherever the color is at the time)</Capability>
   <Capability Min="208" Max="229" Preset="RotationCounterClockwiseSlowToFast">Counter-clockwise color macro rotation (slow -&gt; fast)</Capability>

--- a/resources/fixtures/Briteq/Briteq-BTX-Saturn.qxf
+++ b/resources/fixtures/Briteq/Briteq-BTX-Saturn.qxf
@@ -64,45 +64,45 @@
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="9">CMY color mixing usind channels 8 to 10</Capability>
-  <Capability Min="10" Max="14">LEE 790 - Moroccan pink</Capability>
-  <Capability Min="15" Max="19">LEE 157 - Pink</Capability>
-  <Capability Min="20" Max="24">LEE 332 - Special rose pink</Capability>
-  <Capability Min="25" Max="29">LEE 328 - Follies pink</Capability>
-  <Capability Min="30" Max="34">LEE 345 - Fuchsia pink</Capability>
-  <Capability Min="35" Max="39">LEE 194 - Surprise pink</Capability>
-  <Capability Min="40" Max="44">LEE 181 - Congo Blue</Capability>
-  <Capability Min="45" Max="49">LEE 071 - Tokyo Blue</Capability>
-  <Capability Min="50" Max="54">LEE 120 - Deep Blue</Capability>
-  <Capability Min="55" Max="59">LEE 079 - Just Blue</Capability>
-  <Capability Min="60" Max="64">LEE 132 - Medium Blue</Capability>
-  <Capability Min="65" Max="69">LEE 200 - Double CT Blue</Capability>
-  <Capability Min="70" Max="74">LEE 161 - Slate Blue</Capability>
-  <Capability Min="75" Max="79">LEE 201 - Full CT Blue</Capability>
-  <Capability Min="80" Max="84">LEE 202 - Half CT Blue</Capability>
-  <Capability Min="85" Max="89">LEE 117 - Steel Blue</Capability>
-  <Capability Min="90" Max="94">LEE 353 - Lighter Blue</Capability>
-  <Capability Min="95" Max="99">LEE 118 - Light Blue</Capability>
-  <Capability Min="100" Max="104">LEE 116 - Medium Blue Green</Capability>
-  <Capability Min="105" Max="109">LEE 124 - Dark Green</Capability>
-  <Capability Min="110" Max="114">LEE 139 - Primary Green</Capability>
-  <Capability Min="115" Max="119">LEE 089 - Moss Green</Capability>
-  <Capability Min="120" Max="124">LEE 122 - Fern Green</Capability>
-  <Capability Min="125" Max="129">LEE 738 - JAS Green</Capability>
-  <Capability Min="130" Max="134">LEE 088 - Lime Green</Capability>
-  <Capability Min="135" Max="139">LEE 100 - Spring Yellow</Capability>
-  <Capability Min="140" Max="144">LEE 104 - Deep Amber</Capability>
-  <Capability Min="145" Max="149">LEE 179 - Chrome Orange</Capability>
-  <Capability Min="150" Max="154">LEE 105 - Orange</Capability>
-  <Capability Min="155" Max="159">LEE 021 - Gold Amber</Capability>
-  <Capability Min="160" Max="164">LEE 778 - Millennium Gold</Capability>
-  <Capability Min="165" Max="169">LEE 135 - Deep Golden Amber</Capability>
-  <Capability Min="170" Max="174">LEE 164 - Flame Red</Capability>
-  <Capability Min="175" Max="179" Res1="#ffffff">Open</Capability>
+  <Capability Min="10" Max="14" Preset="ColorMacro" Res1="#ffb4a5">LEE 790 - Moroccan pink</Capability>
+  <Capability Min="15" Max="19" Preset="ColorMacro" Res1="#ff92a3">LEE 157 - Pink</Capability>
+  <Capability Min="20" Max="24" Preset="ColorMacro" Res1="#ff3787">LEE 332 - Special rose pink</Capability>
+  <Capability Min="25" Max="29" Preset="ColorMacro" Res1="#ff64c8">LEE 328 - Follies pink</Capability>
+  <Capability Min="30" Max="34" Preset="ColorMacro" Res1="#cd6ed7">LEE 345 - Fuchsia pink</Capability>
+  <Capability Min="35" Max="39" Preset="ColorMacro" Res1="#be8cf0">LEE 194 - Surprise pink</Capability>
+  <Capability Min="40" Max="44" Preset="ColorMacro" Res1="#5000aa">LEE 181 - Congo Blue</Capability>
+  <Capability Min="45" Max="49" Preset="ColorMacro" Res1="#0000b4">LEE 071 - Tokyo Blue</Capability>
+  <Capability Min="50" Max="54" Preset="ColorMacro" Res1="#005fbe">LEE 120 - Deep Blue</Capability>
+  <Capability Min="55" Max="59" Preset="ColorMacro" Res1="#3c8cd2">LEE 079 - Just Blue</Capability>
+  <Capability Min="60" Max="64" Preset="ColorMacro" Res1="#00a0dc">LEE 132 - Medium Blue</Capability>
+  <Capability Min="65" Max="69" Preset="ColorMacro" Res1="#91bef5">LEE 200 - Double CT Blue</Capability>
+  <Capability Min="70" Max="74" Preset="ColorMacro" Res1="#7dd2f5">LEE 161 - Slate Blue</Capability>
+  <Capability Min="75" Max="79" Preset="ColorMacro" Res1="#c3e1fa">LEE 201 - Full CT Blue</Capability>
+  <Capability Min="80" Max="84" Preset="ColorMacro" Res1="#d7f0ff">LEE 202 - Half CT Blue</Capability>
+  <Capability Min="85" Max="89" Preset="ColorMacro" Res1="#b4faf5">LEE 117 - Steel Blue</Capability>
+  <Capability Min="90" Max="94" Preset="ColorMacro" Res1="#61e8e3">LEE 353 - Lighter Blue</Capability>
+  <Capability Min="95" Max="99" Preset="ColorMacro" Res1="#00e1eb">LEE 118 - Light Blue</Capability>
+  <Capability Min="100" Max="104" Preset="ColorMacro" Res1="#00c8b9">LEE 116 - Medium Blue Green</Capability>
+  <Capability Min="105" Max="109" Preset="ColorMacro" Res1="#00dc78">LEE 124 - Dark Green</Capability>
+  <Capability Min="110" Max="114" Preset="ColorMacro" Res1="#4bc300">LEE 139 - Primary Green</Capability>
+  <Capability Min="115" Max="119" Preset="ColorMacro" Res1="#5adc5a">LEE 089 - Moss Green</Capability>
+  <Capability Min="120" Max="124" Preset="ColorMacro" Res1="#78fa6e">LEE 122 - Fern Green</Capability>
+  <Capability Min="125" Max="129" Preset="ColorMacro" Res1="#aaff00">LEE 738 - JAS Green</Capability>
+  <Capability Min="130" Max="134" Preset="ColorMacro" Res1="#dcff64">LEE 088 - Lime Green</Capability>
+  <Capability Min="135" Max="139" Preset="ColorMacro" Res1="#f5ff00">LEE 100 - Spring Yellow</Capability>
+  <Capability Min="140" Max="144" Preset="ColorMacro" Res1="#ffdc00">LEE 104 - Deep Amber</Capability>
+  <Capability Min="145" Max="149" Preset="ColorMacro" Res1="#ffbe00">LEE 179 - Chrome Orange</Capability>
+  <Capability Min="150" Max="154" Preset="ColorMacro" Res1="#ffa000">LEE 105 - Orange</Capability>
+  <Capability Min="155" Max="159" Preset="ColorMacro" Res1="#ff8c32">LEE 021 - Gold Amber</Capability>
+  <Capability Min="160" Max="164" Preset="ColorMacro" Res1="#ff7600">LEE 778 - Millennium Gold</Capability>
+  <Capability Min="165" Max="169" Preset="ColorMacro" Res1="#ff5f00">LEE 135 - Deep Golden Amber</Capability>
+  <Capability Min="170" Max="174" Preset="ColorMacro" Res1="#ff3200">LEE 164 - Flame Red</Capability>
+  <Capability Min="175" Max="179" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
   <Capability Min="180" Max="201" Preset="RotationClockwiseFastToSlow">Clockwise color macro rotation (fast -&gt; slow)</Capability>
   <Capability Min="202" Max="207" Preset="RotationStop">Stop (this will stop wherever the color is at the time)</Capability>
   <Capability Min="208" Max="229" Preset="RotationCounterClockwiseSlowToFast">Counter-clockwise color macro rotation (slow -&gt; fast)</Capability>
   <Capability Min="230" Max="234" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
-  <Capability Min="235" Max="249">Random color macro (fast -&gt; slow)</Capability>
+  <Capability Min="235" Max="249" Preset="FastToSlow">Random color macro (fast -&gt; slow)</Capability>
   <Capability Min="250" Max="255" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
  </Channel>
  <Channel Name="Gobo wheel 1 - select (rotating gobos)">

--- a/resources/fixtures/Briteq/Briteq-BTX-Saturn.qxf
+++ b/resources/fixtures/Briteq/Briteq-BTX-Saturn.qxf
@@ -46,12 +46,12 @@
   <Capability Min="0" Max="6" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
   <Capability Min="7" Max="12" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="13" Max="18" Preset="ColorMacro" Res1="#00ffb6">Aqua Marine</Capability>
-  <Capability Min="19" Max="25" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
+  <Capability Min="19" Max="25" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="26" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="37" Preset="ColorMacro" Res1="#ffaa00">CTO 8000K</Capability>
   <Capability Min="38" Max="44" Preset="ColorMacro" Res1="#ffff67">CTO 5600K</Capability>
   <Capability Min="45" Max="50" Preset="ColorMacro" Res1="#ffffd0">CTO 3200K</Capability>
-  <Capability Min="51" Max="56" Preset="ColorMacro" Res1="#00ff7f">Lime Green</Capability>
+  <Capability Min="51" Max="56" Preset="ColorMacro" Res1="#32cd32">Lime Green</Capability>
   <Capability Min="57" Max="63" Preset="ColorMacro" Res1="#55007f">UV</Capability>
   <Capability Min="64" Max="127" Preset="RotationIndexed">Color Index</Capability>
   <Capability Min="128" Max="190" Preset="RotationClockwiseFastToSlow">Clockwise color wheel rotation (fast-&gt;slow)</Capability>

--- a/resources/fixtures/Cameo/Cameo-CLPFLATPRO-Series.qxf
+++ b/resources/fixtures/Cameo/Cameo-CLPFLATPRO-Series.qxf
@@ -23,7 +23,7 @@
   <Capability Min="136" Max="152" Preset="ColorMacro" Res1="#ff99cc">Pink</Capability>
   <Capability Min="153" Max="169" Preset="ColorMacro" Res1="#66ff66">Light Green</Capability>
   <Capability Min="170" Max="186" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="187" Max="203" Preset="ColorMacro" Res1="#00ffff">Turquoise</Capability>
+  <Capability Min="187" Max="203" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="204" Max="220" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="221" Max="237" Preset="ColorMacro" Res1="#edfeff">Cool White</Capability>
   <Capability Min="238" Max="255" Preset="ColorMacro" Res1="#fff3f6">Warm White</Capability>
@@ -43,7 +43,7 @@
   <Capability Min="46" Max="50" Preset="ColorMacro" Res1="#ff99cc">Pink</Capability>
   <Capability Min="51" Max="55" Preset="ColorMacro" Res1="#66ff66">Light Green</Capability>
   <Capability Min="56" Max="60" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="61" Max="65" Preset="ColorMacro" Res1="#00ffff">Turquoise</Capability>
+  <Capability Min="61" Max="65" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="66" Max="70" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="71" Max="75" Preset="ColorMacro" Res1="#edfeff">Cool White</Capability>
   <Capability Min="76" Max="80" Preset="ColorMacro" Res1="#fff3f6">Warm White</Capability>
@@ -64,7 +64,7 @@
   <Capability Min="46" Max="50" Preset="ColorMacro" Res1="#ff99cc">Pink</Capability>
   <Capability Min="51" Max="55" Preset="ColorMacro" Res1="#66ff66">Light Green</Capability>
   <Capability Min="56" Max="60" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="61" Max="65" Preset="ColorMacro" Res1="#00ffff">Turquoise</Capability>
+  <Capability Min="61" Max="65" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="66" Max="70" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="71" Max="75" Preset="ColorMacro" Res1="#edfeff">Cool White</Capability>
   <Capability Min="76" Max="80" Preset="ColorMacro" Res1="#fff3f6">Warm White</Capability>

--- a/resources/fixtures/Cameo/Cameo-Multi-FX-Bar-EZ.qxf
+++ b/resources/fixtures/Cameo/Cameo-Multi-FX-Bar-EZ.qxf
@@ -149,9 +149,9 @@
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#efebd8">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#f9faff">Cold White</Capability>
-  <Capability Min="126" Max="127" Preset="ColorMacro">Colour Jumping Stop</Capability>
-  <Capability Min="128" Max="191" Preset="ColorMacro">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
-  <Capability Min="192" Max="255" Preset="ColorMacro">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="126" Max="127">Colour Jumping Stop</Capability>
+  <Capability Min="128" Max="191">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="192" Max="255">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
  </Channel>
  <Channel Name="PAR 2+3 Colour">
   <Group Byte="0">Colour</Group>
@@ -171,9 +171,9 @@
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#efebd8">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#f9faff">Cold White</Capability>
-  <Capability Min="126" Max="127" Preset="ColorMacro">Colour Jumping Stop</Capability>
-  <Capability Min="128" Max="191" Preset="ColorMacro">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
-  <Capability Min="192" Max="255" Preset="ColorMacro">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="126" Max="127">Colour Jumping Stop</Capability>
+  <Capability Min="128" Max="191">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="192" Max="255">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
  </Channel>
  <Channel Name="Flash 1-4">
   <Group Byte="0">Shutter</Group>
@@ -220,9 +220,9 @@
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#efebd8">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#f9faff">Cold White</Capability>
-  <Capability Min="126" Max="127" Preset="ColorMacro">Colour Jumping Stop</Capability>
-  <Capability Min="128" Max="191" Preset="ColorMacro">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
-  <Capability Min="192" Max="255" Preset="ColorMacro">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="126" Max="127">Colour Jumping Stop</Capability>
+  <Capability Min="128" Max="191">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="192" Max="255">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
  </Channel>
  <Channel Name="Colour 2">
   <Group Byte="0">Colour</Group>
@@ -242,9 +242,9 @@
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#efebd8">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#f9faff">Cold White</Capability>
-  <Capability Min="126" Max="127" Preset="ColorMacro">Colour Jumping Stop</Capability>
-  <Capability Min="128" Max="191" Preset="ColorMacro">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
-  <Capability Min="192" Max="255" Preset="ColorMacro">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="126" Max="127">Colour Jumping Stop</Capability>
+  <Capability Min="128" Max="191">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="192" Max="255">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
  </Channel>
  <Channel Name="Derby 1-2">
   <Group Byte="0">Speed</Group>
@@ -276,9 +276,9 @@
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#efebd8">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#f9faff">Cold White</Capability>
-  <Capability Min="126" Max="127" Preset="ColorMacro">Colour Jumping Stop</Capability>
-  <Capability Min="128" Max="191" Preset="ColorMacro">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
-  <Capability Min="192" Max="255" Preset="ColorMacro">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="126" Max="127">Colour Jumping Stop</Capability>
+  <Capability Min="128" Max="191">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="192" Max="255">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
  </Channel>
  <Channel Name="Derby 1-2 Colour">
   <Group Byte="0">Colour</Group>
@@ -298,9 +298,9 @@
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#efebd8">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#f9faff">Cold White</Capability>
-  <Capability Min="126" Max="127" Preset="ColorMacro">Colour Jumping Stop</Capability>
-  <Capability Min="128" Max="191" Preset="ColorMacro">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
-  <Capability Min="192" Max="255" Preset="ColorMacro">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="126" Max="127">Colour Jumping Stop</Capability>
+  <Capability Min="128" Max="191">Colour Jumping Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
+  <Capability Min="192" Max="255">Colour Fading Speed slow -&gt; fast / Colour 1 -&gt; 12</Capability>
  </Channel>
  <Channel Name="PAR 1+4 - Red" Preset="IntensityRed"/>
  <Channel Name="PAR 1+4 - Green" Preset="IntensityGreen"/>

--- a/resources/fixtures/Cameo/Cameo-Multi-FX-Bar-EZ.qxf
+++ b/resources/fixtures/Cameo/Cameo-Multi-FX-Bar-EZ.qxf
@@ -142,7 +142,7 @@
   <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6fafa">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
@@ -164,7 +164,7 @@
   <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6fafa">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
@@ -213,7 +213,7 @@
   <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6fafa">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
@@ -235,7 +235,7 @@
   <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6fafa">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
@@ -269,7 +269,7 @@
   <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6fafa">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
@@ -291,7 +291,7 @@
   <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6fafa">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>

--- a/resources/fixtures/Cameo/Cameo-Multi-PAR-3.qxf
+++ b/resources/fixtures/Cameo/Cameo-Multi-PAR-3.qxf
@@ -57,7 +57,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -76,7 +76,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -95,7 +95,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -114,7 +114,7 @@
   <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
+  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#7f7f00">RG</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#007f7f">GB</Capability>
   <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#7f7fff">BW</Capability>

--- a/resources/fixtures/Cameo/Cameo-Multi-PAR-3.qxf
+++ b/resources/fixtures/Cameo/Cameo-Multi-PAR-3.qxf
@@ -15,7 +15,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>

--- a/resources/fixtures/Cameo/Cameo-Multi-PAR-3.qxf
+++ b/resources/fixtures/Cameo/Cameo-Multi-PAR-3.qxf
@@ -15,7 +15,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">White</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -57,7 +57,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">White</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -76,7 +76,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">White</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -95,7 +95,7 @@
   <Capability Min="18" Max="33" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">White</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#7f7f00">Yellow</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#7fffff">Cyan bright</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#b47fff">Violet bright</Capability>
@@ -114,7 +114,7 @@
   <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#7f0000">Red</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#007f00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00007f">Blue</Capability>
-  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#7f7f7f">White</Capability>
+  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#7f7f7f">Grey</Capability>
   <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#7f7f00">RG</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#007f7f">GB</Capability>
   <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#7f7fff">BW</Capability>

--- a/resources/fixtures/Cameo/Cameo-Pixbar-600-PRO.qxf
+++ b/resources/fixtures/Cameo/Cameo-Pixbar-600-PRO.qxf
@@ -18,7 +18,7 @@
   <Capability Min="22" Max="29" Preset="ColorMacro" Res1="#fdf1a9">Yellow warm</Capability>
   <Capability Min="30" Max="37" Preset="ColorMacro" Res1="#ffff01">Yellow</Capability>
   <Capability Min="38" Max="45" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#00e5ee">Turquoise</Capability>
+  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>

--- a/resources/fixtures/Cameo/Cameo-Studio-PAR-64-Q-8W-(CLPST64Q8W).qxf
+++ b/resources/fixtures/Cameo/Cameo-Studio-PAR-64-Q-8W-(CLPST64Q8W).qxf
@@ -12,16 +12,16 @@
  <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Colour (2CH)">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="16" Preset="ColorMacro" Res1="#e01b24">Red</Capability>
-  <Capability Min="17" Max="33" Preset="ColorMacro" Res1="#33d17a">Green</Capability>
-  <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#3584e4">Blue</Capability>
+  <Capability Min="0" Max="16" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="17" Max="33" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ff7800">Orange</Capability>
-  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#00faff">Cyan</Capability>
-  <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#9141ac">Lavender</Capability>
-  <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#fc2cf4">Pink</Capability>
+  <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
+  <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
+  <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="136" Max="152" Preset="ColorMacro" Res1="#8ff0a4">Bright Green</Capability>
-  <Capability Min="153" Max="169" Preset="ColorMacro" Res1="#da00d8">Magenta</Capability>
+  <Capability Min="153" Max="169" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="170" Max="186" Preset="ColorMacro" Res1="#ff73ea">Pale Pink</Capability>
   <Capability Min="187" Max="203" Preset="ColorMacro" Res1="#c64600">Amber</Capability>
   <Capability Min="204" Max="220" Preset="ColorMacro" Res1="#ff00d4">Bright Magenta</Capability>
@@ -32,16 +32,16 @@
  <Channel Name="Colour-Macro (3CH/7CH)">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="4" Preset="ColorMacro" Res1="#000000">Blackout</Capability>
-  <Capability Min="5" Max="10" Preset="ColorMacro" Res1="#e01b24">Red</Capability>
-  <Capability Min="11" Max="15" Preset="ColorMacro" Res1="#33d17a">Green</Capability>
+  <Capability Min="5" Max="10" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="11" Max="15" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="16" Max="20">Blue</Capability>
   <Capability Min="21" Max="25" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="26" Max="30" Preset="ColorMacro" Res1="#f9f06b">Yellow</Capability>
+  <Capability Min="26" Max="30" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="31" Max="35" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
-  <Capability Min="36" Max="40" Preset="ColorMacro" Res1="#da00d8">Magenta</Capability>
-  <Capability Min="41" Max="45" Preset="ColorMacro" Res1="#ff73ea">Pink</Capability>
+  <Capability Min="36" Max="40" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="41" Max="45" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="46" Max="50" Preset="ColorMacro" Res1="#8ff0a4">Bright Green</Capability>
-  <Capability Min="51" Max="55" Preset="ColorMacro" Res1="#9141ac">Lavender</Capability>
+  <Capability Min="51" Max="55" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="56" Max="60" Preset="ColorMacro" Res1="#ffa2f3">Pale Pink</Capability>
   <Capability Min="61" Max="65" Preset="ColorMacro" Res1="#c64600">Amber</Capability>
   <Capability Min="66" Max="70" Preset="ColorMacro" Res1="#ff00c7">Bright Magenta</Capability>

--- a/resources/fixtures/Cameo/Cameo-Studio-PAR-64-Q-8W-(CLPST64Q8W).qxf
+++ b/resources/fixtures/Cameo/Cameo-Studio-PAR-64-Q-8W-(CLPST64Q8W).qxf
@@ -47,9 +47,9 @@
   <Capability Min="66" Max="70" Preset="ColorMacro" Res1="#ff00c7">Bright Magenta</Capability>
   <Capability Min="71" Max="75" Preset="ColorMacro" Res1="#87fffa">Pale Cyan</Capability>
   <Capability Min="76" Max="80" Preset="ColorMacro" Res1="#fff1d5">Warm White</Capability>
-  <Capability Min="81" Max="150" Preset="ColorMacro">Colour Jumping Speed: from slowest to fastest</Capability>
-  <Capability Min="151" Max="220" Preset="ColorMacro">Colour Fading Speed: from slowest to fastest</Capability>
-  <Capability Min="221" Max="255" Preset="ColorMacro">Sound Control (Mic Sensitivity)</Capability>
+  <Capability Min="81" Max="150">Colour Jumping Speed: from slowest to fastest</Capability>
+  <Capability Min="151" Max="220">Colour Fading Speed: from slowest to fastest</Capability>
+  <Capability Min="221" Max="255">Sound Control (Mic Sensitivity)</Capability>
  </Channel>
  <Channel Name="Red" Preset="IntensityRed"/>
  <Channel Name="Green" Preset="IntensityGreen"/>

--- a/resources/fixtures/Cameo/Cameo-Thunderwash-600-RGBW.qxf
+++ b/resources/fixtures/Cameo/Cameo-Thunderwash-600-RGBW.qxf
@@ -23,13 +23,13 @@
   <Capability Min="22" Max="29" Preset="ColorMacro" Res1="#ffdd1a">Yellow warm</Capability>
   <Capability Min="30" Max="37" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="38" Max="45" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#aaffff">Turquoise</Capability>
+  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#aaaaff">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#aa007f">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
+  <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#fffff6">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#edffff">Cold White</Capability>

--- a/resources/fixtures/Cameo/Cameo-Wookie-series.qxf
+++ b/resources/fixtures/Cameo/Cameo-Wookie-series.qxf
@@ -23,7 +23,7 @@
   <Capability Min="96" Max="127" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="128" Max="159" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="160" Max="191" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="192" Max="223" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="192" Max="223" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="224" Max="255" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
  </Channel>
  <Channel Name="Pattern select">

--- a/resources/fixtures/Cameo/Cameo-Zenit-B60.qxf
+++ b/resources/fixtures/Cameo/Cameo-Zenit-B60.qxf
@@ -33,20 +33,21 @@
  </Channel>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="5">No Macro</Capability>
+  <Capability Min="0" Max="5">Color off</Capability>
   <Capability Min="6" Max="13" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="14" Max="21" Preset="ColorMacro" Res1="#ff5500">Amber</Capability>
   <Capability Min="22" Max="29" Preset="ColorMacro" Res1="#ffdc00">Yellow Warm</Capability>
   <Capability Min="30" Max="37" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="38" Max="45" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#00aaff">Turquoise</Capability>
+  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#aaaaff">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
-  <Capability Min="86" Max="94" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="95" Max="102" Preset="ColorMacro" Res1="#fff0b9">Warm White</Capability>
-  <Capability Min="103" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
+  <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
+  <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#fff0b9">Warm White</Capability>
+  <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#dcf5ff">Cold White</Capability>
   <Capability Min="126" Max="127">Color Jumping Stop</Capability>
   <Capability Min="128" Max="191">Color Jumping Speed slow -&gt; fast / Color 1 -&gt; 12</Capability>

--- a/resources/fixtures/Cameo/Cameo-Zenit-B60.qxf
+++ b/resources/fixtures/Cameo/Cameo-Zenit-B60.qxf
@@ -44,7 +44,7 @@
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#aaaaff">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#e0b0ff">Mauve</Capability>
-  <Capability Min="86" Max="94" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="86" Max="94" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="95" Max="102" Preset="ColorMacro" Res1="#fff0b9">Warm White</Capability>
   <Capability Min="103" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#dcf5ff">Cold White</Capability>

--- a/resources/fixtures/Cameo/Cameo-Zenit-Z120-G2.qxf
+++ b/resources/fixtures/Cameo/Cameo-Zenit-Z120-G2.qxf
@@ -35,13 +35,13 @@
   <Capability Min="22" Max="29" Preset="ColorMacro" Res1="#ffdb6c">Yellow warm</Capability>
   <Capability Min="30" Max="37" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="38" Max="45" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#aaffff">Turquoise</Capability>
+  <Capability Min="46" Max="53" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
   <Capability Min="54" Max="61" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="62" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#aaaaff">Lavender</Capability>
+  <Capability Min="70" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="78" Max="85" Preset="ColorMacro" Res1="#aa557f">Mauve</Capability>
   <Capability Min="86" Max="93" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
+  <Capability Min="94" Max="101" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="102" Max="109" Preset="ColorMacro" Res1="#fffaee">Warm White</Capability>
   <Capability Min="110" Max="117" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="118" Max="125" Preset="ColorMacro" Res1="#edfffc">Cold White</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Cubix-2.0.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Cubix-2.0.qxf
@@ -16,7 +16,7 @@
   <Capability Min="29" Max="56" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="57" Max="84" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="85" Max="112" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
-  <Capability Min="113" Max="140" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="113" Max="140" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="141" Max="168" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="169" Max="197" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="198" Max="224">3-Color switching</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Barrel-300.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Barrel-300.qxf
@@ -20,7 +20,7 @@
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#4cbb17">Kelly green</Capability>
-  <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White/yellow (split colors)</Capability>
   <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#55007f">Yellow/purple (split colors)</Capability>
@@ -29,7 +29,7 @@
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#7f7fff">Red/light blue (split colors)</Capability>
   <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#7f7fff" Res2="#4cbb17">Light blue/Kelly green (split colors)</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#4cbb17" Res2="#ff7f00">Kelly green/orange (split colors)</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00007f">Orange/dark blue (split colors)</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00007f">Orange/dark blue (split colors)</Capability>
   <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00007f" Res2="#ffffff">Dark blue/white (split colors)</Capability>
   <Capability Min="128" Max="191" Preset="RotationCounterClockwiseSlowToFast">Rotate counter-clockwise (slow to fast)</Capability>
   <Capability Min="192" Max="255" Preset="RotationClockwiseSlowToFast">Rotate clockwise (slow to fast)</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Barrel-305-IRC.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Barrel-305-IRC.qxf
@@ -26,7 +26,7 @@
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#4cbb17">Kelly green</Capability>
-  <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White/yellow (split colors)</Capability>
   <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#55007f">Yellow/purple (split colors)</Capability>
@@ -35,7 +35,7 @@
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#7f7fff">Red/light blue (split colors)</Capability>
   <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#7f7fff" Res2="#4cbb17">Light blue/Kelly green (split colors)</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#4cbb17" Res2="#ff7f00">Kelly green/orange (split colors)</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00007f">Orange/dark blue (split colors)</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00007f">Orange/dark blue (split colors)</Capability>
   <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00007f" Res2="#ffffff">Dark blue/white (split colors)</Capability>
   <Capability Min="128" Max="191" Preset="RotationCounterClockwiseSlowToFast">Rotate counter-clockwise (slow to fast)</Capability>
   <Capability Min="192" Max="255" Preset="RotationClockwiseSlowToFast">Rotate clockwise (slow to fast)</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Beam-LED-350.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Beam-LED-350.qxf
@@ -21,19 +21,19 @@
   <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff557f">Pink</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#55ff00">Kelly Green</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
-  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + Yellow</Capability>
   <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Pink</Capability>
   <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00aa00">Pink + Green</Capability>
   <Capability Min="85" Max="91" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff0000">Green + Red</Capability>
-  <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00aaff">Red + Light Blue</Capability>
-  <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#00ff00">Light Blue + Kelly Green</Capability>
+  <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#add8e6">Red + Light Blue</Capability>
+  <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#00ff00">Light Blue + Kelly Green</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#00aa00" Res2="#ff5500">Kelly Green + Orange</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#0000ff">Orange + Dark Blue</Capability>
-  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Dark Blue + White</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#00008b">Orange + Dark Blue</Capability>
+  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark Blue + White</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseSlowToFast">Color cycling rainbow with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="RotationCounterClockwiseSlowToFast">Reverse color cycling rainbow with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Scan-305-IRC.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Scan-305-IRC.qxf
@@ -20,7 +20,7 @@
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#4cbb17">Kelly green</Capability>
-  <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White/yellow (split colors)</Capability>
   <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#55007f">Yellow/purple (split colors)</Capability>
@@ -29,7 +29,7 @@
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#7f7fff">Red/light blue (split colors)</Capability>
   <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#7f7fff" Res2="#4cbb17">Light blue/Kelly green (split colors)</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#4cbb17" Res2="#ff7f00">Kelly green/orange (split colors)</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00007f">Orange/dark blue (split colors)</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00007f">Orange/dark blue (split colors)</Capability>
   <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00007f" Res2="#ffffff">Dark blue/white (split colors)</Capability>
   <Capability Min="128" Max="191" Preset="RotationCounterClockwiseSlowToFast">Rotate counter-clockwise (slow to fast)</Capability>
   <Capability Min="192" Max="255" Preset="RotationClockwiseSlowToFast">Rotate clockwise (slow to fast)</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-100-IRC.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-100-IRC.qxf
@@ -21,7 +21,7 @@
   <Capability Min="32" Max="47" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="48" Max="63" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
   <Capability Min="64" Max="79" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="80" Max="95" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="80" Max="95" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="96" Max="111" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>
   <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#ff4000">Orange red</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseSlowToFast">Color cycling rainbow with increasing speed</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-155.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-155.qxf
@@ -24,7 +24,7 @@
   <Capability Min="30" Max="35" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="36" Max="41" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
   <Capability Min="42" Max="47" Preset="ColorMacro" Res1="#0000aa">Blue</Capability>
-  <Capability Min="48" Max="53" Preset="ColorMacro" Res1="#00ff00">Light green</Capability>
+  <Capability Min="48" Max="53" Preset="ColorMacro" Res1="#90ee90">Light green</Capability>
   <Capability Min="54" Max="63" Preset="ColorMacro" Res1="#ffbf00">Amber</Capability>
   <Capability Min="64" Max="69" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + yellow</Capability>
   <Capability Min="70" Max="75" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + magenta</Capability>
@@ -34,7 +34,7 @@
   <Capability Min="94" Max="99" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#ff5500">Cyan + orange</Capability>
   <Capability Min="100" Max="105" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#0000ff">Orange + blue</Capability>
   <Capability Min="106" Max="111" Preset="ColorDoubleMacro" Res1="#0000aa" Res2="#00ff00">Blue + light green</Capability>
-  <Capability Min="112" Max="117" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffbf00">Light green + amber</Capability>
+  <Capability Min="112" Max="117" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#90ee90">Light green + amber</Capability>
   <Capability Min="118" Max="127" Preset="ColorDoubleMacro" Res1="#ffbf00" Res2="#ffffff">Amber + white</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseSlowToFast">Color cycling rainbow with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="RotationCounterClockwiseSlowToFast">Reverse color cycling rainbow with increasing speed</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-355Z-IRC.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-355Z-IRC.qxf
@@ -21,19 +21,19 @@
   <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff557f">Pink</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#55ff00">Kelly Green</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
-  <Capability Min="56" Max="64" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="56" Max="64" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="65" Max="71" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + Yellow</Capability>
   <Capability Min="72" Max="78" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Pink</Capability>
   <Capability Min="79" Max="85" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00aa00">Pink + Green</Capability>
   <Capability Min="86" Max="92" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff0000">Green + Red</Capability>
-  <Capability Min="93" Max="99" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00aaff">Red + Light Blue</Capability>
-  <Capability Min="100" Max="106" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#00ff00">Light Blue + Kelly Green</Capability>
+  <Capability Min="93" Max="99" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#add8e6">Red + Light Blue</Capability>
+  <Capability Min="100" Max="106" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#00ff00">Light Blue + Kelly Green</Capability>
   <Capability Min="107" Max="113" Preset="ColorDoubleMacro" Res1="#00aa00" Res2="#ff5500">Kelly Green + Orange</Capability>
-  <Capability Min="114" Max="120" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#0000ff">Orange + Dark Blue</Capability>
-  <Capability Min="121" Max="127" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Dark Blue + White</Capability>
+  <Capability Min="114" Max="120" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#00008b">Orange + Dark Blue</Capability>
+  <Capability Min="121" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark Blue + White</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseSlowToFast">Color cycling rainbow with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="RotationCounterClockwiseSlowToFast">Reverse color cycling rainbow with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-375Z-IRC.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-375Z-IRC.qxf
@@ -17,8 +17,8 @@
  <Channel Name="Color">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="8" Max="15" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#aaff7f">Lime green</Capability>
+  <Capability Min="8" Max="15" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#32cd32">Lime green</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#00ff00">Green</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-400-IRC.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-400-IRC.qxf
@@ -17,20 +17,20 @@
  <Channel Name="Color">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="8" Max="15" Preset="ColorMacro" Res1="#0000ff">Dark blue</Capability>
+  <Capability Min="8" Max="15" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#ff557f">Pink</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#ff5500">Orange red</Capability>
-  <Capability Min="64" Max="71" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#0000ff">White + dark blue</Capability>
-  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffff00">Dark blue + yellow</Capability>
+  <Capability Min="64" Max="71" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#00008b">White + dark blue</Capability>
+  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffff00">Dark blue + yellow</Capability>
   <Capability Min="80" Max="87" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff557f">Yellow + pink</Capability>
   <Capability Min="88" Max="95" Preset="ColorDoubleMacro" Res1="#ff557f" Res2="#00ff00">Pink + green</Capability>
   <Capability Min="96" Max="103" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff0000">Green + red</Capability>
-  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00ffff">Red + light blue</Capability>
-  <Capability Min="112" Max="119" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ff5500">Light blue + Orange red</Capability>
+  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#add8e6">Red + light blue</Capability>
+  <Capability Min="112" Max="119" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ff5500">Light blue + Orange red</Capability>
   <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#ffffff">Orange red + white</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseSlowToFast">Rainbow effect with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="RotationCounterClockwiseSlowToFast">Reverse rainbow effect with increasing speed</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-LED-250.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-LED-250.qxf
@@ -21,19 +21,19 @@
   <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff557f">Pink</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
+  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#55ff00">Kelly green</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
-  <Capability Min="56" Max="64" Preset="ColorMacro" Res1="#0000ff">Dark blue</Capability>
+  <Capability Min="56" Max="64" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="65" Max="71" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + yellow</Capability>
   <Capability Min="72" Max="78" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + pink</Capability>
   <Capability Min="79" Max="85" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00aa00">Pink + green</Capability>
   <Capability Min="86" Max="92" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff0000">Green + red</Capability>
-  <Capability Min="93" Max="99" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00aaff">Red + light blue</Capability>
-  <Capability Min="100" Max="106" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#00ff00">Light blue + Kelly green</Capability>
+  <Capability Min="93" Max="99" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#add8e6">Red + light blue</Capability>
+  <Capability Min="100" Max="106" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#00ff00">Light blue + Kelly green</Capability>
   <Capability Min="107" Max="113" Preset="ColorDoubleMacro" Res1="#00aa00" Res2="#ff5500">Kelly green + orange</Capability>
-  <Capability Min="114" Max="120" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#0000ff">Orange + dark blue</Capability>
-  <Capability Min="121" Max="127" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Dark blue + white</Capability>
+  <Capability Min="114" Max="120" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#00008b">Orange + dark blue</Capability>
+  <Capability Min="121" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark blue + white</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseFastToSlow">Color cycling rainbow with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="RotationCounterClockwiseSlowToFast">Reverse color cycling rainbow with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-LED-260.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-LED-260.qxf
@@ -24,7 +24,7 @@
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#21ff06">Green</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#fc02ff">Magenta</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ffff0a">Yellow</Capability>
-  <Capability Min="56" Max="62" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="56" Max="62" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="63" Max="64" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="65" Max="189" Preset="ColorWheelIndex">Color indexing</Capability>
   <Capability Min="190" Max="221" Preset="RotationClockwiseFastToSlow">Color cycling rainbow, fast to slow</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-LED-350.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Intimidator-Spot-LED-350.qxf
@@ -21,19 +21,19 @@
   <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff557f">Pink</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#55ff00">Kelly Green</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
-  <Capability Min="56" Max="64" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="56" Max="64" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="65" Max="71" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + Yellow</Capability>
   <Capability Min="72" Max="78" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Pink</Capability>
   <Capability Min="79" Max="85" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00aa00">Pink + Green</Capability>
   <Capability Min="86" Max="92" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff0000">Green + Red</Capability>
-  <Capability Min="93" Max="99" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00aaff">Red + Light Blue</Capability>
-  <Capability Min="100" Max="106" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#00ff00">Light Blue + Kelly Green</Capability>
+  <Capability Min="93" Max="99" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#add8e6">Red + Light Blue</Capability>
+  <Capability Min="100" Max="106" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#00ff00">Light Blue + Kelly Green</Capability>
   <Capability Min="107" Max="113" Preset="ColorDoubleMacro" Res1="#00aa00" Res2="#ff5500">Kelly Green + Orange</Capability>
-  <Capability Min="114" Max="120" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#0000ff">Orange + Dark Blue</Capability>
-  <Capability Min="121" Max="127" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Dark Blue + White</Capability>
+  <Capability Min="114" Max="120" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#00008b">Orange + Dark Blue</Capability>
+  <Capability Min="121" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark Blue + White</Capability>
   <Capability Min="128" Max="191" Preset="RotationClockwiseSlowToFast">Color cycling rainbow with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="RotationCounterClockwiseSlowToFast">Reverse color cycling rainbow with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Chauvet/Chauvet-Maverick-MK3-Profile-CX.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Maverick-MK3-Profile-CX.qxf
@@ -43,7 +43,7 @@
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
-  <Capability Min="48" Max="59" Preset="ColorMacro">8000k CTB</Capability>
+  <Capability Min="48" Max="59">8000k CTB</Capability>
   <Capability Min="60" Max="187" Preset="RotationIndexed">Color wheel indexing</Capability>
   <Capability Min="188" Max="219" Preset="RotationClockwiseFastToSlow">Color scroll, fast to slow</Capability>
   <Capability Min="220" Max="223" Preset="RotationStop">Stop</Capability>
@@ -247,12 +247,12 @@
  <Channel Name="No function" Preset="NoFunction"/>
  <Channel Name="CMY Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="9" Preset="ColorMacro">No function</Capability>
-  <Capability Min="10" Max="255" Preset="ColorMacro">CMY macro</Capability>
+  <Capability Min="0" Max="9">No function</Capability>
+  <Capability Min="10" Max="255">CMY macro</Capability>
  </Channel>
  <Channel Name="CMY Macro Speed">
   <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="255" Preset="ColorMacro">CMY macro speed, fast to slow</Capability>
+  <Capability Min="0" Max="255">CMY macro speed, fast to slow</Capability>
  </Channel>
  <Channel Name="Control">
   <Group Byte="0">Maintenance</Group>

--- a/resources/fixtures/Chauvet/Chauvet-Maverick-MK3-Profile-CX.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Maverick-MK3-Profile-CX.qxf
@@ -39,10 +39,10 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
   <Capability Min="8" Max="15" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
+  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
+  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="48" Max="59" Preset="ColorMacro">8000k CTB</Capability>
   <Capability Min="60" Max="187" Preset="RotationIndexed">Color wheel indexing</Capability>
   <Capability Min="188" Max="219" Preset="RotationClockwiseFastToSlow">Color scroll, fast to slow</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Q-Beam-260-LED.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Q-Beam-260-LED.qxf
@@ -24,7 +24,7 @@
   <Capability Min="76" Max="90" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="91" Max="105" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="106" Max="120" Preset="ColorMacro" Res1="#55ff7f">Light Green</Capability>
-  <Capability Min="121" Max="135" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="121" Max="135" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="136" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow or linear effect</Capability>
  </Channel>
  <Channel Name="Gobo Wheel">

--- a/resources/fixtures/Chauvet/Chauvet-Q-Spot-260-LED.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Q-Spot-260-LED.qxf
@@ -20,7 +20,7 @@
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>
   <Capability Min="136" Max="152" Preset="ColorMacro" Res1="#7fff7f">Light green</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Q-Spot-560-LED.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Q-Spot-560-LED.qxf
@@ -22,8 +22,8 @@
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
   <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
-  <Capability Min="80" Max="99" Preset="ColorDoubleMacro" Res1="#55ffff" Res2="#ff00ff">Light Blue / Magenta</Capability>
+  <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="80" Max="99" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ff00ff">Light Blue / Magenta</Capability>
   <Capability Min="100" Max="119" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#ff5500">Magenta / Orange</Capability>
   <Capability Min="120" Max="139" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#0000ff">Orange / Blue</Capability>
   <Capability Min="140" Max="159" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffff00">Blue / Yellow</Capability>

--- a/resources/fixtures/Chauvet/Chauvet-Rogue-RH1-Hybrid.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Rogue-RH1-Hybrid.qxf
@@ -31,7 +31,7 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="3" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
   <Capability Min="4" Max="7" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="8" Max="11" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="8" Max="11" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="12" Max="15" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="16" Max="19" Preset="ColorMacro" Res1="#7fff7f">Light green</Capability>
   <Capability Min="20" Max="23" Preset="ColorMacro" Res1="#ffff7f">Light yellow</Capability>

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Alpha-Beam-1500.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Alpha-Beam-1500.qxf
@@ -21,9 +21,9 @@
   <Capability Min="37" Max="45" Preset="ColorMacro" Res1="#eeeeee">CTO 3200</Capability>
   <Capability Min="46" Max="54" Preset="ColorDoubleMacro" Res1="#eeeeee" Res2="#00ff00">CTO 3200 + Green</Capability>
   <Capability Min="55" Max="63" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="64" Max="73" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#00ffff">Green + Aquamarine</Capability>
-  <Capability Min="74" Max="82" Preset="ColorMacro" Res1="#00ffff">Aquamarine</Capability>
-  <Capability Min="83" Max="91" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ffaa00">Aquamarine + Orange</Capability>
+  <Capability Min="64" Max="73" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#7fffd4">Green + Aquamarine</Capability>
+  <Capability Min="74" Max="82" Preset="ColorMacro" Res1="#7fffd4">Aquamarine</Capability>
+  <Capability Min="83" Max="91" Preset="ColorDoubleMacro" Res1="#7fffd4" Res2="#ffaa00">Aquamarine + Orange</Capability>
   <Capability Min="92" Max="100" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="101" Max="109" Preset="ColorDoubleMacro" Res1="#ffaa00" Res2="#0000ff">Orange + Blue</Capability>
   <Capability Min="110" Max="118" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Axcor-Profile-600.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Axcor-Profile-600.qxf
@@ -16,17 +16,17 @@
  <Channel Name="Color Wheel">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="10" Preset="ColorMacro" Res1="#ffffff">Empty position</Capability>
-  <Capability Min="11" Max="20" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#bf0000">Empty + Dark red</Capability>
-  <Capability Min="21" Max="31" Preset="ColorMacro" Res1="#ffffff">Dark red</Capability>
-  <Capability Min="32" Max="41">Dark red + Green</Capability>
-  <Capability Min="42" Max="52" Preset="ColorMacro" Res1="#00d800">Green</Capability>
-  <Capability Min="53" Max="62">Grenn + CRI</Capability>
+  <Capability Min="11" Max="20" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#8b0000">Empty + Dark red</Capability>
+  <Capability Min="21" Max="31" Preset="ColorMacro" Res1="#8b0000">Dark red</Capability>
+  <Capability Min="32" Max="41" Preset="ColorDoubleMacro" Res1="#8b0000" Res2="#00ff00">Dark red + Green</Capability>
+  <Capability Min="42" Max="52" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="53" Max="62">Green + CRI</Capability>
   <Capability Min="63" Max="73">CRI</Capability>
   <Capability Min="74" Max="83">CRI + Gold amber</Capability>
-  <Capability Min="84" Max="94">Gold amber</Capability>
-  <Capability Min="95" Max="105">Gold amber - Navy blue</Capability>
-  <Capability Min="106" Max="117">Navy blue</Capability>
-  <Capability Min="118" Max="127">Navy blue + Empty position</Capability>
+  <Capability Min="84" Max="94" Preset="ColorMacro" Res1="#ffd700">Gold amber</Capability>
+  <Capability Min="95" Max="105" Preset="ColorDoubleMacro" Res1="#ffd700" Res2="#000080">Gold amber - Navy blue</Capability>
+  <Capability Min="106" Max="117" Preset="ColorMacro" Res1="#000080">Navy blue</Capability>
+  <Capability Min="118" Max="127" Preset="ColorDoubleMacro" Res1="#000080" Res2="#ffffff">Navy blue + Empty position</Capability>
   <Capability Min="128" Max="255" Preset="ColorMacro" Res1="#af1f11">Continuous CCW Colour Wheel rotation (slow to fast)</Capability>
  </Channel>
  <Channel Name="Strobe">

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Hepikos.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Hepikos.qxf
@@ -27,31 +27,31 @@
   <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#d3eefd">CTB</Capability>
   <Capability Min="88" Max="95" Preset="ColorDoubleMacro" Res1="#d3eefd" Res2="#004f9f">CTB + Brilliant Blue</Capability>
   <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#004f9f">Brilliant Blue</Capability>
-  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#004f9f" Res2="#77b82a">Brilliant Blue + Green</Capability>
-  <Capability Min="112" Max="119" Preset="ColorMacro" Res1="#77b82a">Green</Capability>
-  <Capability Min="120" Max="126" Preset="ColorDoubleMacro" Res1="#77b82a" Res2="#213a8f">Green + Blue Wood</Capability>
+  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#004f9f" Res2="#00ff00">Brilliant Blue + Green</Capability>
+  <Capability Min="112" Max="119" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="120" Max="126" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#213a8f">Green + Blue Wood</Capability>
   <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#213a8f">Blue Wood</Capability>
   <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Continuous CW colour wheel rotation (slow to fast)</Capability>
  </Channel>
  <Channel Name="Colour Wheel 2">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">Empty position</Capability>
-  <Capability Min="8" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#e40513">Empty + Red</Capability>
-  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#e40513">Red</Capability>
-  <Capability Min="24" Max="31" Preset="ColorDoubleMacro" Res1="#e40513" Res2="#178c39">Red + Dark Green</Capability>
-  <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#178c39">Dark Green</Capability>
-  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#178c39" Res2="#f07e24">Dark Green + Orange</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#f07e24">Orange</Capability>
-  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#f07e24" Res2="#fce2d7">Orange + Light Pink</Capability>
-  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#fce2d7">Light Pink</Capability>
-  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#fce2d7" Res2="#a4bce3">Light Pink + Lavender</Capability>
-  <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#a4bce3">Lavender</Capability>
-  <Capability Min="88" Max="95" Preset="ColorDoubleMacro" Res1="#a4bce3" Res2="#7fc184">Lavender + Aquamarine</Capability>
-  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#7fc184">Aquamarine</Capability>
-  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#7fc184" Res2="#bd1716">Aquamarine + Dark Red</Capability>
-  <Capability Min="112" Max="119" Preset="ColorMacro" Res1="#bd1716">Dark Red</Capability>
-  <Capability Min="120" Max="126" Preset="ColorDoubleMacro" Res1="#bd1716" Res2="#005096">Dark Red + Dark Blue</Capability>
-  <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#005096">Dark Blue</Capability>
+  <Capability Min="8" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff0000">Empty + Red</Capability>
+  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="24" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#006400">Red + Dark Green</Capability>
+  <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#006400">Dark Green</Capability>
+  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#006400" Res2="#ffa500">Dark Green + Orange</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#ffb6c1">Orange + Light Pink</Capability>
+  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#ffb6c1">Light Pink</Capability>
+  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#ffb6c1" Res2="#e6e6fa">Light Pink + Lavender</Capability>
+  <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
+  <Capability Min="88" Max="95" Preset="ColorDoubleMacro" Res1="#e6e6fa" Res2="#7fffd4">Lavender + Aquamarine</Capability>
+  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#7fffd4">Aquamarine</Capability>
+  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#7fffd4" Res2="#8b0000">Aquamarine + Dark Red</Capability>
+  <Capability Min="112" Max="119" Preset="ColorMacro" Res1="#8b0000">Dark Red</Capability>
+  <Capability Min="120" Max="126" Preset="ColorDoubleMacro" Res1="#8b0000" Res2="#00008b">Dark Red + Dark Blue</Capability>
+  <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Continuous CW colour wheel rotation (slow to fast)</Capability>
  </Channel>
  <Channel Name="Stopper / Strobe">

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Midi-B.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Midi-B.qxf
@@ -74,35 +74,35 @@
   <Capability Min="31" Max="31" Preset="ColorMacro" Res1="#ff6400">Gold Amber</Capability>
   <Capability Min="32" Max="34" Preset="ColorMacro" Res1="#ff4100">Dark Amber</Capability>
   <Capability Min="35" Max="44" Preset="ColorMacro" Res1="#ff5302">Sunrise Red</Capability>
-  <Capability Min="45" Max="45" Preset="ColorMacro" Res1="#ffc8d2">Light Pink</Capability>
+  <Capability Min="45" Max="45" Preset="ColorMacro" Res1="#ffb6c1">Light Pink</Capability>
   <Capability Min="46" Max="48" Preset="ColorMacro" Res1="#ffa0b9">Medium Pink</Capability>
   <Capability Min="49" Max="61" Preset="ColorMacro" Res1="#ffbde1">Pink Carnation</Capability>
-  <Capability Min="62" Max="67" Preset="ColorMacro" Res1="#e6aafa">Light Lavender</Capability>
-  <Capability Min="68" Max="77" Preset="ColorMacro" Res1="#b46ef0">Lavender</Capability>
-  <Capability Min="78" Max="88" Preset="ColorMacro" Res1="#00ff87">Sky Blue</Capability>
+  <Capability Min="62" Max="67" Preset="ColorMacro" Res1="#f6fafd">Light Lavender</Capability>
+  <Capability Min="68" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
+  <Capability Min="78" Max="88" Preset="ColorMacro" Res1="#87ceeb">Sky Blue</Capability>
   <Capability Min="89" Max="99" Preset="ColorMacro" Res1="#00c282">Just Blue</Capability>
   <Capability Min="100" Max="109" Preset="ColorMacro" Res1="#29db00">Dark Yellow Green</Capability>
   <Capability Min="110" Max="111" Preset="ColorMacro" Res1="#f5ca00">Spring Yellow</Capability>
   <Capability Min="112" Max="112" Preset="ColorMacro" Res1="#eda300">Light Amber</Capability>
   <Capability Min="113" Max="113" Preset="ColorMacro" Res1="#fceacc">Straw</Capability>
   <Capability Min="114" Max="114" Preset="ColorMacro" Res1="#ffa600">Deep Amber</Capability>
-  <Capability Min="115" Max="116" Preset="ColorMacro" Res1="#ff7a00">Orange</Capability>
+  <Capability Min="115" Max="116" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="117" Max="117" Preset="ColorMacro" Res1="#ffa5af">Light Rose</Capability>
   <Capability Min="118" Max="118" Preset="ColorMacro" Res1="#fcbea9">English Rose</Capability>
-  <Capability Min="119" Max="119" Preset="ColorMacro" Res1="#ffb2af">Light Salmon</Capability>
+  <Capability Min="119" Max="119" Preset="ColorMacro" Res1="#ffa07a">Light Salmon</Capability>
   <Capability Min="120" Max="120" Preset="ColorMacro" Res1="#ffb4c8">Middle Rose</Capability>
   <Capability Min="121" Max="122" Preset="ColorMacro" Res1="#ff8cbe">Dark Pink</Capability>
   <Capability Min="123" Max="124" Preset="ColorMacro" Res1="#ff0064">Magenta2</Capability>
   <Capability Min="125" Max="125" Preset="ColorMacro" Res1="#00ebc8">Peacock Blue</Capability>
   <Capability Min="126" Max="126" Preset="ColorMacro" Res1="#00c8b9">Med Blue Green</Capability>
-  <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#b4faf5">Steel Blue</Capability>
-  <Capability Min="128" Max="128" Preset="ColorMacro" Res1="#00e1eb">Light Blue</Capability>
-  <Capability Min="129" Max="130" Preset="ColorMacro" Res1="#0078c8">Dark Blue</Capability>
+  <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#4682b4">Steel Blue</Capability>
+  <Capability Min="128" Max="128" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="129" Max="130" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="131" Max="133" Preset="ColorMacro" Res1="#b4ff64">Leaf Green</Capability>
-  <Capability Min="134" Max="135" Preset="ColorMacro" Res1="#00dc78">Dark Green</Capability>
+  <Capability Min="134" Max="135" Preset="ColorMacro" Res1="#006400">Dark Green</Capability>
   <Capability Min="136" Max="137" Preset="ColorMacro" Res1="#be009b">Mauve</Capability>
   <Capability Min="138" Max="141" Preset="ColorMacro" Res1="#ff50b4">Bright Pink</Capability>
-  <Capability Min="142" Max="144" Preset="ColorMacro" Res1="#00a0dc">Medium Blue</Capability>
+  <Capability Min="142" Max="144" Preset="ColorMacro" Res1="#0000cd">Medium Blue</Capability>
   <Capability Min="145" Max="145" Preset="ColorMacro" Res1="#ff5f00">Deep Golden Amber</Capability>
   <Capability Min="146" Max="146" Preset="ColorMacro" Res1="#f0bee6">Pale Lavender</Capability>
   <Capability Min="147" Max="148" Preset="ColorMacro" Res1="#c8b4e6">Special Lavender</Capability>
@@ -118,7 +118,7 @@
   <Capability Min="180" Max="183" Preset="ColorMacro" Res1="#e6aadc">Deep Lavender</Capability>
   <Capability Min="184" Max="190" Preset="ColorMacro" Res1="#afe1fa">Dark Steel Blue</Capability>
   <Capability Min="191" Max="206" Preset="ColorMacro" Res1="#5000aa">Congo Blue</Capability>
-  <Capability Min="207" Max="207" Preset="ColorMacro" Res1="#82aae6">Alice Blue</Capability>
+  <Capability Min="207" Max="207" Preset="ColorMacro" Res1="#f0f8ff">Alice Blue</Capability>
   <Capability Min="208" Max="208" Preset="ColorMacro" Res1="#ebd1d3">Dirty White</Capability>
   <Capability Min="209" Max="255" Preset="ColorMacro" Res1="#ffffff">White</Capability>
  </Channel>

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Scenius-Unico.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Scenius-Unico.qxf
@@ -16,21 +16,21 @@
  <Channel Name="Color Wheel">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="9" Preset="ColorMacro" Res1="#ffffff">Empty position</Capability>
-  <Capability Min="10" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#c80000">Empty + Dark Red</Capability>
-  <Capability Min="16" Max="22" Preset="ColorMacro" Res1="#c80000">Dark Red</Capability>
-  <Capability Min="23" Max="31" Preset="ColorDoubleMacro" Res1="#c80000" Res2="#0128ff">Dark Red + Brilliant Blue</Capability>
+  <Capability Min="10" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#8b0000">Empty + Dark Red</Capability>
+  <Capability Min="16" Max="22" Preset="ColorMacro" Res1="#8b0000">Dark Red</Capability>
+  <Capability Min="23" Max="31" Preset="ColorDoubleMacro" Res1="#8b0000" Res2="#0128ff">Dark Red + Brilliant Blue</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#0128ff">Brilliant Blue</Capability>
-  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#0128ff" Res2="#30d401">Brilliant Blue + Green</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#30d401">Green</Capability>
-  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#30d401" Res2="#f0e6dc">Green + Half Minus Green</Capability>
+  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#0128ff" Res2="#00ff00">Brilliant Blue + Green</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#f0e6dc">Green + Half Minus Green</Capability>
   <Capability Min="64" Max="70" Preset="ColorMacro" Res1="#f2e5dc">Half Minus Green</Capability>
   <Capability Min="71" Max="79" Preset="ColorDoubleMacro" Res1="#f0e6dc" Res2="#ffa401">Half Minus Green + Light Orange</Capability>
   <Capability Min="80" Max="86" Preset="ColorMacro" Res1="#ffa401">Light Orange</Capability>
-  <Capability Min="87" Max="95" Preset="ColorDoubleMacro" Res1="#ffa401" Res2="#ff4401">Light Orange + Dark Orange</Capability>
-  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#ff4401">Dark Orange</Capability>
-  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#ff4300" Res2="#005395">Dark Orange + Navy Blue</Capability>
-  <Capability Min="112" Max="117" Preset="ColorMacro" Res1="#005395">Navy Blue</Capability>
-  <Capability Min="118" Max="126" Preset="ColorDoubleMacro" Res1="#005395" Res2="#ffffff">Navy Blue + Empty position</Capability>
+  <Capability Min="87" Max="95" Preset="ColorDoubleMacro" Res1="#ffa401" Res2="#ff8c00">Light Orange + Dark Orange</Capability>
+  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#ff8c00">Dark Orange</Capability>
+  <Capability Min="104" Max="111" Preset="ColorDoubleMacro" Res1="#ff8c00" Res2="#000080">Dark Orange + Navy Blue</Capability>
+  <Capability Min="112" Max="117" Preset="ColorMacro" Res1="#000080">Navy Blue</Capability>
+  <Capability Min="118" Max="126" Preset="ColorDoubleMacro" Res1="#000080" Res2="#ffffff">Navy Blue + Empty position</Capability>
   <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#ffffff">Empty</Capability>
   <Capability Min="128" Max="255" Preset="RotationClockwiseSlowToFast">Continuous CW colour wheel rotation (slow to fast)</Capability>
  </Channel>

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Sharpy-X-Frame.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Sharpy-X-Frame.qxf
@@ -46,7 +46,7 @@
  <Channel Name="Half Color">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="2" Preset="ColorMacro" Res1="#ffffff">Empty position</Capability>
-  <Capability Min="3" Max="5" Preset="ColorDoubleMacro" Res1="#8b0000">Empty position + Dark red</Capability>
+  <Capability Min="3" Max="5" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#8b0000">Empty position + Dark red</Capability>
   <Capability Min="6" Max="8" Preset="ColorMacro" Res1="#8b0000">Dark red</Capability>
   <Capability Min="9" Max="11" Preset="ColorDoubleMacro" Res1="#8b0000" Res2="#ffd260">Dark red + 2500K</Capability>
   <Capability Min="12" Max="14" Preset="ColorMacro" Res1="#ffd260">2500K</Capability>
@@ -96,7 +96,7 @@
   <Capability Min="78" Max="83" Preset="ColorMacro" Res1="#f0f8ff">CCT blue</Capability>
   <Capability Min="84" Max="89" Preset="ColorMacro" Res1="#380088">UV</Capability>
   <Capability Min="90" Max="127">CW rotation from slow to fast</Capability>
-  <Capability Min="128" Max="255" Preset="ColorMacro">Indexing position from 0 to 360°</Capability>
+  <Capability Min="128" Max="255">Indexing position from 0 to 360°</Capability>
  </Channel>
  <Channel Name="Strobe">
   <Group Byte="0">Shutter</Group>

--- a/resources/fixtures/Clay_Paky/Clay-Paky-Volero-Wave.qxf
+++ b/resources/fixtures/Clay_Paky/Clay-Paky-Volero-Wave.qxf
@@ -31,9 +31,9 @@
   <Capability Min="13" Max="13" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="14" Max="14" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="15" Max="15" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#e1ede9" Res2="#ffffff">White 7000 K</Capability>
-  <Capability Min="17" Max="17" Preset="ColorMacro" Res1="#fff5e9" Res2="#ffffff">White 3700 K</Capability>
-  <Capability Min="18" Max="18" Preset="ColorMacro" Res1="#fdfff8" Res2="#ffffff">White 5000 K</Capability>
+  <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#e1ede9">White 7000 K</Capability>
+  <Capability Min="17" Max="17" Preset="ColorMacro" Res1="#fff5e9">White 3700 K</Capability>
+  <Capability Min="18" Max="18" Preset="ColorMacro" Res1="#fdfff8">White 5000 K</Capability>
   <Capability Min="19" Max="19" Preset="ColorMacro" Res1="#000000">Black</Capability>
   <Capability Min="20" Max="22" Preset="ColorMacro" Res1="#9c7e00">Medium Yellow</Capability>
   <Capability Min="23" Max="26" Preset="ColorMacro" Res1="#987309">Straw Tint</Capability>
@@ -43,35 +43,35 @@
   <Capability Min="31" Max="31" Preset="ColorMacro" Res1="#ff6400">Gold Amber</Capability>
   <Capability Min="32" Max="34" Preset="ColorMacro" Res1="#ff4100">Dark Amber</Capability>
   <Capability Min="35" Max="44" Preset="ColorMacro" Res1="#ff5302">Sunrise Red</Capability>
-  <Capability Min="45" Max="45" Preset="ColorMacro" Res1="#ffc8d2">Light Pink</Capability>
+  <Capability Min="45" Max="45" Preset="ColorMacro" Res1="#ffb6c1">Light Pink</Capability>
   <Capability Min="46" Max="48" Preset="ColorMacro" Res1="#ffa0b9">Medium Pink</Capability>
   <Capability Min="49" Max="61" Preset="ColorMacro" Res1="#ffbde1">Pink Carnation</Capability>
   <Capability Min="62" Max="67" Preset="ColorMacro" Res1="#e6aafa">Light Lavender</Capability>
-  <Capability Min="68" Max="77" Preset="ColorMacro" Res1="#b46ef0">Lavender</Capability>
-  <Capability Min="78" Max="88" Preset="ColorMacro" Res1="#00ff87">Sky Blue</Capability>
+  <Capability Min="68" Max="77" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
+  <Capability Min="78" Max="88" Preset="ColorMacro" Res1="#87ceeb">Sky Blue</Capability>
   <Capability Min="89" Max="99" Preset="ColorMacro" Res1="#00c282">Just Blue</Capability>
   <Capability Min="100" Max="109" Preset="ColorMacro" Res1="#29db00">Dark Yellow Green</Capability>
   <Capability Min="110" Max="111" Preset="ColorMacro" Res1="#f5ca00">Spring Yellow</Capability>
   <Capability Min="112" Max="112" Preset="ColorMacro" Res1="#eda300">Light Amber</Capability>
   <Capability Min="113" Max="113" Preset="ColorMacro" Res1="#fceacc">Straw</Capability>
   <Capability Min="114" Max="114" Preset="ColorMacro" Res1="#ffa600">Deep Amber</Capability>
-  <Capability Min="115" Max="116" Preset="ColorMacro" Res1="#ff7a00">Orange</Capability>
+  <Capability Min="115" Max="116" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="117" Max="117" Preset="ColorMacro" Res1="#ffa5af">Light Rose</Capability>
   <Capability Min="118" Max="118" Preset="ColorMacro" Res1="#fcbea9">English Rose</Capability>
-  <Capability Min="119" Max="119" Preset="ColorMacro" Res1="#ffb2af">Light Salmon</Capability>
+  <Capability Min="119" Max="119" Preset="ColorMacro" Res1="#ffa07a">Light Salmon</Capability>
   <Capability Min="120" Max="120" Preset="ColorMacro" Res1="#ffb4c8">Middle Rose</Capability>
   <Capability Min="121" Max="122" Preset="ColorMacro" Res1="#ff8cbe">Dark Pink</Capability>
   <Capability Min="123" Max="124" Preset="ColorMacro" Res1="#ff0064">Magenta2</Capability>
   <Capability Min="125" Max="125" Preset="ColorMacro" Res1="#00ebc8">Peacock Blue</Capability>
   <Capability Min="126" Max="126" Preset="ColorMacro" Res1="#00c8b9">Med Blue Green</Capability>
-  <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#b4faf5">Steel Blue</Capability>
-  <Capability Min="128" Max="128" Preset="ColorMacro" Res1="#00e1eb">Light Blue</Capability>
-  <Capability Min="129" Max="130" Preset="ColorMacro" Res1="#0078c8">Dark Blue</Capability>
+  <Capability Min="127" Max="127" Preset="ColorMacro" Res1="#4682b4">Steel Blue</Capability>
+  <Capability Min="128" Max="128" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="129" Max="130" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="131" Max="133" Preset="ColorMacro" Res1="#b4ff64">Leaf Green</Capability>
-  <Capability Min="134" Max="135" Preset="ColorMacro" Res1="#00dc78">Dark Green</Capability>
+  <Capability Min="134" Max="135" Preset="ColorMacro" Res1="#006400">Dark Green</Capability>
   <Capability Min="136" Max="137" Preset="ColorMacro" Res1="#be009b">Mauve</Capability>
   <Capability Min="138" Max="141" Preset="ColorMacro" Res1="#ff50b4">Bright Pink</Capability>
-  <Capability Min="142" Max="144" Preset="ColorMacro" Res1="#00a0dc">Medium Blue</Capability>
+  <Capability Min="142" Max="144" Preset="ColorMacro" Res1="#0000cd">Medium Blue</Capability>
   <Capability Min="145" Max="145" Preset="ColorMacro" Res1="#ff5f00">Deep Golden Amber</Capability>
   <Capability Min="146" Max="146" Preset="ColorMacro" Res1="#f0bee6">Pale Lavender</Capability>
   <Capability Min="147" Max="148" Preset="ColorMacro" Res1="#c8b4e6">Special Lavender</Capability>
@@ -87,7 +87,7 @@
   <Capability Min="180" Max="183" Preset="ColorMacro" Res1="#e6aadc">Deep Lavender</Capability>
   <Capability Min="184" Max="190" Preset="ColorMacro" Res1="#afe1fa">Dark Steel Blue</Capability>
   <Capability Min="191" Max="206" Preset="ColorMacro" Res1="#5000aa">Congo Blue</Capability>
-  <Capability Min="207" Max="207" Preset="ColorMacro" Res1="#82aae6">Alice Blue</Capability>
+  <Capability Min="207" Max="207" Preset="ColorMacro" Res1="#f0f8ff">Alice Blue</Capability>
   <Capability Min="208" Max="208" Preset="ColorMacro" Res1="#ebd1d3">Dirty White</Capability>
   <Capability Min="209" Max="255" Preset="ColorMacro" Res1="#ffffff">White</Capability>
  </Channel>

--- a/resources/fixtures/Coemar/Coemar-LEDko-FullSpectrum-6.qxf
+++ b/resources/fixtures/Coemar/Coemar-LEDko-FullSpectrum-6.qxf
@@ -45,70 +45,70 @@
   <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
   <Capability Min="0" Max="9">No effect</Capability>
-  <Capability Min="10" Max="34" Preset="ColorMacro">R24 - scarlet red</Capability>
-  <Capability Min="35" Max="59" Preset="ColorMacro">R02 - bastard amber</Capability>
-  <Capability Min="60" Max="84" Preset="ColorMacro">R313 - Light relief yellow</Capability>
-  <Capability Min="85" Max="109" Preset="ColorMacro">R18 - Flame</Capability>
-  <Capability Min="110" Max="134" Preset="ColorMacro">R331 - Shell pink</Capability>
-  <Capability Min="135" Max="159" Preset="ColorMacro">R25 - Orange Red</Capability>
-  <Capability Min="160" Max="184" Preset="ColorMacro">R46 - Magenta</Capability>
-  <Capability Min="185" Max="209" Preset="ColorMacro">R08 - Pale gold</Capability>
-  <Capability Min="210" Max="234" Preset="ColorMacro">R27 - Medium red</Capability>
-  <Capability Min="235" Max="255" Preset="ColorMacro">R318 - Mayan sun</Capability>
+  <Capability Min="10" Max="34">R24 - scarlet red</Capability>
+  <Capability Min="35" Max="59">R02 - bastard amber</Capability>
+  <Capability Min="60" Max="84">R313 - Light relief yellow</Capability>
+  <Capability Min="85" Max="109">R18 - Flame</Capability>
+  <Capability Min="110" Max="134">R331 - Shell pink</Capability>
+  <Capability Min="135" Max="159">R25 - Orange Red</Capability>
+  <Capability Min="160" Max="184">R46 - Magenta</Capability>
+  <Capability Min="185" Max="209">R08 - Pale gold</Capability>
+  <Capability Min="210" Max="234">R27 - Medium red</Capability>
+  <Capability Min="235" Max="255">R318 - Mayan sun</Capability>
  </Channel>
  <Channel Name="Green tone">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
-  <Capability Min="0" Max="9" Preset="ColorMacro">no effect</Capability>
-  <Capability Min="10" Max="34" Preset="ColorMacro">R4460 - calcolor 60 green</Capability>
-  <Capability Min="35" Max="59" Preset="ColorMacro">R2004 - storaro green</Capability>
-  <Capability Min="60" Max="84" Preset="ColorMacro">E730 - liberty green</Capability>
-  <Capability Min="85" Max="109" Preset="ColorMacro">E088 - lime green</Capability>
-  <Capability Min="110" Max="134" Preset="ColorMacro">R90 - kelly green</Capability>
-  <Capability Min="135" Max="159" Preset="ColorMacro">R395 - teal green</Capability>
-  <Capability Min="160" Max="184" Preset="ColorMacro">R91 - primary green</Capability>
-  <Capability Min="185" Max="209" Preset="ColorMacro">R393 - emerald green</Capability>
-  <Capability Min="210" Max="234" Preset="ColorMacro">R393 - leaf green</Capability>
-  <Capability Min="235" Max="255" Preset="ColorMacro">R86 - pea green</Capability>
+  <Capability Min="0" Max="9">no effect</Capability>
+  <Capability Min="10" Max="34">R4460 - calcolor 60 green</Capability>
+  <Capability Min="35" Max="59">R2004 - storaro green</Capability>
+  <Capability Min="60" Max="84">E730 - liberty green</Capability>
+  <Capability Min="85" Max="109">E088 - lime green</Capability>
+  <Capability Min="110" Max="134">R90 - kelly green</Capability>
+  <Capability Min="135" Max="159">R395 - teal green</Capability>
+  <Capability Min="160" Max="184">R91 - primary green</Capability>
+  <Capability Min="185" Max="209">R393 - emerald green</Capability>
+  <Capability Min="210" Max="234">R393 - leaf green</Capability>
+  <Capability Min="235" Max="255">R86 - pea green</Capability>
  </Channel>
  <Channel Name="Blue Tone">
   <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
   <Capability Min="0" Max="9">no effect</Capability>
-  <Capability Min="10" Max="34" Preset="ColorMacro">R2008 - storaro indigo</Capability>
-  <Capability Min="35" Max="59" Preset="ColorMacro">E5058 - french lilac</Capability>
-  <Capability Min="60" Max="84" Preset="ColorMacro">R369 - tahitian blue</Capability>
-  <Capability Min="85" Max="109" Preset="ColorMacro">R347 - belladonna rose</Capability>
-  <Capability Min="110" Max="134" Preset="ColorMacro">R381 - baldassari blue</Capability>
-  <Capability Min="135" Max="159" Preset="ColorMacro">R57 - Lavander</Capability>
-  <Capability Min="160" Max="184" Preset="ColorMacro">R55 - lilac</Capability>
-  <Capability Min="185" Max="209" Preset="ColorMacro">R4790 - calcolor 90 magenta</Capability>
-  <Capability Min="210" Max="234" Preset="ColorMacro">R92 - turquise</Capability>
-  <Capability Min="235" Max="255" Preset="ColorMacro">R370 - italian blue</Capability>
+  <Capability Min="10" Max="34">R2008 - storaro indigo</Capability>
+  <Capability Min="35" Max="59">E5058 - french lilac</Capability>
+  <Capability Min="60" Max="84">R369 - tahitian blue</Capability>
+  <Capability Min="85" Max="109">R347 - belladonna rose</Capability>
+  <Capability Min="110" Max="134">R381 - baldassari blue</Capability>
+  <Capability Min="135" Max="159">R57 - Lavander</Capability>
+  <Capability Min="160" Max="184">R55 - lilac</Capability>
+  <Capability Min="185" Max="209">R4790 - calcolor 90 magenta</Capability>
+  <Capability Min="210" Max="234">R92 - turquise</Capability>
+  <Capability Min="235" Max="255">R370 - italian blue</Capability>
  </Channel>
  <Channel Name="White Tone">
   <Group Byte="0">Intensity</Group>
   <Colour>White</Colour>
   <Capability Min="0" Max="9">no effect</Capability>
-  <Capability Min="10" Max="30" Preset="ColorMacro">2700K</Capability>
-  <Capability Min="31" Max="52" Preset="ColorMacro">proportional value from 2700K to 3200K</Capability>
-  <Capability Min="53" Max="74" Preset="ColorMacro">3200K</Capability>
-  <Capability Min="75" Max="96" Preset="ColorMacro">proportional value from 3200K to 4000K</Capability>
-  <Capability Min="97" Max="118" Preset="ColorMacro">4000K</Capability>
-  <Capability Min="119" Max="140" Preset="ColorMacro">proportional value from 4000K to 5000K</Capability>
-  <Capability Min="141" Max="162" Preset="ColorMacro">5000K</Capability>
-  <Capability Min="163" Max="184" Preset="ColorMacro">proportional value from 5000K to 5600K</Capability>
-  <Capability Min="185" Max="206" Preset="ColorMacro">5600K</Capability>
-  <Capability Min="207" Max="228" Preset="ColorMacro">proportional value from 5600K to 6500K</Capability>
-  <Capability Min="229" Max="255" Preset="ColorMacro">6500K</Capability>
+  <Capability Min="10" Max="30">2700K</Capability>
+  <Capability Min="31" Max="52">proportional value from 2700K to 3200K</Capability>
+  <Capability Min="53" Max="74">3200K</Capability>
+  <Capability Min="75" Max="96">proportional value from 3200K to 4000K</Capability>
+  <Capability Min="97" Max="118">4000K</Capability>
+  <Capability Min="119" Max="140">proportional value from 4000K to 5000K</Capability>
+  <Capability Min="141" Max="162">5000K</Capability>
+  <Capability Min="163" Max="184">proportional value from 5000K to 5600K</Capability>
+  <Capability Min="185" Max="206">5600K</Capability>
+  <Capability Min="207" Max="228">proportional value from 5600K to 6500K</Capability>
+  <Capability Min="229" Max="255">6500K</Capability>
  </Channel>
  <Channel Name="Green Saturation">
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
   <Capability Min="0" Max="9">no effect</Capability>
-  <Capability Min="10" Max="123" Preset="ColorDoubleMacro">exalts the green color in the mixing ans diminishes the presence of magenta</Capability>
+  <Capability Min="10" Max="123">exalts the green color in the mixing ans diminishes the presence of magenta</Capability>
   <Capability Min="124" Max="132">no effect</Capability>
-  <Capability Min="133" Max="246" Preset="ColorDoubleMacro">diminishes the presence of green in the mixing and exalts the magenta color</Capability>
+  <Capability Min="133" Max="246">diminishes the presence of green in the mixing and exalts the magenta color</Capability>
   <Capability Min="247" Max="255">no effect</Capability>
  </Channel>
  <Channel Name="Saturation" Preset="IntensitySaturation"/>

--- a/resources/fixtures/Coemar/Coemar-iSpot-150.qxf
+++ b/resources/fixtures/Coemar/Coemar-iSpot-150.qxf
@@ -57,13 +57,13 @@
  <Channel Name="Colours">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="5" Preset="ColorMacro" Res1="#ffffff">Open/white</Capability>
-  <Capability Min="6" Max="13" Preset="ColorMacro">Colour 1</Capability>
-  <Capability Min="14" Max="20" Preset="ColorMacro">Colour 2</Capability>
-  <Capability Min="21" Max="27" Preset="ColorMacro">Colour 3</Capability>
-  <Capability Min="28" Max="34" Preset="ColorMacro">Colour 4</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro">Colour 5</Capability>
-  <Capability Min="42" Max="48" Preset="ColorMacro">Colour 6</Capability>
-  <Capability Min="49" Max="59" Preset="ColorMacro">Colour 7</Capability>
+  <Capability Min="6" Max="13">Colour 1</Capability>
+  <Capability Min="14" Max="20">Colour 2</Capability>
+  <Capability Min="21" Max="27">Colour 3</Capability>
+  <Capability Min="28" Max="34">Colour 4</Capability>
+  <Capability Min="35" Max="41">Colour 5</Capability>
+  <Capability Min="42" Max="48">Colour 6</Capability>
+  <Capability Min="49" Max="59">Colour 7</Capability>
   <Capability Min="60" Max="127" Preset="RotationIndexed">From white to colour 7, 360° color positioning</Capability>
   <Capability Min="128" Max="190" Preset="RotationClockwiseFastToSlow">Forwards rainbow effect from fast to slow</Capability>
   <Capability Min="191" Max="255" Preset="RotationCounterClockwiseSlowToFast">Backwards rainbow effect from slow to fast</Capability>

--- a/resources/fixtures/DNA/DNA-Pro-Slim-18-RGBW.qxf
+++ b/resources/fixtures/DNA/DNA-Pro-Slim-18-RGBW.qxf
@@ -29,7 +29,7 @@
   <Capability Min="60" Max="79" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="80" Max="99" Preset="ColorMacro" Res1="#7f00ff">Purple</Capability>
   <Capability Min="100" Max="119" Preset="ColorMacro" Res1="#7fff7f">Light green</Capability>
-  <Capability Min="120" Max="139" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="120" Max="139" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="140" Max="159" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#000000">Red on/off (10 sec)</Capability>
   <Capability Min="160" Max="179" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#000000">Green on/off (10 sec)</Capability>
   <Capability Min="180" Max="199" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#000000">Blue on/off (10 sec)</Capability>

--- a/resources/fixtures/EK/EK-E3-LED-Spot.qxf
+++ b/resources/fixtures/EK/EK-E3-LED-Spot.qxf
@@ -29,7 +29,7 @@
   <Capability Min="0" Max="7">Nothing</Capability>
   <Capability Min="8" Max="22" Preset="ColorMacro" Res1="#ff0000">RED</Capability>
   <Capability Min="23" Max="37" Preset="ColorMacro" Res1="#ffff00">YELLOW</Capability>
-  <Capability Min="38" Max="52" Preset="ColorMacro" Res1="#55ff00">GREEN</Capability>
+  <Capability Min="38" Max="52" Preset="ColorMacro" Res1="#00ff00">GREEN</Capability>
   <Capability Min="53" Max="67" Preset="ColorMacro" Res1="#00ffff">CYAN</Capability>
   <Capability Min="68" Max="82" Preset="ColorMacro" Res1="#0000ff">BLUE</Capability>
   <Capability Min="83" Max="97" Preset="ColorMacro" Res1="#ff00ff">MAGENTA</Capability>

--- a/resources/fixtures/Elation/Elation-E-Spot-III.qxf
+++ b/resources/fixtures/Elation/Elation-E-Spot-III.qxf
@@ -15,18 +15,18 @@
  <Channel Name="Fine Control of TILT Movement" Preset="PositionTiltFine"/>
  <Channel Name="Color Wheel">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="14" Preset="ColorMacro" Res1="#ffffff">open/white</Capability>
-  <Capability Min="15" Max="29" Preset="ColorMacro" Res1="#ff0000">red</Capability>
-  <Capability Min="30" Max="44" Preset="ColorMacro" Res1="#0000ff">blue</Capability>
-  <Capability Min="45" Max="59" Preset="ColorMacro" Res1="#55ff00">green</Capability>
-  <Capability Min="60" Max="74" Preset="ColorMacro" Res1="#ffff00">yellow</Capability>
-  <Capability Min="75" Max="89" Preset="ColorMacro" Res1="#ff0648">magenta</Capability>
-  <Capability Min="90" Max="104" Preset="ColorMacro" Res1="#ff5500">orange</Capability>
-  <Capability Min="105" Max="119" Preset="ColorMacro" Res1="#55ffff">light blue</Capability>
-  <Capability Min="120" Max="127" Preset="ColorMacro" Res1="#ff55ff">pink</Capability>
-  <Capability Min="128" Max="189" Preset="RotationClockwiseFastToSlow">clockwise color wheel rotaion from fast to slow</Capability>
+  <Capability Min="0" Max="14" Preset="ColorMacro" Res1="#ffffff">Open/white</Capability>
+  <Capability Min="15" Max="29" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="30" Max="44" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
+  <Capability Min="45" Max="59" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="60" Max="74" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
+  <Capability Min="75" Max="89" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="90" Max="104" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="105" Max="119" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="120" Max="127" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
+  <Capability Min="128" Max="189" Preset="RotationClockwiseFastToSlow">Clockwise color wheel rotaion from fast to slow</Capability>
   <Capability Min="190" Max="193" Preset="RotationStop">no rotation</Capability>
-  <Capability Min="194" Max="255" Preset="RotationCounterClockwiseSlowToFast">conterclockwise color wheel rotation from slow to fast</Capability>
+  <Capability Min="194" Max="255" Preset="RotationCounterClockwiseSlowToFast">Counterclockwise color wheel rotation from slow to fast</Capability>
  </Channel>
  <Channel Name="Color Wheel Fine Adjustment">
   <Group Byte="1">Colour</Group>
@@ -34,23 +34,23 @@
  </Channel>
  <Channel Name="Rotating Gobo">
   <Group Byte="0">Gobo</Group>
-  <Capability Min="0" Max="9" Preset="GoboMacro" Res1="Others/open.svg">open</Capability>
-  <Capability Min="10" Max="19" Preset="GoboMacro" Res1="ClayPaky/gobo00047.svg">rotating gobo1</Capability>
-  <Capability Min="20" Max="29" Preset="GoboMacro" Res1="ClayPaky/gobo00026.svg">rotating gobo2</Capability>
-  <Capability Min="30" Max="39" Preset="GoboMacro" Res1="ClayPaky/gobo00042.svg">rotating gobo3</Capability>
-  <Capability Min="40" Max="49" Preset="GoboMacro" Res1="SGM-Color/gobo00470.png">rotating gobo4</Capability>
-  <Capability Min="50" Max="59" Preset="GoboMacro" Res1="Chauvet/gobo00064.svg">rotating gobo5</Capability>
-  <Capability Min="60" Max="69" Preset="GoboMacro" Res1="ClayPaky/gobo00032.png">rotating gobo6</Capability>
-  <Capability Min="70" Max="79" Preset="GoboMacro" Res1="Robe/gobo00015.svg">rotating gobo7</Capability>
-  <Capability Min="80" Max="89" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00047.svg">gobo shake slow to fast 1</Capability>
-  <Capability Min="90" Max="99" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00026.svg">gobo shake slow to fast 2</Capability>
-  <Capability Min="100" Max="109" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00042.svg">gobo shake slow to fast 3</Capability>
-  <Capability Min="110" Max="119" Preset="GoboShakeMacro" Res1="SGM-Color/gobo00470.png">gobo shake slow to fast 4</Capability>
-  <Capability Min="120" Max="129" Preset="GoboShakeMacro" Res1="Chauvet/gobo00064.svg">gobo shake slow to fast 5</Capability>
-  <Capability Min="130" Max="139" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00032.png">gobo shake slow to fast 6</Capability>
-  <Capability Min="140" Max="149" Preset="GoboShakeMacro" Res1="Robe/gobo00015.svg">gobo shake slow to fast 7</Capability>
-  <Capability Min="150" Max="199" Preset="RotationClockwiseFastToSlow">clockwise gobo wheel rotation from fast to slow</Capability>
-  <Capability Min="200" Max="205" Preset="RotationStop">no rotation</Capability>
+  <Capability Min="0" Max="9" Preset="GoboMacro" Res1="Others/open.svg">Open</Capability>
+  <Capability Min="10" Max="19" Preset="GoboMacro" Res1="ClayPaky/gobo00047.svg">Rotating gobo1</Capability>
+  <Capability Min="20" Max="29" Preset="GoboMacro" Res1="ClayPaky/gobo00026.svg">Rotating gobo2</Capability>
+  <Capability Min="30" Max="39" Preset="GoboMacro" Res1="ClayPaky/gobo00042.svg">Rotating gobo3</Capability>
+  <Capability Min="40" Max="49" Preset="GoboMacro" Res1="SGM-Color/gobo00470.png">Rotating gobo4</Capability>
+  <Capability Min="50" Max="59" Preset="GoboMacro" Res1="Chauvet/gobo00064.svg">Rotating gobo5</Capability>
+  <Capability Min="60" Max="69" Preset="GoboMacro" Res1="ClayPaky/gobo00032.png">Rotating gobo6</Capability>
+  <Capability Min="70" Max="79" Preset="GoboMacro" Res1="Robe/gobo00015.svg">Rotating gobo7</Capability>
+  <Capability Min="80" Max="89" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00047.svg">Gobo shake slow to fast 1</Capability>
+  <Capability Min="90" Max="99" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00026.svg">Gobo shake slow to fast 2</Capability>
+  <Capability Min="100" Max="109" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00042.svg">Gobo shake slow to fast 3</Capability>
+  <Capability Min="110" Max="119" Preset="GoboShakeMacro" Res1="SGM-Color/gobo00470.png">Gobo shake slow to fast 4</Capability>
+  <Capability Min="120" Max="129" Preset="GoboShakeMacro" Res1="Chauvet/gobo00064.svg">Gobo shake slow to fast 5</Capability>
+  <Capability Min="130" Max="139" Preset="GoboShakeMacro" Res1="ClayPaky/gobo00032.png">Gobo shake slow to fast 6</Capability>
+  <Capability Min="140" Max="149" Preset="GoboShakeMacro" Res1="Robe/gobo00015.svg">Gobo shake slow to fast 7</Capability>
+  <Capability Min="150" Max="199" Preset="RotationClockwiseFastToSlow">Clockwise gobo wheel rotation from fast to slow</Capability>
+  <Capability Min="200" Max="205" Preset="RotationStop">No rotation</Capability>
   <Capability Min="206" Max="255" Preset="RotationCounterClockwiseSlowToFast">counterclockwise wheel rotation from slow to fast</Capability>
  </Channel>
  <Channel Name="Rotating Gobos Fine Index Rotation">
@@ -59,102 +59,102 @@
  </Channel>
  <Channel Name="Frost, Trapezoid 3-Facet Rotating Prisms/Macros">
   <Group Byte="0">Prism</Group>
-  <Capability Min="0" Max="31" Preset="PrismEffectOff">open</Capability>
+  <Capability Min="0" Max="31" Preset="PrismEffectOff">Open</Capability>
   <Capability Min="32" Max="63" Preset="PrismEffectOn" Res1="3">3 facet prism</Capability>
-  <Capability Min="64" Max="95">linear prism</Capability>
-  <Capability Min="96" Max="127">frost</Capability>
-  <Capability Min="128" Max="135">prism/gobo macro 1</Capability>
-  <Capability Min="136" Max="143">prism/gobo macro 2</Capability>
-  <Capability Min="144" Max="151">prism/gobo macro 3</Capability>
-  <Capability Min="152" Max="159">prism/gobo macro 4</Capability>
-  <Capability Min="160" Max="167">prism/gobo macro 5</Capability>
-  <Capability Min="168" Max="175">prism/gobo macro 6</Capability>
-  <Capability Min="176" Max="183">prism/gobo macro 7</Capability>
-  <Capability Min="184" Max="191">prism/gobo macro 8</Capability>
-  <Capability Min="192" Max="199">prism/gobo macro 9</Capability>
-  <Capability Min="200" Max="207">prism/gobo macro 10</Capability>
-  <Capability Min="208" Max="215">prism/gobo macro 11</Capability>
-  <Capability Min="216" Max="223">prism/gobo macro 12</Capability>
-  <Capability Min="224" Max="231">prism/gobo macro 13</Capability>
-  <Capability Min="232" Max="239">prism/gobo macro 14</Capability>
-  <Capability Min="240" Max="247">prism/gobo macro 15</Capability>
-  <Capability Min="248" Max="255">prism/gobo macro 16</Capability>
+  <Capability Min="64" Max="95">Linear prism</Capability>
+  <Capability Min="96" Max="127">Frost</Capability>
+  <Capability Min="128" Max="135">Prism/gobo macro 1</Capability>
+  <Capability Min="136" Max="143">Prism/gobo macro 2</Capability>
+  <Capability Min="144" Max="151">Prism/gobo macro 3</Capability>
+  <Capability Min="152" Max="159">Prism/gobo macro 4</Capability>
+  <Capability Min="160" Max="167">Prism/gobo macro 5</Capability>
+  <Capability Min="168" Max="175">Prism/gobo macro 6</Capability>
+  <Capability Min="176" Max="183">Prism/gobo macro 7</Capability>
+  <Capability Min="184" Max="191">Prism/gobo macro 8</Capability>
+  <Capability Min="192" Max="199">Prism/gobo macro 9</Capability>
+  <Capability Min="200" Max="207">Prism/gobo macro 10</Capability>
+  <Capability Min="208" Max="215">Prism/gobo macro 11</Capability>
+  <Capability Min="216" Max="223">Prism/gobo macro 12</Capability>
+  <Capability Min="224" Max="231">Prism/gobo macro 13</Capability>
+  <Capability Min="232" Max="239">Prism/gobo macro 14</Capability>
+  <Capability Min="240" Max="247">Prism/gobo macro 15</Capability>
+  <Capability Min="248" Max="255">Prism/gobo macro 16</Capability>
  </Channel>
  <Channel Name="Trapezoid 3-Facet Rotating Prism Index Rotation">
   <Group Byte="0">Prism</Group>
-  <Capability Min="0" Max="127" Preset="RotationIndexed">prism indexing</Capability>
-  <Capability Min="128" Max="189" Preset="RotationClockwiseFastToSlow">clockwise linear prism rotation from fast to slow</Capability>
-  <Capability Min="190" Max="193" Preset="RotationStop">no rotation</Capability>
-  <Capability Min="194" Max="255" Preset="RotationCounterClockwiseSlowToFast">counterclockwise linear prism rotation from slow to fast</Capability>
+  <Capability Min="0" Max="127" Preset="RotationIndexed">Prism indexing</Capability>
+  <Capability Min="128" Max="189" Preset="RotationClockwiseFastToSlow">Clockwise linear prism rotation from fast to slow</Capability>
+  <Capability Min="190" Max="193" Preset="RotationStop">No rotation</Capability>
+  <Capability Min="194" Max="255" Preset="RotationCounterClockwiseSlowToFast">Counterclockwise linear prism rotation from slow to fast</Capability>
  </Channel>
  <Channel Name="Dimmer intensity" Preset="IntensityMasterDimmer"/>
  <Channel Name="Dimmer Intensity Fine" Preset="IntensityMasterDimmerFine"/>
  <Channel Name="Dimming Mode">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="20">standard</Capability>
-  <Capability Min="21" Max="40">stage</Capability>
-  <Capability Min="41" Max="60">tv</Capability>
-  <Capability Min="61" Max="80">architectural</Capability>
-  <Capability Min="81" Max="100">theatre</Capability>
-  <Capability Min="101" Max="255">default to unit setting</Capability>
+  <Capability Min="0" Max="20">Standard</Capability>
+  <Capability Min="21" Max="40">Stage</Capability>
+  <Capability Min="41" Max="60">TV</Capability>
+  <Capability Min="61" Max="80">Architectural</Capability>
+  <Capability Min="81" Max="100">Theatre</Capability>
+  <Capability Min="101" Max="255">Default to unit setting</Capability>
  </Channel>
- <Channel Name="iris">
+ <Channel Name="Iris">
   <Group Byte="0">Beam</Group>
-  <Capability Min="0" Max="191">max to min diameter</Capability>
-  <Capability Min="192" Max="223">pulse closing fast to slow</Capability>
-  <Capability Min="224" Max="255">pulse opening slow to fast</Capability>
+  <Capability Min="0" Max="191">Max to min diameter</Capability>
+  <Capability Min="192" Max="223">Pulse closing fast to slow</Capability>
+  <Capability Min="224" Max="255">Pulse opening slow to fast</Capability>
  </Channel>
  <Channel Name="Pan/Tilt Speed">
   <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="225">max to min speed</Capability>
-  <Capability Min="226" Max="235">blackout with pan and tilt movement</Capability>
-  <Capability Min="236" Max="245">blackout whith all wheel movement</Capability>
-  <Capability Min="246" Max="255">no function</Capability>
+  <Capability Min="0" Max="225">Max to min speed</Capability>
+  <Capability Min="226" Max="235">Blackout with pan and tilt movement</Capability>
+  <Capability Min="236" Max="245">Blackout whith all wheel movement</Capability>
+  <Capability Min="246" Max="255">No function</Capability>
  </Channel>
  <Channel Name="Special Functions">
   <Group Byte="0">Maintenance</Group>
-  <Capability Min="0" Max="19">color&amp;gobo change normal</Capability>
-  <Capability Min="20" Max="29">color change to any position</Capability>
-  <Capability Min="30" Max="39">color &amp; gobo change to any position</Capability>
-  <Capability Min="40" Max="59">no function</Capability>
-  <Capability Min="60" Max="79">no function</Capability>
-  <Capability Min="80" Max="84">all motor reset</Capability>
-  <Capability Min="85" Max="87">pan &amp; tilt motors reset</Capability>
-  <Capability Min="88" Max="90">color motor reset</Capability>
-  <Capability Min="91" Max="93">gobo motor reset</Capability>
-  <Capability Min="94" Max="96">no function</Capability>
-  <Capability Min="97" Max="99">other motor reset</Capability>
-  <Capability Min="100" Max="119">internal program 1 scene 1-8</Capability>
-  <Capability Min="120" Max="139">internal program 2 scene 9-16</Capability>
-  <Capability Min="140" Max="159">internal program 3 scene 17-24</Capability>
-  <Capability Min="160" Max="179">internal program 4 scene 25-32</Capability>
-  <Capability Min="180" Max="199">internal program 5 scene 33-40</Capability>
-  <Capability Min="200" Max="219">internal program 6 scene 41-48</Capability>
-  <Capability Min="220" Max="239">internal program 7 scene 49-56</Capability>
-  <Capability Min="240" Max="255">no function</Capability>
+  <Capability Min="0" Max="19">Color&amp;gobo change normal</Capability>
+  <Capability Min="20" Max="29">Color change to any position</Capability>
+  <Capability Min="30" Max="39">Color &amp; gobo change to any position</Capability>
+  <Capability Min="40" Max="59">No function</Capability>
+  <Capability Min="60" Max="79">No function</Capability>
+  <Capability Min="80" Max="84">All motor reset</Capability>
+  <Capability Min="85" Max="87">Pan &amp; tilt motors reset</Capability>
+  <Capability Min="88" Max="90">Color motor reset</Capability>
+  <Capability Min="91" Max="93">Gobo motor reset</Capability>
+  <Capability Min="94" Max="96">No function</Capability>
+  <Capability Min="97" Max="99">Other motor reset</Capability>
+  <Capability Min="100" Max="119">Internal program 1 scene 1-8</Capability>
+  <Capability Min="120" Max="139">Internal program 2 scene 9-16</Capability>
+  <Capability Min="140" Max="159">Internal program 3 scene 17-24</Capability>
+  <Capability Min="160" Max="179">Internal program 4 scene 25-32</Capability>
+  <Capability Min="180" Max="199">Internal program 5 scene 33-40</Capability>
+  <Capability Min="200" Max="219">Internal program 6 scene 41-48</Capability>
+  <Capability Min="220" Max="239">Internal program 7 scene 49-56</Capability>
+  <Capability Min="240" Max="255">No function</Capability>
  </Channel>
  <Channel Name="Rotating Gobos Index Rotation">
   <Group Byte="1">Gobo</Group>
-  <Capability Min="0" Max="127" Preset="RotationIndexed">gobo indexing</Capability>
-  <Capability Min="128" Max="189" Preset="RotationClockwiseFastToSlow">clockwise gobo rotation fast to slow</Capability>
-  <Capability Min="190" Max="193" Preset="RotationStop">no rotation</Capability>
-  <Capability Min="194" Max="255" Preset="RotationCounterClockwiseSlowToFast">counterclockwise gobo rotation from slow to fast</Capability>
+  <Capability Min="0" Max="127" Preset="RotationIndexed">Gobo indexing</Capability>
+  <Capability Min="128" Max="189" Preset="RotationClockwiseFastToSlow">Clockwise gobo rotation fast to slow</Capability>
+  <Capability Min="190" Max="193" Preset="RotationStop">No rotation</Capability>
+  <Capability Min="194" Max="255" Preset="RotationCounterClockwiseSlowToFast">Counterclockwise gobo rotation from slow to fast</Capability>
  </Channel>
  <Channel Name="Trapezoid 3-Facet Rotating Prism Fine Index Rotation">
   <Group Byte="1">Prism</Group>
-  <Capability Min="0" Max="255">prism fine rotation</Capability>
+  <Capability Min="0" Max="255">Prism fine rotation</Capability>
  </Channel>
  <Channel Name="Focus" Preset="BeamFocusFarNear"/>
  <Channel Name="Shutter Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="31" Preset="ShutterClose">shutter closed</Capability>
-  <Capability Min="32" Max="63" Preset="ShutterOpen">no func shutter open</Capability>
-  <Capability Min="64" Max="95" Preset="StrobeSlowToFast">strobe effect slow to fast</Capability>
-  <Capability Min="96" Max="127" Preset="ShutterOpen">no function shutter open</Capability>
-  <Capability Min="128" Max="159" Preset="PulseSlowToFast">pulse effect in sequences</Capability>
-  <Capability Min="160" Max="191" Preset="ShutterOpen">no func shutter open</Capability>
-  <Capability Min="192" Max="223" Preset="StrobeRandomSlowToFast">random strobe effect slow to fast</Capability>
-  <Capability Min="224" Max="255" Preset="ShutterOpen">no function shutter open</Capability>
+  <Capability Min="0" Max="31" Preset="ShutterClose">Shutter closed</Capability>
+  <Capability Min="32" Max="63" Preset="ShutterOpen">No func shutter open</Capability>
+  <Capability Min="64" Max="95" Preset="StrobeSlowToFast">Strobe effect slow to fast</Capability>
+  <Capability Min="96" Max="127" Preset="ShutterOpen">No function shutter open</Capability>
+  <Capability Min="128" Max="159" Preset="PulseSlowToFast">Pulse effect in sequences</Capability>
+  <Capability Min="160" Max="191" Preset="ShutterOpen">No func shutter open</Capability>
+  <Capability Min="192" Max="223" Preset="StrobeRandomSlowToFast">Random strobe effect slow to fast</Capability>
+  <Capability Min="224" Max="255" Preset="ShutterOpen">No function shutter open</Capability>
  </Channel>
  <Mode Name="Basic">
   <Channel Number="0">Pan Movement</Channel>
@@ -168,7 +168,7 @@
   <Channel Number="8">Shutter Strobe</Channel>
   <Channel Number="9">Dimmer intensity</Channel>
   <Channel Number="10">Dimming Mode</Channel>
-  <Channel Number="11">iris</Channel>
+  <Channel Number="11">Iris</Channel>
   <Channel Number="12">Pan/Tilt Speed</Channel>
   <Channel Number="13">Special Functions</Channel>
  </Mode>
@@ -186,7 +186,7 @@
   <Channel Number="10">Shutter Strobe</Channel>
   <Channel Number="11">Dimmer intensity</Channel>
   <Channel Number="12">Dimming Mode</Channel>
-  <Channel Number="13">iris</Channel>
+  <Channel Number="13">Iris</Channel>
   <Channel Number="14">Pan/Tilt Speed</Channel>
   <Channel Number="15">Special Functions</Channel>
  </Mode>
@@ -208,7 +208,7 @@
   <Channel Number="14">Dimmer intensity</Channel>
   <Channel Number="15">Dimmer Intensity Fine</Channel>
   <Channel Number="16">Dimming Mode</Channel>
-  <Channel Number="17">iris</Channel>
+  <Channel Number="17">Iris</Channel>
   <Channel Number="18">Pan/Tilt Speed</Channel>
   <Channel Number="19">Special Functions</Channel>
  </Mode>

--- a/resources/fixtures/Elation/Elation-Proteus-Hybrid.qxf
+++ b/resources/fixtures/Elation/Elation-Proteus-Hybrid.qxf
@@ -22,7 +22,7 @@
  <Channel Name="CTO Color" Preset="ColorCTOMixer"/>
  <Channel Name="CTO Color Fine (16bit)">
   <Group Byte="1">Colour</Group>
-  <Capability Min="0" Max="255" Preset="ColorMacro">CTO Fine Adjustement</Capability>
+  <Capability Min="0" Max="255">CTO Fine Adjustement</Capability>
  </Channel>
  <Channel Name="Color Wheel">
   <Group Byte="0">Colour</Group>
@@ -191,34 +191,34 @@
  <Channel Name="CMY Macros">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="31" Preset="ColorMacro" Res1="#ffffff">Off</Capability>
-  <Capability Min="32" Max="39" Preset="ColorMacro">Macro 01</Capability>
-  <Capability Min="40" Max="47" Preset="ColorMacro">Macro 02</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro">Macro 03</Capability>
-  <Capability Min="56" Max="63" Preset="ColorMacro">Macro 04</Capability>
-  <Capability Min="64" Max="71" Preset="ColorMacro">Macro 05</Capability>
-  <Capability Min="72" Max="79" Preset="ColorMacro">Macro 06</Capability>
-  <Capability Min="80" Max="87" Preset="ColorMacro">Macro 07</Capability>
-  <Capability Min="88" Max="95" Preset="ColorMacro">Macro 08</Capability>
-  <Capability Min="96" Max="103" Preset="ColorMacro">Macro 09</Capability>
-  <Capability Min="104" Max="111" Preset="ColorMacro">Macro 10</Capability>
-  <Capability Min="112" Max="119" Preset="ColorMacro">Macro 11</Capability>
-  <Capability Min="120" Max="127" Preset="ColorMacro">Macro 12</Capability>
-  <Capability Min="128" Max="135" Preset="ColorMacro">Macro 13</Capability>
-  <Capability Min="136" Max="143" Preset="ColorMacro">Macro 14</Capability>
-  <Capability Min="144" Max="151" Preset="ColorMacro">Macro 15</Capability>
-  <Capability Min="152" Max="159" Preset="ColorMacro">Macro 16</Capability>
-  <Capability Min="160" Max="167" Preset="ColorMacro">Macro 17</Capability>
-  <Capability Min="168" Max="175" Preset="ColorMacro">Macro 18</Capability>
-  <Capability Min="176" Max="183" Preset="ColorMacro">Macro 19</Capability>
-  <Capability Min="184" Max="191" Preset="ColorMacro">Macro 20</Capability>
-  <Capability Min="192" Max="199" Preset="ColorMacro">Macro 21</Capability>
-  <Capability Min="200" Max="207" Preset="ColorMacro">Macro 22</Capability>
-  <Capability Min="208" Max="215" Preset="ColorMacro">Macro 23</Capability>
-  <Capability Min="216" Max="223" Preset="ColorMacro">Macro 24</Capability>
-  <Capability Min="224" Max="231" Preset="ColorMacro">Macro 25</Capability>
-  <Capability Min="232" Max="239" Preset="ColorMacro">Macro 26</Capability>
-  <Capability Min="240" Max="247" Preset="ColorMacro">Macro 27</Capability>
-  <Capability Min="248" Max="255" Preset="ColorMacro">Random CMY</Capability>
+  <Capability Min="32" Max="39">Macro 01</Capability>
+  <Capability Min="40" Max="47">Macro 02</Capability>
+  <Capability Min="48" Max="55">Macro 03</Capability>
+  <Capability Min="56" Max="63">Macro 04</Capability>
+  <Capability Min="64" Max="71">Macro 05</Capability>
+  <Capability Min="72" Max="79">Macro 06</Capability>
+  <Capability Min="80" Max="87">Macro 07</Capability>
+  <Capability Min="88" Max="95">Macro 08</Capability>
+  <Capability Min="96" Max="103">Macro 09</Capability>
+  <Capability Min="104" Max="111">Macro 10</Capability>
+  <Capability Min="112" Max="119">Macro 11</Capability>
+  <Capability Min="120" Max="127">Macro 12</Capability>
+  <Capability Min="128" Max="135">Macro 13</Capability>
+  <Capability Min="136" Max="143">Macro 14</Capability>
+  <Capability Min="144" Max="151">Macro 15</Capability>
+  <Capability Min="152" Max="159">Macro 16</Capability>
+  <Capability Min="160" Max="167">Macro 17</Capability>
+  <Capability Min="168" Max="175">Macro 18</Capability>
+  <Capability Min="176" Max="183">Macro 19</Capability>
+  <Capability Min="184" Max="191">Macro 20</Capability>
+  <Capability Min="192" Max="199">Macro 21</Capability>
+  <Capability Min="200" Max="207">Macro 22</Capability>
+  <Capability Min="208" Max="215">Macro 23</Capability>
+  <Capability Min="216" Max="223">Macro 24</Capability>
+  <Capability Min="224" Max="231">Macro 25</Capability>
+  <Capability Min="232" Max="239">Macro 26</Capability>
+  <Capability Min="240" Max="247">Macro 27</Capability>
+  <Capability Min="248" Max="255">Random CMY</Capability>
  </Channel>
  <Channel Name="Pan/Tilt Movement Speed">
   <Group Byte="0">Speed</Group>

--- a/resources/fixtures/Elation/Elation-Proteus-Hybrid.qxf
+++ b/resources/fixtures/Elation/Elation-Proteus-Hybrid.qxf
@@ -29,15 +29,15 @@
   <Capability Min="0" Max="15" Preset="ColorMacro" Res1="#ffffff">Open/White</Capability>
   <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
+  <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#aa00ff">Purple</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00aa7f">Aqua</Capability>
-  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
-  <Capability Min="72" Max="79" Preset="ColorMacro" Res1="#ffaaff">Light Pink</Capability>
-  <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#55ff00">Lime Green</Capability>
-  <Capability Min="88" Max="95" Preset="ColorMacro" Res1="#ffff7f">Light Yellow</Capability>
-  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#ff007f">Magenta</Capability>
+  <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="72" Max="79" Preset="ColorMacro" Res1="#ffb6c1">Light Pink</Capability>
+  <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#32cd32">Lime Green</Capability>
+  <Capability Min="88" Max="95" Preset="ColorMacro" Res1="#ffffe0">Light Yellow</Capability>
+  <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="104" Max="111" Preset="ColorMacro" Res1="#aaffff">CTB</Capability>
   <Capability Min="112" Max="119" Preset="ColorMacro" Res1="#ffaa7f">CTO</Capability>
   <Capability Min="120" Max="127" Preset="ColorMacro" Res1="#55007f">UV</Capability>

--- a/resources/fixtures/Eliminator_Lighting/Eliminator-Lighting-Follow-Spot-100-LED.qxf
+++ b/resources/fixtures/Eliminator_Lighting/Eliminator-Lighting-Follow-Spot-100-LED.qxf
@@ -16,7 +16,7 @@
   <Capability Min="64" Max="95" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="96" Max="127" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="128" Max="159" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="160" Max="191" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="160" Max="191" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="192" Max="223" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="224" Max="255" Preset="ColorMacro" Res1="#aaaaff">Lavender</Capability>
  </Channel>

--- a/resources/fixtures/Eurolite/Eurolite-LED-FE-700.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-FE-700.qxf
@@ -17,26 +17,26 @@
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#ffb500">Amber</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="70" Max="79" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00ff00">Red &amp; Green</Capability>
   <Capability Min="80" Max="89" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#0000ff">Green &amp; Blue</Capability>
   <Capability Min="90" Max="99" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Blue &amp; White</Capability>
   <Capability Min="100" Max="109" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffb400">White &amp; Amber</Capability>
-  <Capability Min="110" Max="119" Preset="ColorDoubleMacro" Res1="#ffb400" Res2="#ff00ff">Amber &amp; Pink</Capability>
-  <Capability Min="120" Max="129" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ff00ff">Red &amp; Pink</Capability>
+  <Capability Min="110" Max="119" Preset="ColorDoubleMacro" Res1="#ffb400" Res2="#ff00ff">Amber &amp; Magenta</Capability>
+  <Capability Min="120" Max="129" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ff00ff">Red &amp; Magenta</Capability>
   <Capability Min="130" Max="139" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffb400">Green &amp; Amber</Capability>
   <Capability Min="140" Max="149">Red &amp; Green &amp; Blue</Capability>
   <Capability Min="150" Max="159">Red &amp; Green &amp; Amber</Capability>
-  <Capability Min="160" Max="169">Red &amp; Green &amp; Pink</Capability>
-  <Capability Min="170" Max="179">Red &amp; Blue &amp; Pink</Capability>
-  <Capability Min="180" Max="189">Blue &amp; White &amp; Pink</Capability>
+  <Capability Min="160" Max="169">Red &amp; Green &amp; Magenta</Capability>
+  <Capability Min="170" Max="179">Red &amp; Blue &amp; Magenta</Capability>
+  <Capability Min="180" Max="189">Blue &amp; White &amp; Magenta</Capability>
   <Capability Min="190" Max="199">Blue &amp; White &amp; Amber</Capability>
   <Capability Min="200" Max="209">Green &amp; Blue &amp; White</Capability>
   <Capability Min="210" Max="219">Green &amp; Blue &amp; Amber</Capability>
   <Capability Min="220" Max="229">Red &amp; Blue &amp; White</Capability>
   <Capability Min="230" Max="239">Red &amp; Blue &amp; Amber</Capability>
   <Capability Min="240" Max="249">Red &amp; White &amp; Amber</Capability>
-  <Capability Min="250" Max="255">Green &amp; White &amp; Pink</Capability>
+  <Capability Min="250" Max="255">Green &amp; White &amp; Magenta</Capability>
  </Channel>
  <Channel Name="Strobe">
   <Group Byte="0">Shutter</Group>

--- a/resources/fixtures/Eurolite/Eurolite-LED-SLS-603.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-SLS-603.qxf
@@ -34,16 +34,17 @@
   <Capability Min="10" Max="29" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="30" Max="49" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="50" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="70" Max="109" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="110" Max="129" Preset="ColorMacro" Res1="ff00ff">Magenta</Capability>
+  <Capability Min="70" Max="89" Preset="ColorMacro" Res1="#460764">UV</Capability>
+  <Capability Min="90" Max="109" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
+  <Capability Min="110" Max="129" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="130" Max="149" Preset="ColorDoubleMacro" Res1="#ff2020" Res2="#460764">Red + UV</Capability>
   <Capability Min="150" Max="169" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="170" Max="189" Preset="ColorDoubleMacro" Res1="#20ff20" Res2="#460764">Green + UV</Capability>
   <Capability Min="190" Max="209" Preset="ColorDoubleMacro" Res1="#2020ff" Res2="#460764">Blue + UV</Capability>
   <Capability Min="210" Max="219" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="220" Max="229" Preset="ColorDoubleMacro" Res1="#ffff20" Res2="#460764">Yellow + UV</Capability>
-  <Capability Min="230" Max="239" Preset="ColorDoubleMacro" Res1="#ff20ff" Res2="#460764">Magenta + UV</Capability>
-  <Capability Min="240" Max="249" Preset="ColorDoubleMacro" Res1="#20ffff" Res2="#460764">Cyan + UV</Capability>
+  <Capability Min="220" Max="229" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#460764">Yellow + UV</Capability>
+  <Capability Min="230" Max="239" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#460764">Magenta + UV</Capability>
+  <Capability Min="240" Max="249" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#460764">Cyan + UV</Capability>
   <Capability Min="250" Max="255" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#460764">White + UV</Capability>
  </Channel>
  <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>

--- a/resources/fixtures/Eurolite/Eurolite-LED-SLS-603.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-SLS-603.qxf
@@ -35,14 +35,14 @@
   <Capability Min="30" Max="49" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="50" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="70" Max="109" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="110" Max="129" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="110" Max="129" Preset="ColorMacro" Res1="ff00ff">Magenta</Capability>
   <Capability Min="130" Max="149" Preset="ColorDoubleMacro" Res1="#ff2020" Res2="#460764">Red + UV</Capability>
   <Capability Min="150" Max="169" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="170" Max="189" Preset="ColorDoubleMacro" Res1="#20ff20" Res2="#460764">Green + UV</Capability>
   <Capability Min="190" Max="209" Preset="ColorDoubleMacro" Res1="#2020ff" Res2="#460764">Blue + UV</Capability>
   <Capability Min="210" Max="219" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="220" Max="229" Preset="ColorDoubleMacro" Res1="#ffff20" Res2="#460764">Yellow + UV</Capability>
-  <Capability Min="230" Max="239" Preset="ColorDoubleMacro" Res1="#ff20ff" Res2="#460764">Purple + UV</Capability>
+  <Capability Min="230" Max="239" Preset="ColorDoubleMacro" Res1="#ff20ff" Res2="#460764">Magenta + UV</Capability>
   <Capability Min="240" Max="249" Preset="ColorDoubleMacro" Res1="#20ffff" Res2="#460764">Cyan + UV</Capability>
   <Capability Min="250" Max="255" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#460764">White + UV</Capability>
  </Channel>

--- a/resources/fixtures/Eurolite/Eurolite-LED-TMH-X10.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-TMH-X10.qxf
@@ -26,21 +26,21 @@
   <Capability Min="0" Max="0" Preset="ColorMacro" Res1="#ffffff">white</Capability>
   <Capability Min="1" Max="9" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff0000">white and red</Capability>
   <Capability Min="10" Max="11" Preset="ColorMacro" Res1="#ff0000">red</Capability>
-  <Capability Min="12" Max="19" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ffaa00">red and orange</Capability>
-  <Capability Min="20" Max="21" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="22" Max="29" Preset="ColorDoubleMacro" Res1="#ffaa00" Res2="#00ff00">Orange and green</Capability>
+  <Capability Min="12" Max="19" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ffa500">red and orange</Capability>
+  <Capability Min="20" Max="21" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="22" Max="29" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange and green</Capability>
   <Capability Min="30" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="32" Max="39" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#00aaff">Green and light blue</Capability>
-  <Capability Min="40" Max="41" Preset="ColorMacro" Res1="#00aaff">Light blue</Capability>
-  <Capability Min="42" Max="49" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#aa55ff">Light blue and purple</Capability>
-  <Capability Min="50" Max="51" Preset="ColorMacro" Res1="#aa55ff">Purple</Capability>
-  <Capability Min="52" Max="59" Preset="ColorDoubleMacro" Res1="#aa55ff" Res2="#ffff00">Purple and yellow</Capability>
+  <Capability Min="32" Max="39" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#add8e6">Green and light blue</Capability>
+  <Capability Min="40" Max="41" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="42" Max="49" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#a020f0">Light blue and purple</Capability>
+  <Capability Min="50" Max="51" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
+  <Capability Min="52" Max="59" Preset="ColorDoubleMacro" Res1="#a020f0" Res2="#ffff00">Purple and yellow</Capability>
   <Capability Min="60" Max="61" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="62" Max="69" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#0000ff">Yellow and blue</Capability>
   <Capability Min="70" Max="71" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffaaff">Blue and pink</Capability>
-  <Capability Min="80" Max="81" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
-  <Capability Min="82" Max="89" Preset="ColorDoubleMacro" Res1="#ffaaff" Res2="#ffffff">Pink and white</Capability>
+  <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffc0cb">Blue and pink</Capability>
+  <Capability Min="80" Max="81" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
+  <Capability Min="82" Max="89" Preset="ColorDoubleMacro" Res1="#ffc0cb" Res2="#ffffff">Pink and white</Capability>
   <Capability Min="90" Max="90" Preset="RotationStop">Stop</Capability>
   <Capability Min="91" Max="255" Preset="RotationClockwiseSlowToFast">Rainbow effect with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Eurolite/Eurolite-TB-250.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-TB-250.qxf
@@ -33,7 +33,7 @@
   <Capability Min="144" Max="161" Preset="ColorMacro" Res1="#2aff2e">Light green</Capability>
   <Capability Min="162" Max="179" Preset="ColorMacro" Res1="#46aeff">Light blue</Capability>
   <Capability Min="180" Max="197" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
-  <Capability Min="198" Max="215" Preset="ColorMacro" Res1="#ffff00">Light yellow</Capability>
+  <Capability Min="198" Max="215" Preset="ColorMacro" Res1="#ffffe0">Light yellow</Capability>
   <Capability Min="216" Max="233" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="234" Max="251" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#0000ff">Red/blue</Capability>
   <Capability Min="252" Max="255" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#00ff00">Yellow/green</Capability>

--- a/resources/fixtures/Eurolite/Eurolite-TMH-10.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-TMH-10.qxf
@@ -15,13 +15,13 @@
  <Channel Name="Colour wheel">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7" Preset="ColorMacro" Res1="#ffffff">Open/white</Capability>
-  <Capability Min="8" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff00ff">White/Purple</Capability>
-  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
-  <Capability Min="24" Max="31" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Purple/green</Capability>
+  <Capability Min="8" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#a020f0">White/Purple</Capability>
+  <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
+  <Capability Min="24" Max="31" Preset="ColorDoubleMacro" Res1="#a020f0" Res2="#00ff00">Purple/green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#00ffff">Green/light blue</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
-  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ffff00">Light blue/yellow</Capability>
+  <Capability Min="40" Max="47" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#add8e6">Green/light blue</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ffff00">Light blue/yellow</Capability>
   <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="72" Max="79" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#005500">Yellow/dark green</Capability>
   <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#005500">Dark green</Capability>

--- a/resources/fixtures/Eurolite/Eurolite-TSL-150.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-TSL-150.qxf
@@ -19,10 +19,10 @@
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#55ffff">Light blue</Capability>
-  <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="80" Max="89" Preset="ColorDoubleMacro" Res1="#ffaa00" Res2="#55ffff">Orange + light blue</Capability>
-  <Capability Min="90" Max="99" Preset="ColorDoubleMacro" Res1="#55ffff" Res2="#ff00ff">Light blue + magenta</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="80" Max="89" Preset="ColorDoubleMacro" Res1="#ffaa00" Res2="#add8e6">Orange + light blue</Capability>
+  <Capability Min="90" Max="99" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ff00ff">Light blue + magenta</Capability>
   <Capability Min="100" Max="109" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#ffff00">Magenta + yellow</Capability>
   <Capability Min="110" Max="119" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#0000ff">Yellow + blue</Capability>
   <Capability Min="120" Max="129" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#00ff00">Blue + green</Capability>

--- a/resources/fixtures/Expolite/Expolite-TourSpot-60.qxf
+++ b/resources/fixtures/Expolite/Expolite-TourSpot-60.qxf
@@ -26,7 +26,7 @@
   <Capability Min="38" Max="56" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="57" Max="75" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="76" Max="94" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="95" Max="113" Preset="ColorMacro" Res1="#ff8c00">Orange</Capability>
+  <Capability Min="95" Max="113" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="114" Max="127" Preset="ColorMacro" Res1="#5500ff">Violet</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow Effect, CW, fast to slow</Capability>
   <Capability Min="192" Max="255">Rainbow Effect, counter CW, slow to fast</Capability>

--- a/resources/fixtures/Fun-Generation/Fun-Generation-PicoWash-40-Pixel-Quad-LED.qxf
+++ b/resources/fixtures/Fun-Generation/Fun-Generation-PicoWash-40-Pixel-Quad-LED.qxf
@@ -45,7 +45,7 @@
   <Capability Min="80" Max="89" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="90" Max="99" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="100" Max="109" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
-  <Capability Min="110" Max="119" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="110" Max="119" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="120" Max="129" Preset="ColorMacro" Res1="#ffffff">All White</Capability>
   <Capability Min="130" Max="139">Empty</Capability>
   <Capability Min="140" Max="149">Programme 1</Capability>

--- a/resources/fixtures/Futurelight/Futurelight-PHW-700.qxf
+++ b/resources/fixtures/Futurelight/Futurelight-PHW-700.qxf
@@ -25,7 +25,7 @@
   <Capability Min="16" Max="31" Preset="ColorMacro" Res1="#7f0000">Deep red</Capability>
   <Capability Min="32" Max="47" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="48" Max="63" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="64" Max="79" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="64" Max="79" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="80" Max="95" Preset="ColorMacro" Res1="#ffbc76">Correction filter 3,200 K</Capability>
   <Capability Min="96" Max="111" Preset="ColorMacro" Res1="#fff1ea">Correction filter 5,600 K</Capability>
   <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#cdffaf">UV filter</Capability>

--- a/resources/fixtures/GLP/GLP-Junior-Scan-1.qxf
+++ b/resources/fixtures/GLP/GLP-Junior-Scan-1.qxf
@@ -18,9 +18,9 @@
   <Capability Min="8" Max="11" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
   <Capability Min="12" Max="15" Preset="ColorDoubleMacro" Res1="#00007f" Res2="#007f00">Half-color 2</Capability>
   <Capability Min="16" Max="19" Preset="ColorMacro" Res1="#007f00">Dark green</Capability>
-  <Capability Min="20" Max="23" Preset="ColorDoubleMacro" Res1="#007f00" Res2="#ffff00">Half-color 3</Capability>
-  <Capability Min="24" Max="27" Preset="ColorMacro" Res1="#ffff00">Light yellow</Capability>
-  <Capability Min="28" Max="31" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#7f7fff">Half-color 4</Capability>
+  <Capability Min="20" Max="23" Preset="ColorDoubleMacro" Res1="#007f00" Res2="#ffffe0">Half-color 3</Capability>
+  <Capability Min="24" Max="27" Preset="ColorMacro" Res1="#ffffe0">Light yellow</Capability>
+  <Capability Min="28" Max="31" Preset="ColorDoubleMacro" Res1="#ffffe0" Res2="#7f7fff">Half-color 4</Capability>
   <Capability Min="32" Max="35" Preset="ColorMacro" Res1="#7f7fff">Bright blue</Capability>
   <Capability Min="36" Max="39" Preset="ColorDoubleMacro" Res1="#7f7fff" Res2="#fad2ff">Half-color 5</Capability>
   <Capability Min="40" Max="43" Preset="ColorMacro" Res1="#fad2ff">Lavender</Capability>

--- a/resources/fixtures/GLP/GLP-Junior-Scan-2.qxf
+++ b/resources/fixtures/GLP/GLP-Junior-Scan-2.qxf
@@ -65,9 +65,9 @@
   <Capability Min="8" Max="11" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
   <Capability Min="12" Max="15" Preset="ColorDoubleMacro" Res1="#00007f" Res2="#007f00">Half-color 2</Capability>
   <Capability Min="16" Max="19" Preset="ColorMacro" Res1="#007f00">Dark green</Capability>
-  <Capability Min="20" Max="23" Preset="ColorDoubleMacro" Res1="#007f00" Res2="#ffff00">Half-color 3</Capability>
-  <Capability Min="24" Max="27" Preset="ColorMacro" Res1="#ffff00">Light yellow</Capability>
-  <Capability Min="28" Max="31" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#7f7fff">Half-color 4</Capability>
+  <Capability Min="20" Max="23" Preset="ColorDoubleMacro" Res1="#007f00" Res2="#ffffe0">Half-color 3</Capability>
+  <Capability Min="24" Max="27" Preset="ColorMacro" Res1="#ffffe0">Light yellow</Capability>
+  <Capability Min="28" Max="31" Preset="ColorDoubleMacro" Res1="#ffffe0" Res2="#7f7fff">Half-color 4</Capability>
   <Capability Min="32" Max="35" Preset="ColorMacro" Res1="#7f7fff">Bright blue</Capability>
   <Capability Min="36" Max="39" Preset="ColorDoubleMacro" Res1="#7f7fff" Res2="#fad2ff">Half-color 5</Capability>
   <Capability Min="40" Max="43" Preset="ColorMacro" Res1="#fad2ff">Lavender</Capability>

--- a/resources/fixtures/GLP/GLP-Volkslicht.qxf
+++ b/resources/fixtures/GLP/GLP-Volkslicht.qxf
@@ -24,7 +24,7 @@
   <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#00ff92">Turquoise</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="64" Max="71" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="72" Max="79" Preset="ColorMacro" Res1="#ff00ff">Lavender</Capability>
+  <Capability Min="72" Max="79" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="80" Max="87" Preset="ColorMacro" Res1="#ff00a1">Mauve</Capability>
   <Capability Min="88" Max="95" Preset="ColorMacro" Res1="#ff008a">Magenta</Capability>
   <Capability Min="96" Max="103" Preset="ColorMacro" Res1="#ff355e">Pink</Capability>

--- a/resources/fixtures/Ghost/Ghost-Venum-12W-RGBW.qxf
+++ b/resources/fixtures/Ghost/Ghost-Venum-12W-RGBW.qxf
@@ -16,7 +16,7 @@
  <Channel Name="Pan/Tilt speed" Preset="SpeedPanTiltFastSlow"/>
  <Channel Name="Color wheel">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="10" Preset="ColorMacro">Open</Capability>
+  <Capability Min="0" Max="10" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
   <Capability Min="11" Max="21" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="22" Max="32" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="33" Max="43" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
@@ -29,7 +29,7 @@
  </Channel>
  <Channel Name="Gobo wheel">
   <Group Byte="0">Gobo</Group>
-  <Capability Min="0" Max="15" Preset="GoboMacro" Res1="">Open</Capability>
+  <Capability Min="0" Max="15" Preset="GoboMacro" Res1="Others/open.svg">Open</Capability>
   <Capability Min="16" Max="31" Preset="GoboMacro" Res1="">Gobo 1</Capability>
   <Capability Min="32" Max="46" Preset="GoboMacro" Res1="">Gobo 2</Capability>
   <Capability Min="47" Max="62" Preset="GoboMacro" Res1="">Gobo 3</Capability>

--- a/resources/fixtures/HQ_Power/HQ-Power-Wash-575.qxf
+++ b/resources/fixtures/HQ_Power/HQ-Power-Wash-575.qxf
@@ -38,7 +38,7 @@
   <Capability Min="64" Max="79" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="80" Max="95" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="96" Max="111" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#ff69b4">Pink</Capability>
+  <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow Back</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow Forward</Capability>
  </Channel>

--- a/resources/fixtures/Involight/Involight-LED-CC60S.qxf
+++ b/resources/fixtures/Involight/Involight-LED-CC60S.qxf
@@ -15,22 +15,22 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="6" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="7" Max="13" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#d70000">Red</Capability>
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#11855b">Kelly</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ffaa7f">Salmon Pink</Capability>
-  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#000080">Dark Blue</Capability>
+  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + Yellow</Capability>
-  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Pink</Capability>
-  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Pink + Green</Capability>
+  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Magenta</Capability>
+  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Magenta + Green</Capability>
   <Capability Min="85" Max="91" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#d70000">Green + Red</Capability>
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#d70000" Res2="#0000ff">Red + Blue</Capability>
   <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#11855b">Blue + Kelly</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#11855b" Res2="#ffaa7f">Kelly + Salmon Pink</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ffaa7f" Res2="#000080">Salmon Pink+ Dark Blue</Capability>
-  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00007f" Res2="#ffffff">Dark Blue + White</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ffaa7f" Res2="#00008b">Salmon Pink+ Dark Blue</Capability>
+  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark Blue + White</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Positive rainbow effect with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Negative rainbow effect with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Involight/Involight-LED-MH50S.qxf
+++ b/resources/fixtures/Involight/Involight-LED-MH50S.qxf
@@ -21,22 +21,22 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="6" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="7" Max="13" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#d7735b">Peachblow</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#00ffff">Blue</Capability>
+  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#11855b">Kelly</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + Yellow</Capability>
-  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Pink</Capability>
-  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Pink + Green</Capability>
+  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Magenta</Capability>
+  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Magenta + Green</Capability>
   <Capability Min="85" Max="91" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#d7735b">Green + Peachblow</Capability>
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#d7735b" Res2="#0000ff">Peachblow + Blue</Capability>
-  <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#11855b">Blue + Kelly</Capability>
+  <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#11855b">Blue + Kelly</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#11855b" Res2="#ff0000">Kelly + Red</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#0000ff">Red + Dark Blue</Capability>
-  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Dark Blue + White</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00008b">Red + Dark Blue</Capability>
+  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark Blue + White</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Positive rainbow effect with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Negative rainbow effect with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Involight/Involight-LED-MH60S.qxf
+++ b/resources/fixtures/Involight/Involight-LED-MH60S.qxf
@@ -21,22 +21,22 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="6" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="7" Max="13" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#d7735b">Peachblow</Capability>
-  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#00ffff">Blue</Capability>
+  <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#11855b">Kelly</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + Yellow</Capability>
-  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Pink</Capability>
-  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Pink + Green</Capability>
+  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + Magenta</Capability>
+  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Magenta + Green</Capability>
   <Capability Min="85" Max="91" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#d7735b">Green + Peachblow</Capability>
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#d7735b" Res2="#0000ff">Peachblow + Blue</Capability>
-  <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#11855b">Blue + Kelly</Capability>
+  <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#11855b">Blue + Kelly</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#11855b" Res2="#ff0000">Kelly + Red</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#0000ff">Red + Dark Blue</Capability>
-  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Dark Blue + White</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00008b">Red + Dark Blue</Capability>
+  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark Blue + White</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Positive rainbow effect with increasing speed</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Negative rainbow effect with increasing speed</Capability>
  </Channel>

--- a/resources/fixtures/Involight/Involight-SBL3000.qxf
+++ b/resources/fixtures/Involight/Involight-SBL3000.qxf
@@ -56,7 +56,7 @@
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#aa55ff">Violet</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ee82ee">Violet</Capability>
   <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="80" Max="89">Pr. 1</Capability>
   <Capability Min="90" Max="99">Pr. 2</Capability>

--- a/resources/fixtures/JB_Systems/JB-Systems-The-WinnerII.qxf
+++ b/resources/fixtures/JB_Systems/JB-Systems-The-WinnerII.qxf
@@ -57,9 +57,9 @@
   <Capability Min="0" Max="0" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="1" Max="10" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#00ff00">White/Green</Capability>
   <Capability Min="11" Max="11" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="12" Max="21" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff7f00">Green/Orange</Capability>
-  <Capability Min="22" Max="22" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="23" Max="32" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#7f7fff">Orange/Light blue</Capability>
+  <Capability Min="12" Max="21" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffa500">Green/Orange</Capability>
+  <Capability Min="22" Max="22" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="23" Max="32" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#7f7fff">Orange/Light blue</Capability>
   <Capability Min="33" Max="33" Preset="ColorMacro" Res1="#7f7fff">Light blue</Capability>
   <Capability Min="34" Max="43" Preset="ColorDoubleMacro" Res1="#7f7fff" Res2="#ffc000">Light blue/Amber</Capability>
   <Capability Min="44" Max="44" Preset="ColorMacro" Res1="#ffc000">Amber</Capability>

--- a/resources/fixtures/Lanta/Lanta-Orion-Link-V2.qxf
+++ b/resources/fixtures/Lanta/Lanta-Orion-Link-V2.qxf
@@ -17,7 +17,7 @@
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="64" Max="71">Program 1</Capability>
   <Capability Min="72" Max="79">Program 2</Capability>

--- a/resources/fixtures/Laserworld/Laserworld-PRO-1600RGB.qxf
+++ b/resources/fixtures/Laserworld/Laserworld-PRO-1600RGB.qxf
@@ -61,8 +61,8 @@
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
-  <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#00ffff">Turquoise</Capability>
+  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="119" Max="169" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow color mixing (static)</Capability>
   <Capability Min="170" Max="220" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow color mixing (moving)</Capability>
   <Capability Min="221" Max="237" Preset="ColorMacro" Res1="#ff0000">Red</Capability>

--- a/resources/fixtures/Laserworld/Laserworld-PRO-800RGB.qxf
+++ b/resources/fixtures/Laserworld/Laserworld-PRO-800RGB.qxf
@@ -60,7 +60,7 @@
   <Capability Min="34" Max="50" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="51" Max="67" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="119" Max="169" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow mixing static</Capability>
   <Capability Min="170" Max="220" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow mixing moving</Capability>

--- a/resources/fixtures/Lumeri/Lumeri-Eco-COB-15.qxf
+++ b/resources/fixtures/Lumeri/Lumeri-Eco-COB-15.qxf
@@ -21,7 +21,7 @@
   <Capability Min="58" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="71" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="72" Max="78" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="79" Max="85" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
+  <Capability Min="79" Max="85" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="86" Max="92" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="93" Max="100" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="101" Max="200">Color Fade</Capability>

--- a/resources/fixtures/Lumeri/Lumeri-Eco-COB-15.qxf
+++ b/resources/fixtures/Lumeri/Lumeri-Eco-COB-15.qxf
@@ -21,7 +21,7 @@
   <Capability Min="58" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="71" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="72" Max="78" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="79" Max="85" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="79" Max="85" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="86" Max="92" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="93" Max="100" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="101" Max="200">Color Fade</Capability>

--- a/resources/fixtures/MARQ/MARQ-Colormax-Par64.qxf
+++ b/resources/fixtures/MARQ/MARQ-Colormax-Par64.qxf
@@ -28,7 +28,7 @@
   <Capability Min="96" Max="115" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="116" Max="135" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="136" Max="155" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
-  <Capability Min="156" Max="175" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="156" Max="175" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="176" Max="195" Preset="ColorMacro" Res1="#00007f">Dark Blue</Capability>
   <Capability Min="196" Max="215" Preset="ColorMacro" Res1="#aaffff">Light Cyan</Capability>
   <Capability Min="216" Max="235" Preset="ColorMacro" Res1="#ffffff">White</Capability>

--- a/resources/fixtures/MARQ/MARQ-Gesture-Spot-300.qxf
+++ b/resources/fixtures/MARQ/MARQ-Gesture-Spot-300.qxf
@@ -104,7 +104,7 @@
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#ff007f">Purple</Capability>
-  <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#ff55ff">Pink</Capability>
   <Capability Min="64" Max="127" Preset="RotationIndexed">Colour Indexing</Capability>

--- a/resources/fixtures/Mac_Mah/Mac-Mah-Mac-Follow-1200.qxf
+++ b/resources/fixtures/Mac_Mah/Mac-Mah-Mac-Follow-1200.qxf
@@ -13,7 +13,7 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="24" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="25" Max="49" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="50" Max="74" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="50" Max="74" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="75" Max="99" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="100" Max="124" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="125" Max="149" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>

--- a/resources/fixtures/Martin/Martin-MAC250-Entour.qxf
+++ b/resources/fixtures/Martin/Martin-MAC250-Entour.qxf
@@ -57,12 +57,12 @@
   <Capability Min="110" Max="110" Preset="ColorMacro" Res1="#ff6600">Orange 306</Capability>
   <Capability Min="111" Max="120" Preset="ColorDoubleMacro" Res1="#ff6600" Res2="#00a837">Orange 306/Dark green</Capability>
   <Capability Min="121" Max="121" Preset="ColorMacro" Res1="#00a837">Dark green</Capability>
-  <Capability Min="122" Max="131" Preset="ColorDoubleMacro" Res1="#00a837" Res2="#9c39b5">Dark green/White</Capability>
+  <Capability Min="122" Max="131" Preset="ColorDoubleMacro" Res1="#00a837" Res2="#9c39b5">Dark green/Purple</Capability>
   <Capability Min="132" Max="132" Preset="ColorMacro" Res1="#9c39b5">Purple 502</Capability>
-  <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res2="#ffffff">White</Capability>
+  <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res2="#ffffff">Purple/White</Capability>
   <Capability Min="143" Max="143" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="144" Max="155" Preset="ColorMacro" Res1="#ffffff">/White</Capability>
-  <Capability Min="156" Max="159" Preset="ColorMacro" Res1="#ffffff">White</Capability>
+  <Capability Min="144" Max="155" Preset="ColorMacro" Res1="#ffffff">White/White (continuous rotation)</Capability>
+  <Capability Min="156" Max="159" Preset="ColorMacro" Res1="#ffffff">White (stepwise positioning  )</Capability>
   <Capability Min="160" Max="163" Preset="ColorMacro" Res1="#fb7c41">CTC</Capability>
   <Capability Min="164" Max="167" Preset="ColorMacro" Res1="#fec600">Yellow 603</Capability>
   <Capability Min="168" Max="171" Preset="ColorMacro" Res1="#009cde">Blue 104</Capability>

--- a/resources/fixtures/Martin/Martin-MAC250-Entour.qxf
+++ b/resources/fixtures/Martin/Martin-MAC250-Entour.qxf
@@ -61,7 +61,7 @@
   <Capability Min="132" Max="132" Preset="ColorMacro" Res1="#9c39b5">Purple 502</Capability>
   <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res2="#ffffff">White</Capability>
   <Capability Min="143" Max="143" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="144" Max="155" Preset="ColorDoubleMacro" Res1="" Res2="#ffffff">/White</Capability>
+  <Capability Min="144" Max="155" Preset="ColorMacro" Res1="#ffffff">/White</Capability>
   <Capability Min="156" Max="159" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="160" Max="163" Preset="ColorMacro" Res1="#fb7c41">CTC</Capability>
   <Capability Min="164" Max="167" Preset="ColorMacro" Res1="#fec600">Yellow 603</Capability>

--- a/resources/fixtures/Martin/Martin-MAC250-Krypton.qxf
+++ b/resources/fixtures/Martin/Martin-MAC250-Krypton.qxf
@@ -59,7 +59,7 @@
   <Capability Min="121" Max="121" Preset="ColorMacro" Res1="#00a837">Dark green</Capability>
   <Capability Min="122" Max="131" Preset="ColorDoubleMacro" Res1="#00a837" Res2="#9c39b5">Dark green/White</Capability>
   <Capability Min="132" Max="132" Preset="ColorMacro" Res1="#9c39b5">Purple 502</Capability>
-  <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res1="#ffffff">White</Capability>
+  <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res2="#ffffff">White</Capability>
   <Capability Min="143" Max="159" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="160" Max="163" Preset="ColorMacro" Res1="#fb7c41">CTC</Capability>
   <Capability Min="164" Max="167" Preset="ColorMacro" Res1="#fec600">Yellow 603</Capability>

--- a/resources/fixtures/Martin/Martin-MAC250-Krypton.qxf
+++ b/resources/fixtures/Martin/Martin-MAC250-Krypton.qxf
@@ -59,10 +59,8 @@
   <Capability Min="121" Max="121" Preset="ColorMacro" Res1="#00a837">Dark green</Capability>
   <Capability Min="122" Max="131" Preset="ColorDoubleMacro" Res1="#00a837" Res2="#9c39b5">Dark green/White</Capability>
   <Capability Min="132" Max="132" Preset="ColorMacro" Res1="#9c39b5">Purple 502</Capability>
-  <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res2="#ffffff">White</Capability>
-  <Capability Min="143" Max="143" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="144" Max="155" Preset="ColorDoubleMacro" Res1="" Res2="#ffffff">/White</Capability>
-  <Capability Min="156" Max="159" Preset="ColorMacro" Res1="#ffffff">White</Capability>
+  <Capability Min="133" Max="142" Preset="ColorDoubleMacro" Res1="#9c39b5" Res1="#ffffff">White</Capability>
+  <Capability Min="143" Max="159" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="160" Max="163" Preset="ColorMacro" Res1="#fb7c41">CTC</Capability>
   <Capability Min="164" Max="167" Preset="ColorMacro" Res1="#fec600">Yellow 603</Capability>
   <Capability Min="168" Max="171" Preset="ColorMacro" Res1="#009cde">Blue 104</Capability>

--- a/resources/fixtures/Martin/Martin-MAC500.qxf
+++ b/resources/fixtures/Martin/Martin-MAC500.qxf
@@ -69,7 +69,7 @@
  <Channel Name="Color2">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="0" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="1" Max="15" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="">White/CTC 3200-4100</Capability>
+  <Capability Min="1" Max="15" Preset="ColorMacro" Res1="#ffffff">White/CTC 3200-4100</Capability>
   <Capability Min="16" Max="16">CTC 3200-4100</Capability>
   <Capability Min="17" Max="31" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffffff">CTC 3200-4100/CTC 3200-5600</Capability>
   <Capability Min="32" Max="32">CTC 3200-5600</Capability>

--- a/resources/fixtures/Martin/Martin-MAC600-NT.qxf
+++ b/resources/fixtures/Martin/Martin-MAC600-NT.qxf
@@ -23,7 +23,7 @@
   <Capability Min="188" Max="207" Preset="ShutterClose">Shutter closed</Capability>
   <Capability Min="208" Max="217" Preset="ResetAll">Reset fixture</Capability>
   <Capability Min="218" Max="227" Preset="ShutterClose">Shutter closed</Capability>
-  <Capability Min="228" Max="237" Preset="ColorMacro">Lamp power on</Capability>
+  <Capability Min="228" Max="237" Preset="LampOn">Lamp power on</Capability>
   <Capability Min="238" Max="247" Preset="ShutterClose">Shutter closed</Capability>
   <Capability Min="248" Max="255" Preset="LampOff">Lamp power off Note: T ≥ 5 seconds</Capability>
  </Channel>

--- a/resources/fixtures/Martin/Martin-MX-10.qxf
+++ b/resources/fixtures/Martin/Martin-MX-10.qxf
@@ -25,7 +25,7 @@
   <Capability Min="203" Max="207" Preset="ShutterOpen">Shutter open</Capability>
   <Capability Min="208" Max="217" Preset="ResetAll">Reset</Capability>
   <Capability Min="218" Max="227" Preset="ShutterOpen">Shutter open</Capability>
-  <Capability Min="228" Max="237" Preset="ColorMacro">Lamp on</Capability>
+  <Capability Min="228" Max="237" Preset="LampOn">Lamp on</Capability>
   <Capability Min="238" Max="247" Preset="ShutterOpen">Shutter open</Capability>
   <Capability Min="248" Max="255" Preset="LampOff">Lamp off</Capability>
  </Channel>

--- a/resources/fixtures/Martin/Martin-Roboscan-Pro-918.qxf
+++ b/resources/fixtures/Martin/Martin-Roboscan-Pro-918.qxf
@@ -27,7 +27,7 @@
   <Capability Min="197" Max="199" Preset="StrobeRandom">Random closing pulse, fast</Capability>
   <Capability Min="200" Max="202" Preset="StrobeRandom">Random closing pulse, slow</Capability>
   <Capability Min="203" Max="207" Preset="ShutterOpen">Shutter open</Capability>
-  <Capability Min="208" Max="217" Preset="ColorDoubleMacro">Reset fixture, see note</Capability>
+  <Capability Min="208" Max="217" Preset="ResetAll">Reset fixture, see note</Capability>
   <Capability Min="218" Max="227" Preset="ShutterOpen">Shutter open</Capability>
   <Capability Min="228" Max="237" Preset="LampOn">Lamp power on</Capability>
   <Capability Min="238" Max="247" Preset="ShutterOpen">Shutter open</Capability>

--- a/resources/fixtures/Martin/Martin-Rush-MH1-Profile.qxf
+++ b/resources/fixtures/Martin/Martin-Rush-MH1-Profile.qxf
@@ -39,7 +39,7 @@
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#ffa000">Orange</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#0000ff">Dark Blue</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#00008b">Dark Blue</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="64" Max="127">Indexing</Capability>
   <Capability Min="128" Max="189" Preset="GoboMacro" Res1="Others/rainbow.png">Scroll CW</Capability>

--- a/resources/fixtures/N-Gear/N-Gear-SP12.qxf
+++ b/resources/fixtures/N-Gear/N-Gear-SP12.qxf
@@ -43,7 +43,7 @@
   <Capability Min="180" Max="189" Preset="ColorMacro" Res1="#ffaaff">Red + Blue + White</Capability>
   <Capability Min="190" Max="199" Preset="ColorMacro" Res1="#aaffff">Green + Blue + White</Capability>
   <Capability Min="200" Max="209" Preset="ColorMacro" Res1="#d9d9d9">Red + Green + Blue</Capability>
-  <Capability Min="210" Max="255" Preset="ColorMacro">ALL</Capability>
+  <Capability Min="210" Max="255" Preset="ColorMacro" Res1="#ffffff">ALL</Capability>
  </Channel>
  <Channel Name="Speed">
   <Group Byte="0">Speed</Group>

--- a/resources/fixtures/N-Gear/N-Gear-SP12.qxf
+++ b/resources/fixtures/N-Gear/N-Gear-SP12.qxf
@@ -26,9 +26,9 @@
  <Channel Name="Sequence">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="39" Preset="ColorMacro" Res1="#ffffff">ALL (Flash Cycle)</Capability>
-  <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ff5500">Red</Capability>
+  <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#0055ff">Blue</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffff00">Red + Green</Capability>
   <Capability Min="80" Max="89" Preset="ColorMacro" Res1="#00ffff">Green + Blue</Capability>
   <Capability Min="90" Max="99" Preset="ColorMacro" Res1="#ff55ff">Red + Blue</Capability>

--- a/resources/fixtures/Pro-Lights/Pro-Lights-StudioCOBPLUSFC.qxf
+++ b/resources/fixtures/Pro-Lights/Pro-Lights-StudioCOBPLUSFC.qxf
@@ -57,7 +57,7 @@
   <Capability Min="101" Max="130" Preset="ColorMacro" Res1="#fffac4">RGB W 5000K ~ 6000K</Capability>
   <Capability Min="131" Max="160" Preset="ColorMacro" Res1="#fffabd">RGB W 6000K ~ 7000K</Capability>
   <Capability Min="161" Max="190" Preset="ColorMacro" Res1="#ffffff">RGB W 7000K ~ 8000K</Capability>
-  <Capability Min="191" Max="220" Preset="ColorDoubleMacro" Res1="#cbfff9">RGB W 8000K ~ 9000K</Capability>
+  <Capability Min="191" Max="220" Preset="ColorMacro" Res1="#cbfff9">RGB W 8000K ~ 9000K</Capability>
   <Capability Min="221" Max="255" Preset="ColorMacro" Res1="#aefff6">RGB W 9000K ~ 10000K</Capability>
  </Channel>
  <Channel Name="Color macro">

--- a/resources/fixtures/Pro-Lights/Pro-Lights-StudioCOBPLUSFC.qxf
+++ b/resources/fixtures/Pro-Lights/Pro-Lights-StudioCOBPLUSFC.qxf
@@ -62,11 +62,11 @@
  </Channel>
  <Channel Name="Color macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="60" Preset="ColorMacro">Auto program 1</Capability>
-  <Capability Min="61" Max="110" Preset="ColorMacro">Auto Program 2</Capability>
-  <Capability Min="111" Max="160" Preset="ColorMacro">Auto Program 3</Capability>
-  <Capability Min="161" Max="210" Preset="ColorMacro">Auto Program 4</Capability>
-  <Capability Min="211" Max="255" Preset="ColorMacro">Auto Program 5</Capability>
+  <Capability Min="0" Max="60">Auto program 1</Capability>
+  <Capability Min="61" Max="110">Auto Program 2</Capability>
+  <Capability Min="111" Max="160">Auto Program 3</Capability>
+  <Capability Min="161" Max="210">Auto Program 4</Capability>
+  <Capability Min="211" Max="255">Auto Program 5</Capability>
  </Channel>
  <Channel Name="Color Macro Speed">
   <Group Byte="0">Speed</Group>

--- a/resources/fixtures/Pro-Lights/Pro-Lights-V200.qxf
+++ b/resources/fixtures/Pro-Lights/Pro-Lights-V200.qxf
@@ -50,9 +50,9 @@
   <Capability Min="75" Max="82" Preset="ColorMacro" Res1="#008000">Deep green</Capability>
   <Capability Min="83" Max="89" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff8000">Green + orange</Capability>
   <Capability Min="90" Max="97" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
-  <Capability Min="98" Max="104" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff8000">Yellow + orange</Capability>
-  <Capability Min="105" Max="112" Preset="ColorMacro" Res1="#ffff00">Yellow 2</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffc0c0">Yellow + pink</Capability>
+  <Capability Min="98" Max="104" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#eeee00">Yellow + orange</Capability>
+  <Capability Min="105" Max="112" Preset="ColorMacro" Res1="#eeee00">Yellow 2</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#eeee00" Res2="#ffc0c0">Yellow + pink</Capability>
   <Capability Min="120" Max="127" Preset="ColorMacro" Res1="#ffc0c0">Pink</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow CW speed</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow CCW speed</Capability>

--- a/resources/fixtures/Pulse/Pulse-LEDBAR-320.qxf
+++ b/resources/fixtures/Pulse/Pulse-LEDBAR-320.qxf
@@ -17,7 +17,7 @@
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="64" Max="71">Program 01</Capability>
   <Capability Min="72" Max="79">Program 02</Capability>

--- a/resources/fixtures/QTX/QTX-MHS-60.qxf
+++ b/resources/fixtures/QTX/QTX-MHS-60.qxf
@@ -14,9 +14,9 @@
   <Capability Min="0" Max="16" Preset="GoboMacro" Res1="Others/open.svg">Open</Capability>
   <Capability Min="17" Max="33" Preset="ColorMacro" Res1="#ff0000">Fire red</Capability>
   <Capability Min="34" Max="49" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="50" Max="66" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
+  <Capability Min="50" Max="66" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
   <Capability Min="67" Max="83" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
-  <Capability Min="84" Max="100" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
+  <Capability Min="84" Max="100" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="101" Max="106" Preset="ColorMacro" Res1="#ff007f">Purple</Capability>
   <Capability Min="107" Max="126" Preset="ColorMacro" Res1="#00007f">Dark blue</Capability>
   <Capability Min="127" Max="192" Preset="GoboMacro" Res1="Others/rainbow.png">Scrolling colour wheel, fast to slow</Capability>

--- a/resources/fixtures/Robe/Robe-ClubSpot-150CT.qxf
+++ b/resources/fixtures/Robe/Robe-ClubSpot-150CT.qxf
@@ -27,7 +27,7 @@
   <Capability Min="10" Max="10" Preset="ColorMacro" Res1="#55ffff">Turquoise</Capability>
   <Capability Min="11" Max="20" Preset="ColorDoubleMacro" Res1="#55ffff" Res2="#ff0000">Turquoise/Red</Capability>
   <Capability Min="21" Max="21" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="22" Max="31" Preset="ColorDoubleMacro" Res1="ff0000#" Res2="#6fcbdc">Red/Cyan</Capability>
+  <Capability Min="22" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#6fcbdc">Red/Cyan</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#6fcbdc">Cyan</Capability>
   <Capability Min="33" Max="41" Preset="ColorDoubleMacro" Res1="#6fcbdc" Res2="#a8ff9b">Cyan/Light Green</Capability>
   <Capability Min="42" Max="42" Preset="ColorMacro" Res1="#a8ff9b">Light Green</Capability>

--- a/resources/fixtures/Robe/Robe-ClubSpot-160CT.qxf
+++ b/resources/fixtures/Robe/Robe-ClubSpot-160CT.qxf
@@ -27,7 +27,7 @@
   <Capability Min="10" Max="10" Preset="ColorMacro" Res1="#55ffff">Turquoise</Capability>
   <Capability Min="11" Max="20" Preset="ColorDoubleMacro" Res1="#55ffff" Res2="#ff0000">Turquoise/Red</Capability>
   <Capability Min="21" Max="21" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="22" Max="31" Preset="ColorDoubleMacro" Res1="ff0000#" Res2="#6fcbdc">Red/Cyan</Capability>
+  <Capability Min="22" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#6fcbdc">Red/Cyan</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#6fcbdc">Cyan</Capability>
   <Capability Min="33" Max="41" Preset="ColorDoubleMacro" Res1="#6fcbdc" Res2="#a8ff9b">Cyan/Light Green</Capability>
   <Capability Min="42" Max="42" Preset="ColorMacro" Res1="#a8ff9b">Light Green</Capability>

--- a/resources/fixtures/Robe/Robe-ColorSpot-250-AT.qxf
+++ b/resources/fixtures/Robe/Robe-ColorSpot-250-AT.qxf
@@ -69,7 +69,7 @@
   <Capability Min="46" Max="46" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="47" Max="57" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#400080">Magenta/UV</Capability>
   <Capability Min="58" Max="58" Preset="ColorMacro" Res1="#400080">UV filter</Capability>
-  <Capability Min="59" Max="69" Preset="ColorDoubleMacro" Res1="400080#" Res2="#ffff00">UV/Yellow</Capability>
+  <Capability Min="59" Max="69" Preset="ColorDoubleMacro" Res1="#400080" Res2="#ffff00">UV/Yellow</Capability>
   <Capability Min="70" Max="70" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="71" Max="80" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#00ff00">Yellow/Green</Capability>
   <Capability Min="81" Max="81" Preset="ColorMacro" Res1="#00ff00">Green</Capability>

--- a/resources/fixtures/Robe/Robe-ColorSpot-700E-AT.qxf
+++ b/resources/fixtures/Robe/Robe-ColorSpot-700E-AT.qxf
@@ -49,9 +49,9 @@
   <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="17" Max="31" Preset="ColorDoubleMacro" Res1="#aa0000" Res2="#0000ff">Deep Red/Deep Blue</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ff7f00">Deep Blue/Orange</Capability>
-  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00ff00">Orange/Green</Capability>
+  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffa500">Deep Blue/Orange</Capability>
+  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange/Green</Capability>
   <Capability Min="64" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="79" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff4000">Green/Light Red</Capability>
   <Capability Min="80" Max="80" Preset="ColorMacro" Res1="#ff4000">Light Red</Capability>
@@ -63,7 +63,7 @@
   <Capability Min="128" Max="129" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="130" Max="137" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="138" Max="145" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="154" Max="163" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="164" Max="171" Preset="ColorMacro" Res1="#ff4000">Light Red</Capability>
   <Capability Min="172" Max="181" Preset="ColorMacro" Res1="#ffcc00">Amber</Capability>

--- a/resources/fixtures/Robe/Robe-ColorWash-1200E-AT.qxf
+++ b/resources/fixtures/Robe/Robe-ColorWash-1200E-AT.qxf
@@ -48,9 +48,9 @@
   <Capability Min="37" Max="37" Preset="ColorMacro" Res1="#0000bf">Deep blue</Capability>
   <Capability Min="38" Max="54" Preset="ColorDoubleMacro" Res1="#0000bf" Res2="#00ff00">Deep blue/Green</Capability>
   <Capability Min="55" Max="55" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="56" Max="72" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff7f00">Green/Orange</Capability>
-  <Capability Min="73" Max="73" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="74" Max="90" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#eaf1ff">6000K/Orange</Capability>
+  <Capability Min="56" Max="72" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffa500">Green/Orange</Capability>
+  <Capability Min="73" Max="73" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="74" Max="90" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#eaf1ff">6000K/Orange</Capability>
   <Capability Min="91" Max="91" Preset="ColorMacro" Res1="#eaf1ff">6000K filter</Capability>
   <Capability Min="92" Max="109" Preset="ColorDoubleMacro" Res1="#eaf1ff" Res2="#dcb48c">6000K/UV</Capability>
   <Capability Min="110" Max="110" Preset="ColorMacro" Res1="#dcb48c">UV filter</Capability>
@@ -59,7 +59,7 @@
   <Capability Min="130" Max="139" Preset="ColorMacro" Res1="#bf0000">Deep red</Capability>
   <Capability Min="140" Max="149" Preset="ColorMacro" Res1="#0000bf">Deep blue</Capability>
   <Capability Min="150" Max="159" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="160" Max="169" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="160" Max="169" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="170" Max="179" Preset="ColorMacro" Res1="#eaf1ff">6000K filter</Capability>
   <Capability Min="180" Max="189" Preset="ColorMacro" Res1="#dcb48c">UV filter</Capability>
   <Capability Min="190" Max="215" Preset="GoboMacro" Res1="Others/rainbow.png">Forwards rainbow effect from fast to slow</Capability>

--- a/resources/fixtures/Robe/Robe-Robin-300E-Beam.qxf
+++ b/resources/fixtures/Robe/Robe-Robin-300E-Beam.qxf
@@ -48,9 +48,9 @@
   <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="17" Max="31" Preset="ColorDoubleMacro" Res1="#aa0000" Res2="#0000ff">Deep Red/Deep Blue</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ff7f00">Deep Blue/Orange</Capability>
-  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00ff00">Orange/Green</Capability>
+  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffa500">Deep Blue/Orange</Capability>
+  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange/Green</Capability>
   <Capability Min="64" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="79" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff4000">Green/3200K</Capability>
   <Capability Min="80" Max="80" Preset="ColorMacro" Res1="#ff4000">3200°K Filter</Capability>
@@ -62,7 +62,7 @@
   <Capability Min="128" Max="129" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="130" Max="137" Preset="ColorMacro" Res1="#aa0000">Deep red - positioning</Capability>
   <Capability Min="138" Max="145" Preset="ColorMacro" Res1="#0000ff">Deep blue - positioning</Capability>
-  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ff7f00">Orange - positioning</Capability>
+  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ffa500">Orange - positioning</Capability>
   <Capability Min="154" Max="163" Preset="ColorMacro" Res1="#00ff00">Green - positioning</Capability>
   <Capability Min="164" Max="171" Preset="ColorMacro" Res1="#ffebd2">3200°K temperature filter - positioning</Capability>
   <Capability Min="172" Max="181" Preset="ColorMacro" Res1="#ffcc00">Amber - positioning</Capability>

--- a/resources/fixtures/Robe/Robe-Robin-600E-Beam.qxf
+++ b/resources/fixtures/Robe/Robe-Robin-600E-Beam.qxf
@@ -49,9 +49,9 @@
   <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="17" Max="31" Preset="ColorDoubleMacro" Res1="#aa0000" Res2="#0000ff">Deep Red/Deep Blue</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ff7f00">Deep Blue/Orange</Capability>
-  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00ff00">Orange/Green</Capability>
+  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffa500">Deep Blue/Orange</Capability>
+  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange/Green</Capability>
   <Capability Min="64" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="79" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff4000">Green/3200K</Capability>
   <Capability Min="80" Max="80" Preset="ColorMacro" Res1="#ff4000">3200°K Filter</Capability>
@@ -63,7 +63,7 @@
   <Capability Min="128" Max="129" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="130" Max="137" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="138" Max="145" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="154" Max="163" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="164" Max="171" Preset="ColorMacro" Res1="#ffebd2">3200°K</Capability>
   <Capability Min="172" Max="181" Preset="ColorMacro" Res1="#ffcc00">Amber</Capability>

--- a/resources/fixtures/Robe/Robe-Robin-600E-Spot.qxf
+++ b/resources/fixtures/Robe/Robe-Robin-600E-Spot.qxf
@@ -49,9 +49,9 @@
   <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="17" Max="31" Preset="ColorDoubleMacro" Res1="#aa0000" Res2="#0000ff">Deep Red/Deep Blue</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ff7f00">Deep Blue/Orange</Capability>
-  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00ff00">Orange/Green</Capability>
+  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffa500">Deep Blue/Orange</Capability>
+  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange/Green</Capability>
   <Capability Min="64" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="79" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff4000">Green/Light Red</Capability>
   <Capability Min="80" Max="80" Preset="ColorMacro" Res1="#ff4000">Light Red</Capability>
@@ -63,7 +63,7 @@
   <Capability Min="128" Max="129" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="130" Max="137" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="138" Max="145" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="154" Max="163" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="164" Max="171" Preset="ColorMacro" Res1="#ff4000">Light Red</Capability>
   <Capability Min="172" Max="181" Preset="ColorMacro" Res1="#ffcc00">Amber</Capability>

--- a/resources/fixtures/Robe/Robe-Robin-600E-Wash.qxf
+++ b/resources/fixtures/Robe/Robe-Robin-600E-Wash.qxf
@@ -48,9 +48,9 @@
   <Capability Min="16" Max="16" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="17" Max="31" Preset="ColorDoubleMacro" Res1="#aa0000" Res2="#0000ff">Deep Red/Deep Blue</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ff7f00">Deep Blue/Orange</Capability>
-  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00ff00">Orange/Green</Capability>
+  <Capability Min="33" Max="47" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffa500">Deep Blue/Orange</Capability>
+  <Capability Min="48" Max="48" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="49" Max="63" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange/Green</Capability>
   <Capability Min="64" Max="64" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="65" Max="79" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff4000">Green/Light Red</Capability>
   <Capability Min="80" Max="80" Preset="ColorMacro" Res1="#ff4000">Light Red</Capability>
@@ -62,7 +62,7 @@
   <Capability Min="128" Max="129" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="130" Max="137" Preset="ColorMacro" Res1="#aa0000">Deep Red</Capability>
   <Capability Min="138" Max="145" Preset="ColorMacro" Res1="#0000ff">Deep Blue</Capability>
-  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="146" Max="153" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="154" Max="163" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="164" Max="171" Preset="ColorMacro" Res1="#ff4000">Light Red</Capability>
   <Capability Min="172" Max="181" Preset="ColorMacro" Res1="#ffcc00">Amber</Capability>

--- a/resources/fixtures/Robe/Robe-Robin-Viva-CMY.qxf
+++ b/resources/fixtures/Robe/Robe-Robin-Viva-CMY.qxf
@@ -78,73 +78,73 @@
  <Channel Name="Yellow" Preset="IntensityYellow"/>
  <Channel Name="Virtual colour wheel">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="0">No function (0=default)</Capability>
-  <Capability Min="1" Max="2">LEE 4 (Medium Bastard Amber)</Capability>
-  <Capability Min="3" Max="4">LEE 10 (Medium Yellow)</Capability>
-  <Capability Min="5" Max="6">LEE 19 (Fire)</Capability>
-  <Capability Min="7" Max="8">LEE 24 (Scarlet)</Capability>
-  <Capability Min="9" Max="10">LEE 58 (Lavender)</Capability>
-  <Capability Min="11" Max="12">LEE 68 (Sky Blue)</Capability>
-  <Capability Min="13" Max="14">LEE 71 (Tokyo Blue)</Capability>
-  <Capability Min="15" Max="16">LEE 79 (Just Blue)</Capability>
-  <Capability Min="17" Max="18">LEE 88 (Lime Green)</Capability>
-  <Capability Min="19" Max="20">LEE 90 (Dark Yellow Green)</Capability>
-  <Capability Min="21" Max="22">LEE 100 (Spring Yellow)</Capability>
-  <Capability Min="23" Max="24">LEE 101 (Yellow)</Capability>
-  <Capability Min="25" Max="26">LEE 102 (Light Amber)</Capability>
-  <Capability Min="27" Max="28">LEE 103 (Straw)</Capability>
-  <Capability Min="29" Max="30">Lee 104 (Deep Amber)</Capability>
-  <Capability Min="31" Max="32">LEE 105 (Orange)</Capability>
-  <Capability Min="33" Max="34">LEE 781 (Terry Red)</Capability>
-  <Capability Min="35" Max="36">LEE 111 (Dark Pink)</Capability>
-  <Capability Min="37" Max="38">LEE 115 (Peacock Blue)</Capability>
-  <Capability Min="39" Max="40">LEE 505 (Sally Green)</Capability>
-  <Capability Min="41" Max="42">LEE 117 (Steel Blue)</Capability>
-  <Capability Min="43" Max="44">LEE 118 (Light Blue)</Capability>
-  <Capability Min="45" Max="46">LEE 724 (Ocean Blue)</Capability>
-  <Capability Min="47" Max="48">LEE 725 (Old Steel Blue</Capability>
-  <Capability Min="49" Max="50">LEE 121 (LEE Green)</Capability>
-  <Capability Min="51" Max="52">LEE 128 (Bright Pink)</Capability>
-  <Capability Min="53" Max="54">LEE 131 (Marine Blue)</Capability>
-  <Capability Min="55" Max="56">LEE 132 (Medium Blue)</Capability>
-  <Capability Min="57" Max="58">LEE 134 (Golden Amber)</Capability>
-  <Capability Min="59" Max="60">LEE 135 (Deep Golden Amber)</Capability>
-  <Capability Min="61" Max="62">LEE 136 (Pale Lavender)</Capability>
-  <Capability Min="63" Max="64">LEE 137 (Special Lavender)</Capability>
-  <Capability Min="65" Max="66">LEE 138 (Pale Green)</Capability>
-  <Capability Min="67" Max="68">LEE 139 (Primary Green)</Capability>
-  <Capability Min="69" Max="70">LEE 141 (Bright Blue)</Capability>
-  <Capability Min="71" Max="72">LEE 147 (Apricot)</Capability>
-  <Capability Min="73" Max="74">LEE 148 (Bright Rose)</Capability>
-  <Capability Min="75" Max="76">LEE 152 (Pale Gold)</Capability>
-  <Capability Min="77" Max="78">LEE 154 (Pale Rose)</Capability>
-  <Capability Min="79" Max="80">LEE 157 (Pink)</Capability>
-  <Capability Min="81" Max="82">LEE 158 (Deep Orange)</Capability>
-  <Capability Min="83" Max="84">LEE 162 (Bastard Amber)</Capability>
-  <Capability Min="85" Max="86">LEE 164 (Flame Red)</Capability>
-  <Capability Min="87" Max="88">LEE 165 (Daylight Blue)</Capability>
-  <Capability Min="89" Max="90">LEE 169 (Lilac Tint)</Capability>
-  <Capability Min="91" Max="92">LEE 170 (Deep Lavender)</Capability>
-  <Capability Min="93" Max="94">LEE 172 (Lagoon Blue)</Capability>
-  <Capability Min="95" Max="96">LEE 179 (Chrome Orange)</Capability>
-  <Capability Min="97" Max="98">LEE 180 (Dark Lavender)</Capability>
-  <Capability Min="99" Max="100">LEE 181 (Congo Blue)</Capability>
-  <Capability Min="101" Max="102">LEE 197 (Alice Blue)</Capability>
-  <Capability Min="103" Max="104">LEE 201 (Full C.T. Blue)</Capability>
-  <Capability Min="105" Max="106">LEE 202 (Half C.T. Blue)</Capability>
-  <Capability Min="107" Max="108">LEE 203 (Quarter C.T. Blue)</Capability>
-  <Capability Min="109" Max="110">LEE 204 (Full C.T. Orange)</Capability>
-  <Capability Min="111" Max="112">LEE 205 (Half C.T. Orange)</Capability>
-  <Capability Min="113" Max="114">LEE 206 (Quarter C.T. Orange)</Capability>
-  <Capability Min="115" Max="116">LEE 247 (LEE Minus Green)</Capability>
-  <Capability Min="117" Max="118">LEE 248 (Half Minus Green)</Capability>
-  <Capability Min="119" Max="120">LEE 281 (Three Quarter C.T. Blue)</Capability>
-  <Capability Min="121" Max="122">LEE 285 (Three Quarter C.T. Orange)</Capability>
-  <Capability Min="123" Max="124">LEE 352 (Glacier Blue)</Capability>
-  <Capability Min="125" Max="126">LEE 353 (Lighter Blue)</Capability>
-  <Capability Min="127" Max="128">LEE 715 (Cabana Blue)</Capability>
-  <Capability Min="129" Max="130">LEE 778 (Millennium Gold)</Capability>
-  <Capability Min="131" Max="132">LEE 328 (Follies Pink)</Capability>
+  <Capability Min="0" Max="0" Preset="ColorMacro" Res1="#ffffff">No function (0=default)</Capability>
+  <Capability Min="1" Max="2" Preset="ColorMacro" Res1="#ffc8b4">LEE 004 (Medium Bastard Amber)</Capability>
+  <Capability Min="3" Max="4" Preset="ColorMacro" Res1="#000000">LEE 010 (Medium Yellow)</Capability>
+  <Capability Min="5" Max="6" Preset="ColorMacro" Res1="#ff4600">LEE 019 (Fire)</Capability>
+  <Capability Min="7" Max="8" Preset="ColorMacro" Res1="#ff5a64">LEE 024 (Scarlet)</Capability>
+  <Capability Min="9" Max="10" Preset="ColorMacro" Res1="#b46ef0">LEE 058 (Lavender)</Capability>
+  <Capability Min="11" Max="12" Preset="ColorMacro" Res1="#46b4f0">LEE 068 (Sky Blue)</Capability>
+  <Capability Min="13" Max="14" Preset="ColorMacro" Res1="#0000b4">LEE 071 (Tokyo Blue)</Capability>
+  <Capability Min="15" Max="16" Preset="ColorMacro" Res1="#3c8cd2">LEE 079 (Just Blue)</Capability>
+  <Capability Min="17" Max="18" Preset="ColorMacro" Res1="#dcff64">LEE 088 (Lime Green)</Capability>
+  <Capability Min="19" Max="20" Preset="ColorMacro" Res1="#00be00">LEE 090 (Dark Yellow Green)</Capability>
+  <Capability Min="21" Max="22" Preset="ColorMacro" Res1="#f5ff00">LEE 100 (Spring Yellow)</Capability>
+  <Capability Min="23" Max="24" Preset="ColorMacro" Res1="#fff500">LEE 101 (Yellow)</Capability>
+  <Capability Min="25" Max="26" Preset="ColorMacro" Res1="#ffdc5f">LEE 102 (Light Amber)</Capability>
+  <Capability Min="27" Max="28" Preset="ColorMacro" Res1="#fceacc">LEE 103 (Straw)</Capability>
+  <Capability Min="29" Max="30" Preset="ColorMacro" Res1="#ffdc00">Lee 104 (Deep Amber)</Capability>
+  <Capability Min="31" Max="32" Preset="ColorMacro" Res1="#ffa000">LEE 105 (Orange)</Capability>
+  <Capability Min="33" Max="34" Preset="ColorMacro" Res1="#ff5000">LEE 781 (Terry Red)</Capability>
+  <Capability Min="35" Max="36" Preset="ColorMacro" Res1="#ff8cbe">LEE 111 (Dark Pink)</Capability>
+  <Capability Min="37" Max="38" Preset="ColorMacro" Res1="#00ebc8">LEE 115 (Peacock Blue)</Capability>
+  <Capability Min="39" Max="40" Preset="ColorMacro" Res1="#e3ff5a">LEE 505 (Sally Green)</Capability>
+  <Capability Min="41" Max="42" Preset="ColorMacro" Res1="#b4faf5">LEE 117 (Steel Blue)</Capability>
+  <Capability Min="43" Max="44" Preset="ColorMacro" Res1="#00e1eb">LEE 118 (Light Blue)</Capability>
+  <Capability Min="45" Max="46" Preset="ColorMacro" Res1="#69e1eb">LEE 724 (Ocean Blue)</Capability>
+  <Capability Min="47" Max="48" Preset="ColorMacro" Res1="#bef2f3">LEE 725 (Old Steel Blue</Capability>
+  <Capability Min="49" Max="50" Preset="ColorMacro" Res1="#b4ff64">LEE 121 (LEE Green)</Capability>
+  <Capability Min="51" Max="52" Preset="ColorMacro" Res1="#ff50b4">LEE 128 (Bright Pink)</Capability>
+  <Capability Min="53" Max="54" Preset="ColorMacro" Res1="#64fad2">LEE 131 (Marine Blue)</Capability>
+  <Capability Min="55" Max="56" Preset="ColorMacro" Res1="#00a0dc">LEE 132 (Medium Blue)</Capability>
+  <Capability Min="57" Max="58" Preset="ColorMacro" Res1="#faa873">LEE 134 (Golden Amber)</Capability>
+  <Capability Min="59" Max="60" Preset="ColorMacro" Res1="#ff5f00">LEE 135 (Deep Golden Amber)</Capability>
+  <Capability Min="61" Max="62" Preset="ColorMacro" Res1="#f0bee6">LEE 136 (Pale Lavender)</Capability>
+  <Capability Min="63" Max="64" Preset="ColorMacro" Res1="#c8b4e6">LEE 137 (Special Lavender)</Capability>
+  <Capability Min="65" Max="66" Preset="ColorMacro" Res1="#dcffa0">LEE 138 (Pale Green)</Capability>
+  <Capability Min="67" Max="68" Preset="ColorMacro" Res1="#4bc300">LEE 139 (Primary Green)</Capability>
+  <Capability Min="69" Max="70" Preset="ColorMacro" Res1="#00d2e6">LEE 141 (Bright Blue)</Capability>
+  <Capability Min="71" Max="72" Preset="ColorMacro" Res1="#fcb98c">LEE 147 (Apricot)</Capability>
+  <Capability Min="73" Max="74" Preset="ColorMacro" Res1="#ff507d">LEE 148 (Bright Rose)</Capability>
+  <Capability Min="75" Max="76" Preset="ColorMacro" Res1="#ffd2c1">LEE 152 (Pale Gold)</Capability>
+  <Capability Min="77" Max="78" Preset="ColorMacro" Res1="#ffd5cf">LEE 154 (Pale Rose)</Capability>
+  <Capability Min="79" Max="80" Preset="ColorMacro" Res1="#ff92a3">LEE 157 (Pink)</Capability>
+  <Capability Min="81" Max="82" Preset="ColorMacro" Res1="#ff8700">LEE 158 (Deep Orange)</Capability>
+  <Capability Min="83" Max="84" Preset="ColorMacro" Res1="#fcded8">LEE 162 (Bastard Amber)</Capability>
+  <Capability Min="85" Max="86" Preset="ColorMacro" Res1="#ff3200">LEE 164 (Flame Red)</Capability>
+  <Capability Min="87" Max="88" Preset="ColorMacro" Res1="#5ac8eb">LEE 165 (Daylight Blue)</Capability>
+  <Capability Min="89" Max="90" Preset="ColorMacro" Res1="#fadcf0">LEE 169 (Lilac Tint)</Capability>
+  <Capability Min="91" Max="92" Preset="ColorMacro" Res1="#e6aadc">LEE 170 (Deep Lavender)</Capability>
+  <Capability Min="93" Max="94" Preset="ColorMacro" Res1="#00dcdc">LEE 172 (Lagoon Blue)</Capability>
+  <Capability Min="95" Max="96" Preset="ColorMacro" Res1="#ffbe00">LEE 179 (Chrome Orange)</Capability>
+  <Capability Min="97" Max="98" Preset="ColorMacro" Res1="#a064e6">LEE 180 (Dark Lavender)</Capability>
+  <Capability Min="99" Max="100" Preset="ColorMacro" Res1="#5000aa">LEE 181 (Congo Blue)</Capability>
+  <Capability Min="101" Max="102" Preset="ColorMacro" Res1="#82aae6">LEE 197 (Alice Blue)</Capability>
+  <Capability Min="103" Max="104" Preset="ColorMacro" Res1="#c3e1fa">LEE 201 (Full C.T. Blue)</Capability>
+  <Capability Min="105" Max="106" Preset="ColorMacro" Res1="#d7f0ff">LEE 202 (Half C.T. Blue)</Capability>
+  <Capability Min="107" Max="108" Preset="ColorMacro" Res1="#ebfcff">LEE 203 (Quarter C.T. Blue)</Capability>
+  <Capability Min="109" Max="110" Preset="ColorMacro" Res1="#fac387">LEE 204 (Full C.T. Orange)</Capability>
+  <Capability Min="111" Max="112" Preset="ColorMacro" Res1="#fcd9b1">LEE 205 (Half C.T. Orange)</Capability>
+  <Capability Min="113" Max="114" Preset="ColorMacro" Res1="#fcead6">LEE 206 (Quarter C.T. Orange)</Capability>
+  <Capability Min="115" Max="116" Preset="ColorMacro" Res1="#fac3d7">LEE 247 (LEE Minus Green)</Capability>
+  <Capability Min="117" Max="118" Preset="ColorMacro" Res1="#ffe2e4">LEE 248 (Half Minus Green)</Capability>
+  <Capability Min="119" Max="120" Preset="ColorMacro" Res1="#cde6fa">LEE 281 (Three Quarter C.T. Blue)</Capability>
+  <Capability Min="121" Max="122" Preset="ColorMacro" Res1="#fccd94">LEE 285 (Three Quarter C.T. Orange)</Capability>
+  <Capability Min="123" Max="124" Preset="ColorMacro" Res1="#5ac8e1">LEE 352 (Glacier Blue)</Capability>
+  <Capability Min="125" Max="126" Preset="ColorMacro" Res1="#61e8e3">LEE 353 (Lighter Blue)</Capability>
+  <Capability Min="127" Max="128" Preset="ColorMacro" Res1="#3c6edc">LEE 715 (Cabana Blue)</Capability>
+  <Capability Min="129" Max="130" Preset="ColorMacro" Res1="#ff7600">LEE 778 (Millennium Gold)</Capability>
+  <Capability Min="131" Max="132" Preset="ColorMacro" Res1="#ff64c8">LEE 328 (Follies Pink)</Capability>
   <Capability Min="133" Max="255">Reserved</Capability>
  </Channel>
  <Channel Name="Effect speed">

--- a/resources/fixtures/Robe/Robe-Scan-575-XT.qxf
+++ b/resources/fixtures/Robe/Robe-Scan-575-XT.qxf
@@ -29,9 +29,9 @@
  <Channel Name="Colours">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="0" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="1" Max="9" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#00ff7f">While/Turquoise</Capability>
-  <Capability Min="10" Max="10" Preset="ColorMacro" Res1="#00ff7f">Turquoise</Capability>
-  <Capability Min="11" Max="20" Preset="ColorDoubleMacro" Res1="#00ff7f" Res2="#ff0000">Turquoise/Red</Capability>
+  <Capability Min="1" Max="9" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#40e0d0">While/Turquoise</Capability>
+  <Capability Min="10" Max="10" Preset="ColorMacro" Res1="#40e0d0">Turquoise</Capability>
+  <Capability Min="11" Max="20" Preset="ColorDoubleMacro" Res1="#40e0d0" Res2="#ff0000">Turquoise/Red</Capability>
   <Capability Min="21" Max="21" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="22" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00ffff">Red/Cyan</Capability>
   <Capability Min="32" Max="32" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>

--- a/resources/fixtures/SGM/SGM-Giotto-Spot-250.qxf
+++ b/resources/fixtures/SGM/SGM-Giotto-Spot-250.qxf
@@ -25,7 +25,7 @@
   <Capability Min="150" Max="174" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="175" Max="200" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
   <Capability Min="201" Max="225" Preset="ColorMacro" Res1="#ffc000">Amber</Capability>
-  <Capability Min="226" Max="255" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="226" Max="255" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
  </Channel>
  <Channel Name="Gobo">
   <Group Byte="0">Gobo</Group>

--- a/resources/fixtures/SGM/SGM-Giotto-Spot-400-CMY.qxf
+++ b/resources/fixtures/SGM/SGM-Giotto-Spot-400-CMY.qxf
@@ -20,7 +20,7 @@
   <Capability Min="36" Max="71" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="72" Max="107" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="108" Max="145" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="146" Max="181" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="146" Max="181" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="182" Max="215" Preset="ColorMacro" Res1="#ff8000">Amber</Capability>
   <Capability Min="216" Max="255" Preset="ColorMacro" Res1="#876d2f">Wood</Capability>
  </Channel>

--- a/resources/fixtures/SGM/SGM-Giotto-Wash-400.qxf
+++ b/resources/fixtures/SGM/SGM-Giotto-Wash-400.qxf
@@ -18,7 +18,7 @@
   <Capability Min="0" Max="20" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="21" Max="40" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="41" Max="60" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="61" Max="80" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
+  <Capability Min="61" Max="80" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="81" Max="100" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="101" Max="120" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="121" Max="140" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>

--- a/resources/fixtures/SGM/SGM-Victory-250.qxf
+++ b/resources/fixtures/SGM/SGM-Victory-250.qxf
@@ -19,9 +19,9 @@
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="50" Max="59" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ffff">Magenta + cyan</Capability>
   <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
-  <Capability Min="70" Max="79" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ff7f00">Cyan + orange</Capability>
-  <Capability Min="80" Max="89" Preset="ColorMacro" Res1="#ff7f00">Orange</Capability>
-  <Capability Min="90" Max="99" Preset="ColorDoubleMacro" Res1="#ff7f00" Res2="#00ff00">Orange + green</Capability>
+  <Capability Min="70" Max="79" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ffa500">Cyan + orange</Capability>
+  <Capability Min="80" Max="89" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="90" Max="99" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange + green</Capability>
   <Capability Min="100" Max="109" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="110" Max="119" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#0000ff">Green + blue</Capability>
   <Capability Min="120" Max="129" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>

--- a/resources/fixtures/Sagitter/Sagitter-Slimpar-12DL.qxf
+++ b/resources/fixtures/Sagitter/Sagitter-Slimpar-12DL.qxf
@@ -20,10 +20,10 @@
  <Channel Name="Color Macro / Sound Mode">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="50">No function</Capability>
-  <Capability Min="51" Max="101" Preset="ColorMacro">Color Macro 1 (Fade)
+  <Capability Min="51" Max="101">Color Macro 1 (Fade)
    <Alias Mode="10 Channels Mode" Channel="Color Macro speed" With="Microphone Sensibility"/>
   </Capability>
-  <Capability Min="102" Max="152" Preset="ColorMacro">Color Macro 2 (Color Change)</Capability>
+  <Capability Min="102" Max="152">Color Macro 2 (Color Change)</Capability>
   <Capability Min="153" Max="203" Preset="Alias">Sound Mode 1 (Strobe)
    <Alias Mode="10 Channels Mode" Channel="Color Macro speed" With="Microphone Sensibility"/>
   </Capability>

--- a/resources/fixtures/Showtec/Showtec-Compact-Par-18-MKII.qxf
+++ b/resources/fixtures/Showtec/Showtec-Compact-Par-18-MKII.qxf
@@ -42,7 +42,7 @@
   <Capability Min="92" Max="114" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="115" Max="137" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="138" Max="160" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
-  <Capability Min="161" Max="183" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="161" Max="183" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="184" Max="206" Preset="ColorMacro" Res1="#00007f">Dark Blue</Capability>
   <Capability Min="207" Max="229" Preset="ColorMacro" Res1="#aaff7f">Light Green</Capability>
   <Capability Min="230" Max="252" Preset="ColorMacro" Res1="#ffffff">White</Capability>

--- a/resources/fixtures/Showtec/Showtec-Compact-Power-Lightset-COB.qxf
+++ b/resources/fixtures/Showtec/Showtec-Compact-Power-Lightset-COB.qxf
@@ -17,7 +17,7 @@
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="80" Max="89">Built-in program 1</Capability>
   <Capability Min="90" Max="99">Built-in program 2</Capability>

--- a/resources/fixtures/Showtec/Showtec-Compact-Power-Lightset-COB.qxf
+++ b/resources/fixtures/Showtec/Showtec-Compact-Power-Lightset-COB.qxf
@@ -17,7 +17,7 @@
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="80" Max="89">Built-in program 1</Capability>
   <Capability Min="90" Max="99">Built-in program 2</Capability>

--- a/resources/fixtures/Showtec/Showtec-Giant-XL-LED.qxf
+++ b/resources/fixtures/Showtec/Showtec-Giant-XL-LED.qxf
@@ -18,7 +18,7 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="4" Preset="ColorMacro" Res1="#ffffff">Open / White</Capability>
   <Capability Min="5" Max="9" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="10" Max="14" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="10" Max="14" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="15" Max="19" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="20" Max="24" Preset="ColorMacro" Res1="#ffaa7f">Peach</Capability>
   <Capability Min="25" Max="29" Preset="ColorMacro" Res1="#55aaff">Light Blue</Capability>
@@ -26,8 +26,8 @@
   <Capability Min="35" Max="39" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="40" Max="44" Preset="ColorMacro" Res1="#00007f">Dark Blue</Capability>
   <Capability Min="45" Max="54" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White-&gt;Yellow</Capability>
-  <Capability Min="55" Max="63" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffaaff">Yellow-&gt;Pink</Capability>
-  <Capability Min="64" Max="73" Preset="ColorDoubleMacro" Res1="#ffaaff" Res2="#00ff00">Pink-&gt;Green</Capability>
+  <Capability Min="55" Max="63" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffc0cb">Yellow-&gt;Pink</Capability>
+  <Capability Min="64" Max="73" Preset="ColorDoubleMacro" Res1="#ffc0cb" Res2="#00ff00">Pink-&gt;Green</Capability>
   <Capability Min="74" Max="82" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffaa7f">Green-&gt;Peach</Capability>
   <Capability Min="83" Max="91" Preset="ColorDoubleMacro" Res1="#ffaa7f" Res2="#00aaff">Peach-&gt;Light Blue</Capability>
   <Capability Min="92" Max="100" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#aaff00">Light Blue-&gt;Light Green</Capability>

--- a/resources/fixtures/Showtec/Showtec-Indigo-4500.qxf
+++ b/resources/fixtures/Showtec/Showtec-Indigo-4500.qxf
@@ -23,8 +23,8 @@
   <Capability Min="68" Max="84" Preset="ColorMacro" Res1="#008000">Green</Capability>
   <Capability Min="85" Max="101" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="102" Max="118" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
-  <Capability Min="136" Max="152" Preset="ColorMacro" Res1="#00ff00">Light Green</Capability>
+  <Capability Min="119" Max="135" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="136" Max="152" Preset="ColorMacro" Res1="#90ee90">Light Green</Capability>
   <Capability Min="153" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Reverse (CCW) Rainbow slow to fast</Capability>
  </Channel>
  <Channel Name="Static Gobo">

--- a/resources/fixtures/Showtec/Showtec-Phantom-130-LED-Spot.qxf
+++ b/resources/fixtures/Showtec/Showtec-Phantom-130-LED-Spot.qxf
@@ -140,7 +140,7 @@
   <Capability Min="16" Max="23" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#55ff7f">Light green</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#55ffff">Light blue</Capability>
   <Capability Min="64" Max="83" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff0000">White/red</Capability>

--- a/resources/fixtures/StageTech/StageTech-LeaderScan-Roto.qxf
+++ b/resources/fixtures/StageTech/StageTech-LeaderScan-Roto.qxf
@@ -49,8 +49,8 @@
   <Capability Min="200" Max="210" Preset="ColorMacro" Res1="#e251c8">Pink</Capability>
   <Capability Min="211" Max="221" Preset="ColorDoubleMacro" Res1="#e251c8" Res2="#aaff00">Pink / Light green</Capability>
   <Capability Min="222" Max="232" Preset="ColorMacro" Res1="#aaff00">Light green</Capability>
-  <Capability Min="233" Max="243" Preset="ColorDoubleMacro" Res1="#aaff00" Res2="#ff8c00">Light green / Orange</Capability>
-  <Capability Min="244" Max="250" Preset="ColorMacro" Res1="#ff8c00">Orange</Capability>
+  <Capability Min="233" Max="243" Preset="ColorDoubleMacro" Res1="#aaff00" Res2="#ffa500">Light green / Orange</Capability>
+  <Capability Min="244" Max="250" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="251" Max="253">Rainbow 1</Capability>
   <Capability Min="254" Max="255">Rainbow 2</Capability>
  </Channel>

--- a/resources/fixtures/Stage_Right/Stage-Right-3-Color-LED-Light-Bar.qxf
+++ b/resources/fixtures/Stage_Right/Stage-Right-3-Color-LED-Light-Bar.qxf
@@ -19,7 +19,7 @@
   <Capability Min="24" Max="35" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="36" Max="47" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="48" Max="59" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="60" Max="71" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="60" Max="71" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="72" Max="83" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="84" Max="95" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="96" Max="107">Program 1</Capability>

--- a/resources/fixtures/Stage_Right/Stage-Right-30W-LED-Spot.qxf
+++ b/resources/fixtures/Stage_Right/Stage-Right-30W-LED-Spot.qxf
@@ -19,9 +19,9 @@
  <Channel Name="Color wheel">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="9" Preset="ColorMacro" Res1="#ffffff">Open</Capability>
-  <Capability Min="10" Max="19" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
+  <Capability Min="10" Max="19" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
   <Capability Min="20" Max="29" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
-  <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#aaaaff">Lavender</Capability>
+  <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#e6e6fa">Lavender</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>

--- a/resources/fixtures/Stairville/Stairville-MH-250-S.qxf
+++ b/resources/fixtures/Stairville/Stairville-MH-250-S.qxf
@@ -36,12 +36,12 @@
   <Capability Min="0" Max="12" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="13" Max="25" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="26" Max="38" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="39" Max="51" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
+  <Capability Min="39" Max="51" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
   <Capability Min="52" Max="63" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="64" Max="76" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
   <Capability Min="77" Max="89" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="90" Max="102" Preset="ColorMacro" Res1="#aa00ff">UV purple</Capability>
-  <Capability Min="103" Max="115" Preset="ColorMacro" Res1="#00ff00">Light green</Capability>
+  <Capability Min="103" Max="115" Preset="ColorMacro" Res1="#90ee90">Light green</Capability>
   <Capability Min="116" Max="127" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
   <Capability Min="128" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect slow to fast</Capability>
  </Channel>
@@ -51,9 +51,9 @@
   <Capability Min="8" Max="15" Preset="ColorMacro" Res1="#00aa00">Green</Capability>
   <Capability Min="16" Max="22" Preset="ColorDoubleMacro" Res1="#00aa00" Res2="#ff00ff">Green + Magenta</Capability>
   <Capability Min="23" Max="30" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
-  <Capability Min="31" Max="37" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ffff">Magenta + Light blue</Capability>
-  <Capability Min="38" Max="45" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
-  <Capability Min="46" Max="52" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#ffff00">Light blue + Yellow</Capability>
+  <Capability Min="31" Max="37" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#add8e6">Magenta + Light blue</Capability>
+  <Capability Min="38" Max="45" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="46" Max="52" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ffff00">Light blue + Yellow</Capability>
   <Capability Min="53" Max="60" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="61" Max="67" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffaa00">Yellow + Orange</Capability>
   <Capability Min="68" Max="75" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
@@ -61,8 +61,8 @@
   <Capability Min="83" Max="90" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="91" Max="97" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#aa00ff">Blue + UV purple</Capability>
   <Capability Min="98" Max="105" Preset="ColorMacro" Res1="#aa00ff">UV purple</Capability>
-  <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#aa00ff" Res2="#00ff00">UV purple + Light green</Capability>
-  <Capability Min="113" Max="120" Preset="ColorMacro" Res1="#00ff00">Light green</Capability>
+  <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#aa00ff" Res2="#90ee90">UV purple + Light green</Capability>
+  <Capability Min="113" Max="120" Preset="ColorMacro" Res1="#90ee90">Light green</Capability>
   <Capability Min="121" Max="127" Preset="ColorMacro" Res1="#ffaaff">Pink</Capability>
   <Capability Min="128" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect slow to fast</Capability>
  </Channel>

--- a/resources/fixtures/Stairville/Stairville-MH-X20.qxf
+++ b/resources/fixtures/Stairville/Stairville-MH-X20.qxf
@@ -26,7 +26,7 @@
   <Capability Min="64" Max="79" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="80" Max="95" Preset="ColorMacro" Res1="#55ffff">Light Blue</Capability>
   <Capability Min="96" Max="111" Preset="ColorMacro" Res1="#ff5500">Orange</Capability>
-  <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#000080">Blue</Capability>
+  <Capability Min="112" Max="127" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect in positive roration (speed)</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect in négative roration (speed)</Capability>
  </Channel>

--- a/resources/fixtures/Stairville/Stairville-MH-X25.qxf
+++ b/resources/fixtures/Stairville/Stairville-MH-X25.qxf
@@ -23,19 +23,19 @@
   <Capability Min="5" Max="9" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="10" Max="14" Preset="ColorMacro" Res1="#ff55ff">Pink</Capability>
   <Capability Min="15" Max="19" Preset="ColorMacro" Res1="#55aa00">Green</Capability>
-  <Capability Min="20" Max="24" Preset="ColorMacro" Res1="#ff00ff">Violet</Capability>
+  <Capability Min="20" Max="24" Preset="ColorMacro" Res1="#ee82ee">Violet</Capability>
   <Capability Min="25" Max="29" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="30" Max="34" Preset="ColorMacro" Res1="#00c000">Kelly-green</Capability>
   <Capability Min="35" Max="39" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="40" Max="44" Preset="ColorMacro" Res1="#000080">Dark blue</Capability>
+  <Capability Min="40" Max="44" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="45" Max="56" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White+Yellow</Capability>
   <Capability Min="57" Max="65" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffc0c0">Yellow+Pink</Capability>
   <Capability Min="66" Max="74" Preset="ColorDoubleMacro" Res1="#ffc0c0" Res2="#00ff00">Pink+Green</Capability>
-  <Capability Min="75" Max="83" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ff00ff">Green+Violet</Capability>
-  <Capability Min="84" Max="92" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#0000ff">Violet+Blue</Capability>
+  <Capability Min="75" Max="83" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ee82ee">Green+Violet</Capability>
+  <Capability Min="84" Max="92" Preset="ColorDoubleMacro" Res1="#ee82ee" Res2="#0000ff">Violet+Blue</Capability>
   <Capability Min="93" Max="101" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#00c000">Blue+Kelly-green</Capability>
   <Capability Min="102" Max="110" Preset="ColorDoubleMacro" Res1="#00c000" Res2="#ff0000">Kelly-green+Red</Capability>
-  <Capability Min="111" Max="127" Preset="ColorDoubleMacro" Res1="#000080" Res2="#ffffff">Dark blue+White</Capability>
+  <Capability Min="111" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark blue+White</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect in positive roration (speed)</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect in négative roration (speed)</Capability>
  </Channel>

--- a/resources/fixtures/Stairville/Stairville-MH-X50.qxf
+++ b/resources/fixtures/Stairville/Stairville-MH-X50.qxf
@@ -27,7 +27,7 @@
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="42" Max="48" Preset="ColorMacro" Res1="#00c000">Kelly-green</Capability>
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#000080">Dark blue</Capability>
+  <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White+Yellow</Capability>
   <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffc0c0">Yellow+Pink</Capability>
   <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ffc0c0" Res2="#00ff00">Pink+Green</Capability>
@@ -35,8 +35,8 @@
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#ffa858" Res2="#0000ff">Peachblow+Blue</Capability>
   <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#00c000">Blue+Kelly-green</Capability>
   <Capability Min="106" Max="112" Preset="ColorDoubleMacro" Res1="#00c000" Res2="#ff0000">Kelly-green+Red</Capability>
-  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#000080">Red+Dark blue</Capability>
-  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#000080" Res2="#ffffff">Dark blue+White</Capability>
+  <Capability Min="113" Max="119" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00008b">Red+Dark blue</Capability>
+  <Capability Min="120" Max="127" Preset="ColorDoubleMacro" Res1="#00008b" Res2="#ffffff">Dark blue+White</Capability>
   <Capability Min="128" Max="191" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect in positive roration (speed)</Capability>
   <Capability Min="192" Max="255" Preset="GoboMacro" Res1="Others/rainbow.png">Rainbow effect in négative roration (speed)</Capability>
  </Channel>

--- a/resources/fixtures/Stairville/Stairville-MH-X60th-LED-Spot.qxf
+++ b/resources/fixtures/Stairville/Stairville-MH-X60th-LED-Spot.qxf
@@ -33,7 +33,7 @@
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="6" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="7" Max="13" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="14" Max="20" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="21" Max="27" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="28" Max="34" Preset="ColorMacro" Res1="#d76aed">Peachblow</Capability>
   <Capability Min="35" Max="41" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
@@ -41,8 +41,8 @@
   <Capability Min="49" Max="55" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#00008b">Dark blue</Capability>
   <Capability Min="64" Max="70" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ffff00">White + yellow</Capability>
-  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ff00ff">Yellow + pink</Capability>
-  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ff00ff" Res2="#00ff00">Pink + green</Capability>
+  <Capability Min="71" Max="77" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#ffc0cb">Yellow + pink</Capability>
+  <Capability Min="78" Max="84" Preset="ColorDoubleMacro" Res1="#ffc0cb" Res2="#00ff00">Pink + green</Capability>
   <Capability Min="85" Max="91" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#d76aed">Green + peachblow</Capability>
   <Capability Min="92" Max="98" Preset="ColorDoubleMacro" Res1="#d76aed" Res2="#0000ff">Peachblow + blue</Capability>
   <Capability Min="99" Max="105" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#4cbb17">Blue + kelly-green</Capability>

--- a/resources/fixtures/Stairville/Stairville-MH-x200-Pro-Spot.qxf
+++ b/resources/fixtures/Stairville/Stairville-MH-x200-Pro-Spot.qxf
@@ -23,7 +23,7 @@
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#55ff00">Green</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#00aaff">Light blue</Capability>
-  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#ff0000">Orange Red</Capability>
+  <Capability Min="56" Max="63" Preset="ColorDoubleMacro" Res1="#ff5500" Res2="#ff0000">Orange/Red</Capability>
   <Capability Min="64" Max="66" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="67" Max="78" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#0000ff">Stepwise transition from white to blue</Capability>
   <Capability Min="79" Max="92" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffff00">Stepwise transition from blue to yellow</Capability>

--- a/resources/fixtures/Stairville/Stairville-Mobile-Color.qxf
+++ b/resources/fixtures/Stairville/Stairville-Mobile-Color.qxf
@@ -22,7 +22,7 @@
   <Capability Min="128" Max="143" Preset="ColorMacro" Res1="#4eff6b">Light Green</Capability>
   <Capability Min="144" Max="159" Preset="ColorMacro" Res1="#3374ff">Light Blue</Capability>
   <Capability Min="160" Max="175" Preset="ColorMacro" Res1="#ff6fff">Magenta</Capability>
-  <Capability Min="176" Max="191" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="176" Max="191" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="192" Max="223" Preset="SlowToFast">Rainbow effect, slow -&gt; fast</Capability>
   <Capability Min="224" Max="255" Preset="StrobeSlowToFast">Strobe, slow -&gt; fast</Capability>
  </Channel>

--- a/resources/fixtures/Stairville/Stairville-Quad-Par-Profile-RGBW-5x8W.qxf
+++ b/resources/fixtures/Stairville/Stairville-Quad-Par-Profile-RGBW-5x8W.qxf
@@ -16,35 +16,35 @@
  <Channel Name="White" Preset="IntensityWhite"/>
  <Channel Name="Macro">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="0">manual mode</Capability>
-  <Capability Min="1" Max="24">constant color controled by Ch. 7</Capability>
-  <Capability Min="25" Max="49">automatic show 1</Capability>
-  <Capability Min="50" Max="74">automatic show 2</Capability>
-  <Capability Min="75" Max="99">automatic show 3</Capability>
-  <Capability Min="100" Max="124">automatic show 4</Capability>
-  <Capability Min="125" Max="149">automatic show 5</Capability>
-  <Capability Min="150" Max="174">automatic show 6</Capability>
-  <Capability Min="175" Max="199">automatic show 7</Capability>
-  <Capability Min="200" Max="224">automatic show 8</Capability>
-  <Capability Min="225" Max="249">automatic show 9</Capability>
-  <Capability Min="250" Max="255">sound show</Capability>
+  <Capability Min="0" Max="0">Manual mode</Capability>
+  <Capability Min="1" Max="24">Constant color controled by Ch. 7</Capability>
+  <Capability Min="25" Max="49">Automatic show 1</Capability>
+  <Capability Min="50" Max="74">Automatic show 2</Capability>
+  <Capability Min="75" Max="99">Automatic show 3</Capability>
+  <Capability Min="100" Max="124">Automatic show 4</Capability>
+  <Capability Min="125" Max="149">Automatic show 5</Capability>
+  <Capability Min="150" Max="174">Automatic show 6</Capability>
+  <Capability Min="175" Max="199">Automatic show 7</Capability>
+  <Capability Min="200" Max="224">Automatic show 8</Capability>
+  <Capability Min="225" Max="249">Automatic show 9</Capability>
+  <Capability Min="250" Max="255">Sound show</Capability>
  </Channel>
  <Channel Name="Constant Color/Chasespeed Ch. 6">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="18" Preset="ColorMacro" Res1="#000000">black</Capability>
-  <Capability Min="19" Max="37" Preset="ColorMacro" Res1="#ff0000">red</Capability>
-  <Capability Min="38" Max="56" Preset="ColorMacro" Res1="#ff8600">orange</Capability>
-  <Capability Min="57" Max="75" Preset="ColorMacro" Res1="#ffff14">yellow</Capability>
-  <Capability Min="76" Max="94" Preset="ColorMacro" Res1="#00ff00">green</Capability>
-  <Capability Min="95" Max="113" Preset="ColorMacro" Res1="#5ecdff">light blue</Capability>
-  <Capability Min="114" Max="132" Preset="ColorMacro" Res1="#0000ff">blue</Capability>
-  <Capability Min="133" Max="151" Preset="ColorMacro" Res1="#ff00ff">violet</Capability>
-  <Capability Min="152" Max="170" Preset="ColorMacro" Res1="#ff3270">pink</Capability>
-  <Capability Min="171" Max="189" Preset="ColorMacro" Res1="#ffffff">white</Capability>
-  <Capability Min="190" Max="208" Preset="ColorMacro" Res1="#ffb0b2">red + white</Capability>
-  <Capability Min="209" Max="227" Preset="ColorMacro" Res1="#9dffa8">green + white</Capability>
-  <Capability Min="228" Max="246" Preset="ColorMacro" Res1="#85d0ff">blue + white</Capability>
-  <Capability Min="247" Max="255" Preset="ColorMacro" Res1="#ffffff">red + green + blue + white</Capability>
+  <Capability Min="0" Max="18" Preset="ColorMacro" Res1="#000000">Black</Capability>
+  <Capability Min="19" Max="37" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="38" Max="56" Preset="ColorMacro" Res1="#ff8600">Orange</Capability>
+  <Capability Min="57" Max="75" Preset="ColorMacro" Res1="#ffff14">Yellow</Capability>
+  <Capability Min="76" Max="94" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="95" Max="113" Preset="ColorMacro" Res1="#5ecdff">Light blue</Capability>
+  <Capability Min="114" Max="132" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
+  <Capability Min="133" Max="151" Preset="ColorMacro" Res1="#ee82ee">Violet</Capability>
+  <Capability Min="152" Max="170" Preset="ColorMacro" Res1="#ff3270">Pink</Capability>
+  <Capability Min="171" Max="189" Preset="ColorMacro" Res1="#ffffff">White</Capability>
+  <Capability Min="190" Max="208" Preset="ColorMacro" Res1="#ffb0b2">Red + white</Capability>
+  <Capability Min="209" Max="227" Preset="ColorMacro" Res1="#9dffa8">Green + white</Capability>
+  <Capability Min="228" Max="246" Preset="ColorMacro" Res1="#85d0ff">Blue + white</Capability>
+  <Capability Min="247" Max="255" Preset="ColorMacro" Res1="#ffffff">Red + green + blue + white</Capability>
  </Channel>
  <Channel Name="Strobe" Preset="ShutterStrobeSlowFast"/>
  <Mode Name="4ch">

--- a/resources/fixtures/Stairville/Stairville-TRI-LED-Bundle-Complete.qxf
+++ b/resources/fixtures/Stairville/Stairville-TRI-LED-Bundle-Complete.qxf
@@ -51,7 +51,7 @@
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="80" Max="89">Program01</Capability>
   <Capability Min="90" Max="99">Program02</Capability>

--- a/resources/fixtures/UKing/UKing-LED-Spot-Moving-Head-100W.qxf
+++ b/resources/fixtures/UKing/UKing-LED-Spot-Moving-Head-100W.qxf
@@ -15,7 +15,7 @@
  <Channel Name="Tilt Fine" Preset="PositionTiltFine"/>
  <Channel Name="Color Select">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="9" Preset="ColorMacro">Clear</Capability>
+  <Capability Min="0" Max="9" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="10" Max="19" Preset="ColorMacro" Res1="#fc012f">Red</Capability>
   <Capability Min="20" Max="29" Preset="ColorMacro" Res1="#24ff1e">Green</Capability>
   <Capability Min="30" Max="39" Preset="ColorMacro" Res1="#0e00ff">Blue</Capability>

--- a/resources/fixtures/UKing/UKing-Wall-Washer-24x3W.qxf
+++ b/resources/fixtures/UKing/UKing-Wall-Washer-24x3W.qxf
@@ -18,12 +18,12 @@
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="5">No function</Capability>
   <Capability Min="6" Max="16" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="17" Max="27" Preset="ColorMacro" Res1="#55ff00">Green</Capability>
+  <Capability Min="17" Max="27" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="28" Max="38" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="39" Max="49" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="50" Max="60" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="50" Max="60" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="61" Max="71" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
-  <Capability Min="72" Max="82" Preset="ColorMacro">White</Capability>
+  <Capability Min="72" Max="82" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="83" Max="93">Point-to-Point-1</Capability>
   <Capability Min="94" Max="104">Point-to-Point-2</Capability>
   <Capability Min="105" Max="115">Point-to-Point-3</Capability>

--- a/resources/fixtures/Varytec/Varytec-Hero-Spot-90.qxf
+++ b/resources/fixtures/Varytec/Varytec-Hero-Spot-90.qxf
@@ -58,10 +58,10 @@
   <Capability Min="68" Max="76" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="77" Max="85" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffff00">Blue/Yellow</Capability>
   <Capability Min="86" Max="94" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="95" Max="103" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#00ffff">Yellow/Light Blue</Capability>
-  <Capability Min="104" Max="112" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
-  <Capability Min="113" Max="121" Preset="ColorDoubleMacro" Res1="#00ffff" Res2="#8a2be2">Light Blue/Violet</Capability>
-  <Capability Min="122" Max="130" Preset="ColorMacro" Res1="#8a2be2">Violet</Capability>
+  <Capability Min="95" Max="103" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#add8e6">Yellow/Light Blue</Capability>
+  <Capability Min="104" Max="112" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
+  <Capability Min="113" Max="121" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#ee82ee">Light Blue/Violet</Capability>
+  <Capability Min="122" Max="130" Preset="ColorMacro" Res1="#ee82ee">Violet</Capability>
   <Capability Min="131" Max="139" Preset="ColorMacro" Res1="#ffffff">Open (White)</Capability>
   <Capability Min="140" Max="195" Preset="RotationClockwiseFastToSlow">Rainbow Clockwise</Capability>
   <Capability Min="196" Max="199" Preset="RotationStop">Rotation Stop</Capability>

--- a/resources/fixtures/Varytec/Varytec-Hero-Spot-Wash-140-2in1-RGBW+W.qxf
+++ b/resources/fixtures/Varytec/Varytec-Hero-Spot-Wash-140-2in1-RGBW+W.qxf
@@ -26,18 +26,18 @@
   <Capability Min="0" Max="4" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="5" Max="13" Preset="ColorDoubleMacro" Res1="#ffffff" Res2="#ff0000">White, red</Capability>
   <Capability Min="14" Max="22" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
-  <Capability Min="23" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ffaa00">Red, orange</Capability>
-  <Capability Min="32" Max="40" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="41" Max="49" Preset="ColorDoubleMacro" Res1="#ffaa00" Res2="#00ff00">Orange, green</Capability>
+  <Capability Min="23" Max="31" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ffa500">Red, orange</Capability>
+  <Capability Min="32" Max="40" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="41" Max="49" Preset="ColorDoubleMacro" Res1="#ffa500" Res2="#00ff00">Orange, green</Capability>
   <Capability Min="50" Max="58" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="59" Max="67" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#0000ff">Green, blue</Capability>
   <Capability Min="68" Max="76" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="77" Max="85" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffff00">Blue, yellow</Capability>
   <Capability Min="86" Max="94" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="95" Max="103" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#00aaff">Yellow, light blue</Capability>
-  <Capability Min="104" Max="112" Preset="ColorMacro" Res1="#00aaff">Light blue</Capability>
-  <Capability Min="113" Max="121" Preset="ColorDoubleMacro" Res1="#00aaff" Res2="#aa55ff">Light blue, purple</Capability>
-  <Capability Min="122" Max="130" Preset="ColorMacro" Res1="#aa55ff">Purple</Capability>
+  <Capability Min="95" Max="103" Preset="ColorDoubleMacro" Res1="#ffff00" Res2="#add8e6">Yellow, light blue</Capability>
+  <Capability Min="104" Max="112" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="113" Max="121" Preset="ColorDoubleMacro" Res1="#add8e6" Res2="#a020f0">Light blue, purple</Capability>
+  <Capability Min="122" Max="130" Preset="ColorMacro" Res1="#a020f0">Purple</Capability>
   <Capability Min="131" Max="139" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="140" Max="195" Preset="RotationCounterClockwiseFastToSlow">Counter-clockwise rotation, speed decreasing</Capability>
   <Capability Min="196" Max="199" Preset="RotationStop">Rotation stop</Capability>

--- a/resources/fixtures/Varytec/Varytec-Hero-Spot-Wash-80-2in1-RGBW+W.qxf
+++ b/resources/fixtures/Varytec/Varytec-Hero-Spot-Wash-80-2in1-RGBW+W.qxf
@@ -87,7 +87,7 @@
   <Capability Min="76" Max="100" Preset="ColorMacro" Res1="#aaffff">Light Blue</Capability>
   <Capability Min="101" Max="125" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="126" Max="150" Preset="ColorMacro" Res1="#ffff7f">Amber</Capability>
-  <Capability Min="151" Max="175" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="151" Max="175" Preset="ColorMacro" Res1="#ee82ee">Violet</Capability>
   <Capability Min="176" Max="200" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="201" Max="255" Preset="SlowToFast">Rotating</Capability>
  </Channel>

--- a/resources/fixtures/Varytec/Varytec-Hero-Wash-712-Z-RGBW-Zoom.qxf
+++ b/resources/fixtures/Varytec/Varytec-Hero-Wash-712-Z-RGBW-Zoom.qxf
@@ -32,16 +32,16 @@
  <Channel Name="Colour macros">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="10">No function</Capability>
-  <Capability Min="11" Max="20" Preset="ColorMacro" Res1="#e01b24">Red</Capability>
-  <Capability Min="21" Max="30" Preset="ColorMacro" Res1="#33d17a">Green</Capability>
-  <Capability Min="31" Max="40" Preset="ColorMacro" Res1="#3584e4">Blue</Capability>
+  <Capability Min="11" Max="20" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
+  <Capability Min="21" Max="30" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="31" Max="40" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="41" Max="50" Preset="ColorMacro" Res1="#ffffff">White</Capability>
-  <Capability Min="51" Max="60" Preset="ColorDoubleMacro" Res1="#e01b24" Res2="#ffffff">Red, white</Capability>
-  <Capability Min="61" Max="70" Preset="ColorDoubleMacro" Res1="#33d17a" Res2="#ffffff">Green, white</Capability>
-  <Capability Min="71" Max="80" Preset="ColorDoubleMacro" Res1="#3584e4" Res2="#ffffff">Blue, white</Capability>
-  <Capability Min="81" Max="90" Preset="ColorDoubleMacro" Res1="#e01b24" Res2="#33d17a">Red, green</Capability>
-  <Capability Min="91" Max="100" Preset="ColorDoubleMacro" Res1="#33d17a" Res2="#3584e4">Green, blue</Capability>
-  <Capability Min="101" Max="110" Preset="ColorDoubleMacro" Res1="#e01b24" Res2="#3584e4">Red, blue</Capability>
+  <Capability Min="51" Max="60" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#ffffff">Red, white</Capability>
+  <Capability Min="61" Max="70" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#ffffff">Green, white</Capability>
+  <Capability Min="71" Max="80" Preset="ColorDoubleMacro" Res1="#0000ff" Res2="#ffffff">Blue, white</Capability>
+  <Capability Min="81" Max="90" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#00ff00">Red, green</Capability>
+  <Capability Min="91" Max="100" Preset="ColorDoubleMacro" Res1="#00ff00" Res2="#0000ff">Green, blue</Capability>
+  <Capability Min="101" Max="110" Preset="ColorDoubleMacro" Res1="#ff0000" Res2="#0000ff">Red, blue</Capability>
   <Capability Min="111" Max="120" Preset="ColorDoubleMacro" Res1="#f66151" Res2="#8ff0a4">Red, green, white</Capability>
   <Capability Min="121" Max="130" Preset="ColorDoubleMacro" Res1="#8ff0a4" Res2="#99c1f1">Green, blue, white</Capability>
   <Capability Min="131" Max="140" Preset="ColorDoubleMacro" Res1="#f66151" Res2="#99c1f1">Red, blue, white</Capability>

--- a/resources/fixtures/Varytec/Varytec-Hero-Wash-712-Z-RGBW-Zoom.qxf
+++ b/resources/fixtures/Varytec/Varytec-Hero-Wash-712-Z-RGBW-Zoom.qxf
@@ -27,7 +27,7 @@
  <Channel Name="White" Preset="IntensityWhite"/>
  <Channel Name="Colour temperature">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="255" Preset="ColorMacro">Colour temperature (0 % to 100 %)</Capability>
+  <Capability Min="0" Max="255">Colour temperature (0 % to 100 %)</Capability>
  </Channel>
  <Channel Name="Colour macros">
   <Group Byte="0">Colour</Group>
@@ -45,9 +45,9 @@
   <Capability Min="111" Max="120" Preset="ColorDoubleMacro" Res1="#f66151" Res2="#8ff0a4">Red, green, white</Capability>
   <Capability Min="121" Max="130" Preset="ColorDoubleMacro" Res1="#8ff0a4" Res2="#99c1f1">Green, blue, white</Capability>
   <Capability Min="131" Max="140" Preset="ColorDoubleMacro" Res1="#f66151" Res2="#99c1f1">Red, blue, white</Capability>
-  <Capability Min="141" Max="150" Preset="ColorMacro">Red, green, blue, white</Capability>
-  <Capability Min="151" Max="200" Preset="ColorMacro">Colour sequence, increasing speed</Capability>
-  <Capability Min="201" Max="255" Preset="ColorMacro">Colour transition (fade), increasing speed</Capability>
+  <Capability Min="141" Max="150">Red, green, blue, white</Capability>
+  <Capability Min="151" Max="200">Colour sequence, increasing speed</Capability>
+  <Capability Min="201" Max="255">Colour transition (fade), increasing speed</Capability>
  </Channel>
  <Channel Name="Zoom" Preset="BeamZoomSmallBig"/>
  <Channel Name="Auto programs">

--- a/resources/fixtures/XStatic/XStatic-X-240Bar-RGB.qxf
+++ b/resources/fixtures/XStatic/XStatic-X-240Bar-RGB.qxf
@@ -47,7 +47,7 @@
   <Capability Min="24" Max="31" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="32" Max="39" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="40" Max="47" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="48" Max="55" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="56" Max="63" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="64" Max="71" Preset="GoboMacro" Res1="Others/rainbow.png">Program 02</Capability>
   <Capability Min="72" Max="79" Preset="GoboMacro" Res1="Others/rainbow.png">Program 03</Capability>

--- a/resources/fixtures/beamZ/beamZ-BAC302.qxf
+++ b/resources/fixtures/beamZ/beamZ-BAC302.qxf
@@ -48,7 +48,7 @@
   <Capability Min="40" Max="49" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="50" Max="59" Preset="ColorMacro" Res1="#ffaa00">Amber</Capability>
   <Capability Min="60" Max="69" Preset="ColorMacro" Res1="#aa55ff">UV</Capability>
-  <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#f9f06b">Yellow</Capability>
+  <Capability Min="70" Max="79" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="80" Max="89" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="90" Max="99" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="100" Max="109" Preset="ColorMacro" Res1="#ff8c00">Dark orange</Capability>

--- a/resources/fixtures/iSolution/iSolution-5-Series.qxf
+++ b/resources/fixtures/iSolution/iSolution-5-Series.qxf
@@ -43,7 +43,7 @@
   <Capability Min="0" Max="10" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="11" Max="21" Preset="ColorMacro" Res1="#55aa00">Green</Capability>
   <Capability Min="22" Max="31" Preset="ColorMacro" Res1="#ff55ff">Magenta</Capability>
-  <Capability Min="32" Max="42" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="32" Max="42" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="43" Max="53" Preset="ColorMacro" Res1="#ffaa00">Amber</Capability>
   <Capability Min="54" Max="63" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="64" Max="74" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
@@ -51,7 +51,7 @@
   <Capability Min="86" Max="95" Preset="ColorMacro" Res1="#55ff7f">Light Green</Capability>
   <Capability Min="96" Max="106" Preset="ColorMacro" Res1="#ff9318">Orange</Capability>
   <Capability Min="107" Max="117" Preset="ColorMacro" Res1="#f5f500">Yellow</Capability>
-  <Capability Min="118" Max="127" Preset="ColorMacro" Res1="#ff00ff">Pink</Capability>
+  <Capability Min="118" Max="127" Preset="ColorMacro" Res1="#ffc0cb">Pink</Capability>
   <Capability Min="128" Max="255">Rainbow Effect Speed</Capability>
  </Channel>
  <Channel Name="No function" Preset="NoFunction"/>

--- a/resources/fixtures/iSolution/iSolution-iMove-250w.qxf
+++ b/resources/fixtures/iSolution/iSolution-iMove-250w.qxf
@@ -31,7 +31,7 @@
   <Capability Min="37" Max="54" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
   <Capability Min="55" Max="72" Preset="ColorMacro" Res1="#ff8000">Orange</Capability>
   <Capability Min="73" Max="90" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
-  <Capability Min="91" Max="108" Preset="ColorMacro" Res1="#00ffff">Light Blue</Capability>
+  <Capability Min="91" Max="108" Preset="ColorMacro" Res1="#add8e6">Light Blue</Capability>
   <Capability Min="109" Max="127" Preset="ColorMacro" Res1="#800080">Purple</Capability>
   <Capability Min="128" Max="187" Preset="GoboMacro" Res1="Others/rainbow.png">Slow to fast anticlockwise rotation</Capability>
   <Capability Min="188" Max="247" Preset="GoboMacro" Res1="Others/rainbow.png">Fast to slow rotation clockwise</Capability>

--- a/resources/fixtures/lightmaXX/lightmaXX-Platinum-CLS-1.qxf
+++ b/resources/fixtures/lightmaXX/lightmaXX-Platinum-CLS-1.qxf
@@ -18,7 +18,7 @@
   <Capability Min="44" Max="54" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="55" Max="65" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="66" Max="76" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="77" Max="87" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="77" Max="87" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="88" Max="98" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="99" Max="109">Dream</Capability>
   <Capability Min="110" Max="120">Meteor</Capability>

--- a/resources/fixtures/lightmaXX/lightmaXX-Platinum-CLS-2.qxf
+++ b/resources/fixtures/lightmaXX/lightmaXX-Platinum-CLS-2.qxf
@@ -18,7 +18,7 @@
   <Capability Min="44" Max="54" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
   <Capability Min="55" Max="65" Preset="ColorMacro" Res1="#00ffff">Cyan</Capability>
   <Capability Min="66" Max="76" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
-  <Capability Min="77" Max="87" Preset="ColorMacro" Res1="#ff00ff">Purple</Capability>
+  <Capability Min="77" Max="87" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
   <Capability Min="88" Max="98" Preset="ColorMacro" Res1="#ffffff">White</Capability>
   <Capability Min="99" Max="109">Program &quot;Dream&quot;</Capability>
   <Capability Min="110" Max="120">Program &quot;Meteor&quot;</Capability>

--- a/resources/fixtures/lightmaXX/lightmaXX-Vega-Spot-60.qxf
+++ b/resources/fixtures/lightmaXX/lightmaXX-Vega-Spot-60.qxf
@@ -26,11 +26,11 @@
   <Capability Min="0" Max="13" Preset="ColorMacro" Res1="#ffffff">Open (white)</Capability>
   <Capability Min="14" Max="31" Preset="ColorMacro" Res1="#ff0000">Red</Capability>
   <Capability Min="32" Max="49" Preset="ColorMacro" Res1="#ffff00">Yellow</Capability>
-  <Capability Min="50" Max="67" Preset="ColorMacro" Res1="#00ffff">Light blue</Capability>
-  <Capability Min="68" Max="85" Preset="ColorMacro" Res1="#55ff00">Green</Capability>
-  <Capability Min="86" Max="103" Preset="ColorMacro" Res1="#ffaa00">Orange</Capability>
-  <Capability Min="104" Max="121" Preset="ColorMacro" Res1="#ff55ff">Magenta</Capability>
-  <Capability Min="122" Max="130" Preset="ColorMacro" Res1="#0055ff">Blue</Capability>
+  <Capability Min="50" Max="67" Preset="ColorMacro" Res1="#add8e6">Light blue</Capability>
+  <Capability Min="68" Max="85" Preset="ColorMacro" Res1="#00ff00">Green</Capability>
+  <Capability Min="86" Max="103" Preset="ColorMacro" Res1="#ffa500">Orange</Capability>
+  <Capability Min="104" Max="121" Preset="ColorMacro" Res1="#ff00ff">Magenta</Capability>
+  <Capability Min="122" Max="130" Preset="ColorMacro" Res1="#0000ff">Blue</Capability>
   <Capability Min="131" Max="139" Preset="ColorMacro" Res1="#ffffff">Open (white)</Capability>
   <Capability Min="140" Max="195" Preset="GenericPicture" Res1="Others/rainbow.png">Forward rainbow effect from fast to slow</Capability>
   <Capability Min="196" Max="199" Preset="RotationStop">Rotation stop</Capability>

--- a/resources/fixtures/scripts/check
+++ b/resources/fixtures/scripts/check
@@ -1,5 +1,6 @@
 #!/bin/sh
 DIR=`dirname $0`
+set -e
 
 # Validate the fixtures against the XML scheme
 xmllint --noout --schema "$DIR"/../../schemas/fixture.xsd $(find "$DIR"/.. -name *.qxf) >/dev/null 2>&1 
@@ -13,7 +14,7 @@ else
 fi
 
 cd "$DIR"/.. && ./scripts/fixtures-tool.py --validate || exit $?
-cd -
+cd - >>/dev/null
 
 # Validate the fixture map against the XML scheme
 xmllint --noout --schema "$DIR"/../../schemas/fixturesmap.xsd "$DIR"/../FixturesMap.xml >/dev/null 2>&1

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -687,6 +687,9 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
             # Check for consistent color codes for given color names
             capPreset = capability.attrib.get('Preset', "")
             if capPreset == "ColorMacro" or capPreset == "ColorDoubleMacro":
+                if capability.attrib.get('Res1', "") == "":
+                    print(absname + ":" + chName + ": Res1 required in Preset=ColorMacro and ColorDoubleMacro")
+                    errNum += 1
                 errNum = validate_color_codes(
                     absname + ":" + chName + "/" + capName + "/Res1",
                     capability.text,
@@ -695,6 +698,9 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
                     errNum,
                     colorRgb)
             if capPreset == "ColorDoubleMacro":
+                if capability.attrib.get('Res2', "") == "":
+                    print(absname + ":" + chName + ": Res2 required in ColorDoubleMacro")
+                    errNum += 1
                 errNum = validate_color_codes(
                     absname + ":" + chName + "/" + capName + "/Res2",
                     capability.text,

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -515,11 +515,11 @@ def validate_fx_modes(absname, xmlObj, hasPan, hasTilt, channelNames, colorRgb):
 
 def validate_color_codes(propName, fxColorName, fxColorCode, qlc_version, errNum, colorRgb):
     targetCode = ""
-    
+
     # Normalize name and code
     fxSearchName = fxColorName.title()
     fxSearchCode = fxColorCode.lower()
-    
+
     # Try to find the code for the given name
     if fxSearchName in colorRgb["nameToRgb"]:
          targetCode = colorRgb["nameToRgb"][fxSearchName]
@@ -894,7 +894,7 @@ if args.validate is not None:
     rgbParser = etree.XMLParser(ns_clean=True, recover=True)
     rgbObj = etree.parse(rgbAbsname, parser=rgbParser)
     rgbRoot = rgbObj.getroot()
-    
+
     colorRgb = {}
     colorRgb["nameToRgb"] = {}
     colorRgb["rgbToName"] = {}
@@ -902,7 +902,7 @@ if args.validate is not None:
         rgbCode = colorEntry.attrib['RGB'].lower()
         colorName = colorEntry.attrib['Name'].title()
         colorRgb["nameToRgb"][colorName] = rgbCode
-        colorRgb["rgbToName"][rgbCode] = colorName 
+        colorRgb["rgbToName"][rgbCode] = colorName
 
     paths = ["."]
     if len(args.validate) >= 1:

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -688,7 +688,10 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
             capPreset = capability.attrib.get('Preset', "")
             if capPreset == "ColorMacro" or capPreset == "ColorDoubleMacro":
                 if capability.attrib.get('Res1', "") == "":
-                    print(absname + ":" + chName + ": Res1 required in Preset=ColorMacro and ColorDoubleMacro")
+                    alternativeMsg = ""
+                    if capability.text in colorRgb["nameToRgb"]:
+                        alternativeMsg = " (" + colorRgb["NameToRgb"][capability.text] + ")"
+                    print(absname + ":" + chName + "/" + capName + ": Res1 required in Preset=ColorMacro and ColorDoubleMacro" + alternativeMsg)
                     errNum += 1
                 errNum = validate_color_codes(
                     absname + ":" + chName + "/" + capName + "/Res1",
@@ -699,7 +702,7 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
                     colorRgb)
             if capPreset == "ColorDoubleMacro":
                 if capability.attrib.get('Res2', "") == "":
-                    print(absname + ":" + chName + ": Res2 required in ColorDoubleMacro")
+                    print(absname + ":" + chName + "/" + capName + ": Res2 required in ColorDoubleMacro")
                     errNum += 1
                 errNum = validate_color_codes(
                     absname + ":" + chName + "/" + capName + "/Res2",

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -525,8 +525,8 @@ def validate_color_codes(propName, fxColorName, fxColorCode, qlc_version, errNum
          targetCode = colorRgb["nameToRgb"][fxSearchName]
     else:
         # Search for alternative color name from potential list
-        if fxSearchName in colorRgb:
-            targetCode = colorRgb[fxSearchName + " 1"]
+        if fxSearchName in colorRgb["nameToRgb"]:
+            targetCode = colorRgb["nameToRgb"][fxSearchName + " 1"]
         # else the string cannot be aligned to a known color code.
 
     if targetCode != "":
@@ -685,29 +685,32 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
                             capability.set('Res', resource)
 
             # Check for consistent color codes for given color names
+            hexPattern = re.compile(r'^#([0-9a-fA-F]){6}$')
             capPreset = capability.attrib.get('Preset', "")
             if capPreset == "ColorMacro" or capPreset == "ColorDoubleMacro":
-                if capability.attrib.get('Res1', "") == "":
+                res = capability.attrib.get('Res1', "")
+                if not re.search(hexPattern, res):
                     alternativeMsg = ""
                     if capability.text in colorRgb["nameToRgb"]:
-                        alternativeMsg = " (" + colorRgb["NameToRgb"][capability.text] + ")"
-                    print(absname + ":" + chName + "/" + capName + ": Res1 required in Preset=ColorMacro and ColorDoubleMacro" + alternativeMsg)
+                        alternativeMsg = " (" + colorRgb["nameToRgb"][capability.text] + ")"
+                    print(absname + ":" + chName + "/" + capName + ": Res1 (" + res + ") required to start with '#' in Preset=ColorMacro and ColorDoubleMacro" + alternativeMsg)
                     errNum += 1
                 errNum = validate_color_codes(
                     absname + ":" + chName + "/" + capName + "/Res1",
                     capability.text,
-                    capability.attrib.get('Res1', ""),
+                    res,
                     qlc_version,
                     errNum,
                     colorRgb)
             if capPreset == "ColorDoubleMacro":
-                if capability.attrib.get('Res2', "") == "":
-                    print(absname + ":" + chName + "/" + capName + ": Res2 required in ColorDoubleMacro")
+                res = capability.attrib.get('Res2', "")
+                if not re.search(hexPattern, res):
+                    print(absname + ":" + chName + "/" + capName + ": Res2 (" + res + ") required to start with '#' in ColorDoubleMacro")
                     errNum += 1
                 errNum = validate_color_codes(
                     absname + ":" + chName + "/" + capName + "/Res2",
                     capability.text,
-                    capability.attrib.get('Res2', ""),
+                    res,
                     qlc_version,
                     errNum,
                     colorRgb)

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -714,8 +714,17 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
                     qlc_version,
                     errNum,
                     colorRgb)
+            elif capPreset == "":
+                res = capability.attrib.get('Res1', "__.NOT._.SET.___")
+                if res != "__.NOT._.SET.___":
+                    print(absname + ":" + chName + "/" + capName + ": Res1 not evaluated withour Preset=")
+                    errNum += 1
+                res = capability.attrib.get('Res2', "__.NOT._.SET.___")
+                if res != "__.NOT._.SET.___":
+                    print(absname + ":" + chName + "/" + capName + ": Res2 not evaluated withour Preset=")
+                    errNum += 1
             if capPreset == "ColorMacro" and capability.attrib.get('Res2', "") != "":
-                print(absname + ":" + chName + ": Res2 not evaluated in Preset=ColorMacro")
+                print(absname + ":" + chName + "/" + capName + ": Res2 not evaluated in Preset=ColorMacro")
                 errNum += 1
 
             capCount += 1

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -703,6 +703,9 @@ def validate_fx_channels(absname, xmlObj, errNum, colorRgb):
                     qlc_version,
                     errNum,
                     colorRgb)
+            if capPreset == "ColorMacro" and capability.attrib.get('Res2', "") != "":
+                print(absname + ":" + chName + ": Res2 not evaluated in Preset=ColorMacro")
+                errNum += 1
 
             capCount += 1
 

--- a/resources/fixtures/scripts/fixtures-tool.py
+++ b/resources/fixtures/scripts/fixtures-tool.py
@@ -537,8 +537,7 @@ def validate_color_codes(propName, fxColorName, fxColorCode, qlc_version, errNum
             if fxSearchCode in colorRgb["rgbToName"]:
                 alternativeMsg = ", the name for given FX color code is " + colorRgb["rgbToName"][fxSearchCode]
 
-            #if qlc_version >= 41206 or alternativeMsg != "":
-            if qlc_version >= 41206:
+            if qlc_version >= 41206 or alternativeMsg != "":
                 print(propName + ": FX color " + fxColorName + " (" + fxColorCode + ") should have color code " + targetCode + alternativeMsg)
                 errNum += 1
 


### PR DESCRIPTION
As the list of RGB codes was available, I was interested to see how big the problem between color codes and names really is and if it could be reduced to a digestable size by restricting the check to newer versions.
So sorry, I did it again and exceeded 100 modified files, but only with very small patches and not as much as last time (only a handful of diffs to click extra).

- For color capabilities with only full channel (0xFF) channels, I preferred to update the color name (Magenta, which was named wrongly.) - for all files, to not have wrong names on named codes,
- for all most others, I updated the codes (only for files from 4.12.6)
- in uncertain cases, I checked the manual.
- Color Presets with no meaning or with unknown color codes (e.g. where the LEE colors had a ColorMacro but no color code) have been removed
- Useless Res2 for single ColorMacros are now cleaned up.
- For two files, I capitalized the all-lower-case color names

Take your time to look at it and decide if you want to integrate it (or parts of it). Let me know what to improve.