### PR TITLE
Alternate halfs

### DIFF
--- a/resources/rgbscripts/alternate.js
+++ b/resources/rgbscripts/alternate.js
@@ -209,7 +209,7 @@ var testAlgo;
     var colorSelectOne = (step === 1) ? false : true;
     var rowColorOne = colorSelectOne;
     var realBlockSize = algo.blockSize;
-    
+
     var xMax = width;
     if (algo.align === 1 && width % 2 === 0) {
       // Centered mode


### PR DESCRIPTION
Integrate feature request #1361 into alternate.js: Split the matrix into halfs and by any other divisor.

I would really like to extend the script further, to obey to the colors set in the background (through the virtual console matrix widget) instead of setting them as an array, but we would need to extend the rgbMatrix interface to allow two (or more) colors to be pushed into the matrix script (as an array). Just pushing one color fails in the test script as it does not expect another color to be set.