### PR TITLE
v4 soloframe monitoring button fix

### DIFF
--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -714,16 +714,24 @@ void VCButton::pressFunction()
         if (f == NULL)
             return;
 
-        // if the button is in a SoloFrame and the function is running but was
-        // started by a different function (a chaser or collection), turn other
-        // functions off and start this one.
-        if (state() == Active && !(isChildOfSoloFrame() && f->startedAsChild()))
+        if (state() == Active)
         {
+            // this stops "On/Active" buttons (with green border)
             f->stop(functionParent());
             resetIntensityOverrideAttribute();
         }
         else
         {
+            // this starts "Off/Inactive" buttons (with no border),
+            // *and* it starts "Monitoring" buttons (with orange border).
+
+            /** Note: if a button is in a SoloFrame and the function is running,
+             *   but was started by a different function (such as a chaser or collection), 
+             *   we want to turn other functions off and start this one.
+             *  This previously checked isChildOfSoloFrame() and f->startedAsChild() 
+             *   to help in deciding what to do, but with the addition of the tri-state
+             *   ButtonState values, these helpers might no longer be needed. */
+
             adjustFunctionIntensity(f, intensity());
 
             // starting a Chaser is a special case, since it is necessary


### PR DESCRIPTION
This fixes an issue where a button in a soloframe in "monitoring" mode can't be de-activated. It can be activated, but then it gets stuck in the on state until after the parent function stops.

The docs say it should be able to be stopped: https://docs.qlcplus.org/v4/virtual-console/button (at the bottom of the page). And v5 (qmlui) allows it to be stopped.