### PR TITLE
Fix build/linker issues with recent GCC releases and static libraries

### DIFF
--- a/engine/audio/src/CMakeLists.txt
+++ b/engine/audio/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(${module_name}
     audioplugincache.cpp audioplugincache.h
     audiorenderer.cpp audiorenderer.h
 )
+set_property(TARGET ${module_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(${module_name} PUBLIC
     ../../../plugins/interfaces
     ../../src

--- a/hotplugmonitor/src/CMakeLists.txt
+++ b/hotplugmonitor/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(hotplugmonitor
     hotplugmonitor.cpp hotplugmonitor.h
 )
+set_property(TARGET hotplugmonitor PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(hotplugmonitor PUBLIC
     Qt${QT_MAJOR_VERSION}::Core


### PR DESCRIPTION
Building qlcplus (upstream/master) with GCC 13.2.1 (Fedora 39) triggers build errors when using the following commands:

```
mkdir build
cd build
cmake ..
make
```

The first error is:

```
[...]
[ 10%] Linking CXX shared library libqlcplusengine.so
/usr/bin/ld: ../audio/src/libqlcplusaudio.a(audio.cpp.o): relocation R_X86_64_32 against symbol `_ZTV5Audio' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```

The second error is:
```
[...]
[ 46%] Linking CXX shared library libqlcplusengine.so
/usr/bin/ld: ../../hotplugmonitor/src/libhotplugmonitor.a(hotplugmonitor.cpp.o): relocation R_X86_64_32 against symbol `_ZTV14HotPlugMonitor' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```

Both errors are caused by linking a static library without position-independent code into a shared object.

This patch addresses the build errors by enabling position-independent code generation for the two static libraries.