### PR TITLE
Copy VCXYPad presets (v4)

### DIFF
--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -228,6 +228,13 @@ VCWidget* VCXYPad::createCopy(VCWidget* parent)
         xypad = NULL;
     }
 
+    for (QHash<QWidget*, VCXYPadPreset*>::iterator it = m_presets.begin();
+            it != m_presets.end(); ++it)
+    {
+        VCXYPadPreset *preset = it.value();
+        xypad->addPreset(*preset);
+    }
+
     return xypad;
 }
 


### PR DESCRIPTION
In v4, the VCXYPad did not copy the presets. This patch completes the copy action by adding the presets in createCopy.

Sample workspace for testing the copy action:
[VCXYPad.qxw.zip](https://github.com/mcallegari/qlcplus/files/14780777/VCXYPad.qxw.zip)
