### PR TITLE
Enable Werror on C files and add compiler hint where needed

### DIFF
--- a/variables.pri
+++ b/variables.pri
@@ -17,6 +17,7 @@ qmlui:  APPVERSION = 5.0.0 Beta 2
 
 # Treat all compiler warnings as errors
 QMAKE_CXXFLAGS += -Werror
+QMAKE_CFLAGS += -Werror
 
 CONFIG         += warn_on
 

--- a/variables.pri
+++ b/variables.pri
@@ -17,7 +17,7 @@ qmlui:  APPVERSION = 5.0.0 Beta 2
 
 # Treat all compiler warnings as errors
 QMAKE_CXXFLAGS += -Werror
-QMAKE_CFLAGS += -Werror
+unix:QMAKE_CFLAGS += -Werror
 
 CONFIG         += warn_on
 

--- a/webaccess/src/qhttpserver/http_parser.c
+++ b/webaccess/src/qhttpserver/http_parser.c
@@ -2418,8 +2418,11 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
       case s_req_server_with_at:
         found_at = 1;
+        /* FALLTROUGH */
+#ifdef __GNUC__
+        __attribute__ ((fallthrough));
+#endif
 
-      /* FALLTROUGH */
       case s_req_server:
         uf = UF_HOST;
         break;


### PR DESCRIPTION
During analysis of the build, one warning was detected: The `-Werror` flag was set only on C++ files, not on C files.
This patch adds the `-Werror` flag also on C files and adds a compiler hint on the one occasion where the switch-case fallthrough is intentional.