### PR TITLE
Wizard naming

### DIFF
--- a/ui/src/palettegenerator.cpp
+++ b/ui/src/palettegenerator.cpp
@@ -248,12 +248,12 @@ void PaletteGenerator::createColorScene(QList<SceneValue> chMap, QString name, P
             even = !even;
         }
     }
-    scene->setName(m_model + " - color - " + name);
+    scene->setName(getNamePrefix(name, "color"));
     m_scenes.append(scene);
     if (subType == OddEven)
     {
-        evenScene->setName(tr("%1 - color - %2 (Even)").arg(m_model).arg(name));
-        oddScene->setName(tr("%1 - color - %2 (Odd)").arg(m_model).arg(name));
+        evenScene->setName(tr("%1 (Even)").arg(getNamePrefix(name, "color")));
+        oddScene->setName(tr("%1 (Odd)").arg(getNamePrefix(name, "color")));
         m_scenes.append(evenScene);
         m_scenes.append(oddScene);
     }
@@ -357,12 +357,12 @@ void PaletteGenerator::createRGBCMYScene(QList<SceneValue> rcMap,
         }
         qDebug() << "color name:" << m_colNames.at(i) << "i:" << i << "count:" << m_colNames.count();
 
-        scene->setName(tr("%1 - %2 %3").arg(m_model).arg(m_colNames.at(i)).arg(name));
+        scene->setName(tr("%1").arg(getNamePrefix(m_colNames.at(i),arg(name))));
         m_scenes.append(scene);
         if (subType == OddEven)
         {
-            evenScene->setName(tr("%1 - %2 %3 (Even)").arg(m_model).arg(m_colNames.at(i)).arg(name));
-            oddScene->setName(tr("%1 - %2 %3 (Odd)").arg(m_model).arg(m_colNames.at(i)).arg(name));
+            evenScene->setName(tr("%1 (Even)").arg(getNamePrefix(m_colNames.at(i),arg(name))));
+            oddScene->setName(tr("%1 (Odd)").arg(getNamePrefix(m_colNames.at(i),arg(name))));
             m_scenes.append(evenScene);
             m_scenes.append(oddScene);
         }
@@ -420,12 +420,12 @@ void PaletteGenerator::createCapabilityScene(QHash<quint32, quint32> chMap,
             }
         }
 
-        scene->setName(m_model + " - " + name);
+        scene->setName(getNamePrefix(name));
         m_scenes.append(scene);
         if (subType == OddEven)
         {
-            evenScene->setName(m_model + " - " + name + tr(" - Even"));
-            oddScene->setName(m_model + " - " + name + tr(" - Odd"));
+            evenScene->setName(getNamePrefix(name) + tr(" - Even"));
+            oddScene->setName(getNamePrefix(name) + tr(" - Odd"));
             m_scenes.append(evenScene);
             m_scenes.append(oddScene);
         }
@@ -586,4 +586,21 @@ void PaletteGenerator::createFunctions(PaletteGenerator::PaletteType type,
 
     }
 
+}
+
+QString PaletteGenerator::getNamePrefix(QString name) {
+    if(true) { // Use new naming
+        return m_model + " - " + name;
+    }
+    else {
+        return name + " - " + m_model;
+    }
+}
+QString PaletteGenerator::getNamePrefix(QString type, QString name) {
+    if(true) { // Use new naming
+        return m_model + " - " + type + " - " + name;
+    }
+    else {
+        return name + " - " + type + " - " + m_model;
+    }
 }

--- a/ui/src/palettegenerator.cpp
+++ b/ui/src/palettegenerator.cpp
@@ -248,12 +248,12 @@ void PaletteGenerator::createColorScene(QList<SceneValue> chMap, QString name, P
             even = !even;
         }
     }
-    scene->setName(name + " - " + m_model);
+    scene->setName(m_model + " - color - " + name);
     m_scenes.append(scene);
     if (subType == OddEven)
     {
-        evenScene->setName(tr("%1 - %2 (Even)").arg(name).arg(m_model));
-        oddScene->setName(tr("%1 - %2 (Odd)").arg(name).arg(m_model));
+        evenScene->setName(tr("%1 - color - %2 (Even)").arg(m_model).arg(name));
+        oddScene->setName(tr("%1 - color - %2 (Odd)").arg(m_model).arg(name));
         m_scenes.append(evenScene);
         m_scenes.append(oddScene);
     }
@@ -357,12 +357,12 @@ void PaletteGenerator::createRGBCMYScene(QList<SceneValue> rcMap,
         }
         qDebug() << "color name:" << m_colNames.at(i) << "i:" << i << "count:" << m_colNames.count();
 
-        scene->setName(tr("%1 %2 - %3").arg(name).arg(m_colNames.at(i)).arg(m_model));
+        scene->setName(tr("%1 - %2 %3").arg(m_model).arg(m_colNames.at(i)).arg(name));
         m_scenes.append(scene);
         if (subType == OddEven)
         {
-            evenScene->setName(tr("%1 %2 - %3 (Even)").arg(name).arg(m_colNames.at(i)).arg(m_model));
-            oddScene->setName(tr("%1 %2 - %3 (Odd)").arg(name).arg(m_colNames.at(i)).arg(m_model));
+            evenScene->setName(tr("%1 - %2 %3 (Even)").arg(m_model).arg(m_colNames.at(i)).arg(name));
+            oddScene->setName(tr("%1 - %2 %3 (Odd)").arg(m_model).arg(m_colNames.at(i)).arg(name));
             m_scenes.append(evenScene);
             m_scenes.append(oddScene);
         }
@@ -420,12 +420,12 @@ void PaletteGenerator::createCapabilityScene(QHash<quint32, quint32> chMap,
             }
         }
 
-        scene->setName(name + " - " + m_model);
+        scene->setName(m_model + " - " + name);
         m_scenes.append(scene);
         if (subType == OddEven)
         {
-            evenScene->setName(name + " - " + m_model + tr(" - Even"));
-            oddScene->setName(name + " - " + m_model + tr(" - Odd"));
+            evenScene->setName(m_model + " - " + name + tr(" - Even"));
+            oddScene->setName(m_model + " - " + name + tr(" - Odd"));
             m_scenes.append(evenScene);
             m_scenes.append(oddScene);
         }

--- a/ui/src/palettegenerator.cpp
+++ b/ui/src/palettegenerator.cpp
@@ -357,12 +357,12 @@ void PaletteGenerator::createRGBCMYScene(QList<SceneValue> rcMap,
         }
         qDebug() << "color name:" << m_colNames.at(i) << "i:" << i << "count:" << m_colNames.count();
 
-        scene->setName(tr("%1").arg(getNamePrefix(m_colNames.at(i),arg(name))));
+        scene->setName(tr("%1").arg(getNamePrefix(m_colNames.at(i),name)));
         m_scenes.append(scene);
         if (subType == OddEven)
         {
-            evenScene->setName(tr("%1 (Even)").arg(getNamePrefix(m_colNames.at(i),arg(name))));
-            oddScene->setName(tr("%1 (Odd)").arg(getNamePrefix(m_colNames.at(i),arg(name))));
+            evenScene->setName(tr("%1 (Even)").arg(getNamePrefix(m_colNames.at(i),name)));
+            oddScene->setName(tr("%1 (Odd)").arg(getNamePrefix(m_colNames.at(i),name)));
             m_scenes.append(evenScene);
             m_scenes.append(oddScene);
         }

--- a/ui/src/palettegenerator.h
+++ b/ui/src/palettegenerator.h
@@ -138,6 +138,9 @@ private:
      */
     void createFunctions(PaletteType type, PaletteSubType subType);
 
+    QString getNamePrefix(QString name);
+    QString getNamePrefix(QString type, QString name);
+
 private:
     Doc* m_doc;
     QString m_name;


### PR DESCRIPTION
The current naming convention for the functions wizard places the name of the fixture at the end. This makes it hard to find all the scences that relate to a certain fixture
![Screenshot from 2023-04-17 16-46-18](https://user-images.githubusercontent.com/442066/232541990-a2971f3e-8a42-462b-bd2e-2a5dc3222626.png)

I find it much better to see all the scenes for the same fixure grouped together like this
![Screenshot from 2023-04-17 16-43-03](https://user-images.githubusercontent.com/442066/232541998-556417a7-6d0e-4318-b0c6-983def96acb4.png)

https://qlcplus.org/forum/viewtopic.php?t=16337
