### PR TITLE
Distinctive AppImage artefact names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,19 +232,19 @@ jobs:
           wget -c https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O ./appimagetool-x86_64.AppImage
           chmod a+x ./appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage -v ${INSTALL_ROOT}
-          mv Q_Light_Controller_Plus-x86_64.AppImage Q_Light_Controller_Plus_${TASK}-x86_64.AppImage
+          mv -v Q_Light_Controller_Plus-x86_64.AppImage Q_Light_Controller_Plus_${{ env.TASK }}-x86_64.AppImage
 
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          ./Q_Light_Controller_Plus_${TASK}-x86_64.AppImage --platform offscreen --version
+          ./Q_Light_Controller_Plus_${{ env.TASK }}-x86_64.AppImage --platform offscreen --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.task }}-AppImage
-          path: Q_Light_Controller_Plus_${TASK}-x86_64.AppImage
+          path: Q_Light_Controller_Plus_${{ env.TASK }}-x86_64.AppImage
 
   build-windows:
     if: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,18 +232,19 @@ jobs:
           wget -c https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O ./appimagetool-x86_64.AppImage
           chmod a+x ./appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage -v ${INSTALL_ROOT}
+          mv Q_Light_Controller_Plus-x86_64.AppImage Q_Light_Controller_Plus_${TASK}-x86_64.AppImage
 
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}
         run: |
-          ./Q_Light_Controller_Plus-x86_64.AppImage --platform offscreen --version
+          ./Q_Light_Controller_Plus_${TASK}-x86_64.AppImage --platform offscreen --version
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.task }}-AppImage
-          path: Q_Light_Controller_Plus-x86_64.AppImage
+          path: Q_Light_Controller_Plus_${TASK}-x86_64.AppImage
 
   build-windows:
     if: false


### PR DESCRIPTION
I would like to propose letting the AppImages in the Github artifacts to carry a distinctive name, each.

This will allow to download and extract both artefacts side by side for comparison of both programs in development, extract and execute the contained binaries which would otherwise overwrite each other (or need manual renaming).