### PR TITLE
Cuelist slider fix

### DIFF
--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -260,13 +260,13 @@ void VCCueList::setSideFaderLevel(int level)
         if (ch->stepsCount() < 256)
         {
             float stepSize = 256 / float(ch->stepsCount()); //divide up the full 0..255 range
-            stepSize = qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
+            stepSize = (float)qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
             if(level >= 256.0 - stepSize)
                 newStep = ch->stepsCount() - 1;
             else
                 newStep = qFloor(qreal(level) / qreal(stepSize));
+            //qDebug() << "value:" << value << " new step:" << newStep << " stepSize:" << stepSize;
         }
-        //qDebug() << "value:" << value << " steps:" << ch->stepsCount() << "new step:" << newStep;
 
         ChaserAction action;
         action.m_action = ChaserSetStepIndex;

--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -259,13 +259,14 @@ void VCCueList::setSideFaderLevel(int level)
         int newStep = level; // by default we assume the Chaser has more than 256 steps
         if (ch->stepsCount() < 256)
         {
-            float stepSize = 255 / float(ch->stepsCount());
-            if (level >= 255 - stepSize)
+            float stepSize = 256 / float(ch->stepsCount()); //divide up the full 0..255 range
+            stepSize = qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
+            if(level >= 256.0 - stepSize)
                 newStep = ch->stepsCount() - 1;
             else
                 newStep = qFloor(qreal(level) / qreal(stepSize));
         }
-        //qDebug() << "value:" << value << "steps:" << ch->stepsCount() << "new step:" << newStep;
+        //qDebug() << "value:" << value << " steps:" << ch->stepsCount() << "new step:" << newStep;
 
         ChaserAction action;
         action.m_action = ChaserSetStepIndex;

--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -260,8 +260,8 @@ void VCCueList::setSideFaderLevel(int level)
         if (ch->stepsCount() < 256)
         {
             float stepSize = 256 / float(ch->stepsCount()); //divide up the full 0..255 range
-            stepSize = (float)qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
-            if(level >= 256.0 - stepSize)
+            stepSize = qFloor((stepSize * 100000.0) + 0.5) / 100000.0; //round to 5 decimals to fix corner cases
+            if (level >= 256.0 - stepSize)
                 newStep = ch->stepsCount() - 1;
             else
                 newStep = qFloor(qreal(level) / qreal(stepSize));

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -828,15 +828,15 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
 
         int upperBound = 255 - qCeil(slValue);
         int lowerBound = qFloor((float)256.0 - slValue - stepVal);
-        //qDebug() << "Slider value:" << m_sideFader->value() << "->" << 255-slValue << "( disp:" << slValue << ") Step range:" << upperBound << lowerBound;
         // if the Step slider is already in range, then do not set its value
         // this means a user interaction is going on, either with the mouse or external controller
         if (m_sideFader->value() < lowerBound || m_sideFader->value() >= upperBound)
         {
             m_sideFader->blockSignals(true);
             m_sideFader->setValue(upperBound);
-            m_topPercentageLabel->setText(QString("%1").arg(slValue));
+            m_topPercentageLabel->setText(QString("%1").arg(qCeil(slValue)));
             m_sideFader->blockSignals(false);
+            //qDebug() << "Slider value:" << m_sideFader->value() << "->" << 255-qCeil(slValue) << "( disp:" << slValue << ") Step range:" << upperBound << lowerBound;
         }
     }
     else
@@ -1218,13 +1218,13 @@ void VCCueList::slotSideFaderValueChanged(int value)
         if (ch->stepsCount() < 256)
         {
             float stepSize = 256.0 / (float)ch->stepsCount();  //divide up the full 0..255 range
-            stepSize = qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
+            stepSize = (float)qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
             if(value >= 256.0 - stepSize)
                 newStep = ch->stepsCount() - 1;
             else
                 newStep = qFloor((float)value / stepSize);
+            qDebug() << "value:" << value << " new step:" << newStep << " stepSize:" << stepSize;
         }
-        //qDebug() << "value:" << value << " steps:" << ch->stepsCount() << "new step:" << newStep;
 
         if (newStep == ch->currentStepIndex())
             return;

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -817,10 +817,12 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
 
         float stepVal;
         int stepsCount = m_tree->topLevelItemCount();
-        if (stepsCount < 256)
+        if (stepsCount < 256) {
             stepVal = 256.0 / (float)stepsCount; //divide up the full 0..255 range
-        else
+            stepVal = (float)qFloor((stepVal * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
+        } else { 
             stepVal = 1.0;
+        }
         // value->step# truncates down in slotSideFaderValueChanged; so use ceiling for step#->value
         float slValue = stepVal * (float)stepNumber;
         if (slValue > 255)
@@ -836,7 +838,11 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
             m_sideFader->setValue(upperBound);
             m_topPercentageLabel->setText(QString("%1").arg(qCeil(slValue)));
             m_sideFader->blockSignals(false);
-            //qDebug() << "Slider value:" << m_sideFader->value() << "->" << 255-qCeil(slValue) << "( disp:" << slValue << ") Step range:" << upperBound << lowerBound;
+
+            //qDebug() << "Slider value:" << m_sideFader->value() << "->" << 255-qCeil(slValue) 
+            //    << "(disp:" << slValue << ")" << "Step range:" << upperBound << lowerBound 
+            //    << "(stepSize:" << stepVal << ")" 
+            //    << "(raw lower:" << ((float)256.0 - slValue - stepVal) << ")";
         }
     }
     else
@@ -1223,7 +1229,7 @@ void VCCueList::slotSideFaderValueChanged(int value)
                 newStep = ch->stepsCount() - 1;
             else
                 newStep = qFloor((float)value / stepSize);
-            qDebug() << "value:" << value << " new step:" << newStep << " stepSize:" << stepSize;
+            //qDebug() << "value:" << value << " new step:" << newStep << " stepSize:" << stepSize;
         }
 
         if (newStep == ch->currentStepIndex())

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -827,7 +827,7 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
             slValue = 255.0;
 
         int upperBound = 255 - qCeil(slValue);
-        int lowerBound = qFloor((float)256.0 - flValue - stepVal);
+        int lowerBound = qFloor((float)256.0 - slValue - stepVal);
         //qDebug() << "Slider value:" << m_sideFader->value() << "->" << 255-slValue << "( disp:" << slValue << ") Step range:" << upperBound << lowerBound;
         // if the Step slider is already in range, then do not set its value
         // this means a user interaction is going on, either with the mouse or external controller

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -817,12 +817,16 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
 
         float stepVal;
         int stepsCount = m_tree->topLevelItemCount();
-        if (stepsCount < 256) {
+        if (stepsCount < 256) 
+        {
             stepVal = 256.0 / (float)stepsCount; //divide up the full 0..255 range
             stepVal = (float)qFloor((stepVal * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
-        } else { 
+        } 
+        else 
+        {
             stepVal = 1.0;
         }
+        
         // value->step# truncates down in slotSideFaderValueChanged; so use ceiling for step#->value
         float slValue = stepVal * (float)stepNumber;
         if (slValue > 255)

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -820,8 +820,8 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
         if (stepsCount < 256) 
         {
             stepVal = 256.0 / (float)stepsCount; //divide up the full 0..255 range
-            stepVal = (float)qFloor((stepVal * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
-        } 
+            stepVal = qFloor((stepVal * 100000.0) + 0.5) / 100000.0; //round to 5 decimals to fix corner cases
+        }
         else 
         {
             stepVal = 1.0;
@@ -833,7 +833,7 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
             slValue = 255.0;
 
         int upperBound = 255 - qCeil(slValue);
-        int lowerBound = qFloor((float)256.0 - slValue - stepVal);
+        int lowerBound = qFloor(256.0 - slValue - stepVal);
         // if the Step slider is already in range, then do not set its value
         // this means a user interaction is going on, either with the mouse or external controller
         if (m_sideFader->value() < lowerBound || m_sideFader->value() >= upperBound)
@@ -846,7 +846,7 @@ void VCCueList::slotCurrentStepChanged(int stepNumber)
             //qDebug() << "Slider value:" << m_sideFader->value() << "->" << 255-qCeil(slValue) 
             //    << "(disp:" << slValue << ")" << "Step range:" << upperBound << lowerBound 
             //    << "(stepSize:" << stepVal << ")" 
-            //    << "(raw lower:" << ((float)256.0 - slValue - stepVal) << ")";
+            //    << "(raw lower:" << (256.0 - slValue - stepVal) << ")";
         }
     }
     else
@@ -1228,8 +1228,8 @@ void VCCueList::slotSideFaderValueChanged(int value)
         if (ch->stepsCount() < 256)
         {
             float stepSize = 256.0 / (float)ch->stepsCount();  //divide up the full 0..255 range
-            stepSize = (float)qFloor((stepSize * 100000) + 0.5) / 100000; //round to 5 decimals to fix corner cases
-            if(value >= 256.0 - stepSize)
+            stepSize = qFloor((stepSize * 100000.0) + 0.5) / 100000.0; //round to 5 decimals to fix corner cases
+            if (value >= 256.0 - stepSize)
                 newStep = ch->stepsCount() - 1;
             else
                 newStep = qFloor((float)value / stepSize);


### PR DESCRIPTION
Adjust CueList slider value calculation to fully align ValueChanged->Step# and Step#Changed->Value calculations.

Previously, clicking the PreviousStep button didn't always update the slider position, due to off-by-one issues          near whole-numbered calculated values.  Example: with a 6-step chaser, advance to the end, then click the Previous Cue button and note that the slider only jumps up every other click. Also, if you move the slider position with keystrokes up and down (or presumably also via a midi encoder wheel up/down), note that it jumps to the next step at slightly different values than the ones that are calculated when using next/previous step buttons -- and then the displayed value at the top of the slider "jumps" to the top end of the subset of values calculated to belong to the newly selected chaser step #, which causes the visual feedback to "jump".
