### PR TITLE
MIDI Out Rework

### DIFF
--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -767,6 +767,23 @@ bool InputOutputMap::sendFeedBack(quint32 universe, quint32 channel, uchar value
     }
 }
 
+bool InputOutputMap::isMidiFeedback(quint32 universe)
+{
+    if (universe >= universesCount())
+        return false;
+
+    OutputPatch* patch = m_universeArray.at(universe)->feedbackPatch();
+
+    if (patch != NULL && patch->isPatched())
+    {
+        return patch->plugin()->name()==QString("MIDI");
+    }
+    else
+    {
+        return false;
+    }
+}
+
 void InputOutputMap::slotPluginConfigurationChanged(QLCIOPlugin* plugin)
 {
     QMutexLocker locker(&m_universeMutex);

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -501,6 +501,8 @@ public:
      */
     bool sendFeedBack(quint32 universe, quint32 channel, uchar value, const QString& key = 0);
 
+    bool isMidiFeedback(quint32 universe);
+
 private:
     /** In case of duplicate strings, append a number to make them unique */
     void removeDuplicates(QStringList &list);

--- a/engine/src/qlcinputchannel.h
+++ b/engine/src/qlcinputchannel.h
@@ -211,7 +211,7 @@ signals:
 protected:
     bool m_sendExtraPress;
     uchar m_lower, m_upper;
-    uchar m_channel_lower, m_channel_upper;
+    uchar m_channel_lower=0, m_channel_upper=0;
 
     /********************************************************************
      * Load & Save

--- a/engine/src/qlcinputchannel.h
+++ b/engine/src/qlcinputchannel.h
@@ -51,6 +51,8 @@ class QString;
 #define KXMLQLCInputChannelFeedbacks QString("Feedbacks")
 #define KXMLQLCInputChannelLowerValue QString("LowerValue")
 #define KXMLQLCInputChannelUpperValue QString("UpperValue")
+#define KXMLQLCInputChannelLowerChannel QString("LowerChannelValue")
+#define KXMLQLCInputChannelUpperChannel QString("UpperChannelValue")
 
 class QLCInputChannel : public QObject
 {
@@ -66,6 +68,8 @@ class QLCInputChannel : public QObject
     Q_PROPERTY(int movementSensitivity READ movementSensitivity WRITE setMovementSensitivity NOTIFY movementSensitivityChanged FINAL)
     Q_PROPERTY(uchar lowerValue READ lowerValue WRITE setLowerValue NOTIFY lowerValueChanged FINAL)
     Q_PROPERTY(uchar upperValue READ upperValue WRITE setUpperValue NOTIFY upperValueChanged FINAL)
+    Q_PROPERTY(uchar lowerChannelValue READ lowerChannelValue WRITE setLowerChannelValue NOTIFY lowerValueChannelChanged FINAL)
+    Q_PROPERTY(uchar upperChannelValue READ upperChannelValue WRITE setUpperChannelValue NOTIFY upperValueChannelChanged FINAL)
 
     /********************************************************************
      * Initialization
@@ -190,14 +194,24 @@ public:
     uchar upperValue() const;
     void setUpperValue(const uchar value);
 
+    void setChannelRange(uchar lower, uchar upper);
+    uchar lowerChannelValue() const;
+    void setLowerChannelValue(const uchar value);
+
+    uchar upperChannelValue() const;
+    void setUpperChannelValue(const uchar value);
+
 signals:
     void sendExtraPressChanged();
     void lowerValueChanged();
     void upperValueChanged();
+    void lowerValueChannelChanged();
+    void upperValueChannelChanged();
 
 protected:
     bool m_sendExtraPress;
     uchar m_lower, m_upper;
+    uchar m_channel_lower, m_channel_upper;
 
     /********************************************************************
      * Load & Save

--- a/engine/src/qlcinputsource.cpp
+++ b/engine/src/qlcinputsource.cpp
@@ -126,14 +126,31 @@ void QLCInputSource::setRange(uchar lower, uchar upper)
     m_upper = upper;
 }
 
-uchar QLCInputSource::lowerValue() const
+void QLCInputSource::setChannelRange(uchar lower, uchar upper)
+{
+    m_lower_channel = lower;
+    m_upper_channel = upper;
+}
+
+
+uchar QLCInputSource::lowerVelocityValue() const
 {
     return m_lower;
 }
 
-uchar QLCInputSource::upperValue() const
+uchar QLCInputSource::upperVelocityValue() const
 {
     return m_upper;
+}
+
+uchar QLCInputSource::lowerChannelValue() const
+{
+    return m_lower_channel;
+}
+
+uchar QLCInputSource::upperChannelValue() const
+{
+    return m_upper_channel;
 }
 
 /*********************************************************************

--- a/engine/src/qlcinputsource.h
+++ b/engine/src/qlcinputsource.h
@@ -85,7 +85,7 @@ public:
 
 protected:
     uchar m_lower, m_upper;
-    uchar m_lower_channel, m_upper_channel;
+    uchar m_lower_channel=0, m_upper_channel=0;
 
     /*********************************************************************
      * Working mode

--- a/engine/src/qlcinputsource.h
+++ b/engine/src/qlcinputsource.h
@@ -77,11 +77,15 @@ private:
      *********************************************************************/
 public:
     void setRange(uchar lower, uchar upper);
-    uchar lowerValue() const;
-    uchar upperValue() const;
+    void setChannelRange(uchar lower, uchar upper);
+    uchar lowerVelocityValue() const;
+    uchar upperVelocityValue() const;
+    uchar lowerChannelValue() const;
+    uchar upperChannelValue() const;
 
 protected:
     uchar m_lower, m_upper;
+    uchar m_lower_channel, m_upper_channel;
 
     /*********************************************************************
      * Working mode

--- a/plugins/midi/src/common/midiplugin.cpp
+++ b/plugins/midi/src/common/midiplugin.cpp
@@ -285,7 +285,7 @@ QString MidiPlugin::inputInfo(quint32 input)
     return str;
 }
 
-void MidiPlugin::sendFeedBack(quint32 universe, quint32 output, quint32 channel, uchar value, const QString &)
+void MidiPlugin::sendFeedBack(quint32 universe, quint32 output, quint32 channel, uchar value, const QString &m_channel)
 {
     Q_UNUSED(universe)
 
@@ -294,10 +294,11 @@ void MidiPlugin::sendFeedBack(quint32 universe, quint32 output, quint32 channel,
     MidiOutputDevice* dev = outputDevice(output);
     if (dev != NULL)
     {
+        int midi_channel = m_channel.toInt();
         qDebug() << "[sendFeedBack] Dev:" << dev->name() << ", channel:" << channel << ", value:" << value << dev->sendNoteOff();
         uchar cmd = 0;
         uchar data1 = 0, data2 = 0;
-        if (QLCMIDIProtocol::feedbackToMidi(channel, value, dev->midiChannel(), dev->sendNoteOff(),
+        if (QLCMIDIProtocol::feedbackToMidi(channel, value, midi_channel, dev->sendNoteOff(),
                                         &cmd, &data1, &data2) == true)
         {
             qDebug() << "[sendFeedBack] cmd:" << cmd << "data1:" << data1 << "data2:" << data2;

--- a/plugins/midi/src/common/midiprotocol.h
+++ b/plugins/midi/src/common/midiprotocol.h
@@ -91,7 +91,7 @@ namespace QLCMIDIProtocol
 #define MIDI2DMX(x) uchar((x == 127U) ? 255U : x << 1)
 
 /** Convert DMX value to MIDI value */
-#define DMX2MIDI(x) (uchar(x) & 0x7F)
+#define DMX2MIDI(x) (uchar(x >> 1) & 0x7F)
 
 /****************************************************************************
  * MIDI channels

--- a/plugins/midi/src/common/midiprotocol.h
+++ b/plugins/midi/src/common/midiprotocol.h
@@ -91,7 +91,7 @@ namespace QLCMIDIProtocol
 #define MIDI2DMX(x) uchar((x == 127U) ? 255U : x << 1)
 
 /** Convert DMX value to MIDI value */
-#define DMX2MIDI(x) (uchar(x >> 1) & 0x7F)
+#define DMX2MIDI(x) (uchar(x) & 0x7F)
 
 /****************************************************************************
  * MIDI channels

--- a/ui/src/inputchanneleditor.h
+++ b/ui/src/inputchanneleditor.h
@@ -71,8 +71,9 @@ protected:
 protected slots:
     void slotMidiChanged();
 
-private:
+public:
     static void numberToMidi(int number, int & channel, int & message, int & param);
+private: 
     static int midiToNumber(int channel, int message, int param);
 
     void enableMidiParam(int midiMessage, int midiParam);

--- a/ui/src/inputprofileeditor.cpp
+++ b/ui/src/inputprofileeditor.cpp
@@ -86,9 +86,9 @@ InputProfileEditor::InputProfileEditor(QWidget* parent, QLCInputProfile* profile
     connect(m_extraPressCheck, SIGNAL(toggled(bool)),
             this, SLOT(slotExtraPressChecked(bool)));
     connect(m_lowerVelocitySpin, SIGNAL(valueChanged(int)),
-            this, SLOT(slotLowerVelocityValueSpinChanged(int)));
+            this, SLOT(slotLowerValueSpinChanged(int)));
     connect(m_upperVelocitySpin, SIGNAL(valueChanged(int)),
-            this, SLOT(slotUpperVelocityValueSpinChanged(int)));
+            this, SLOT(slotUpperValueSpinChanged(int)));
     connect(m_lowerChannelSpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotLowerChannelValueSpinChanged(int)));
     connect(m_upperChannelSpin, SIGNAL(valueChanged(int)),
@@ -129,6 +129,10 @@ InputProfileEditor::InputProfileEditor(QWidget* parent, QLCInputProfile* profile
             {
                 m_midiGroupSettings->setVisible(true);
                 m_noteOffCheck->setChecked(m_profile->midiSendNoteOff());
+            }
+            else
+            {
+                m_ChannelfeedbackGroup->setVisible(false);
             }
         }
     }

--- a/ui/src/inputprofileeditor.cpp
+++ b/ui/src/inputprofileeditor.cpp
@@ -89,6 +89,10 @@ InputProfileEditor::InputProfileEditor(QWidget* parent, QLCInputProfile* profile
             this, SLOT(slotLowerVelocityValueSpinChanged(int)));
     connect(m_upperVelocitySpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotUpperVelocityValueSpinChanged(int)));
+    connect(m_lowerChannelSpin, SIGNAL(valueChanged(int)),
+            this, SLOT(slotLowerChannelValueSpinChanged(int)));
+    connect(m_upperChannelSpin, SIGNAL(valueChanged(int)),
+            this, SLOT(slotUpperChannelValueSpinChanged(int)));
 
     /* Listen to input data */
     connect(m_ioMap, SIGNAL(inputValueChanged(quint32, quint32, uchar, const QString&)),
@@ -501,10 +505,23 @@ void InputProfileEditor::slotItemClicked(QTreeWidgetItem *item, int col)
             m_extraPressCheck->setChecked(ich->sendExtraPress());
             m_lowerVelocitySpin->blockSignals(true);
             m_upperVelocitySpin->blockSignals(true);
+
             m_lowerVelocitySpin->setValue(ich->lowerValue());
             m_upperVelocitySpin->setValue(ich->upperValue());
             m_lowerVelocitySpin->blockSignals(false);
             m_upperVelocitySpin->blockSignals(false);
+            if (m_profile->type() == QLCInputProfile::Type::MIDI)
+            {
+                m_lowerChannelSpin->blockSignals(true);
+                m_upperChannelSpin->blockSignals(true);
+                m_lowerChannelSpin->setValue(ich->lowerChannelValue());
+                m_upperChannelSpin->setValue(ich->upperChannelValue());
+                m_lowerChannelSpin->blockSignals(false);
+                m_upperChannelSpin->blockSignals(false);
+            }
+            else {
+                m_ChannelfeedbackGroup->setVisible(false);
+            }
         }
     }
     else
@@ -568,6 +585,24 @@ void InputProfileEditor::slotUpperValueSpinChanged(int value)
     {
         if (channel->type() == QLCInputChannel::Button)
             channel->setRange(uchar(m_lowerVelocitySpin->value()), uchar(value));
+    }
+}
+
+void InputProfileEditor::slotLowerChannelValueSpinChanged(int value)
+{
+    foreach (QLCInputChannel *channel, selectedChannels())
+    {
+        if (channel->type() == QLCInputChannel::Button)
+            channel->setChannelRange(uchar(value), uchar(m_upperChannelSpin->value()));
+    }
+}
+
+void InputProfileEditor::slotUpperChannelValueSpinChanged(int value)
+{
+    foreach (QLCInputChannel *channel, selectedChannels())
+    {
+        if (channel->type() == QLCInputChannel::Button)
+            channel->setChannelRange(uchar(m_lowerChannelSpin->value()), uchar(value));
     }
 }
 

--- a/ui/src/inputprofileeditor.cpp
+++ b/ui/src/inputprofileeditor.cpp
@@ -85,10 +85,10 @@ InputProfileEditor::InputProfileEditor(QWidget* parent, QLCInputProfile* profile
             this, SLOT(slotSensitivitySpinChanged(int)));
     connect(m_extraPressCheck, SIGNAL(toggled(bool)),
             this, SLOT(slotExtraPressChecked(bool)));
-    connect(m_lowerSpin, SIGNAL(valueChanged(int)),
-            this, SLOT(slotLowerValueSpinChanged(int)));
-    connect(m_upperSpin, SIGNAL(valueChanged(int)),
-            this, SLOT(slotUpperValueSpinChanged(int)));
+    connect(m_lowerVelocitySpin, SIGNAL(valueChanged(int)),
+            this, SLOT(slotLowerVelocityValueSpinChanged(int)));
+    connect(m_upperVelocitySpin, SIGNAL(valueChanged(int)),
+            this, SLOT(slotUpperVelocityValueSpinChanged(int)));
 
     /* Listen to input data */
     connect(m_ioMap, SIGNAL(inputValueChanged(quint32, quint32, uchar, const QString&)),
@@ -499,12 +499,12 @@ void InputProfileEditor::slotItemClicked(QTreeWidgetItem *item, int col)
         else if (ich->type() == QLCInputChannel::Button)
         {
             m_extraPressCheck->setChecked(ich->sendExtraPress());
-            m_lowerSpin->blockSignals(true);
-            m_upperSpin->blockSignals(true);
-            m_lowerSpin->setValue(ich->lowerValue());
-            m_upperSpin->setValue(ich->upperValue());
-            m_lowerSpin->blockSignals(false);
-            m_upperSpin->blockSignals(false);
+            m_lowerVelocitySpin->blockSignals(true);
+            m_upperVelocitySpin->blockSignals(true);
+            m_lowerVelocitySpin->setValue(ich->lowerValue());
+            m_upperVelocitySpin->setValue(ich->upperValue());
+            m_lowerVelocitySpin->blockSignals(false);
+            m_upperVelocitySpin->blockSignals(false);
         }
     }
     else
@@ -558,7 +558,7 @@ void InputProfileEditor::slotLowerValueSpinChanged(int value)
     foreach (QLCInputChannel *channel, selectedChannels())
     {
         if (channel->type() == QLCInputChannel::Button)
-            channel->setRange(uchar(value), uchar(m_upperSpin->value()));
+            channel->setRange(uchar(value), uchar(m_upperVelocitySpin->value()));
     }
 }
 
@@ -567,7 +567,7 @@ void InputProfileEditor::slotUpperValueSpinChanged(int value)
     foreach (QLCInputChannel *channel, selectedChannels())
     {
         if (channel->type() == QLCInputChannel::Button)
-            channel->setRange(uchar(m_lowerSpin->value()), uchar(value));
+            channel->setRange(uchar(m_lowerVelocitySpin->value()), uchar(value));
     }
 }
 

--- a/ui/src/inputprofileeditor.cpp
+++ b/ui/src/inputprofileeditor.cpp
@@ -132,7 +132,7 @@ InputProfileEditor::InputProfileEditor(QWidget* parent, QLCInputProfile* profile
             }
             else
             {
-                m_ChannelfeedbackGroup->setVisible(false);
+                m_ChannelFeedbackGroup->setVisible(false);
             }
         }
     }
@@ -524,7 +524,7 @@ void InputProfileEditor::slotItemClicked(QTreeWidgetItem *item, int col)
                 m_upperChannelSpin->blockSignals(false);
             }
             else {
-                m_ChannelfeedbackGroup->setVisible(false);
+                m_ChannelFeedbackGroup->setVisible(false);
             }
         }
     }
@@ -621,7 +621,7 @@ void InputProfileEditor::slotInputValueChanged(quint32 universe,
 
     /* Get a list of items that represent the given channel. Basically
        the list should always contain just one item. */
-    QList <QTreeWidgetItem*> list;
+        QList <QTreeWidgetItem*> list;
     if (channel == UINT_MAX && key.isEmpty() == false)
         list = m_tree->findItems(key, Qt::MatchExactly, KColumnName);
     else
@@ -641,6 +641,10 @@ void InputProfileEditor::slotInputValueChanged(quint32 universe,
             ch->setName(key);
         ch->setType(QLCInputChannel::Button);
         m_profile->insertChannel(channel, ch);
+        
+        int midiChannel = 0, midiMessage = 0, midiParam = 0;
+        InputChannelEditor::numberToMidi(channel, midiChannel, midiMessage, midiParam);
+        ch->setChannelRange(midiChannel, midiChannel);
 
         latestItem = new QTreeWidgetItem(m_tree);
         updateChannelItem(latestItem, ch);

--- a/ui/src/inputprofileeditor.h
+++ b/ui/src/inputprofileeditor.h
@@ -80,6 +80,8 @@ protected slots:
     void slotExtraPressChecked(bool checked);
     void slotLowerValueSpinChanged(int value);
     void slotUpperValueSpinChanged(int value);
+    void slotLowerChannelValueSpinChanged(int value);
+    void slotUpperChannelValueSpinChanged(int value);
 
     void slotInputValueChanged(quint32 universe, quint32 channel, uchar value, const QString& key = 0);
     void slotTimerTimeout();

--- a/ui/src/inputprofileeditor.ui
+++ b/ui/src/inputprofileeditor.ui
@@ -382,6 +382,52 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0" colspan="4">
+          <widget class="QFrame" name="m_ChannelfeedbackGroup">
+            <layout class="QGridLayout" name="m_channelGridLayout"> 
+              <property name="leftMargin">
+                <number>0</number>
+              </property>
+              <property name="rightMargin">
+                <number>0</number>
+              </property>      
+              <item row="0" column="2">
+                <widget class="QLabel" name="label_3">
+                <property name="text">
+                  <string>Upper channel</string>
+                </property>
+                </widget>
+              </item>
+              <item row="0" column="3">
+                <widget class="QSpinBox" name="m_upperChannelSpin">
+                <property name="minimum">
+                  <number>0</number>
+                </property>
+                <property name="maximum">
+                  <number>16</number>
+                </property>
+                <property name="value">
+                  <number>0</number>
+                </property>
+                </widget>
+              </item>
+              <item row="0" column="0">
+                <widget class="QLabel" name="label">
+                <property name="text">
+                  <string>Lower channel</string>
+                </property>
+                </widget>
+              </item>
+              <item row="0" column="1">
+                <widget class="QSpinBox" name="m_lowerChannelSpin">
+                <property name="maximum">
+                  <number>16</number>
+                </property>
+                </widget>
+              </item>
+            </layout>
+          </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/ui/src/inputprofileeditor.ui
+++ b/ui/src/inputprofileeditor.ui
@@ -383,7 +383,7 @@
            </widget>
           </item>
           <item row="1" column="0" colspan="4">
-          <widget class="QFrame" name="m_ChannelfeedbackGroup">
+          <widget class="QFrame" name="m_ChannelFeedbackGroup">
             <layout class="QGridLayout" name="m_channelGridLayout"> 
               <property name="leftMargin">
                 <number>0</number>

--- a/ui/src/inputprofileeditor.ui
+++ b/ui/src/inputprofileeditor.ui
@@ -356,7 +356,7 @@
            </widget>
           </item>
           <item row="0" column="3">
-           <widget class="QSpinBox" name="m_upperSpin">
+           <widget class="QSpinBox" name="m_upperVelocitySpin">
             <property name="minimum">
              <number>0</number>
             </property>
@@ -376,7 +376,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QSpinBox" name="m_lowerSpin">
+           <widget class="QSpinBox" name="m_lowerVelocitySpin">
             <property name="maximum">
              <number>255</number>
             </property>

--- a/ui/src/inputselectionwidget.cpp
+++ b/ui/src/inputselectionwidget.cpp
@@ -251,8 +251,8 @@ void InputSelectionWidget::updateInputSource()
         }
         m_lowerVelocitySpin->setValue((m_inputSource->lowerVelocityValue() != 0) ? m_inputSource->lowerVelocityValue() : min);
         m_upperVelocitySpin->setValue((m_inputSource->upperVelocityValue() != UCHAR_MAX) ? m_inputSource->upperVelocityValue() : max);
-        m_lowerChannelSpin->setValue((m_inputSource->lowerChannelValue() != 0) ? m_inputSource->lowerChannelValue() : 0);
-        m_upperChannelSpin->setValue((m_inputSource->upperChannelValue() != 0) ? m_inputSource->upperChannelValue() : 0);
+        m_lowerChannelSpin->setValue(m_inputSource->lowerChannelValue());
+        m_upperChannelSpin->setValue(m_inputSource->upperChannelValue());
         if (m_lowerVelocitySpin->value() != 0 || m_upperVelocitySpin->value() != UCHAR_MAX || m_lowerChannelSpin->value() != 0 || m_upperChannelSpin->value() != 0)
         {
             m_customFbButton->setChecked(true);

--- a/ui/src/inputselectionwidget.cpp
+++ b/ui/src/inputselectionwidget.cpp
@@ -162,7 +162,6 @@ void InputSelectionWidget::slotAutoDetectInputToggled(bool checked)
 
 void InputSelectionWidget::slotInputValueChanged(quint32 universe, quint32 channel)
 {
-    qDebug()<<"SOMETHING DETECTED"<<universe<<channel;
     if (m_emitOdd == true && m_signalsReceived % 2)
     {
         emit inputValueChanged(universe, (m_widgetPage << 16) | channel);

--- a/ui/src/inputselectionwidget.cpp
+++ b/ui/src/inputselectionwidget.cpp
@@ -40,8 +40,10 @@ InputSelectionWidget::InputSelectionWidget(Doc *doc, QWidget *parent)
 
     m_customFbButton->setVisible(false);
     m_feedbackGroup->setVisible(false);
-    m_lowerSpin->setEnabled(false);
-    m_upperSpin->setEnabled(false);
+    m_lowerVelocitySpin->setEnabled(false);
+    m_upperVelocitySpin->setEnabled(false);
+    m_lowerChannelSpin->setEnabled(false);
+    m_upperChannelSpin->setEnabled(false);
 
     connect(m_attachKey, SIGNAL(clicked()), this, SLOT(slotAttachKey()));
     connect(m_detachKey, SIGNAL(clicked()), this, SLOT(slotDetachKey()));
@@ -53,10 +55,14 @@ InputSelectionWidget::InputSelectionWidget(Doc *doc, QWidget *parent)
 
     connect(m_customFbButton, SIGNAL(toggled(bool)),
             this, SLOT(slotCustomFeedbackToggled(bool)));
-    connect(m_lowerSpin, SIGNAL(valueChanged(int)),
+    connect(m_lowerVelocitySpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotLowerSpinValueChanged(int)));
-    connect(m_upperSpin, SIGNAL(valueChanged(int)),
+    connect(m_upperVelocitySpin, SIGNAL(valueChanged(int)),
             this, SLOT(slotUpperSpinValueChanged(int)));
+    connect(m_lowerChannelSpin, SIGNAL(valueChanged(int)),
+            this, SLOT(slotLowerChannelSpinChanged(int)));
+    connect(m_upperChannelSpin, SIGNAL(valueChanged(int)),
+             this, SLOT(slotUpperChannelSpinChanged(int)));
 }
 
 InputSelectionWidget::~InputSelectionWidget()
@@ -156,6 +162,7 @@ void InputSelectionWidget::slotAutoDetectInputToggled(bool checked)
 
 void InputSelectionWidget::slotInputValueChanged(quint32 universe, quint32 channel)
 {
+    qDebug()<<"SOMETHING DETECTED"<<universe<<channel;
     if (m_emitOdd == true && m_signalsReceived % 2)
     {
         emit inputValueChanged(universe, (m_widgetPage << 16) | channel);
@@ -189,12 +196,22 @@ void InputSelectionWidget::slotCustomFeedbackToggled(bool checked)
 
 void InputSelectionWidget::slotLowerSpinValueChanged(int value)
 {
-    m_inputSource->setRange(uchar(value), uchar(m_upperSpin->value()));
+    m_inputSource->setRange(uchar(value), uchar(m_upperVelocitySpin->value()));
 }
 
 void InputSelectionWidget::slotUpperSpinValueChanged(int value)
 {
-    m_inputSource->setRange(uchar(m_lowerSpin->value()), uchar(value));
+    m_inputSource->setRange(uchar(m_lowerVelocitySpin->value()), uchar(value));
+}
+
+void InputSelectionWidget::slotLowerChannelSpinChanged(int value)
+{
+    m_inputSource->setChannelRange(uchar(value), uchar(m_upperChannelSpin->value()));
+}
+
+void InputSelectionWidget::slotUpperChannelSpinChanged(int value)
+{
+    m_inputSource->setChannelRange(uchar(m_lowerChannelSpin->value()), uchar(value));
 }
 
 void InputSelectionWidget::updateInputSource()
@@ -206,15 +223,19 @@ void InputSelectionWidget::updateInputSource()
     {
         uniName = KInputNone;
         chName = KInputNone;
-        m_lowerSpin->setEnabled(false);
-        m_upperSpin->setEnabled(false);
+        m_lowerVelocitySpin->setEnabled(false);
+        m_upperVelocitySpin->setEnabled(false);
+        m_lowerChannelSpin->setEnabled(false);
+        m_upperChannelSpin->setEnabled(false);
         m_customFbButton->setChecked(false);
         m_feedbackGroup->setVisible(false);
     }
     else
     {
-        m_lowerSpin->blockSignals(true);
-        m_upperSpin->blockSignals(true);
+        m_lowerVelocitySpin->blockSignals(true);
+        m_upperVelocitySpin->blockSignals(true);
+        m_lowerChannelSpin->blockSignals(true);
+        m_upperChannelSpin->blockSignals(true);
 
         uchar min = 0, max = UCHAR_MAX;
 
@@ -228,9 +249,11 @@ void InputSelectionWidget::updateInputSource()
                 max = ich->upperValue();
             }
         }
-        m_lowerSpin->setValue((m_inputSource->lowerValue() != 0) ? m_inputSource->lowerValue() : min);
-        m_upperSpin->setValue((m_inputSource->upperValue() != UCHAR_MAX) ? m_inputSource->upperValue() : max);
-        if (m_lowerSpin->value() != 0 || m_upperSpin->value() != UCHAR_MAX)
+        m_lowerVelocitySpin->setValue((m_inputSource->lowerVelocityValue() != 0) ? m_inputSource->lowerVelocityValue() : min);
+        m_upperVelocitySpin->setValue((m_inputSource->upperVelocityValue() != UCHAR_MAX) ? m_inputSource->upperVelocityValue() : max);
+        m_lowerChannelSpin->setValue((m_inputSource->lowerChannelValue() != 0) ? m_inputSource->lowerChannelValue() : 0);
+        m_upperChannelSpin->setValue((m_inputSource->upperChannelValue() != 0) ? m_inputSource->upperChannelValue() : 0);
+        if (m_lowerVelocitySpin->value() != 0 || m_upperVelocitySpin->value() != UCHAR_MAX || m_lowerChannelSpin->value() != 0 || m_upperChannelSpin->value() != 0)
         {
             m_customFbButton->setChecked(true);
         }
@@ -239,10 +262,14 @@ void InputSelectionWidget::updateInputSource()
             m_customFbButton->setChecked(false);
             m_feedbackGroup->setVisible(false);
         }
-        m_lowerSpin->blockSignals(false);
-        m_upperSpin->blockSignals(false);
-        m_lowerSpin->setEnabled(true);
-        m_upperSpin->setEnabled(true);
+        m_lowerVelocitySpin->blockSignals(false);
+        m_upperVelocitySpin->blockSignals(false);
+        m_lowerChannelSpin->blockSignals(false);
+        m_upperChannelSpin->blockSignals(false);
+        m_lowerVelocitySpin->setEnabled(true);
+        m_upperVelocitySpin->setEnabled(true);
+        m_lowerChannelSpin->setEnabled(true);
+        m_upperChannelSpin->setEnabled(true);
     }
 
     m_inputUniverseEdit->setText(uniName);

--- a/ui/src/inputselectionwidget.cpp
+++ b/ui/src/inputselectionwidget.cpp
@@ -254,9 +254,23 @@ void InputSelectionWidget::updateInputSource()
             if(ip->profile()->type()==QLCInputProfile::MIDI){
                 int midiChannel = 0, midiMessage = 0, midiParam = 0;
                 InputChannelEditor::numberToMidi(m_inputSource->channel(), midiChannel, midiMessage, midiParam);
-                // If profile has different value than default, use them; otherwise the input channel
-                const int lowerMidiChannel = lowerProfileChannel != 0 ? lowerProfileChannel : midiChannel;
-                const int upperMidiChannel = upperProfileChannel != 0 ? upperProfileChannel : midiChannel;
+
+                // Lower channel priority is: widgetProprieties, inputProfile, midi input channel
+                int lowerMidiChannel;
+                if (m_inputSource->lowerChannelValue() != 0)
+                    lowerMidiChannel = m_inputSource->lowerChannelValue();
+                else if (lowerProfileChannel!=0) // 
+                    lowerMidiChannel = lowerProfileChannel;
+                else
+                    lowerMidiChannel = midiChannel; 
+
+                int upperMidiChannel;
+                if (m_inputSource->upperChannelValue() != 0)
+                    upperMidiChannel = m_inputSource->upperChannelValue();
+                else if (lowerProfileChannel!=0)
+                    upperMidiChannel = upperProfileChannel;
+                else
+                    upperMidiChannel = midiChannel; 
 
                 m_inputSource->setChannelRange(lowerMidiChannel, upperMidiChannel);
                 m_lowerChannelSpin->setValue(m_inputSource->lowerChannelValue());

--- a/ui/src/inputselectionwidget.h
+++ b/ui/src/inputselectionwidget.h
@@ -63,7 +63,6 @@ protected slots:
     void slotUpperSpinValueChanged(int value);
     void slotLowerChannelSpinChanged(int value);
     void slotUpperChannelSpinChanged(int value);
-    void st(int a);
 
 signals:
     void autoDetectToggled(bool checked);

--- a/ui/src/inputselectionwidget.h
+++ b/ui/src/inputselectionwidget.h
@@ -61,6 +61,9 @@ protected slots:
     void slotCustomFeedbackToggled(bool checked);
     void slotLowerSpinValueChanged(int value);
     void slotUpperSpinValueChanged(int value);
+    void slotLowerChannelSpinChanged(int value);
+    void slotUpperChannelSpinChanged(int value);
+    void st(int a);
 
 signals:
     void autoDetectToggled(bool checked);

--- a/ui/src/inputselectionwidget.ui
+++ b/ui/src/inputselectionwidget.ui
@@ -179,14 +179,48 @@
           <number>3</number>
          </property>
          <item row="0" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Lower Channel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QSpinBox" name="m_upperChannelSpin">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>16</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="m_lowerChannelSpin">
+           <property name="maximum">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Upper channel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
             <string>Lower value</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="3">
-          <widget class="QSpinBox" name="m_upperSpin">
+         <item row="1" column="3">
+          <widget class="QSpinBox" name="m_upperVelocitySpin">
            <property name="minimum">
             <number>0</number>
            </property>
@@ -198,14 +232,14 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="m_lowerSpin">
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="m_lowerVelocitySpin">
            <property name="maximum">
             <number>255</number>
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
+         <item row="1" column="2">
           <widget class="QLabel" name="label_2">
            <property name="text">
             <string>Upper value</string>

--- a/ui/src/virtualconsole/vcbutton.cpp
+++ b/ui/src/virtualconsole/vcbutton.cpp
@@ -523,9 +523,9 @@ void VCButton::updateFeedback()
     if (!src.isNull() && src->isValid() == true)
     {
         if (m_state == Inactive)
-            sendFeedback(src->lowerValue());
+            sendFeedback(src->lowerVelocityValue(), 0U, src->lowerChannelValue());
         else
-            sendFeedback(src->upperValue());
+            sendFeedback(src->upperVelocityValue(), 0U, src->upperChannelValue());
     }
 }
 

--- a/ui/src/virtualconsole/vcbuttonproperties.cpp
+++ b/ui/src/virtualconsole/vcbuttonproperties.cpp
@@ -28,7 +28,6 @@
 #include <QSpinBox>
 #include <QAction>
 #include <qmath.h>
-#include <QDebug>
 
 #include "inputselectionwidget.h"
 #include "vcbuttonproperties.h"
@@ -213,7 +212,6 @@ void VCButtonProperties::slotFadeOutTextEdited()
 
 void VCButtonProperties::accept()
 {
-    qDebug()<<"VCBUTTONPROP_ACCEPT";
     m_button->setCaption(m_nameEdit->text());
     m_button->setFunction(m_function);
     m_button->setKeySequence(m_inputSelWidget->keySequence());

--- a/ui/src/virtualconsole/vcbuttonproperties.cpp
+++ b/ui/src/virtualconsole/vcbuttonproperties.cpp
@@ -28,6 +28,7 @@
 #include <QSpinBox>
 #include <QAction>
 #include <qmath.h>
+#include <QDebug>
 
 #include "inputselectionwidget.h"
 #include "vcbuttonproperties.h"
@@ -212,6 +213,7 @@ void VCButtonProperties::slotFadeOutTextEdited()
 
 void VCButtonProperties::accept()
 {
+    qDebug()<<"VCBUTTONPROP_ACCEPT";
     m_button->setCaption(m_nameEdit->text());
     m_button->setFunction(m_function);
     m_button->setKeySequence(m_inputSelWidget->keySequence());

--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -750,14 +750,14 @@ void VCFrame::updateFeedback()
     {
         if (m_disableState == false)
         {
-            sendFeedback(src->upperValue(), enableInputSourceId);
+            sendFeedback(src->upperVelocityValue(), enableInputSourceId);
         }
         else
         {
             // temporarily revert the disabled state otherwise this
             // feedback will never go through (cause of acceptsInput)
             m_disableState = false;
-            sendFeedback(src->lowerValue(), enableInputSourceId);
+            sendFeedback(src->lowerVelocityValue(), enableInputSourceId);
             m_disableState = true;
         }
     }
@@ -768,9 +768,9 @@ void VCFrame::updateFeedback()
         if (!src.isNull() && src->isValid() == true)
         {
             if (m_currentPage == shortcut->m_page)
-                sendFeedback(src->upperValue(), src);
+                sendFeedback(src->upperVelocityValue(), src);
             else
-                sendFeedback(src->lowerValue(), src);
+                sendFeedback(src->lowerVelocityValue(), src);
         }
     }
 

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -1013,8 +1013,8 @@ void VCMatrix::updateFeedback()
             {
                 QPushButton* button = reinterpret_cast<QPushButton*>(it.key());
                 sendFeedback(button->isDown() ?
-                                 control->m_inputSource->upperValue() :
-                                 control->m_inputSource->lowerValue(),
+                                 control->m_inputSource->upperVelocityValue() :
+                                 control->m_inputSource->lowerVelocityValue(),
                                  control->m_inputSource);
             }
         }

--- a/ui/src/virtualconsole/vcmatrixcontrol.cpp
+++ b/ui/src/virtualconsole/vcmatrixcontrol.cpp
@@ -51,7 +51,7 @@ VCMatrixControl &VCMatrixControl::operator=(const VCMatrixControl &vcmc)
         {
             m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(vcmc.m_inputSource->universe(),
                                                    vcmc.m_inputSource->channel()));
-            m_inputSource->setRange(vcmc.m_inputSource->lowerValue(), vcmc.m_inputSource->upperValue());
+            m_inputSource->setRange(vcmc.m_inputSource->lowerVelocityValue(), vcmc.m_inputSource->upperVelocityValue());
         }
     }
 

--- a/ui/src/virtualconsole/vcspeeddial.cpp
+++ b/ui/src/virtualconsole/vcspeeddial.cpp
@@ -571,8 +571,8 @@ void VCSpeedDial::updateFeedback()
             QPushButton* button = reinterpret_cast<QPushButton*>(it.key());
             if (preset->m_inputSource.isNull() == false)
                 sendFeedback(button->isDown() ?
-                             preset->m_inputSource->upperValue() :
-                             preset->m_inputSource->lowerValue(),
+                             preset->m_inputSource->upperVelocityValue() :
+                             preset->m_inputSource->lowerVelocityValue(),
                              preset->m_inputSource);
         }
     }

--- a/ui/src/virtualconsole/vcspeeddialpreset.cpp
+++ b/ui/src/virtualconsole/vcspeeddialpreset.cpp
@@ -52,7 +52,7 @@ VCSpeedDialPreset &VCSpeedDialPreset::operator=(const VCSpeedDialPreset &preset)
         {
             m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(preset.m_inputSource->universe(),
                                                            preset.m_inputSource->channel()));
-            m_inputSource->setRange(preset.m_inputSource->lowerValue(), preset.m_inputSource->upperValue());
+            m_inputSource->setRange(preset.m_inputSource->lowerVelocityValue(), preset.m_inputSource->upperVelocityValue());
         }
     }
     return *this;

--- a/ui/src/virtualconsole/vcwidget.h
+++ b/ui/src/virtualconsole/vcwidget.h
@@ -59,12 +59,14 @@ class QFile;
 #define KVCFrameStyleRaised (QFrame::Panel | QFrame::Raised)
 #define KVCFrameStyleNone   (QFrame::NoFrame)
 
-#define KXMLQLCVCWidgetKey              QString("Key")
-#define KXMLQLCVCWidgetInput            QString("Input")
-#define KXMLQLCVCWidgetInputUniverse    QString("Universe")
-#define KXMLQLCVCWidgetInputChannel     QString("Channel")
-#define KXMLQLCVCWidgetInputLowerValue  QString("LowerValue")
-#define KXMLQLCVCWidgetInputUpperValue  QString("UpperValue")
+#define KXMLQLCVCWidgetKey                      QString("Key")
+#define KXMLQLCVCWidgetInput                    QString("Input")
+#define KXMLQLCVCWidgetInputUniverse            QString("Universe")
+#define KXMLQLCVCWidgetInputChannel             QString("Channel")
+#define KXMLQLCVCWidgetInputLowerValue          QString("LowerValue")
+#define KXMLQLCVCWidgetInputUpperValue          QString("UpperValue")
+#define KXMLQLCVCWidgetInputChannelLowerValue   QString("LowerChannelValue")
+#define KXMLQLCVCWidgetInputChannelUpperValue   QString("UpperChannelValue")
 
 #define KXMLQLCWindowState          QString("WindowState")
 #define KXMLQLCWindowStateVisible   QString("Visible")
@@ -437,16 +439,18 @@ public:
      *
      * @param value value from 0 to 255 to be sent
      * @param id ID of the input source where to send feedback
+     * @param midi_channel value from 0 to 16 of midi channel
      */
-    void sendFeedback(int value, quint8 id = 0);
+    void sendFeedback(int value, quint8 id = 0, quint8 midi_channel = 0);
 
     /**
      * Send feedback to an external controller.
      *
      * @param value value from 0 to 255 to be sent
      * @param src the QLCInputSource reference to send the feedback to
+     * @param midi_channel value from 0 to 16 of midi channel
      */
-    void sendFeedback(int value, QSharedPointer<QLCInputSource> src);
+    void sendFeedback(int value, QSharedPointer<QLCInputSource> src, quint8 midi_channel = 0);
 
     /**
      * Send the feedback data again, e.g. after page flip

--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -736,7 +736,7 @@ void VCXYPad::slotPresetClicked(bool checked)
             {
                 cBtn->setChecked(false);
                 if (cPr->m_inputSource.isNull() == false)
-                    sendFeedback(cPr->m_inputSource->lowerValue(), cPr->m_inputSource);
+                    sendFeedback(cPr->m_inputSource->lowerVelocityValue(), cPr->m_inputSource);
             }
         }
         else if (cPr->m_type == VCXYPadPreset::EFX ||
@@ -746,7 +746,7 @@ void VCXYPad::slotPresetClicked(bool checked)
             {
                 cBtn->setChecked(false);
                 if (cPr->m_inputSource.isNull() == false)
-                    sendFeedback(cPr->m_inputSource->lowerValue(), cPr->m_inputSource);
+                    sendFeedback(cPr->m_inputSource->lowerVelocityValue(), cPr->m_inputSource);
             }
         }
         else
@@ -755,12 +755,12 @@ void VCXYPad::slotPresetClicked(bool checked)
             {
                 cBtn->setDown(false);
                 if (cPr->m_inputSource.isNull() == false)
-                    sendFeedback(cPr->m_inputSource->lowerValue(), cPr->m_inputSource);
+                    sendFeedback(cPr->m_inputSource->lowerVelocityValue(), cPr->m_inputSource);
             }
         }
         cBtn->blockSignals(false);
         if (cPr->m_inputSource.isNull() == false)
-            sendFeedback(cPr->m_inputSource->lowerValue(), cPr->m_inputSource);
+            sendFeedback(cPr->m_inputSource->lowerVelocityValue(), cPr->m_inputSource);
     }
 
     if (preset->m_type == VCXYPadPreset::EFX)
@@ -801,7 +801,7 @@ void VCXYPad::slotPresetClicked(bool checked)
         connect(m_efx, SIGNAL(durationChanged(uint)), this, SLOT(slotEFXDurationChanged(uint)));
 
         if (preset->m_inputSource.isNull() == false)
-            sendFeedback(preset->m_inputSource->upperValue(), preset->m_inputSource);
+            sendFeedback(preset->m_inputSource->upperVelocityValue(), preset->m_inputSource);
     }
     else if (preset->m_type == VCXYPadPreset::Scene)
     {
@@ -843,7 +843,7 @@ void VCXYPad::slotPresetClicked(bool checked)
         m_scene->start(m_doc->masterTimer(), functionParent());
 
         if (preset->m_inputSource.isNull() == false)
-            sendFeedback(preset->m_inputSource->upperValue(), preset->m_inputSource);
+            sendFeedback(preset->m_inputSource->upperVelocityValue(), preset->m_inputSource);
     }
     else if (preset->m_type == VCXYPadPreset::Position)
     {
@@ -854,7 +854,7 @@ void VCXYPad::slotPresetClicked(bool checked)
         m_area->setPosition(preset->m_dmxPos);
         m_area->repaint();
         if (preset->m_inputSource.isNull() == false)
-            sendFeedback(preset->m_inputSource->upperValue(), preset->m_inputSource);
+            sendFeedback(preset->m_inputSource->upperVelocityValue(), preset->m_inputSource);
         btn->blockSignals(true);
         btn->setDown(true);
         btn->blockSignals(false);
@@ -924,8 +924,8 @@ void VCXYPad::updateFeedback()
                 QPushButton* button = reinterpret_cast<QPushButton*>(it.key());
                 if (preset->m_inputSource.isNull() == false)
                     sendFeedback(button->isDown() ?
-                                 preset->m_inputSource->upperValue() :
-                                 preset->m_inputSource->lowerValue(),
+                                 preset->m_inputSource->upperVelocityValue() :
+                                 preset->m_inputSource->lowerVelocityValue(),
                                  preset->m_inputSource);
             }
         }

--- a/ui/src/virtualconsole/vcxypadpreset.cpp
+++ b/ui/src/virtualconsole/vcxypadpreset.cpp
@@ -103,7 +103,7 @@ VCXYPadPreset &VCXYPadPreset::operator=(const VCXYPadPreset &vcpp)
         {
             m_inputSource = QSharedPointer<QLCInputSource>(new QLCInputSource(vcpp.m_inputSource->universe(),
                                                    vcpp.m_inputSource->channel()));
-            m_inputSource->setRange(vcpp.m_inputSource->lowerValue(), vcpp.m_inputSource->upperValue());
+            m_inputSource->setRange(vcpp.m_inputSource->lowerVelocityValue(), vcpp.m_inputSource->upperVelocityValue());
         }
     }
     return *this;


### PR DESCRIPTION
Actually how QLC+ works with midi out is not the best.
QLC+ actually can use only a MIDI out for the entire midi device, but if you use a controller like the Akai APC mini mk2, in which the brightness and the flashing rate of the RGB pads depends by the MIDI channel, you have to choose only one MIDI channel for the entire controller, loosing al the LEDs functionalities.
Some developer have release tool like that https://github.com/revilo196/mk2apc_4light to mitigate this problem, in which the different velocity are mapped on different channel, but if this kind of controllers can work directly with QLC+ is better.

My idea is to add in the custom feedback section of the widget proprieties two SpinBox, one for lower channel and another for higher channel, that will be used together with the two old SpinBox.
![immagine](https://github.com/mcallegari/qlcplus/assets/40276199/208e98c5-c758-4e0a-84eb-4df4087b475f)

THE PULL REQUEST IS NOT FINISHED, il will remove the draft state once the implementation is end.
I have open a pull request just to have a feedback if this kind of feature will be merged, otherwise i will not spend too much time to finalize it, maybe other people likes the current working principle, 

The missing parts are:

- Implementing them also on Input Profiles
- Takes as default value the midi channel used for the input
- Check retro-compatibility with previous project and eventually fix it
- (If needed) Add it also on QLC+ 5

Finally another parts which i like to modify is the how the values are send in out, actually they are in DMX format [0-255] but before to be sent as MIDI packet they are converted by `#define DMX2MIDI(x) (uchar(x >> 1) & 0x7F)`, and in the case when i have a tables with the velocity related to the pad color by the controller manufacturer like this

![immagine](https://github.com/mcallegari/qlcplus/assets/40276199/b26e8bef-a5f4-498e-9cb8-2defd2f1fcb9)
It is a nightmare and the users need to calculate the right value to match the color, so i would like to do this conversion only when needed, in a way that the user can enter directly midi values [0-127] if in the current universe the feedback is midi, otherwise for OSC and Loopback [0-255]
But this can broke the compatibility with the previous saved projects.
