### PR TITLE
Fix fixture patch address verification

### DIFF
--- a/qmlui/fixturemanager.cpp
+++ b/qmlui/fixturemanager.cpp
@@ -274,7 +274,7 @@ bool FixtureManager::addFixture(QString manuf, QString model, QString mode, QStr
     {
         Fixture *fxi = new Fixture(m_doc);
         //quint32 fxAddress = address + (i * channels) + (i * gap);
-        if (fxAddress + channels >= UNIVERSE_SIZE)
+        if (fxAddress + channels > UNIVERSE_SIZE)
         {
             uniIdx++;
             if (m_doc->inputOutputMap()->getUniverseID(uniIdx) == m_doc->inputOutputMap()->invalidUniverse())


### PR DESCRIPTION
Fix for issue #1542 . 

fxAddress is 0 based (0-511). If the requested address is 511 and the unit has 1 channel, it should fit. In this case, (fxAddress = 511) + (channels = 1) == (UNIVERSE_SIZE = 512) => Should be ok. 

Simply need to remove the "=" to fix the issue.

Easy fix for a first timer! Was fun to figure my way around. ;)