### PR TITLE
Override flash functionality: Fix options not copied when copying buttons

### DIFF
--- a/qmlui/virtualconsole/vcbutton.cpp
+++ b/qmlui/virtualconsole/vcbutton.cpp
@@ -114,6 +114,9 @@ bool VCButton::copyFrom(const VCWidget* widget)
     setActionType(button->actionType());
     setState(button->state());
 
+    m_flashForceLTP = button->flashForceLTP();
+    m_flashOverrides = button->flashOverrides();
+
     /* Copy common stuff */
     return VCWidget::copyFrom(widget);
 }

--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -168,6 +168,9 @@ bool VCButton::copyFrom(const VCWidget* widget)
     setAction(button->action());
     m_state = button->m_state;
 
+    m_flashForceLTP = button->flashForceLTP();
+    m_flashOverrides = button->flashOverrides();
+
     /* Copy common stuff */
     return VCWidget::copyFrom(widget);
 }
@@ -672,7 +675,7 @@ void VCButton::slotAttributeChanged(int value)
  * Flash Properties
  *****************************************************************************/
 
-bool VCButton::flashOverrides()
+bool VCButton::flashOverrides() const
 {
     return m_flashOverrides;
 }
@@ -682,7 +685,7 @@ void VCButton::setFlashOverride(bool shouldOverride)
     m_flashOverrides = shouldOverride;
 }
 
-bool VCButton::flashForceLTP()
+bool VCButton::flashForceLTP() const
 {
     return m_flashForceLTP;
 }

--- a/ui/src/virtualconsole/vcbutton.h
+++ b/ui/src/virtualconsole/vcbutton.h
@@ -315,11 +315,11 @@ protected slots:
     *****************************************************************************/
 public:
     /** Gets if flashing overrides newer values */
-    bool flashOverrides();
+    bool flashOverrides() const;
     /** Sets if flashing should override values */
     void setFlashOverride(bool shouldOverride);
     /** Gets if flash channels should behave like LTP channels */
-    bool flashForceLTP();
+    bool flashForceLTP() const;
     /** Sets if the flash channels should behave like LTP channels */
     void setFlashForceLTP(bool forceLTP);
 


### PR DESCRIPTION
As described in the forum post the copying of the buttons was not implemented correctly.
I added the copying of the options to the copyfrom method.