### PR TITLE
Introduce error evaluation on the QJSEngine::call calls

### DIFF
--- a/engine/src/rgbscript.cpp
+++ b/engine/src/rgbscript.cpp
@@ -215,7 +215,8 @@ void RGBScript::initEngine()
 
 void RGBScript::displayError(QScriptValue e, const QString& fileName)
 {
-    if (e.isError()) {
+    if (e.isError()) 
+    {
         QString msg("%1: Exception at line %2. Error: %3");
         qWarning() << msg.arg(fileName)
                          .arg(e.property("lineNumber").toInt32())
@@ -242,7 +243,9 @@ int RGBScript::rgbMapStepCount(const QSize& size)
     {
         displayError(value, m_fileName);
         return -1;
-    } else {
+    } 
+    else 
+    {
         int ret = value.isNumber() ? value.toInteger() : -1;
         return ret;
     }
@@ -258,10 +261,9 @@ void RGBScript::rgbMap(const QSize& size, uint rgb, int step, RGBMap &map)
     QScriptValueList args;
     args << size.width() << size.height() << rgb << step;
     QScriptValue yarray = m_rgbMap.call(QScriptValue(), args);
+
     if (yarray.isError())
-    {
         displayError(yarray, m_fileName);
-    }
 
     if (yarray.isArray())
     {
@@ -376,7 +378,9 @@ QHash<QString, QString> RGBScript::propertiesAsStrings()
                 displayError(value, m_fileName);
             }
             else if (value.isValid())
+            {
                 properties.insert(cap.m_name, value.toString());
+            }
         }
     }
     return properties;
@@ -403,7 +407,9 @@ bool RGBScript::setProperty(QString propertyName, QString value)
             {
                 displayError(written, m_fileName);
                 return false;
-            } else {
+            }
+            else
+            {
                 return true;
             }
         }
@@ -431,10 +437,15 @@ QString RGBScript::property(QString propertyName) const
             {
                 displayError(value, m_fileName);
                 return QString();
-            } else if (value.isValid())
+            }
+            else if (value.isValid())
+            {
                 return value.toString();
+            }
             else
+            {
                 return QString();
+            }
         }
     }
     return QString();

--- a/engine/src/rgbscript.h
+++ b/engine/src/rgbscript.h
@@ -80,6 +80,9 @@ private:
     /** Init engine, engine mutex, and scripts map */
     static void initEngine();
 
+    /** Handle an error after evaluate() or call() of a script */
+    static void displayError(QScriptValue e, const QString& fileName);
+
     /************************************************************************
      * RGBAlgorithm API
      ************************************************************************/

--- a/engine/src/rgbscriptv4.cpp
+++ b/engine/src/rgbscriptv4.cpp
@@ -148,11 +148,7 @@ bool RGBScript::evaluate()
     m_script = s_engine->evaluate(m_contents, m_fileName);
     if (m_script.isError())
     {
-        QString msg("%1: Uncaught exception at line %2. Error: %3");
-        qWarning() << msg.arg(m_fileName)
-                         .arg(m_script.property("lineNumber").toInt())
-                         .arg(m_script.toString());
-        qDebug() << "Stack: " << m_script.property("stack").toString();
+        displayError(m_script, m_fileName);
         return false;
     }
 
@@ -199,6 +195,17 @@ void RGBScript::initEngine()
     Q_ASSERT(s_engine != NULL);
 }
 
+void RGBScript::displayError(QJSValue e, const QString& fileName)
+{
+    if (e.isError()) {
+        QString msg("%1: Exception at line %2. Error: %3");
+        qWarning() << msg.arg(fileName)
+                         .arg(e.property("lineNumber").toInt())
+                         .arg(e.toString());
+        qDebug() << "Stack: " << e.property("stack").toString();
+    }
+}
+
 /****************************************************************************
  * Script API
  ****************************************************************************/
@@ -213,8 +220,14 @@ int RGBScript::rgbMapStepCount(const QSize& size)
     QJSValueList args;
     args << size.width() << size.height();
     QJSValue value = m_rgbMapStepCount.call(args);
-    int ret = value.isNumber() ? value.toInt() : -1;
-    return ret;
+    if (value.isError())
+    {
+        displayError(value, m_fileName);
+        return -1;
+    } else {
+        int ret = value.isNumber() ? value.toInt() : -1;
+        return ret;
+    }
 }
 
 void RGBScript::rgbMap(const QSize& size, uint rgb, int step, RGBMap &map)
@@ -227,8 +240,12 @@ void RGBScript::rgbMap(const QSize& size, uint rgb, int step, RGBMap &map)
     QJSValueList args;
     args << size.width() << size.height() << rgb << step;
     QJSValue yarray(m_rgbMap.call(args));
+    if (yarray.isError())
+    {
+        displayError(yarray, m_fileName);
+    }
 
-    if (yarray.isArray() == true)
+    if (yarray.isArray())
     {
         QVariantList yvArray = yarray.toVariant().toList();
         int ylen = yvArray.length();
@@ -336,7 +353,11 @@ QHash<QString, QString> RGBScript::propertiesAsStrings()
         {
             QJSValueList args;
             QJSValue value = readMethod.call(args);
-            if (!value.isUndefined())
+            if (value.isError())
+            {
+                displayError(value, m_fileName);
+            }
+            else if (!value.isUndefined())
                 properties.insert(cap.m_name, value.toString());
         }
     }
@@ -359,8 +380,14 @@ bool RGBScript::setProperty(QString propertyName, QString value)
             }
             QJSValueList args;
             args << value;
-            writeMethod.call(args);
-            return true;
+            QJSValue written = writeMethod.call(args);
+            if (written.isError())
+            {
+                displayError(written, m_fileName);
+                return false;
+            } else {
+                return true;
+            }
         }
     }
     return false;
@@ -382,7 +409,11 @@ QString RGBScript::property(QString propertyName) const
             }
             QJSValueList args;
             QJSValue value = readMethod.call(args);
-            if (!value.isUndefined())
+            if (value.isError())
+            {
+                displayError(value, m_fileName);
+                return QString();
+            } else if (!value.isUndefined())
                 return value.toString();
             else
                 return QString();

--- a/engine/src/rgbscriptv4.cpp
+++ b/engine/src/rgbscriptv4.cpp
@@ -197,7 +197,8 @@ void RGBScript::initEngine()
 
 void RGBScript::displayError(QJSValue e, const QString& fileName)
 {
-    if (e.isError()) {
+    if (e.isError())
+    {
         QString msg("%1: Exception at line %2. Error: %3");
         qWarning() << msg.arg(fileName)
                          .arg(e.property("lineNumber").toInt())

--- a/engine/src/rgbscriptv4.cpp
+++ b/engine/src/rgbscriptv4.cpp
@@ -224,7 +224,9 @@ int RGBScript::rgbMapStepCount(const QSize& size)
     {
         displayError(value, m_fileName);
         return -1;
-    } else {
+    } 
+    else 
+    {
         int ret = value.isNumber() ? value.toInt() : -1;
         return ret;
     }
@@ -241,9 +243,7 @@ void RGBScript::rgbMap(const QSize& size, uint rgb, int step, RGBMap &map)
     args << size.width() << size.height() << rgb << step;
     QJSValue yarray(m_rgbMap.call(args));
     if (yarray.isError())
-    {
         displayError(yarray, m_fileName);
-    }
 
     if (yarray.isArray())
     {
@@ -354,9 +354,7 @@ QHash<QString, QString> RGBScript::propertiesAsStrings()
             QJSValueList args;
             QJSValue value = readMethod.call(args);
             if (value.isError())
-            {
                 displayError(value, m_fileName);
-            }
             else if (!value.isUndefined())
                 properties.insert(cap.m_name, value.toString());
         }
@@ -385,7 +383,9 @@ bool RGBScript::setProperty(QString propertyName, QString value)
             {
                 displayError(written, m_fileName);
                 return false;
-            } else {
+            } 
+            else 
+            {
                 return true;
             }
         }
@@ -413,10 +413,15 @@ QString RGBScript::property(QString propertyName) const
             {
                 displayError(value, m_fileName);
                 return QString();
-            } else if (!value.isUndefined())
+            } 
+            else if (!value.isUndefined())
+            {
                 return value.toString();
+            }
             else
+            {
                 return QString();
+            }
         }
     }
     return QString();

--- a/engine/src/rgbscriptv4.h
+++ b/engine/src/rgbscriptv4.h
@@ -71,6 +71,9 @@ private:
     /** Init engine, engine mutex, and scripts map */
     static void initEngine();
 
+    /** Handle an error after evaluate() or call() of a script */
+    static void displayError(QJSValue e, const QString& fileName);
+
 private:
     static QJSEngine* s_engine;      //! The engine that runs all scripts
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)


### PR DESCRIPTION
Introduce error evaluation on the QJSEngine::call calls, to detect dynamic script errors during code interpretation (::call --> undefined indices etc.).

The error detection during evaluate() only detects static error classes while loading the scripts (::evaluate --> parse errors, missing brackets etc.).