### PR TITLE
webaccess: improve vcbutton overflow and alignment

### DIFF
--- a/webaccess/res/virtualconsole.css
+++ b/webaccess/res/virtualconsole.css
@@ -11,13 +11,16 @@ form {
 }
 
 .vcbutton {
- display: table-cell;
+ display: flex;
+ overflow: hidden;
+ align-items: center;
+ justify-content: center;
+ box-sizing: border-box;
  border: 3px solid #A0A0A0;
  border-radius: 4px;
  font-family: arial, verdana, sans-serif;
  text-decoration: none;
  text-align: center;
- vertical-align: middle;
 }
 
 .vccuelist {


### PR DESCRIPTION
Some improvements to button widgets in the web view:

- Hide the overflow of text in vcbuttons when the button name does not fit.
- Center the text vertically and horizontally to match the layout in Qt.
- Include the borders in the button width/height to avoid shifting the layout and hiding parts of other widgets.

(Tested in Firefox and Chromium, should work anywhere.)

Attached below are screenshots of some test widgets in the Virtual Console and in Webaccess.

![qlcplus-webaccess-vcbutton-pullrequest](https://user-images.githubusercontent.com/81287967/236017225-f312d176-ab51-479b-b638-6721e4c97f9c.png)
