### PR TITLE
resources: Add fixture definition for Showtec LED Par 64 Short V2

### DIFF
--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -1488,6 +1488,7 @@
     <F n="Showtec-LED-Light-Bar-8" m="LED Light Bar 8"/>
     <F n="Showtec-LED-Light-Bar-RGB-V3" m="LED Light Bar RGB V3"/>
     <F n="Showtec-LED-Par-56" m="LED Par 56"/>
+    <F n="Showtec-LED-Par-64-Short-V2" m="LED Par 64 Short V2"/>
     <F n="Showtec-LED-Pixel-Track-Pro" m="LED Pixel Track Pro"/>
     <F n="Showtec-LED-Powerline-16-Bar" m="LED Powerline 16 Bar"/>
     <F n="Showtec-Lightbrick" m="Lightbrick"/>

--- a/resources/fixtures/Showtec/Showtec-LED-Par-64-Short-V2.qxf
+++ b/resources/fixtures/Showtec/Showtec-LED-Par-64-Short-V2.qxf
@@ -16,8 +16,8 @@
  <Channel Name="Strobe with dead zone">
   <Group Byte="0">Shutter</Group>
   <Capability Min="0" Max="5">No Function</Capability>
-  <Capability Min="6" Max="10">Full on</Capability>
-  <Capability Min="11" Max="255">Strobe (Slow to fast)</Capability>
+  <Capability Min="6" Max="10" Preset="ShutterOpen">Full on</Capability>
+  <Capability Min="11" Max="255" Preset="StrobeSlowToFast">Strobe (Slow to fast)</Capability>
  </Channel>
  <Channel Name="Built-in programs / Sound-controlled">
   <Group Byte="0">Effect</Group>

--- a/resources/fixtures/Showtec/Showtec-LED-Par-64-Short-V2.qxf
+++ b/resources/fixtures/Showtec/Showtec-LED-Par-64-Short-V2.qxf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.12.7</Version>
+  <Author>Oystein Steimler</Author>
+ </Creator>
+ <Manufacturer>Showtec</Manufacturer>
+ <Model>LED Par 64 Short V2</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Red" Preset="IntensityRed"/>
+ <Channel Name="Green" Preset="IntensityGreen"/>
+ <Channel Name="Blue" Preset="IntensityBlue"/>
+ <Channel Name="Dimmer" Preset="IntensityDimmer"/>
+ <Channel Name="Strobe with dead zone">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="5">No Function</Capability>
+  <Capability Min="6" Max="10">Full on</Capability>
+  <Capability Min="11" Max="255">Strobe (Slow to fast)</Capability>
+ </Channel>
+ <Channel Name="Built-in programs / Sound-controlled">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="0">No function</Capability>
+  <Capability Min="1" Max="35">Program 1: 7-color fading</Capability>
+  <Capability Min="36" Max="71">Program 2: 7-color jump</Capability>
+  <Capability Min="72" Max="107">Program 3: Color dreaming</Capability>
+  <Capability Min="108" Max="143">Program 4: Red fading</Capability>
+  <Capability Min="144" Max="179">Program 5: Green fading</Capability>
+  <Capability Min="180" Max="215">Program 6: Blue fading</Capability>
+  <Capability Min="216" Max="255">Sound active (Ch 2 is audio sensivity)</Capability>
+ </Channel>
+ <Channel Name="Speed / Sensitivity">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Speed from slow to fast / Audio sensitivity from low to high</Capability>
+ </Channel>
+ <Channel Name="Strobe" Preset="ShutterStrobeSlowFast"/>
+ <Channel Name="Macro Colors" Preset="ColorMacro"/>
+ <Mode Name="d-P1">
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">Dimmer</Channel>
+  <Channel Number="4">Strobe with dead zone</Channel>
+ </Mode>
+ <Mode Name="d-P2">
+  <Channel Number="0">Built-in programs / Sound-controlled</Channel>
+  <Channel Number="1">Speed / Sensitivity</Channel>
+  <Channel Number="2">Strobe</Channel>
+ </Mode>
+ <Mode Name="d-P3">
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+ </Mode>
+ <Mode Name="d-P4">
+  <Channel Number="0">Macro Colors</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="3.1" Width="250" Height="250" Depth="270"/>
+  <Lens Name="Other" DegreesMin="45" DegreesMax="45"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical PowerConsumption="65" DmxConnector="3-pin"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION
Add fixture definition for the Showtec LED Par 64 Short V2