### PR TITLE
Add support for AKAI APC Mini mk2

### DIFF
--- a/resources/inputprofiles/Akai-APCMini-mk2.qxi
+++ b/resources/inputprofiles/Akai-APCMini-mk2.qxi
@@ -1,0 +1,453 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE InputProfile>
+<InputProfile xmlns="http://www.qlcplus.org/InputProfile">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.12.6</Version>
+  <Author>Michael Mertens</Author>
+ </Creator>
+ <Manufacturer>Akai</Manufacturer>
+ <Model>APC Mini mk2</Model>
+ <Type>MIDI</Type>
+ <Channel Number="48">
+  <Name>Slider 1</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="49">
+  <Name>Slider 2</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="50">
+  <Name>Slider 3</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="51">
+  <Name>Slider 4</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="52">
+  <Name>Slider 5</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="53">
+  <Name>Slider 6</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="54">
+  <Name>Slider 7</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="55">
+  <Name>Slider 8</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="56">
+  <Name>Slider 9</Name>
+  <Type>Slider</Type>
+ </Channel>
+ <Channel Number="128">
+  <Name>Button 1-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="129">
+  <Name>Button 2-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="130">
+  <Name>Button 3-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="131">
+  <Name>Button 4-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="132">
+  <Name>Button 5-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="133">
+  <Name>Button 6-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="134">
+  <Name>Button 7-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="135">
+  <Name>Button 8-8</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="136">
+  <Name>Button 1-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="137">
+  <Name>Button 2-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="138">
+  <Name>Button 3-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="139">
+  <Name>Button 4-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="140">
+  <Name>Button 5-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="141">
+  <Name>Button 6-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="142">
+  <Name>Button 7-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="143">
+  <Name>Button 8-7</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="144">
+  <Name>Button 1-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="145">
+  <Name>Button 2-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="146">
+  <Name>Button 3-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="147">
+  <Name>Button 4-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="148">
+  <Name>Button 5-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="149">
+  <Name>Button 6-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="150">
+  <Name>Button 7-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="151">
+  <Name>Button 8-6</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="152">
+  <Name>Button 1-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="153">
+  <Name>Button 2-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="154">
+  <Name>Button 3-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="155">
+  <Name>Button 4-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="156">
+  <Name>Button 5-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="157">
+  <Name>Button 6-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="158">
+  <Name>Button 7-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="159">
+  <Name>Button 8-5</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="160">
+  <Name>Button 1-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="161">
+  <Name>Button 2-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="162">
+  <Name>Button 3-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="163">
+  <Name>Button 4-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="164">
+  <Name>Button 5-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="165">
+  <Name>Button 6-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="166">
+  <Name>Button 7-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="167">
+  <Name>Button 8-4</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="168">
+  <Name>Button 1-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="169">
+  <Name>Button 2-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="170">
+  <Name>Button 3-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="171">
+  <Name>Button 4-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="172">
+  <Name>Button 5-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="173">
+  <Name>Button 6-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="174">
+  <Name>Button 7-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="175">
+  <Name>Button 8-3</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="176">
+  <Name>Button 1-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="177">
+  <Name>Button 2-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="178">
+  <Name>Button 3-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="179">
+  <Name>Button 4-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="180">
+  <Name>Button 5-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="181">
+  <Name>Button 6-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="182">
+  <Name>Button 7-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="183">
+  <Name>Button 8-2</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="184">
+  <Name>Button 1-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="185">
+  <Name>Button 2-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="186">
+  <Name>Button 3-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="187">
+  <Name>Button 4-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="188">
+  <Name>Button 5-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="189">
+  <Name>Button 6-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="190">
+  <Name>Button 7-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="191">
+  <Name>Button 8-1</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="26"/>
+ </Channel>
+ <Channel Number="228">
+  <Name>Volume Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="229">
+  <Name>Pan Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="230">
+  <Name>Send Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="231">
+  <Name>Device Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="232">
+  <Name>Up Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="233">
+  <Name>Down Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="234">
+  <Name>Left Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="235">
+  <Name>Right Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="240">
+  <Name>Clip stop Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="241">
+  <Name>Solo Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="242">
+  <Name>Mute Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="243">
+  <Name>Rec arm Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="244">
+  <Name>Select Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="245">
+  <Name>Drum Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="246">
+  <Name>Note Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="247">
+  <Name>Stop all clips Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+ <Channel Number="250">
+  <Name>Shift Button</Name>
+  <Type>Button</Type>
+  <Feedbacks LowerValue="1" UpperValue="3"/>
+ </Channel>
+</InputProfile>

--- a/resources/miditemplates/APCminiMK2.qxm
+++ b/resources/miditemplates/APCminiMK2.qxm
@@ -1,0 +1,9 @@
+<!DOCTYPE MidiTemplate>
+<MidiTemplate>
+ <Creator>
+  <Author>Michael Mertens</Author>
+ </Creator>
+ <Description>Sets the APC mini mk2 into Ableton mode 2. This is needed to control the button LEDs.</Description>
+ <Name>APC mini mk2 Ableton mode 2</Name>
+ <InitMessage>F0 47 7F 4F 60 00 04 41 09 01 04 F7</InitMessage>
+</MidiTemplate>


### PR DESCRIPTION
Color feedback values can be found here:
https://www.qlcplus.org/forum/viewtopic.php?f=30&t=16203

Some things to keep in mind:
* The output MIDI channel must be set to 7 to get 100% brightness (when MIDI channel 1 is chosen, you'll only get 10% brightness)
* The control buttons on the side however (Volume, Pan, etc.) have single LEDs which unfortunately only react to messages on MIDI channel 1. Maybe we could add a FixedMidiChannel attribute on the Feedbacks element that could be configured to overwrite the output MIDI channel used for feedback to allow 1 profile can output to multiple MIDI channels?