### PR TITLE
inputprofiles: Adding Worlde Easypad.12 MIDI pad

### DIFF
--- a/resources/docs/html_en_EN/supported-input-devices.html
+++ b/resources/docs/html_en_EN/supported-input-devices.html
@@ -337,6 +337,16 @@ in <a href="https://www.qlcplus.org/forum/">QLC+ forum</a>.
 </TR>
 
 <TR>
+<TD><a href="https://www.worlde.com.cn/products_37/38.html">Worlde Easypad.12</a></TD>
+<TD><a href="midiplugin.html">MIDI</a></TD>
+<TD>1</TD>
+<TD>Worlde Easypad.12</TD>
+<TD>none</TD>
+<TD>no</TD>
+<TD>No bank button and slider (require SYSEX support)</TD>
+</TR>
+
+<TR>
 <TD><a href="https://www.zoom-na.com/products/production-recording/multi-track-recorders/zoom-r16-recorder-interface-controller">Zoom R16</a></TD>
 <TD><a href="midiplugin.html">MIDI</a></TD>
 <TD>1-16</TD>

--- a/resources/inputprofiles/Worlde-Easypad.12.qxi
+++ b/resources/inputprofiles/Worlde-Easypad.12.qxi
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE InputProfile>
+<InputProfile xmlns="http://www.qlcplus.org/InputProfile">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.13.0 GIT</Version>
+  <Author>Christoph Müllner</Author>
+ </Creator>
+ <Manufacturer>Worlde</Manufacturer>
+ <Model>Easypad.12</Model>
+ <Type>MIDI</Type>
+ <Channel Number="36908">
+  <Name>Record</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36909">
+  <Name>Play</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36910">
+  <Name>Stop</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36911">
+  <Name>Back</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36912">
+  <Name>Next</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36913">
+  <Name>Refresh</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36993">
+  <Name>Left</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="36994">
+  <Name>Right</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37028">
+  <Name>Pad 7</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37030">
+  <Name>Pad 8</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37031">
+  <Name>Pad 1</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37032">
+  <Name>Pad 9</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37034">
+  <Name>Pad 10</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37035">
+  <Name>Pad 4</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37036">
+  <Name>Pad 11</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37037">
+  <Name>Pad 3</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37038">
+  <Name>Pad 12</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37040">
+  <Name>Pad 2</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37041">
+  <Name>Pad 6</Name>
+  <Type>Button</Type>
+ </Channel>
+ <Channel Number="37043">
+  <Name>Pad 5</Name>
+  <Type>Button</Type>
+ </Channel>
+</InputProfile>


### PR DESCRIPTION
The Worlde Easypad.12 is a relatively cheap MIDI pad, that can be used as MIDI input. All controls that standard MIDI messages are supported here.

However, there are a few missing features:
* The slider sends SYSEX commands
* The bank button sends SYSEX commands
* Unclear how to set LED color. (using the feedback mechanism did not change anything)

I created this profile six years ago and forgot about it.
When I recently stumbled over the pad, I wanted to add support but found the old profile in my `.qlcplus` folder.
Enough reason to create a PR and see if it will be accepted.