### PR TITLE
resources: add Eurolite LED PLL-480 CW/WW

### DIFF
--- a/resources/fixtures/Eurolite/Eurolite-LED-PLL-480-CW-WW.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-PLL-480-CW-WW.qxf
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.12.7</Version>
+  <Author>Benjamin Drung</Author>
+ </Creator>
+ <Manufacturer>Eurolite</Manufacturer>
+ <Model>LED PLL-480 CW/WW</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Warm White" Preset="IntensityWhite"/>
+ <Channel Name="Cold White" Preset="IntensityWhite"/>
+ <Channel Name="Dimmer" Preset="IntensityDimmer"/>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="9" Preset="ShutterOpen">No function</Capability>
+  <Capability Min="10" Max="255" Preset="StrobeSlowToFast">Strobe (Slow to fast)</Capability>
+ </Channel>
+ <Channel Name="Dimmer Speed (step response)">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="63">Response characteristics of LEDs</Capability>
+  <Capability Min="64" Max="127">Response characteristics of halogen lamps, fast</Capability>
+  <Capability Min="128" Max="191">Response characteristics of halogen lamps, middle</Capability>
+  <Capability Min="192" Max="255">Response characteristics of halogen lamps, slow</Capability>
+ </Channel>
+ <Mode Name="Standard">
+  <Channel Number="0">Warm White</Channel>
+  <Channel Number="1">Cold White</Channel>
+  <Channel Number="2">Dimmer</Channel>
+  <Channel Number="3">Strobe</Channel>
+  <Channel Number="4">Dimmer Speed (step response)</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="17470" ColourTemperature="3200"/>
+  <Dimensions Weight="12.6" Width="640" Height="330" Depth="125"/>
+  <Lens Name="Other" DegreesMin="120" DegreesMax="120"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical PowerConsumption="205" DmxConnector="3-pin"/>
+ </Physical>
+</FixtureDefinition>

--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -751,6 +751,7 @@
     <F n="Eurolite-LED-PARty-Hybrid-spot" m="LED PARty Hybrid Spot"/>
     <F n="Eurolite-LED-Party-Panel-RGB+UV" m="LED Party Panel RGB+UV"/>
     <F n="Eurolite-LED-PARty-RGBW" m="LED PARty RGBW"/>
+    <F n="Eurolite-LED-PLL-480-CW-WW" m="LED PLL-480 CW/WW"/>
     <F n="Eurolite-LED-PMB-4-COB-RGB-30W-Bar" m="LED PMB-4 COB RGB 30W Bar"/>
     <F n="Eurolite-LED-PMB-8-COB-RGB-30W" m="LED PMB-8 COB RGB 30W"/>
     <F n="Eurolite-LED-PT-100-32-Pixel-DMX-Tube" m="LED PT-100/32 Pixel DMX Tube"/>


### PR DESCRIPTION
Add Eurolite LED PLL-480 CW/WW [1]. The names and description were taken from 40001895-Manual-119588-1.000-de_en.pdf [2]. This fixture definition has some shortcomings:

1. There is no type for floodlights, so ColorChanger is used.
2. There are no separate presets for warm and cold white. So both warm and cold white have to use the same preset.
3. The bulb colour temperature field does not allow specifying the color range 3200K - 5600K. So the lower warm white colour is specified.

[1] https://www.steinigke.de/en/mpn40001895-eurolite-led-pll-480-cw-ww-panel.html
[2] https://www.steinigke.de/download/40001895-Manual-119588-1.000-eurolite-led-pll-480-cw-ww-panel-de_en.pdf