### PR TITLE
Fixture definition: Betopper LM108

### DIFF
--- a/resources/fixtures/Betopper/Betopper-LM108.qxf
+++ b/resources/fixtures/Betopper/Betopper-LM108.qxf
@@ -4,7 +4,7 @@
  <Creator>
   <Name>Q Light Controller Plus</Name>
   <Version>4.12.6</Version>
-  <Author>Luca</Author>
+  <Author>Luca Giovannesi</Author>
  </Creator>
  <Manufacturer>Betopper</Manufacturer>
  <Model>LM108 Wash Moving Head</Model>

--- a/resources/fixtures/Betopper/Betopper-LM108.qxf
+++ b/resources/fixtures/Betopper/Betopper-LM108.qxf
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.12.6</Version>
+  <Author>Luca</Author>
+ </Creator>
+ <Manufacturer>Betopper</Manufacturer>
+ <Model>LM108 Wash Moving Head</Model>
+ <Type>Moving Head</Type>
+ <Channel Name="Pan" Preset="PositionPan"/>
+ <Channel Name="Tilt" Preset="PositionTilt"/>
+ <Channel Name="Dimmer" Preset="IntensityDimmer"/>
+ <Channel Name="Red" Preset="IntensityRed"/>
+ <Channel Name="Green" Preset="IntensityGreen"/>
+ <Channel Name="Blue" Preset="IntensityBlue"/>
+ <Channel Name="White" Preset="IntensityWhite"/>
+ <Channel Name="Strobe" Preset="ShutterStrobeSlowFast"/>
+ <Channel Name="Pan/Tilt speed" Preset="SpeedPanTiltSlowFast"/>
+ <Channel Name="Color presets">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="10">Other channels work</Capability>
+  <Capability Min="11" Max="127">Color combination change</Capability>
+  <Capability Min="128" Max="160">Color saltus step</Capability>
+  <Capability Min="161" Max="200">Color gradual change 1</Capability>
+  <Capability Min="201" Max="255">Color gradual change 2</Capability>
+ </Channel>
+ <Channel Name="Color change speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">From slot to fast</Capability>
+ </Channel>
+ <Channel Name="Built-in Effect">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="255">Built-in Effect</Capability>
+ </Channel>
+ <Channel Name="Built-in effect speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">From slot to fast</Capability>
+ </Channel>
+ <Channel Name="Pan fine" Preset="PositionPanFine"/>
+ <Channel Name="Tilt fine" Preset="PositionTiltFine"/>
+ <Channel Name="Reset">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="149">No action</Capability>
+  <Capability Min="150" Max="255">Reset</Capability>
+ </Channel>
+ <Mode Name="9 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Tilt</Channel>
+  <Channel Number="2">Dimmer</Channel>
+  <Channel Number="3">Red</Channel>
+  <Channel Number="4">Green</Channel>
+  <Channel Number="5">Blue</Channel>
+  <Channel Number="6">White</Channel>
+  <Channel Number="7">Strobe</Channel>
+  <Channel Number="8">Pan/Tilt speed</Channel>
+ </Mode>
+ <Mode Name="16 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Tilt</Channel>
+  <Channel Number="2">Dimmer</Channel>
+  <Channel Number="3">Red</Channel>
+  <Channel Number="4">Green</Channel>
+  <Channel Number="5">Blue</Channel>
+  <Channel Number="6">White</Channel>
+  <Channel Number="7">Strobe</Channel>
+  <Channel Number="8">Pan/Tilt speed</Channel>
+  <Channel Number="9">Color presets</Channel>
+  <Channel Number="10">Color change speed</Channel>
+  <Channel Number="11">Built-in Effect</Channel>
+  <Channel Number="12">Built-in effect speed</Channel>
+  <Channel Number="13">Pan fine</Channel>
+  <Channel Number="14">Tilt fine</Channel>
+  <Channel Number="15">Reset</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="4.8" Width="252" Height="315" Depth="165"/>
+  <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+  <Focus Type="Fixed" PanMax="540" TiltMax="180"/>
+  <Technical PowerConsumption="150" DmxConnector="3-pin"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION
Fixture definition for Betopper LM108
https://betopperdj.com/products/betopper-36x3w-rgbw-moving-head-lights

Manual: 
[BETOPPER_Moving_Head_Stage_Light_LM108_User_Manual.pdf](https://github.com/mcallegari/qlcplus/files/11090574/BETOPPER_Moving_Head_Stage_Light_LM108_User_Manual.pdf)
