### PR TITLE
Save dialog geometry for all QLC+ dialogs

### DIFF
--- a/fixtureeditor/addchannelsdialog.cpp
+++ b/fixtureeditor/addchannelsdialog.cpp
@@ -17,9 +17,13 @@
   limitations under the License.
 */
 
+#include <QSettings>
+
 #include "qlcchannel.h"
 #include "addchannelsdialog.h"
 #include "ui_addchannelsdialog.h"
+
+#define SETTINGS_GEOMETRY "addchannelsdialog/geometry"
 
 AddChannelsDialog::AddChannelsDialog(QList<QLCChannel *> allList, QVector<QLCChannel *> modeList, QWidget *parent) :
     QDialog(parent)
@@ -37,6 +41,11 @@ AddChannelsDialog::AddChannelsDialog(QList<QLCChannel *> allList, QVector<QLCCha
     m_modeTree->setDropIndicatorShown(true);
     m_modeTree->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_addChannel, SIGNAL(clicked()),
             this, SLOT(slotAddChannel()));
     connect(m_removeChannel, SIGNAL(clicked()),
@@ -47,7 +56,8 @@ AddChannelsDialog::AddChannelsDialog(QList<QLCChannel *> allList, QVector<QLCCha
 
 AddChannelsDialog::~AddChannelsDialog()
 {
-
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 QList<QLCChannel *> AddChannelsDialog::getModeChannelsList()

--- a/fixtureeditor/edithead.cpp
+++ b/fixtureeditor/edithead.cpp
@@ -21,11 +21,14 @@
 #include <QTreeWidget>
 #include <QDebug>
 #include <QAction>
+#include <QSettings>
 
 #include "qlcfixturehead.h"
 #include "qlcfixturemode.h"
 #include "qlcchannel.h"
 #include "edithead.h"
+
+#define SETTINGS_GEOMETRY "edithead/geometry"
 
 EditHead::EditHead(QWidget* parent, const QLCFixtureHead& head, const QLCFixtureMode* mode)
     : QDialog(parent)
@@ -40,12 +43,19 @@ EditHead::EditHead(QWidget* parent, const QLCFixtureHead& head, const QLCFixture
 
     fillChannelTree(mode);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_tree, SIGNAL(itemChanged(QTreeWidgetItem*,int)),
             this, SLOT(slotItemChanged(QTreeWidgetItem*,int)));
 }
 
 EditHead::~EditHead()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 QLCFixtureHead EditHead::head() const

--- a/plugins/E1.31/configuree131.cpp
+++ b/plugins/E1.31/configuree131.cpp
@@ -48,6 +48,8 @@
 #define E131_PRIORITY_MIN 0
 #define E131_PRIORITY_MAX 200
 
+#define SETTINGS_GEOMETRY "conifguree131/geometry"
+
 /*****************************************************************************
  * Initialization
  *****************************************************************************/
@@ -67,10 +69,15 @@ ConfigureE131::ConfigureE131(E131Plugin* plugin, QWidget* parent)
     QVariant value = settings.value(SETTINGS_IFACE_WAIT_TIME);
     if (value.isValid() == true)
         m_waitReadySpin->setValue(value.toInt());
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 ConfigureE131::~ConfigureE131()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void ConfigureE131::fillMappingTree()

--- a/plugins/artnet/src/configureartnet.cpp
+++ b/plugins/artnet/src/configureartnet.cpp
@@ -46,6 +46,7 @@
 
 // ArtNet universe is a 15bit value
 #define ARTNET_UNIVERSE_MAX 0x7fff
+#define SETTINGS_GEOMETRY "configureartnet/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -67,6 +68,9 @@ ConfigureArtNet::ConfigureArtNet(ArtNetPlugin* plugin, QWidget* parent)
     QVariant value = settings.value(SETTINGS_IFACE_WAIT_TIME);
     if (value.isValid() == true)
         m_waitReadySpin->setValue(value.toInt());
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 
@@ -200,6 +204,8 @@ void ConfigureArtNet::showIPAlert(QString ip)
 
 ConfigureArtNet::~ConfigureArtNet()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /*****************************************************************************

--- a/plugins/dummy/dummyconfiguration.cpp
+++ b/plugins/dummy/dummyconfiguration.cpp
@@ -17,8 +17,12 @@
   limitations under the License.
 */
 
+#include <QSettings>
+
 #include "dummyconfiguration.h"
 #include "dummyplugin.h"
+
+#define SETTINGS_GEOMETRY "dummyconfiguration/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -33,6 +37,11 @@ DummyConfiguration::DummyConfiguration(DummyPlugin* plugin, QWidget* parent)
     /* Setup UI controls */
     setupUi(this);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     /**
      * Do the dialog initializations here.
      *  E.g.: fill combo boxes, set spin boxes values, fill lists, etc...
@@ -41,7 +50,8 @@ DummyConfiguration::DummyConfiguration(DummyPlugin* plugin, QWidget* parent)
 
 DummyConfiguration::~DummyConfiguration()
 {
-    /** Cleanup the allocated resources, if any */
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /*****************************************************************************

--- a/plugins/gpio/gpioconfiguration.cpp
+++ b/plugins/gpio/gpioconfiguration.cpp
@@ -18,12 +18,15 @@
 */
 
 #include <QComboBox>
+#include <QSettings>
 
 #include "gpioconfiguration.h"
 #include "gpioplugin.h"
 
 #define KColumnGPIONumber       0
 #define KColumnGPIOUsage        1
+
+#define SETTINGS_GEOMETRY "gpioconfiguration/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -38,12 +41,18 @@ GPIOConfiguration::GPIOConfiguration(GPIOPlugin* plugin, QWidget* parent)
     /* Setup UI controls */
     setupUi(this);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     fillTree();
 }
 
 GPIOConfiguration::~GPIOConfiguration()
 {
-    /** Cleanup the allocated resources, if any */
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void GPIOConfiguration::fillTree()

--- a/plugins/hid/configurehid.cpp
+++ b/plugins/hid/configurehid.cpp
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QTimer>
 #include <QDebug>
+#include <QSettings>
 
 #include "configurehid.h"
 #include "hiddevice.h"
@@ -31,6 +32,8 @@
 
 #define KColumnNumber  0
 #define KColumnName    1
+
+#define SETTINGS_GEOMETRY "configurehid/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -44,6 +47,11 @@ ConfigureHID::ConfigureHID(QWidget* parent, HIDPlugin* plugin)
 
     /* Setup UI controls */
     setupUi(this);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     connect(m_refreshButton, SIGNAL(clicked()),
             this, SLOT(slotRefreshClicked()));
@@ -59,6 +67,8 @@ ConfigureHID::ConfigureHID(QWidget* parent, HIDPlugin* plugin)
 
 ConfigureHID::~ConfigureHID()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /*****************************************************************************

--- a/plugins/midi/src/common/configuremidiplugin.cpp
+++ b/plugins/midi/src/common/configuremidiplugin.cpp
@@ -22,6 +22,7 @@
 #include <QComboBox>
 #include <QSpinBox>
 #include <QDebug>
+#include <QSettings>
 
 #include "configuremidiplugin.h"
 #include "midioutputdevice.h"
@@ -37,6 +38,8 @@
 #define COL_MODE        2
 #define COL_INITMESSAGE 3
 
+#define SETTINGS_GEOMETRY "configuremidiplugin/geometry"
+
 ConfigureMidiPlugin::ConfigureMidiPlugin(MidiPlugin* plugin, QWidget* parent)
     : QDialog(parent)
     , m_plugin(plugin)
@@ -44,12 +47,19 @@ ConfigureMidiPlugin::ConfigureMidiPlugin(MidiPlugin* plugin, QWidget* parent)
     Q_ASSERT(plugin != NULL);
     setupUi(this);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(plugin, SIGNAL(configurationChanged()), this, SLOT(slotUpdateTree()));
     slotUpdateTree();
 }
 
 ConfigureMidiPlugin::~ConfigureMidiPlugin()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void ConfigureMidiPlugin::slotRefresh()

--- a/plugins/ola/configureolaio.cpp
+++ b/plugins/ola/configureolaio.cpp
@@ -24,12 +24,15 @@
 #include <QDialog>
 #include <QString>
 #include <QTimer>
+#include <QSettings>
 
 #include "configureolaio.h"
 #include "olaio.h"
 
 #define COL_NAME 0
 #define COL_LINE 1
+
+#define SETTINGS_GEOMETRY "configureolaio/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -45,11 +48,19 @@ ConfigureOlaIO::ConfigureOlaIO(OlaIO* plugin, QWidget* parent)
     populateOutputList();
 
     m_standaloneCheck->setChecked(m_plugin->isServerEmbedded());
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 ConfigureOlaIO::~ConfigureOlaIO()
 {
     m_plugin->setServerEmbedded(m_standaloneCheck->isChecked());
+
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void ConfigureOlaIO::populateOutputList()

--- a/plugins/os2l/os2lconfiguration.cpp
+++ b/plugins/os2l/os2lconfiguration.cpp
@@ -17,8 +17,12 @@
   limitations under the License.
 */
 
+#include <QSettings>
+
 #include "os2lconfiguration.h"
 #include "os2lplugin.h"
+
+#define SETTINGS_GEOMETRY "os2lconfiguration/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -37,11 +41,17 @@ OS2LConfiguration::OS2LConfiguration(OS2LPlugin* plugin, QWidget* parent)
         m_hostGroup->hide();
     else
         m_activateLabel->hide();
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 OS2LConfiguration::~OS2LConfiguration()
 {
-    /** Cleanup the allocated resources, if any */
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /*****************************************************************************

--- a/plugins/osc/configureosc.cpp
+++ b/plugins/osc/configureosc.cpp
@@ -24,6 +24,7 @@
 #include <QSpinBox>
 #include <QLabel>
 #include <QDebug>
+#include <QSettings>
 
 #include "configureosc.h"
 #include "oscplugin.h"
@@ -37,6 +38,8 @@
 #define PROP_UNIVERSE (Qt::UserRole + 0)
 #define PROP_LINE (Qt::UserRole + 1)
 #define PROP_TYPE (Qt::UserRole + 2)
+
+#define SETTINGS_GEOMETRY "configureosc/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -60,10 +63,15 @@ ConfigureOSC::ConfigureOSC(OSCPlugin* plugin, QWidget* parent)
     QVariant value = settings.value(SETTINGS_IFACE_WAIT_TIME);
     if (value.isValid() == true)
         m_waitReadySpin->setValue(value.toInt());
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 ConfigureOSC::~ConfigureOSC()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void ConfigureOSC::fillMappingTree()

--- a/plugins/spi/spiconfiguration.cpp
+++ b/plugins/spi/spiconfiguration.cpp
@@ -23,6 +23,8 @@
 #include "spiconfiguration.h"
 #include "spiplugin.h"
 
+#define SETTINGS_GEOMETRY "spiconfiguration/geometry"
+
 /*****************************************************************************
  * Initialization
  *****************************************************************************/
@@ -48,10 +50,15 @@ SPIConfiguration::SPIConfiguration(SPIPlugin* plugin, QWidget* parent)
             case 8000000: m_freqCombo->setCurrentIndex(3); break;
         }
     }
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 SPIConfiguration::~SPIConfiguration()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /*****************************************************************************

--- a/ui/src/addchannelsgroup.cpp
+++ b/ui/src/addchannelsgroup.cpp
@@ -35,6 +35,7 @@
 #define KColumnChIdx 3
 #define KColumnID    4
 
+#define SETTINGS_GEOMETRY "addchannelsgroup/geometry"
 #define SETTINGS_APPLYALL "addchannelsgroup/applyall"
 
 AddChannelsGroup::AddChannelsGroup(QWidget* parent, Doc* doc, ChannelsGroup *group)
@@ -119,9 +120,12 @@ AddChannelsGroup::AddChannelsGroup(QWidget* parent, Doc* doc, ChannelsGroup *gro
     m_tree->header()->resizeSections(QHeaderView::ResizeToContents);
 
     QSettings settings;
-    QVariant var = settings.value(SETTINGS_APPLYALL);
-    if (var.isValid() == true)
-       m_applyAllCheck->setChecked(var.toBool());
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+    QVariant apply4AllSettings = settings.value(SETTINGS_APPLYALL);
+    if (apply4AllSettings.isValid() == true)
+       m_applyAllCheck->setChecked(apply4AllSettings.toBool());
 
     m_inputSelWidget = new InputSelectionWidget(m_doc, this);
     m_inputSelWidget->setKeyInputVisibility(false);
@@ -143,6 +147,7 @@ AddChannelsGroup::AddChannelsGroup(QWidget* parent, Doc* doc, ChannelsGroup *gro
 AddChannelsGroup::~AddChannelsGroup()
 {
     QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
     settings.setValue(SETTINGS_APPLYALL, m_applyAllCheck->isChecked());
 }
 

--- a/ui/src/addresstool.cpp
+++ b/ui/src/addresstool.cpp
@@ -20,9 +20,12 @@
 #include <QPainter>
 #include <QPixmap>
 #include <QMouseEvent>
+#include <QSettings>
 
 #include "addresstool.h"
 #include "ui_addresstool.h"
+
+#define SETTINGS_GEOMETRY "addresstool/geometry"
 
 AddressTool::AddressTool(QWidget *parent, int presetValue) :
     QDialog(parent)
@@ -47,6 +50,11 @@ AddressTool::AddressTool(QWidget *parent, int presetValue) :
     ui->m_gridLayout->addWidget(m_dipSwitch, 0, 0, 1, 5);
     m_dipSwitch->setMinimumHeight(80);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(ui->m_addressSpin, SIGNAL(valueChanged(int)),
             m_dipSwitch, SLOT(slotSetValue(int)));
     connect(m_dipSwitch, SIGNAL(valueChanged(int)),
@@ -60,6 +68,9 @@ AddressTool::AddressTool(QWidget *parent, int presetValue) :
 
 AddressTool::~AddressTool()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
+
     delete ui;
 }
 

--- a/ui/src/addrgbpanel.cpp
+++ b/ui/src/addrgbpanel.cpp
@@ -19,10 +19,13 @@
 
 #include <QPushButton>
 #include <QDebug>
+#include <QSettings>
 
 #include "addrgbpanel.h"
 #include "ui_addrgbpanel.h"
 #include "doc.h"
+
+#define SETTINGS_GEOMETRY "addrgbpanel/geometry"
 
 AddRGBPanel::AddRGBPanel(QWidget *parent, const Doc *doc)
     : QDialog(parent)
@@ -43,6 +46,11 @@ AddRGBPanel::AddRGBPanel(QWidget *parent, const Doc *doc)
 
     checkAddressAvailability();
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_uniCombo, SIGNAL(currentIndexChanged(int)),
             this, SLOT(slotUniverseChanged()));
     connect(m_addressSpin, SIGNAL(valueChanged(int)),
@@ -55,6 +63,8 @@ AddRGBPanel::AddRGBPanel(QWidget *parent, const Doc *doc)
 
 AddRGBPanel::~AddRGBPanel()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 bool AddRGBPanel::checkAddressAvailability()
 {

--- a/ui/src/assignhotkey.cpp
+++ b/ui/src/assignhotkey.cpp
@@ -23,9 +23,11 @@
 #include <QLineEdit>
 #include <QKeyEvent>
 #include <QDebug>
+#include <QSettings>
 
 #include "assignhotkey.h"
 
+#define SETTINGS_GEOMETRY "assignhotkey/geometry"
 #define SETTINGS_AUTOCLOSE "assignhotkey/autoclose"
 
 /*****************************************************************************
@@ -65,11 +67,16 @@ AssignHotKey::AssignHotKey(QWidget* parent, const QKeySequence& keySequence)
 
     QSettings settings;
     m_autoCloseCheckBox->setChecked(settings.value(SETTINGS_AUTOCLOSE).toBool());
+
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 AssignHotKey::~AssignHotKey()
 {
     QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
     settings.setValue(SETTINGS_AUTOCLOSE, m_autoCloseCheckBox->isChecked());
 }
 

--- a/ui/src/channelmodifiereditor.cpp
+++ b/ui/src/channelmodifiereditor.cpp
@@ -19,6 +19,7 @@
 
 #include <QMessageBox>
 #include <QUrl>
+#include <QSettings>
 
 #include "channelmodifiergraphicsview.h"
 #include "channelmodifiereditor.h"
@@ -26,6 +27,8 @@
 #include "channelmodifier.h"
 #include "qlcfile.h"
 #include "doc.h"
+
+#define SETTINGS_GEOMETRY "channelmodifiereditor/geometry"
 
 ChannelModifierEditor::ChannelModifierEditor(Doc *doc, QString modifier, QWidget *parent)
     : QDialog(parent)
@@ -46,6 +49,11 @@ ChannelModifierEditor::ChannelModifierEditor(Doc *doc, QString modifier, QWidget
     m_origDMXSpin->setEnabled(false);
     m_modifiedDMXSpin->setEnabled(false);
     m_deleteHandlerButton->setEnabled(false);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     connect(m_view, SIGNAL(itemClicked(uchar,uchar)),
             this, SLOT(slotHandlerClicked(uchar,uchar)));
@@ -77,7 +85,8 @@ ChannelModifierEditor::ChannelModifierEditor(Doc *doc, QString modifier, QWidget
 
 ChannelModifierEditor::~ChannelModifierEditor()
 {
-
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 ChannelModifier *ChannelModifierEditor::selectedModifier()

--- a/ui/src/channelsselection.cpp
+++ b/ui/src/channelsselection.cpp
@@ -21,6 +21,7 @@
 #include <QPushButton>
 #include <QComboBox>
 #include <QDebug>
+#include <QSettings>
 
 #include "channelmodifiereditor.h"
 #include "channelsselection.h"
@@ -36,6 +37,8 @@
 #define KColumnModifier     4
 #define KColumnChIdx        5
 #define KColumnID           6
+
+#define SETTINGS_GEOMETRY "channelsselection/geometry"
 
 ChannelsSelection::ChannelsSelection(Doc *doc, QWidget *parent, ChannelSelectionType mode)
     : QDialog(parent)
@@ -64,6 +67,11 @@ ChannelsSelection::ChannelsSelection(Doc *doc, QWidget *parent, ChannelSelection
 
     updateFixturesTree();
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_channelsTree, SIGNAL(itemChanged(QTreeWidgetItem*,int)),
             this, SLOT(slotItemChecked(QTreeWidgetItem*, int)));
     connect(m_channelsTree, SIGNAL(expanded(QModelIndex)),
@@ -78,6 +86,8 @@ ChannelsSelection::ChannelsSelection(Doc *doc, QWidget *parent, ChannelSelection
 
 ChannelsSelection::~ChannelsSelection()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void ChannelsSelection::setChannelsList(QList<SceneValue> list)

--- a/ui/src/createfixturegroup.cpp
+++ b/ui/src/createfixturegroup.cpp
@@ -17,16 +17,27 @@
   limitations under the License.
 */
 
+#include <QSettings>
+
 #include "createfixturegroup.h"
+
+#define SETTINGS_GEOMETRY "createfixturegroup/geometry"
 
 CreateFixtureGroup::CreateFixtureGroup(QWidget* parent)
     : QDialog(parent)
 {
     setupUi(this);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 CreateFixtureGroup::~CreateFixtureGroup()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 QString CreateFixtureGroup::name() const

--- a/ui/src/dmxdumpfactory.cpp
+++ b/ui/src/dmxdumpfactory.cpp
@@ -20,6 +20,7 @@
 #include <QTreeWidgetItem>
 #include <QTreeWidget>
 #include <QDebug>
+#include <QSettings>
 
 #include "dmxdumpfactoryproperties.h"
 #include "fixturetreewidget.h"
@@ -41,6 +42,8 @@
 
 #define KColumnTargetName 0
 #define KColumnTargetID   1
+
+#define SETTINGS_GEOMETRY "dmxdumpfactory/geometry"
 
 DmxDumpFactory::DmxDumpFactory(Doc *doc, DmxDumpFactoryProperties *props, QWidget *parent)
     : QDialog(parent)
@@ -83,12 +86,19 @@ DmxDumpFactory::DmxDumpFactory(Doc *doc, DmxDumpFactoryProperties *props, QWidge
     if (m_properties->nonZeroValuesMode() == true)
         m_nonZeroCheck->setChecked(true);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_sceneButton, SIGNAL(clicked(bool)),
             this, SLOT(slotSelectSceneButtonClicked()));
 }
 
 DmxDumpFactory::~DmxDumpFactory()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void DmxDumpFactory::slotUpdateChasersTree()

--- a/ui/src/fixtureremap.cpp
+++ b/ui/src/fixtureremap.cpp
@@ -24,6 +24,7 @@
 #include <QScrollBar>
 #include <QDebug>
 #include <QDir>
+#include <QSettings>
 
 #include "monitorproperties.h"
 #include "vcaudiotriggers.h"
@@ -56,6 +57,8 @@
 #define KColumnID           3
 #define KColumnChIdx        4
 
+#define SETTINGS_GEOMETRY "fixturemap/geometry"
+
 FixtureRemap::FixtureRemap(Doc *doc, QWidget *parent)
     : QDialog(parent)
     , m_doc(doc)
@@ -64,6 +67,10 @@ FixtureRemap::FixtureRemap(Doc *doc, QWidget *parent)
 
     setupUi(this);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     connect(m_importButton, SIGNAL(clicked()),
             this, SLOT(slotImportFixtures()));
@@ -143,6 +150,9 @@ FixtureRemap::FixtureRemap(Doc *doc, QWidget *parent)
 
 FixtureRemap::~FixtureRemap()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
+
     delete m_targetDoc;
 }
 

--- a/ui/src/fixtureselection.cpp
+++ b/ui/src/fixtureselection.cpp
@@ -22,10 +22,13 @@
 #include <QHeaderView>
 #include <QLabel>
 #include <QAction>
+#include <QSettings>
 
 #include "fixturetreewidget.h"
 #include "fixtureselection.h"
 #include "doc.h"
+
+#define SETTINGS_GEOMETRY "fixtureselection/geometry"
 
 FixtureSelection::FixtureSelection(QWidget* parent, Doc* doc)
     : QDialog(parent)
@@ -50,6 +53,11 @@ FixtureSelection::FixtureSelection(QWidget* parent, Doc* doc)
     m_tree = new FixtureTreeWidget(m_doc, m_treeFlags, this);
     m_mainLayout->addWidget(m_tree);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_tree, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)),
             this, SLOT(slotItemDoubleClicked()));
 
@@ -59,6 +67,8 @@ FixtureSelection::FixtureSelection(QWidget* parent, Doc* doc)
 
 FixtureSelection::~FixtureSelection()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 int FixtureSelection::exec()

--- a/ui/src/functionwizard.cpp
+++ b/ui/src/functionwizard.cpp
@@ -22,6 +22,7 @@
 #include <QDebug>
 #include <QHash>
 #include <QAction>
+#include <QSettings>
 
 #include "palettegenerator.h"
 #include "fixtureselection.h"
@@ -53,6 +54,8 @@
 
 #define KWidgetName                 0
 
+#define SETTINGS_GEOMETRY "functionwizard/geometry"
+
 FunctionWizard::FunctionWizard(QWidget* parent, Doc* doc)
     : QDialog(parent)
     , m_doc(doc)
@@ -71,6 +74,11 @@ FunctionWizard::FunctionWizard(QWidget* parent, Doc* doc)
 
     m_fixtureTree->sortItems(KFixtureColumnName, Qt::AscendingOrder);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_nextButton, SIGNAL(clicked()),
             this, SLOT(slotNextPageClicked()));
 
@@ -82,6 +90,9 @@ FunctionWizard::FunctionWizard(QWidget* parent, Doc* doc)
 
 FunctionWizard::~FunctionWizard()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
+
     m_paletteList.clear();
 }
 

--- a/ui/src/inputchanneleditor.cpp
+++ b/ui/src/inputchanneleditor.cpp
@@ -22,6 +22,7 @@
 #include <QSpinBox>
 #include <QIcon>
 #include <QAction>
+#include <QSettings>
 
 #include "inputchanneleditor.h"
 #include "qlcinputprofile.h"
@@ -42,6 +43,8 @@
 
 #include "../../plugins/midi/src/common/midiprotocol.h"
 
+#define SETTINGS_GEOMETRY "inputchanneleditor/geometry"
+
 /****************************************************************************
  * Initialization
  ****************************************************************************/
@@ -61,6 +64,11 @@ InputChannelEditor::InputChannelEditor(QWidget* parent,
     action->setShortcut(QKeySequence(QKeySequence::Close));
     connect(action, SIGNAL(triggered(bool)), this, SLOT(reject()));
     addAction(action);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     /* Connect to these already now so that the handlers get called
        during initialization. */
@@ -128,6 +136,8 @@ InputChannelEditor::InputChannelEditor(QWidget* parent,
 
 InputChannelEditor::~InputChannelEditor()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /****************************************************************************

--- a/ui/src/monitor/monitorbackgroundselection.cpp
+++ b/ui/src/monitor/monitorbackgroundselection.cpp
@@ -19,6 +19,7 @@
 
 #include <QTreeWidgetItem>
 #include <QFileDialog>
+#include <QSettings>
 
 #include "monitorbackgroundselection.h"
 #include "monitorproperties.h"
@@ -28,6 +29,8 @@
 
 #define KColumnName     0
 #define KColumnImage    1
+
+#define SETTINGS_GEOMETRY "monitorbackgroundselection/geometry"
 
 MonitorBackgroundSelection::MonitorBackgroundSelection(QWidget *parent, Doc *doc)
     : QDialog(parent)
@@ -43,6 +46,11 @@ MonitorBackgroundSelection::MonitorBackgroundSelection(QWidget *parent, Doc *doc
     m_customBackgroundImages = m_props->customBackgroundList();
 
     m_lastUsedPath = QString();
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     connect(m_noBgRadio, SIGNAL(clicked(bool)),
             this, SLOT(slotNoBackgroundChecked(bool)));
@@ -79,7 +87,8 @@ MonitorBackgroundSelection::MonitorBackgroundSelection(QWidget *parent, Doc *doc
 
 MonitorBackgroundSelection::~MonitorBackgroundSelection()
 {
-
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void MonitorBackgroundSelection::accept()

--- a/ui/src/positiontool.cpp
+++ b/ui/src/positiontool.cpp
@@ -19,9 +19,12 @@
 
 #include <QDebug>
 #include <QPoint>
+#include <QSettings>
 
 #include "positiontool.h"
 #include "vcxypadarea.h"
+
+#define SETTINGS_GEOMETRY "positiontool/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -39,12 +42,19 @@ PositionTool::PositionTool(const QPointF & initial, QRectF degreesRange, QWidget
     m_area->setFocus();
     m_gridLayout->addWidget(m_area, 0, 0);
 
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     connect(m_area, SIGNAL(positionChanged(const QPointF &)),
             this, SLOT(slotPositionChanged(const QPointF &)));
 }
 
 PositionTool::~PositionTool()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /*****************************************************************************

--- a/ui/src/virtualconsole/addvcbuttonmatrix.cpp
+++ b/ui/src/virtualconsole/addvcbuttonmatrix.cpp
@@ -34,6 +34,7 @@
 #define VERTICAL_COUNT "addvcbuttonmatrix/verticalcount"
 #define BUTTON_SIZE "addvcbuttonmatrix/buttonsize"
 #define FRAME_STYLE "addvcbuttonmatrix/framestyle"
+#define SETTINGS_GEOMETRY "addvcbuttonmatrix/geometry"
 
 AddVCButtonMatrix::AddVCButtonMatrix(QWidget* parent, Doc* doc)
     : QDialog(parent)
@@ -78,6 +79,10 @@ AddVCButtonMatrix::AddVCButtonMatrix(QWidget* parent, Doc* doc)
     else
         setFrameStyle(AddVCButtonMatrix::NormalFrame);
 
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     setAllocationText();
 }
 
@@ -87,6 +92,7 @@ AddVCButtonMatrix::~AddVCButtonMatrix()
     settings.setValue(HORIZONTAL_COUNT, horizontalCount());
     settings.setValue(VERTICAL_COUNT, verticalCount());
     settings.setValue(BUTTON_SIZE, buttonSize());
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 QList <quint32> AddVCButtonMatrix::functions() const

--- a/ui/src/virtualconsole/addvcslidermatrix.cpp
+++ b/ui/src/virtualconsole/addvcslidermatrix.cpp
@@ -24,6 +24,7 @@
 #include "addvcslidermatrix.h"
 #include "vcpropertieseditor.h"
 
+#define SETTINGS_GEOMETRY "addvcslidermatrix/geometry"
 #define SETTINGS_SLIDER_MATRIX_SIZE "slidermatrix/defaultSize"
 
 AddVCSliderMatrix::AddVCSliderMatrix(QWidget* parent)
@@ -56,6 +57,10 @@ AddVCSliderMatrix::AddVCSliderMatrix(QWidget* parent)
         m_height = size.height();
     }
 
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     m_amountSpin->setValue(m_amount);
     m_heightSpin->setValue(m_height);
     m_widthSpin->setValue(m_width);
@@ -63,6 +68,8 @@ AddVCSliderMatrix::AddVCSliderMatrix(QWidget* parent)
 
 AddVCSliderMatrix::~AddVCSliderMatrix()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 int AddVCSliderMatrix::amount() const

--- a/ui/src/virtualconsole/vcframeproperties.cpp
+++ b/ui/src/virtualconsole/vcframeproperties.cpp
@@ -21,6 +21,7 @@
 #include <QComboBox>
 #include <QDebug>
 #include <algorithm>
+#include <QSettings>
 
 #include "inputselectionwidget.h"
 #include "vcframepageshortcut.h"
@@ -28,6 +29,7 @@
 #include "vcframe.h"
 #include "doc.h"
 
+#define SETTINGS_GEOMETRY "vcframeproperties/geometry"
 
 VCFrameProperties::VCFrameProperties(QWidget* parent, VCFrame* frame, Doc *doc)
     : QDialog(parent)
@@ -51,6 +53,11 @@ VCFrameProperties::VCFrameProperties(QWidget* parent, VCFrame* frame, Doc *doc)
     m_totalPagesSpin->setValue(frame->totalPagesNumber());
     if (frame->totalPagesNumber() != 1)
         m_cloneFirstPageCheck->setEnabled(false);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     connect(m_enablePaging, SIGNAL(toggled(bool)),
             this, SLOT(slotMultipageChecked(bool)));
@@ -130,6 +137,9 @@ VCFrameProperties::VCFrameProperties(QWidget* parent, VCFrame* frame, Doc *doc)
 
 VCFrameProperties::~VCFrameProperties()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
+
     foreach (VCFramePageShortcut* shortcut, m_shortcuts)
     {
         delete shortcut;

--- a/ui/src/virtualconsole/vcmatrixpresetselection.cpp
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.cpp
@@ -22,6 +22,7 @@
 #include <QSpinBox>
 #include <QLabel>
 #include <QDebug>
+#include <QSettings>
 
 #include "vcmatrixpresetselection.h"
 #include "ui_vcmatrixpresetselection.h"
@@ -33,6 +34,8 @@
 #endif
 #include "doc.h"
 
+#define SETTINGS_GEOMETRY "vcmatrixpresetselection/geometry"
+
 VCMatrixPresetSelection::VCMatrixPresetSelection(Doc *doc, QWidget *parent)
     : QDialog(parent)
     , m_doc(doc)
@@ -40,6 +43,12 @@ VCMatrixPresetSelection::VCMatrixPresetSelection(Doc *doc, QWidget *parent)
     Q_ASSERT(doc != NULL);
 
     setupUi(this);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     m_presetCombo->addItems(RGBAlgorithm::algorithms(m_doc));
     slotUpdatePresetProperties();
     connect(m_presetCombo, SIGNAL(currentIndexChanged(int)),
@@ -48,6 +57,8 @@ VCMatrixPresetSelection::VCMatrixPresetSelection(Doc *doc, QWidget *parent)
 
 VCMatrixPresetSelection::~VCMatrixPresetSelection()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 /**

--- a/ui/src/virtualconsole/vcpropertieseditor.cpp
+++ b/ui/src/virtualconsole/vcpropertieseditor.cpp
@@ -31,6 +31,8 @@
 #include "inputpatch.h"
 #include "function.h"
 
+#define SETTINGS_GEOMETRY "vcpropertieseditor/geometry"
+
 /*****************************************************************************
  * Initialization
  *****************************************************************************/
@@ -189,6 +191,10 @@ VCPropertiesEditor::VCPropertiesEditor(QWidget* parent, const VCProperties& prop
         m_matrixHspin->setValue(120);
     }
 
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
+
     /* Grand Master page */
     switch (properties.grandMasterChannelMode())
     {
@@ -228,6 +234,8 @@ VCPropertiesEditor::VCPropertiesEditor(QWidget* parent, const VCProperties& prop
 
 VCPropertiesEditor::~VCPropertiesEditor()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 VCProperties VCPropertiesEditor::properties() const

--- a/ui/src/virtualconsole/vcwidgetselection.cpp
+++ b/ui/src/virtualconsole/vcwidgetselection.cpp
@@ -19,6 +19,7 @@
 
 #include <QPushButton>
 #include <QDebug>
+#include <QSettings>
 
 #include "vcwidgetselection.h"
 #include "virtualconsole.h"
@@ -26,6 +27,8 @@
 
 #define KColumnName         0
 #define KColumnType         1
+
+#define SETTINGS_GEOMETRY "vcwidgetselection/geometry"
 
 VCWidgetSelection::VCWidgetSelection(QList<int> filters, QWidget *parent)
     : QDialog(parent)
@@ -36,6 +39,11 @@ VCWidgetSelection::VCWidgetSelection(QList<int> filters, QWidget *parent)
     m_tree->setRootIsDecorated(false);
     m_tree->setSelectionMode(QAbstractItemView::SingleSelection);
     m_tree->setAllColumnsShowFocus(true);
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 
     connect(m_tree, SIGNAL(itemSelectionChanged()),
             this, SLOT(slotItemSelectionChanged()));
@@ -49,7 +57,8 @@ VCWidgetSelection::VCWidgetSelection(QList<int> filters, QWidget *parent)
 
 VCWidgetSelection::~VCWidgetSelection()
 {
-
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 VCWidget *VCWidgetSelection::getSelectedWidget()

--- a/ui/src/virtualconsole/vcxypadfixtureeditor.cpp
+++ b/ui/src/virtualconsole/vcxypadfixtureeditor.cpp
@@ -22,9 +22,12 @@
 #include <QDialog>
 #include <QString>
 #include <cmath>
+#include <QSettings>
 
 #include "vcxypadfixtureeditor.h"
 #include "vcxypadfixture.h"
+
+#define SETTINGS_GEOMETRY "vcxypadfixtureeditor/geometry"
 
 /*****************************************************************************
  * Initialization
@@ -74,10 +77,17 @@ VCXYPadFixtureEditor::VCXYPadFixtureEditor(QWidget* parent, QList <VCXYPadFixtur
         m_yMax->setValue(int(floor((fxi.yMax() * qreal(m_maxYVal)) + qreal(0.5))));
         m_yReverse->setChecked(fxi.yReverse());
     }
+
+    QSettings settings;
+    QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
+    if (geometrySettings.isValid() == true)
+        restoreGeometry(geometrySettings.toByteArray());
 }
 
 VCXYPadFixtureEditor::~VCXYPadFixtureEditor()
 {
+    QSettings settings;
+    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
 }
 
 void VCXYPadFixtureEditor::slotXMinChanged(int value)


### PR DESCRIPTION
This PR stores geometry settings for all dialogs in QLC+ that did not yet have this feature implemented. Some of the dialogs already had this (`AddFixture`, ...) which is very convenient, but some of them did not which can be incredibly frustrating when working on a 4K monitor and having to repeat an action many times during programming, but always having to resize the tiny dialog before you can make any change.

This PR does not include the same functionality for `QWidgets`, I think I saw a few of those that also used the `saveGeometry()` logic but not entirely sure if they all need this as well. If you think so @mcallegari I'll gladly do a pass over those as well! 