### PR TITLE
Add MIDI Note Off Triggers Scene behaviour

### DIFF
--- a/plugins/dmxusb/src/enttecdmxusbpro.cpp
+++ b/plugins/dmxusb/src/enttecdmxusbpro.cpp
@@ -440,7 +440,7 @@ void EnttecDMXUSBPro::slotDataReceived(QByteArray data, bool isMidi)
                 uchar value = 0;
                 if (QLCMIDIProtocol::midiToInput(midiCmd, midiData1, midiData2,
                                                  MAX_MIDI_CHANNELS, // always listen in OMNI mode
-                                                 &channel, &value) == true)
+                                                 &channel, &value, false) == true)
                 {
                     emit valueChanged(UINT_MAX, emitLine, channel, value);
                     // for MIDI beat clock signals,

--- a/plugins/midi/src/alsa/alsamidiinputthread.cpp
+++ b/plugins/midi/src/alsa/alsamidiinputthread.cpp
@@ -295,7 +295,7 @@ void AlsaMidiInputThread::readEvent()
         //         << "channel" << MIDI_CH(cmd) << "devch" << device->midiChannel();
 
         if (QLCMIDIProtocol::midiToInput(cmd, data1, data2, uchar(device->midiChannel()),
-                                         &channel, &value) == true)
+                                         &channel, &value, device->noteOffTriggersScene()) == true)
         {
             device->emitValueChanged(channel, value);
             // for MIDI beat clock signals,

--- a/plugins/midi/src/common/configuremidiplugin.cpp
+++ b/plugins/midi/src/common/configuremidiplugin.cpp
@@ -20,6 +20,7 @@
 #include <QTreeWidgetItem>
 #include <QTreeWidget>
 #include <QComboBox>
+#include <QCheckBox>
 #include <QSpinBox>
 #include <QDebug>
 
@@ -31,11 +32,12 @@
 #include "mididevice.h"
 #include "midiplugin.h"
 
-#define PROP_DEV        "dev"
-#define COL_NAME        0
-#define COL_CHANNEL     1
-#define COL_MODE        2
-#define COL_INITMESSAGE 3
+#define PROP_DEV              "dev"
+#define COL_NAME              0
+#define COL_CHANNEL           1
+#define COL_MODE              2
+#define COL_INITMESSAGE       3
+#define COL_NOTE_OFF_TRIGGERS 4
 
 ConfigureMidiPlugin::ConfigureMidiPlugin(MidiPlugin* plugin, QWidget* parent)
     : QDialog(parent)
@@ -118,6 +120,18 @@ void ConfigureMidiPlugin::slotInitMessageChanged(QString midiTemplateName)
     dev->setMidiTemplateName(midiTemplateName);
 }
 
+void ConfigureMidiPlugin::slotNoteOffTriggersSceneActivated(bool noteOffTriggersScene)
+{
+    QWidget* widget = qobject_cast<QWidget*> (QObject::sender());
+    Q_ASSERT(widget != NULL);
+
+    QVariant var = widget->property(PROP_DEV);
+    Q_ASSERT(var.isValid() == true);
+
+    MidiDevice* dev = (MidiDevice*) var.toULongLong();
+    Q_ASSERT(dev != NULL);
+    dev->setNoteOffTriggersScene(noteOffTriggersScene);
+}
 
 void ConfigureMidiPlugin::slotUpdateTree()
 {
@@ -144,6 +158,10 @@ void ConfigureMidiPlugin::slotUpdateTree()
         widget = createInitMessageWidget(dev->midiTemplateName());
         widget->setProperty(PROP_DEV, (qulonglong) dev);
         m_tree->setItemWidget(item, COL_INITMESSAGE, widget);
+
+        widget = createNoteOffTriggersSceneWidget(dev->noteOffTriggersScene());
+        widget->setProperty(PROP_DEV, (qulonglong) dev);
+        m_tree->setItemWidget(item, COL_NOTE_OFF_TRIGGERS, widget);
     }
 
     QTreeWidgetItem* inputs = new QTreeWidgetItem(m_tree);
@@ -167,6 +185,10 @@ void ConfigureMidiPlugin::slotUpdateTree()
         widget = createInitMessageWidget(dev->midiTemplateName());
         widget->setProperty(PROP_DEV, (qulonglong) dev);
         m_tree->setItemWidget(item, COL_INITMESSAGE, widget);
+
+        widget = createNoteOffTriggersSceneWidget(dev->noteOffTriggersScene());
+        widget->setProperty(PROP_DEV, (qulonglong) dev);
+        m_tree->setItemWidget(item, COL_NOTE_OFF_TRIGGERS, widget);
     }
 
     outputs->setExpanded(true);
@@ -234,4 +256,18 @@ QWidget* ConfigureMidiPlugin::createInitMessageWidget(QString midiTemplateName)
     connect(combo, SIGNAL(editTextChanged(QString)), this, SLOT(slotInitMessageChanged(QString)));
 
     return combo;
+}
+
+QWidget* ConfigureMidiPlugin::createNoteOffTriggersSceneWidget(bool noteOffTriggersScene)
+{
+    QCheckBox* checkbox = new QCheckBox;
+    if (noteOffTriggersScene) {
+        checkbox->setChecked(true);
+    } else {
+        checkbox->setChecked(false);
+    }
+
+    connect(checkbox, SIGNAL(clicked(bool)), this, SLOT(slotNoteOffTriggersSceneActivated(bool)));
+
+    return checkbox;
 }

--- a/plugins/midi/src/common/configuremidiplugin.h
+++ b/plugins/midi/src/common/configuremidiplugin.h
@@ -44,12 +44,14 @@ private slots:
     void slotModeActivated(int index);
     void slotInitMessageActivated(int index);
     void slotInitMessageChanged(QString midiTemplateName);
+    void slotNoteOffTriggersSceneActivated(bool noteoffTriggersScene);
     void slotUpdateTree();
 
 private:
     QWidget* createMidiChannelWidget(int select);
     QWidget* createModeWidget(MidiDevice::Mode mode);
     QWidget* createInitMessageWidget(QString midiTemplateName);
+    QWidget* createNoteOffTriggersSceneWidget(bool noteOffTriggersScene);
 
 private:
     MidiPlugin* m_plugin;

--- a/plugins/midi/src/common/configuremidiplugin.ui
+++ b/plugins/midi/src/common/configuremidiplugin.ui
@@ -81,6 +81,11 @@
        <string>Init Message</string>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>Note Off Triggers Scene</string>
+      </property>
+     </column>
     </widget>
    </item>
   </layout>

--- a/plugins/midi/src/common/mididevice.cpp
+++ b/plugins/midi/src/common/mididevice.cpp
@@ -72,6 +72,7 @@ MidiDevice::MidiDevice(const QVariant& uid, const QString& name, DeviceType devi
     , m_midiChannel(0)
     , m_mode(ControlChange)
     , m_sendNoteOff(true)
+    , m_noteOffTriggersScene(false)
 {
     loadSettings();
 }
@@ -158,6 +159,20 @@ void MidiDevice::setSendNoteOff(bool sendNoteOff)
 bool MidiDevice::sendNoteOff() const
 {
     return m_sendNoteOff;
+}
+
+/****************************************************************************
+ * Note Off Trigger Scene
+ ****************************************************************************/
+
+void MidiDevice::setNoteOffTriggersScene(bool noteOffTriggersScene)
+{
+    m_noteOffTriggersScene = noteOffTriggersScene;
+}
+
+bool MidiDevice::noteOffTriggersScene() const
+{
+    return m_noteOffTriggersScene;
 }
 
 /****************************************************************************

--- a/plugins/midi/src/common/mididevice.cpp
+++ b/plugins/midi/src/common/mididevice.cpp
@@ -24,6 +24,7 @@
 #define SETTINGS_MIDICHANNEL "midiplugin/%1/%2/midichannel"
 #define SETTINGS_MODE "midiplugin/%1/%2/mode"
 #define SETTINGS_INITMESSAGE "midiplugin/%1/%2/initmessage"
+#define SETTINGS_NOTE_OFF_TRIGGERS_SCENE "midiplugin/%1/%2/noteofftriggersscene"
 
 #define SETTINGS_MIDICHANNEL_OLD "midiplugin/%1/midichannel"
 #define SETTINGS_MODE_OLD "midiplugin/%1/mode"
@@ -233,6 +234,13 @@ void MidiDevice::loadSettings()
         setMidiTemplateName(value.toString());
     else
         setMidiTemplateName("");
+
+    key = QString(SETTINGS_NOTE_OFF_TRIGGERS_SCENE).arg(devType, name());
+    value = settings.value(key);
+    if (value.isValid() == true)
+        setNoteOffTriggersScene(value.toBool());
+    else
+        setNoteOffTriggersScene(false);
 }
 
 void MidiDevice::saveSettings() const
@@ -248,6 +256,9 @@ void MidiDevice::saveSettings() const
 
     key = QString(SETTINGS_INITMESSAGE).arg(devType, name());
     settings.setValue(key, midiTemplateName());
+
+    key = QString(SETTINGS_NOTE_OFF_TRIGGERS_SCENE).arg(devType, name());
+    settings.setValue(key, noteOffTriggersScene());
 
     qDebug() << "[MIDI] Saving mididevice with template name: " << midiTemplateName();
 }

--- a/plugins/midi/src/common/mididevice.h
+++ b/plugins/midi/src/common/mididevice.h
@@ -98,6 +98,16 @@ private:
     bool m_sendNoteOff;
 
     /************************************************************************
+    * Note Off Triggers Scene
+    ************************************************************************/
+public:
+    void setNoteOffTriggersScene(bool noteOffTriggersScene);
+    bool noteOffTriggersScene() const;
+
+private:
+    bool m_noteOffTriggersScene;
+
+    /************************************************************************
      * Midi template
      ************************************************************************/
 public:

--- a/plugins/midi/src/common/midiprotocol.cpp
+++ b/plugins/midi/src/common/midiprotocol.cpp
@@ -28,7 +28,7 @@
 
 bool QLCMIDIProtocol::midiToInput(uchar cmd, uchar data1, uchar data2,
                                   uchar midiChannel, quint32* channel,
-                                  uchar* value)
+                                  uchar* value, bool noteOffTriggersScene)
 {
     /* Check if cmd is a MIDI COMMAND byte */
     if (!MIDI_IS_CMD(cmd))
@@ -48,7 +48,11 @@ bool QLCMIDIProtocol::midiToInput(uchar cmd, uchar data1, uchar data2,
     {
         case MIDI_NOTE_OFF:
             *channel = CHANNEL_OFFSET_NOTE + quint32(data1);
-            *value = 0;
+            if(noteOffTriggersScene) {
+                *value = 64;
+            } else {
+                *value = 0;
+            }
         break;
 
         case MIDI_NOTE_ON:

--- a/plugins/midi/src/common/midiprotocol.h
+++ b/plugins/midi/src/common/midiprotocol.h
@@ -35,10 +35,11 @@ namespace QLCMIDIProtocol
      * @param midiChannel MIDI channel to expect data on (255 for all)
      * @param channel The input channel that is mapped from the given MIDI data
      * @param value The value for the input channel
+     * @param noteOffTriggersScene Note off values will trigger QLC scenes
      * @return true if the values were parsed successfully, otherwise false
      */
     bool midiToInput(uchar cmd, uchar data1, uchar data2, uchar midiChannel,
-                     quint32* channel, uchar* value);
+                     quint32* channel, uchar* value, bool noteOffTriggersScene);
 
     /**
      * Convert MIDI system common message to QLC input data

--- a/plugins/midi/src/macx/coremidiinputdevice.cpp
+++ b/plugins/midi/src/macx/coremidiinputdevice.cpp
@@ -75,7 +75,7 @@ static void MidiInProc(const MIDIPacketList* pktList, void* readProcRefCon,
 
             // Convert the data to QLC input channel & value
             if (QLCMIDIProtocol::midiToInput(cmd, data1, data2, self->midiChannel(),
-                                             &channel, &value) == true)
+                                             &channel, &value, self->noteOffTriggersScene()) == true)
             {
                 self->emitValueChanged(channel, value);
                 // for MIDI beat clock signals,

--- a/plugins/midi/src/win32/win32midiinputdevice.cpp
+++ b/plugins/midi/src/win32/win32midiinputdevice.cpp
@@ -50,7 +50,7 @@ static void CALLBACK MidiInProc(HMIDIIN hMidiIn, UINT wMsg,
         uchar value = 0;
 
         if (QLCMIDIProtocol::midiToInput(cmd, data1, data2,
-            uchar(self->midiChannel()), &channel, &value) == true)
+            uchar(self->midiChannel()), &channel, &value, self->noteOffTriggersScene()) == true)
         {
             self->emitValueChanged(channel, value);
             // for MIDI beat clock signals,

--- a/plugins/midi/test/midi_test.cpp
+++ b/plugins/midi/test/midi_test.cpp
@@ -38,8 +38,9 @@ void Midi_Test::midiToInput()
     uchar cmd = MIDI_NOTE_ON | midiChannel;
     uchar data1 = 10;
     uchar data2 = 127;
+    bool noteOffTriggersScene = false;
 
-    QLCMIDIProtocol::midiToInput(cmd, data1, data2, midiChannel, &channel, &value);
+    QLCMIDIProtocol::midiToInput(cmd, data1, data2, midiChannel, &channel, &value, noteOffTriggersScene);
 
     QCOMPARE(channel, 138U);
     QCOMPARE(value, uchar(255U));

--- a/resources/docs/html_en_EN/midiplugin.html
+++ b/resources/docs/html_en_EN/midiplugin.html
@@ -50,6 +50,10 @@ Each line has three options that can be changed depending on your needs:
         that QLC+ will send when opening a MIDI device before using it. A detailed explanation of this functionality
         is written below.
  </li>
+ <li><b>Note Off Triggers Scene</b>: By default MIDI Note Off is translated into a 0 value in QLC+, which means Note Off will not
+        toggle a button. In some cases, you want a button to toggle both when Note On, as well as Note Off is received in which case
+        you can activate this setting.
+ </li>
 </ul>
 </P>
 


### PR DESCRIPTION
Hi,

This PR introduces a new MIDI Plugin setting. As it stands right now, when QLC+ receives a `Note Off` command, it gets [auto-mapped to value 0](https://github.com/Timebutt/qlcplus/blob/master/plugins/midi/src/common/midiprotocol.cpp#L51). Because of this, a `Note Off` can never toggle a switch, which can be very much desired.

The specific use case for this is as follows: effects and chases cannot be flashed, and as such have to be toggled. When programming lights through MIDI in Cubase, I want to make sure that whenever I point anywhere in the track, all of the correct animations immediately start playing, and not for those animations to be triggered at specific points in the song only. To do this, I use very long MIDI notes (for the length of the chorus for instance). To make sure the animations stop running, I always need a second note at the very end of that note (see screenshot below).

<img width="517" alt="Screenshot 2023-05-24 at 19 46 54" src="https://github.com/mcallegari/qlcplus/assets/10674081/b696d708-7fb0-4ac2-899b-df8e01a58471">

This is very counter intuitive for me and has lead to many cases of animations still going on when they shouldn't have (not nice to see moving heads go crazy when a quiet bridge sets in ...). Having the ability to toggle a scene whenever a MIDI note ends is a great feature in my opinion.

This PR doesn't affect existing behaviour, only provides users the ability to configure the plugin in a way that might better suit their needs. It has drastically improved my own flow for sure!

The PR is an initial proposal and I'm very welcome to feedback. I'm not a C++ or Qt developer and just try to adhere to the existing code style. Let me know!

Edit: the name _noteOffTriggersScene_ is probably not the best yet, does anyone have a better suggestion?

Edit2: I also updated the documentation to reflect this new configuration option
