### PR TITLE
Save side-fader-input to qxw files

### DIFF
--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -1053,6 +1053,7 @@ bool VCCueList::saveXML(QXmlStreamWriter *doc)
     saveXMLInputControl(doc, INPUT_PREVIOUS_STEP_ID, KXMLQLCVCCueListPrevious);
     saveXMLInputControl(doc, INPUT_PLAY_PAUSE_ID, KXMLQLCVCCueListPlayback);
     saveXMLInputControl(doc, INPUT_STOP_PAUSE_ID, KXMLQLCVCCueListStop);
+    saveXMLInputControl(doc, INPUT_SIDE_FADER_ID, KXMLQLCVCCueListCrossfadeLeft);
 
     /* End the <CueList> tag */
     doc->writeEndElement();


### PR DESCRIPTION
Added missing saveXMLInputControl call for Side Fader external input configuration