### PR TITLE
error on a fixture : Prolights cromospot 300 

### DIFF
--- a/resources/fixtures/Pro-Lights/Pro-Lights-CromoSpot300.qxf
+++ b/resources/fixtures/Pro-Lights/Pro-Lights-CromoSpot300.qxf
@@ -139,8 +139,8 @@
  </Mode>
  <Mode Name="Person1">
   <Channel Number="0">Pan</Channel>
-  <Channel Number="1">Tilt</Channel>
-  <Channel Number="2">Pan Fine</Channel>
+  <Channel Number="1">Pan Fine</Channel>
+  <Channel Number="2">Tilt</Channel>
   <Channel Number="3">Tilt Fine</Channel>
   <Channel Number="4">Pan/Tilt Speed</Channel>
   <Channel Number="5">Color</Channel>


### PR DESCRIPTION
hi, yesterday i have use that light and i had have found an error on Person1 Mode : two channels are inverted

Now is ok