### PR TITLE
Gh action fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       #fail-fast: false
       matrix:
-        #task: [compile-qt5, compile-qt5qml,coverage-qt5]
-        task: [compile-qt5qml]
+        task: [compile-qt5, compile-qt5qml,coverage-qt5]
+        #task: [compile-qt5qml]
     env:
       CI_REPO_SLUG: ${{ github.repository }}
       CI_BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
+          QT_QPA_PLATFORM=xcb xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          QT_QPA_PLATFORM=xcb xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
+          export QT_QPA_PLATFORM=xcb && xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: QLCplus Linux ${{matrix.task}}
     strategy:
-      #fail-fast: false
+      fail-fast: false
       matrix:
         task: [compile-qt5, compile-qt5qml,coverage-qt5]
         #task: [compile-qt5qml]
@@ -161,6 +161,21 @@ jobs:
       - name: Build
         run: make -j $NPROC
 
+      - name: Test
+        if: ${{ ! startsWith( matrix.task, 'coverage') }}
+        run: make check
+
+      - name: Test with Coverage
+        if: ${{ startsWith( matrix.task, 'coverage') }}
+        run: make lcov
+
+      - name: Coveralls
+        if: ${{ startsWith( matrix.task, 'coverage') }}
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage/coverage.info
+
       - name: Install
         if: ${{ ! startsWith( matrix.task, 'coverage') }}
         run: |
@@ -229,21 +244,6 @@ jobs:
         with:
           name: ${{ matrix.task }}-AppImage
           path: Q_Light_Controller_Plus-x86_64.AppImage
-
-      - name: Test
-        if: ${{ ! startsWith( matrix.task, 'coverage') }}
-        run: make check
-
-      - name: Test with Coverage
-        if: ${{ startsWith( matrix.task, 'coverage') }}
-        run: make lcov
-
-      - name: Coveralls
-        if: ${{ startsWith( matrix.task, 'coverage') }}
-        uses: coverallsapp/github-action@1.1.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage/coverage.info
 
   build-windows:
     if: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
     name: QLCplus Linux ${{matrix.task}}
     strategy:
-      fail-fast: false
+      #fail-fast: false
       matrix:
-        task: [compile-qt5, compile-qt5qml,coverage-qt5]
-        #task: [compile-qt5qml]
+        #task: [compile-qt5, compile-qt5qml,coverage-qt5]
+        task: [compile-qt5qml]
     env:
       CI_REPO_SLUG: ${{ github.repository }}
       CI_BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          xvfb-run ./Q_Light_Controller_Plus-x86_64.AppImage --version
+          xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          export QT_QPA_PLATFORM=xcb && xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
+          export QT_QPA_PLATFORM=minimal && xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          export QT_QPA_PLATFORM=minimal && xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
+          QT_QPA_PLATFORM=minimal xvfb-run --auto-servernum ./Q_Light_Controller_Plus-x86_64.AppImage --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}

--- a/unittest.sh
+++ b/unittest.sh
@@ -81,7 +81,7 @@ do
     # Execute the test
     pushd ${TESTDIR}/${test}
     echo "$TESTPREFIX ./test.sh"
-    $TESTPREFIX ./test.sh
+    eval $TESTPREFIX ./test.sh
     RESULT=${?}
     popd
     if [ ${RESULT} != 0 ]; then

--- a/unittest.sh
+++ b/unittest.sh
@@ -22,7 +22,7 @@ if [ "$CURRUSER" == "runner" ] \
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
-    TESTPREFIX="xvfb-run --auto-servernum"
+    TESTPREFIX="QT_QPA_PLATFORM=xcb xvfb-run --auto-servernum"
     HAS_XSERVER="1"
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"

--- a/unittest.sh
+++ b/unittest.sh
@@ -22,7 +22,7 @@ if [ "$CURRUSER" == "runner" ] \
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
-    TESTPREFIX="QT_QPA_PLATFORM=minimal && xvfb-run --auto-servernum"
+    TESTPREFIX="QT_QPA_PLATFORM=minimal xvfb-run --auto-servernum"
     HAS_XSERVER="1"
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"

--- a/unittest.sh
+++ b/unittest.sh
@@ -13,14 +13,16 @@ if [ "$TARGET" != "ui" ] && [ "$TARGET" != "qmlui" ]; then
   exit 1
 fi
 
-if [ "$CURRUSER" == "buildbot" ] || \
-   [ "$CURRUSER" == "abuild" ]; then
+if [ "$CURRUSER" == "runner" ] \
+    || [ "$CURRUSER" == "buildbot" ] \
+    || [ "$CURRUSER" == "abuild" ]; then
+  echo "Found build environment with CURRUSER='$CURRUSER' and OSTYPE='$OSTYPE'"
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     if [ $(which xvfb-run) == "" ]; then
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
-    TESTPREFIX="xvfb-run"
+    TESTPREFIX="xvfb-run --auto-servernum"
     HAS_XSERVER="1"
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"
@@ -78,6 +80,7 @@ do
     $SLEEPCMD
     # Execute the test
     pushd ${TESTDIR}/${test}
+    echo "$TESTPREFIX ./test.sh"
     $TESTPREFIX ./test.sh
     RESULT=${?}
     popd

--- a/unittest.sh
+++ b/unittest.sh
@@ -22,7 +22,7 @@ if [ "$CURRUSER" == "runner" ] \
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
-    TESTPREFIX="QT_QPA_PLATFORM=xcb xvfb-run --auto-servernum"
+    TESTPREFIX="export QT_QPA_PLATFORM=xcb && xvfb-run --auto-servernum"
     HAS_XSERVER="1"
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"

--- a/unittest.sh
+++ b/unittest.sh
@@ -22,7 +22,7 @@ if [ "$CURRUSER" == "runner" ] \
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
-    TESTPREFIX="export QT_QPA_PLATFORM=xcb && xvfb-run --auto-servernum"
+    TESTPREFIX="export QT_QPA_PLATFORM=minimal && xvfb-run --auto-servernum"
     HAS_XSERVER="1"
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"

--- a/unittest.sh
+++ b/unittest.sh
@@ -22,7 +22,7 @@ if [ "$CURRUSER" == "runner" ] \
       echo "xvfb-run not found in this system. Please install with: sudo apt-get install xvfb"
       exit
     fi
-    TESTPREFIX="export QT_QPA_PLATFORM=minimal && xvfb-run --auto-servernum"
+    TESTPREFIX="QT_QPA_PLATFORM=minimal && xvfb-run --auto-servernum"
     HAS_XSERVER="1"
     # if we're running as build slave, set a sleep time to start/stop xvfb between tests
     SLEEPCMD="sleep 1"
@@ -112,7 +112,7 @@ do
     $SLEEPCMD
     # Execute the test
     pushd ${TESTDIR}/${test}
-    DYLD_FALLBACK_LIBRARY_PATH=../../../engine/src:../../src:$DYLD_FALLBACK_LIBRARY_PATH \
+    eval DYLD_FALLBACK_LIBRARY_PATH=../../../engine/src:../../src:$DYLD_FALLBACK_LIBRARY_PATH \
         LD_LIBRARY_PATH=../../../engine/src:../../src:$LD_LIBRARY_PATH $TESTPREFIX ./${test}_test
     RESULT=${?}
     popd
@@ -130,7 +130,7 @@ fi
 
 $SLEEPCMD
 pushd plugins/enttecwing/test
-$TESTPREFIX ./test.sh
+eval $TESTPREFIX ./test.sh
 RESULT=$?
 if [ $RESULT != 0 ]; then
 	echo "${RESULT} Enttec wing unit tests failed. Please fix before commit."
@@ -147,7 +147,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
   $SLEEPCMD
   pushd plugins/velleman/test
-  $TESTPREFIX ./test.sh
+  eval $TESTPREFIX ./test.sh
   RESULT=$?
   if [ $RESULT != 0 ]; then
     echo "Velleman unit test failed ($RESULT). Please fix before commit."
@@ -162,7 +162,7 @@ fi
 
 $SLEEPCMD
 pushd plugins/midi/test
-$TESTPREFIX ./test.sh
+eval $TESTPREFIX ./test.sh
 RESULT=$?
 if [ $RESULT != 0 ]; then
 	echo "${RESULT} MIDI unit tests failed. Please fix before commit."
@@ -176,7 +176,7 @@ popd
 
 $SLEEPCMD
 pushd plugins/artnet/test
-$TESTPREFIX ./test.sh
+eval $TESTPREFIX ./test.sh
 RESULT=$?
 if [ $RESULT != 0 ]; then
 	echo "${RESULT} ArtNet unit tests failed. Please fix before commit."


### PR DESCRIPTION
This patch fixes the window rendering tests.
- Move tests before install targets
- Enforce QT_QPA_PLATFORM=minimal
- Let the tests evaluate the extra environment variable

Note that this is just one way to make it work. Alternatively, there could be a solution in finding and installing some missing library or library version that causes QT to being unable to render the screens during tests.