### PR TITLE
Flash override: Change button border to red when button uses override functions.

### DIFF
--- a/qmlui/qml/virtualconsole/VCButtonItem.qml
+++ b/qmlui/qml/virtualconsole/VCButtonItem.qml
@@ -29,6 +29,7 @@ VCWidgetItem
 
     property int btnState: buttonObj ? buttonObj.state : VCButton.Inactive
     property int btnAction: buttonObj ? buttonObj.actionType : VCButton.Toggle
+    property string activeColor: buttonObj.flashOverrides || buttonObj.flashForceLTP ? "#FF0000" : "#00FF00"
 
     radius: 4
 
@@ -76,7 +77,7 @@ VCWidgetItem
         height: parent.height - 2
         color: "transparent"
         border.width: (buttonRoot.width > 80) ? 3 : 2
-        border.color: btnState === VCButton.Active ? "#00FF00" : btnState === VCButton.Monitoring ? "orange" : "#A0A0A0"
+        border.color: btnState === VCButton.Active ? activeColor : btnState === VCButton.Monitoring ? "orange" : "#A0A0A0"
         radius: 3
 
         Rectangle

--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -1114,7 +1114,12 @@ void VCButton::paintEvent(QPaintEvent* e)
         painter.setPen(QPen(QColor(160, 160, 160, 255), 2));
 
         if (state() == Active)
-            painter.setBrush(QBrush(QColor(0, 230, 0, 255)));
+        {
+            if(m_flashForceLTP || m_flashOverrides)
+                painter.setBrush(QBrush(QColor(230, 0, 0, 255)));
+            else
+                painter.setBrush(QBrush(QColor(0, 230, 0, 255)));
+        }
         else if (state() == Monitoring)
             painter.setBrush(QBrush(QColor(255, 170, 0, 255)));
         else
@@ -1141,7 +1146,12 @@ void VCButton::paintEvent(QPaintEvent* e)
             if (state() == Monitoring)
                 painter.setPen(QPen(QColor(255, 170, 0, 255), borderWidth));
             else
-                painter.setPen(QPen(QColor(0, 230, 0, 255), borderWidth));
+            {
+                if(m_flashForceLTP || m_flashOverrides)
+                    painter.setPen(QPen(QColor(230, 0, 0, 255), borderWidth));
+                else
+                    painter.setPen(QPen(QColor(0, 230, 0, 255), borderWidth));
+            }
             painter.drawRoundedRect(borderWidth, borderWidth,
                                     rect().width() - borderWidth * 2, rect().height() - (borderWidth * 2),
                                     borderWidth, borderWidth);


### PR DESCRIPTION
As suggested by mcallegari in the forum discussion about the overriding flash functionality, I changed the visualization of the flash button to display the border red instead of green when FlashForceLTP or OverridePriority is used. 