### PR TITLE
NanoDMX/StageProfi/Enttec fix 

### DIFF
--- a/plugins/dmxusb/src/enttecdmxusbpro.cpp
+++ b/plugins/dmxusb/src/enttecdmxusbpro.cpp
@@ -530,7 +530,7 @@ void EnttecDMXUSBPro::run()
                 {
                     uchar val = uchar(m_outputLines[i].m_universeData[j]);
 
-                    if (val == m_outputLines[i].m_compareData[j])
+                    if (val == uchar(m_outputLines[i].m_compareData[j]))
                         continue;
 
                     m_outputLines[i].m_compareData[j] = val;

--- a/plugins/dmxusb/src/enttecdmxusbpro.cpp
+++ b/plugins/dmxusb/src/enttecdmxusbpro.cpp
@@ -528,9 +528,9 @@ void EnttecDMXUSBPro::run()
                 // send only values that changed
                 for (int j = 0; j < m_outputLines[i].m_universeData.length(); j++)
                 {
-                    uchar val = uchar(m_outputLines[i].m_universeData[j]);
+                    char val = m_outputLines[i].m_universeData[j];
 
-                    if (val == uchar(m_outputLines[i].m_compareData[j]))
+                    if (val == m_outputLines[i].m_compareData[j])
                         continue;
 
                     m_outputLines[i].m_compareData[j] = val;

--- a/plugins/dmxusb/src/nanodmx.cpp
+++ b/plugins/dmxusb/src/nanodmx.cpp
@@ -307,9 +307,9 @@ void NanoDMX::run()
 
         for (int i = 0; i < m_outputLines[0].m_universeData.length(); i++)
         {
-            uchar val = uchar(m_outputLines[0].m_universeData[i]);
+            char val = m_outputLines[0].m_universeData[i];
 
-            if (val == uchar(m_outputLines[0].m_compareData[i]))
+            if (val == m_outputLines[0].m_compareData[i])
                 continue;
 
             //qDebug() << "Writing value at index" << i;

--- a/plugins/dmxusb/src/nanodmx.cpp
+++ b/plugins/dmxusb/src/nanodmx.cpp
@@ -309,7 +309,7 @@ void NanoDMX::run()
         {
             uchar val = uchar(m_outputLines[0].m_universeData[i]);
 
-            if (val == m_outputLines[0].m_compareData[i])
+            if (val == uchar(m_outputLines[0].m_compareData[i]))
                 continue;
 
             //qDebug() << "Writing value at index" << i;

--- a/plugins/dmxusb/src/stageprofi.cpp
+++ b/plugins/dmxusb/src/stageprofi.cpp
@@ -205,9 +205,9 @@ void Stageprofi::run()
 
         for (int i = 0; i < m_outputLines[0].m_universeData.length(); i++)
         {
-            uchar val = uchar(m_outputLines[0].m_universeData[i]);
+            char val = m_outputLines[0].m_universeData[i];
 
-            if (val == uchar(m_outputLines[0].m_compareData[i]))
+            if (val == m_outputLines[0].m_compareData[i])
                 continue;
 
             QByteArray fastTrans;

--- a/plugins/dmxusb/src/stageprofi.cpp
+++ b/plugins/dmxusb/src/stageprofi.cpp
@@ -207,7 +207,7 @@ void Stageprofi::run()
         {
             uchar val = uchar(m_outputLines[0].m_universeData[i]);
 
-            if (val == m_outputLines[0].m_compareData[i])
+            if (val == uchar(m_outputLines[0].m_compareData[i]))
                 continue;
 
             QByteArray fastTrans;


### PR DESCRIPTION
For any value over 127, the nanodmx code sends the update to the device repeatedly rather than just once, as happens for any value <= 127

This is caused by a signed/unsigned value comparison in nanodmx.cpp

Fixed and tested. Also fixed the same code in stageprofi.cpp and enttecdmxusbpro.cpp, but not tested.