### PR TITLE
Fix random order chaser always starts with first step

### DIFF
--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -750,7 +750,14 @@ bool ChaserRunner::write(MasterTimer *timer, QList<Universe *> universes)
             if (m_pendingAction.m_stepIndex != -1)
             {
                 clearRunningList();
-                m_lastRunStepIdx = m_pendingAction.m_stepIndex;
+                if(m_chaser->runOrder() == Function::Random)
+                {
+                    m_lastRunStepIdx = randomStepIndex(m_pendingAction.m_stepIndex);
+                }
+                else
+                {
+                    m_lastRunStepIdx = m_pendingAction.m_stepIndex;
+                }
                 qDebug() << "[ChaserRunner] Starting from step" << m_lastRunStepIdx << "@ offset" << m_startOffset;
                 startNewStep(m_lastRunStepIdx, timer, m_pendingAction.m_masterIntensity,
                              m_pendingAction.m_stepIntensity, m_pendingAction.m_fadeMode);


### PR DESCRIPTION
Instead of using the random order of a chaser, the chaserrunner sets the step index to zero when started by a virtual console button. Fixed by using the randomStepIndex method instead of just setting the index.