### PR TITLE
Added missing unittest_cmake.sh

### DIFF
--- a/unittest_cmake.sh
+++ b/unittest_cmake.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Define the source and destination directories
+SOURCE_DIR="."
+DEST_DIR="./build"
+if [ -d "$2" ]; then
+  DEST_DIR="$2"
+fi
+
+echo "Using the destination directory $DEST_DIR"
+
+if [ ! -d $DEST_DIR/resources/ ]; then
+  mkdir -p $DEST_DIR/resources/
+fi
+
+# Copy resources directories necessary for unittest
+cp -r $SOURCE_DIR/resources/colorfilters $DEST_DIR/resources
+cp -r $SOURCE_DIR/resources/fixtures $DEST_DIR/resources
+cp -r $SOURCE_DIR/resources/gobos $DEST_DIR/resources
+cp -r $SOURCE_DIR/resources/icons $DEST_DIR/resources
+cp -r $SOURCE_DIR/resources/inputprofiles $DEST_DIR/resources
+cp -r $SOURCE_DIR/resources/rgbscripts $DEST_DIR/resources
+cp -r $SOURCE_DIR/resources/schemas $DEST_DIR/resources
+
+# Find all files necessary for tests recursively in the source directory and copy to destination directory
+for file in $(find $SOURCE_DIR -path $DEST_DIR -prune -o \( -name "test.sh" -o -name "*.xml*" \)); do
+
+    # Get the directory of the file (excluding the "./" prefix)
+    dir=$(dirname ${file#./})
+
+    # Create the destination directory if it doesn't exist
+    mkdir -p $DEST_DIR/$dir
+
+    # Move the file to the new destination
+    cp $file $DEST_DIR/$dir/
+done
+
+cp $SOURCE_DIR/unittest.sh $DEST_DIR/
+
+cd $DEST_DIR
+./unittest.sh $1


### PR DESCRIPTION
#1408 
@mcallegari 
- I am not so clear how `engine/test/qlci18n` works.
Because `qlci18n_fi_FI.ts_` is required for testing `qlci18n` and `qlci18n_fi_FI.ts` is required for compiling the target and now both are omitted from Git.
Tested on my side and it looks like working when I manually added these 2 files.
- It looks like `make check` for Windows is missing in the todo list. Don't we need it anymore? It looks like that it was there in the original "qlc.pro" file.
- I manually modified the 1st line of `resources/fixtures/scripts/fixtures-tool.py` from `#!/usr/bin/env python` to `#!/usr/bin/env python3`, otherwise it did not work. Not sure if python3 is default in your develop environment.
