### PR TITLE
VC Click & Go Gobo control on limited-range knobs and sliders

### DIFF
--- a/qmlui/qml/QLCPlusKnob.qml
+++ b/qmlui/qml/QLCPlusKnob.qml
@@ -82,6 +82,34 @@ Dial
             context.stroke()
             context.closePath()
         }
+
+        MouseArea
+        {
+            anchors.fill: parent
+            z: 2
+            onWheel: {
+                console.log("Wheel delta: " + wheel.angleDelta.y)
+                from: sliderObj ? sliderObj.rangeLowLimit : 0
+                to: sliderObj ? sliderObj.rangeHighLimit : 255
+
+                if (wheel.angleDelta.y > 0)
+                    //if (sliderObj && sliderValue < to)
+                        sliderObj.value += 1
+                else
+                    //if (sliderObj && sliderValue > from)
+                        sliderObj.value -= 1
+            }
+            onPressed: {
+                mouse.accepted = false
+            }
+            onPositionChanged: {
+                mouse.accepted = false
+                kCanvas.requestPaint()
+            }
+            onReleased: {
+                mouse.accepted = false
+            }
+        }
     }
 
     handle: Rectangle {

--- a/qmlui/qml/QLCPlusKnob.qml
+++ b/qmlui/qml/QLCPlusKnob.qml
@@ -88,16 +88,20 @@ Dial
             anchors.fill: parent
             z: 2
             onWheel: {
-                console.log("Wheel delta: " + wheel.angleDelta.y)
-                from: sliderObj ? sliderObj.rangeLowLimit : 0
-                to: sliderObj ? sliderObj.rangeHighLimit : 255
+                //console.log("Wheel delta: " + wheel.angleDelta.y)
+                var from = sliderObj ? sliderObj.rangeLowLimit : 0
+                var to = sliderObj ? sliderObj.rangeHighLimit : 255
+                var sliderValue = sliderObj ? sliderObj.value : 128
 
-                if (wheel.angleDelta.y > 0)
-                    //if (sliderObj && sliderValue < to)
+                if (wheel.angleDelta.y > 0) {
+                    if (sliderObj && sliderValue < to) {
                         sliderObj.value += 1
-                else
-                    //if (sliderObj && sliderValue > from)
+                    }
+                } else {
+                    if (sliderObj && sliderValue > from) {
                         sliderObj.value -= 1
+                    }
+                }
             }
             onPressed: {
                 mouse.accepted = false

--- a/qmlui/qml/QLCPlusKnob.qml
+++ b/qmlui/qml/QLCPlusKnob.qml
@@ -17,8 +17,8 @@
   limitations under the License.
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.14
+import QtQuick.Controls 2.14
 
 import "CanvasDrawFunctions.js" as DrawFuncs
 import "."
@@ -33,6 +33,8 @@ Dial
 
     from: 0
     to: 255
+    stepSize: 1.0
+    wheelEnabled: true
 
     onPositionChanged: kCanvas.requestPaint()
     onHeightChanged: kCanvas.requestPaint()
@@ -81,38 +83,6 @@ Dial
                         DrawFuncs.degToRad(startAngle + (control.position * 280)))
             context.stroke()
             context.closePath()
-        }
-
-        MouseArea
-        {
-            anchors.fill: parent
-            z: 2
-            onWheel: {
-                //console.log("Wheel delta: " + wheel.angleDelta.y)
-                var from = sliderObj ? sliderObj.rangeLowLimit : 0
-                var to = sliderObj ? sliderObj.rangeHighLimit : 255
-                var sliderValue = sliderObj ? sliderObj.value : 128
-
-                if (wheel.angleDelta.y > 0) {
-                    if (sliderObj && sliderValue < to) {
-                        sliderObj.value += 1
-                    }
-                } else {
-                    if (sliderObj && sliderValue > from) {
-                        sliderObj.value -= 1
-                    }
-                }
-            }
-            onPressed: {
-                mouse.accepted = false
-            }
-            onPositionChanged: {
-                mouse.accepted = false
-                kCanvas.requestPaint()
-            }
-            onReleased: {
-                mouse.accepted = false
-            }
         }
     }
 

--- a/qmlui/qml/fixturesfunctions/PresetCapabilityItem.qml
+++ b/qmlui/qml/fixturesfunctions/PresetCapabilityItem.qml
@@ -42,6 +42,9 @@ Rectangle
             return
 
         var resArray = capability.resources
+        var slMin = (sliderRoot && sliderRoot.sliderObj) ? sliderRoot.sliderObj.rangeLowLimit : 0
+        var slMax = (sliderRoot && sliderRoot.sliderObj) ? sliderRoot.sliderObj.rangeHighLimit : 255
+        visible = (capability.min <= slMax || capability.max <= slMin)
         capName.label = capability.name
 
         if (resArray.length === 0)
@@ -147,7 +150,11 @@ Rectangle
         onReleased: iRoot.color = "white"
         onClicked:
         {
-            var value = ((capability.max - capability.min) * capBar.width) / iRoot.width
+            var slMin = (sliderRoot && sliderRoot.sliderObj) ? sliderRoot.sliderObj.rangeLowLimit : 0
+            var slMax = (sliderRoot && sliderRoot.sliderObj) ? sliderRoot.sliderObj.rangeHighLimit : 255
+            var cMin = Math.max(capability.min, slMin)
+            var cMax = Math.min(capability.max, slMax)
+            var value = ((cMax - cMin) * capBar.width) / iRoot.width
             //console.log("max: " + capability.max + " min: " + capability.min + " value: " + value)
             valueChanged(value + capability.min)
         }

--- a/qmlui/qml/fixturesfunctions/PresetCapabilityItem.qml
+++ b/qmlui/qml/fixturesfunctions/PresetCapabilityItem.qml
@@ -63,7 +63,7 @@ Rectangle
             if (Qt.platform.os === "android")
                 pic.source = resArray[0]
             else
-                pic.source = "file:/" + resArray[0]
+                pic.source = "file:" + resArray[0]
         }
     }
 

--- a/qmlui/qml/fixturesfunctions/PresetCapabilityItem.qml
+++ b/qmlui/qml/fixturesfunctions/PresetCapabilityItem.qml
@@ -154,8 +154,8 @@ Rectangle
             var slMax = (sliderRoot && sliderRoot.sliderObj) ? sliderRoot.sliderObj.rangeHighLimit : 255
             var cMin = Math.max(capability.min, slMin)
             var cMax = Math.min(capability.max, slMax)
-            var value = ((cMax - cMin) * capBar.width) / iRoot.width
-            //console.log("max: " + capability.max + " min: " + capability.min + " value: " + value)
+            var value = Math.round(((cMax - cMin) * capBar.width) / iRoot.width)
+            //console.log("max: " + capability.max + "|" + slMax + "|" + cMax + " min: " + capability.min + "|" + slMin + "|" + cMin + " value: " + value)
             valueChanged(value + capability.min)
         }
     }

--- a/qmlui/qml/virtualconsole/VCSliderItem.qml
+++ b/qmlui/qml/virtualconsole/VCSliderItem.qml
@@ -230,7 +230,7 @@ VCWidgetItem
                 if (Qt.platform.os === "android")
                     presetImageBox.source = cngResource
                 else
-                    presetImageBox.source = "file:/" + cngResource
+                    presetImageBox.source = "file:" + cngResource
             }
 
             onClicked: colorToolLoader.toggleVisibility()

--- a/qmlui/qml/virtualconsole/VCSliderItem.qml
+++ b/qmlui/qml/virtualconsole/VCSliderItem.qml
@@ -17,7 +17,7 @@
   limitations under the License.
 */
 
-import QtQuick 2.0
+import QtQuick 2.14
 import QtQuick.Layouts 1.1
 
 import org.qlcplus.classes 1.0
@@ -149,7 +149,7 @@ VCWidgetItem
             to: sliderObj ? sliderObj.rangeHighLimit : 255
             value: sliderValue
 
-            onMoved: if (sliderObj) sliderObj.value = value // position * 255
+            onValueChanged: if (sliderObj) sliderObj.value = value
         }
 
         // widget name text box

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -387,7 +387,9 @@ void VCSlider::setValue(int value, bool setDMX, bool updateFeedback)
 
     Tardis::instance()->enqueueAction(Tardis::VCSliderSetValue, id(), m_value, value);
 
-    m_value = value;
+    m_value = SCALE(float(value), float(0), float(UCHAR_MAX),
+            float(rangeLowLimit()),
+            float(rangeHighLimit()));
 
     switch(sliderMode())
     {

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -1029,7 +1029,7 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
 
     if (clickAndGoType() == CnGColors)
     {
-        float f = SCALE(float(m_value), rangeLowLimit(), rangeHighLimit(), 0.0, 200.0);
+        float f = SCALE(float(modLevel), rangeLowLimit(), rangeHighLimit(), 0.0, 200.0);
 
         if ((uchar)f != 0)
         {
@@ -1135,6 +1135,10 @@ void VCSlider::writeDMXLevel(MasterTimer* timer, QList<Universe *> universes)
             // on override, force channel to LTP
             if (m_isOverriding)
                 fc->addFlag(FadeChannel::Override);
+
+            // request to autoremove LTP channels when set
+            if (! (chType & FadeChannel::Intensity))
+                fc->addFlag(FadeChannel::AutoRemove);
 
             if (chType & FadeChannel::Intensity && clickAndGoType() == CnGColors)
             {

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -387,9 +387,7 @@ void VCSlider::setValue(int value, bool setDMX, bool updateFeedback)
 
     Tardis::instance()->enqueueAction(Tardis::VCSliderSetValue, id(), m_value, value);
 
-    m_value = SCALE(float(value), float(0), float(UCHAR_MAX),
-            float(rangeLowLimit()),
-            float(rangeHighLimit()));
+    m_value = value;
 
     switch(sliderMode())
     {
@@ -1235,10 +1233,13 @@ void VCSlider::updateFeedback()
 
 void VCSlider::slotInputValueChanged(quint8 id, uchar value)
 {
+    int scaledValue = SCALE(float(value), float(0), float(UCHAR_MAX),
+            float(rangeLowLimit()),
+            float(rangeHighLimit()));
     switch (id)
     {
         case INPUT_SLIDER_CONTROL_ID:
-            setValue(value, true, false);
+            setValue(scaledValue, true, false);
         break;
         case INPUT_SLIDER_RESET_ID:
             if (value)

--- a/ui/src/clickandgowidget.h
+++ b/ui/src/clickandgowidget.h
@@ -64,6 +64,12 @@ public:
      */
     int getType();
 
+    /** Set the low limits from the fader as a preset filter */
+    void setLevelLowLimit(int min);
+
+    /** Set the high limits from the fader as a preset filter */
+    void setLevelHighLimit(int max);
+
     /**
      * Returns the color at pos position.
      * Used with primary colors linear gradient
@@ -123,8 +129,8 @@ private:
     public:
         QImage m_thumbnail;
         QString m_descr;
-        uchar m_min;
-        uchar m_max;
+        int m_resLowLimit;
+        int m_resHighLimit;
     };
 
 protected:
@@ -144,6 +150,10 @@ protected:
 
     QString m_title;
     QList<ClickAndGoWidget::PresetResource> m_resources;
+
+    /** Fader limits to also limit the presets */
+    int m_levelLowLimit;
+    int m_levelHighLimit;
 
     /** Used to group all the primary colors */
     bool m_linearColor;

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -572,6 +572,8 @@ QList <VCSlider::LevelChannel> VCSlider::levelChannels()
 void VCSlider::setLevelLowLimit(uchar value)
 {
     m_levelLowLimit = value;
+    if (m_cngWidget != NULL)
+        m_cngWidget->setLevelLowLimit(value);
 }
 
 uchar VCSlider::levelLowLimit() const
@@ -582,6 +584,8 @@ uchar VCSlider::levelLowLimit() const
 void VCSlider::setLevelHighLimit(uchar value)
 {
     m_levelHighLimit = value;
+    if (m_cngWidget != NULL)
+        m_cngWidget->setLevelHighLimit(value);
 }
 
 uchar VCSlider::levelHighLimit() const
@@ -762,6 +766,8 @@ void VCSlider::setupClickAndGoWidget()
             {
                 const QLCChannel *chan = fxi->channel(lChan.channel);
                 m_cngWidget->setType(m_cngType, chan);
+                m_cngWidget->setLevelLowLimit(this->levelLowLimit());
+                m_cngWidget->setLevelHighLimit(this->levelHighLimit());
             }
         }
         else

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -804,7 +804,7 @@ void VCSlider::setClickAndGoWidgetFromLevel(uchar level)
 
 void VCSlider::slotClickAndGoLevelChanged(uchar level)
 {
-    setSliderValue(level);
+    setSliderValue(level, false, false);
     updateFeedback();
 
     QColor col = m_cngWidget->getColorAt(level);
@@ -832,7 +832,7 @@ void VCSlider::slotClickAndGoColorChanged(QRgb color)
 
 void VCSlider::slotClickAndGoLevelAndPresetChanged(uchar level, QImage img)
 {
-    setSliderValue(level);
+    setSliderValue(level, false, false);
     updateFeedback();
 
     QPixmap px = QPixmap::fromImage(img);


### PR DESCRIPTION
Originally, I came from the v4 issue that having a gobo knot which is limited to values for static gobos only did not select the correct gobo values when clicking on the CnG Gobo entry.

Please find attached the simple workspace showing an example setup:
"Midi" input (simulated on an Artnet universe) --> Range- limited knob --> Fixture

[gobo-vc.qxw.txt](https://github.com/mcallegari/qlcplus/files/14746163/gobo-vc.qxw.txt)

Along the way when also trying the example in v5, I cam across a few otherv5  knob / slider  limitations which are fixed in this patch:

- Gobo images were not shown
- VCslider limits were not respected when attaching to an Input Event (e.g. Midi)
- Mouse Wheel inputs were not yet supported for the vcKnob
- only the youngest knob or fader was able to modify a LTP channel value
- The highest value was not accessible in the CnG selection list

I think, the functionality only applies to the Gobo / CnGPresets CnG type, not the CngColors type. Please review if that is correct.

I hope this helps. Please review carefully as this is my first QML patch.