### PR TITLE
UI scaling improvements

### DIFF
--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -161,6 +161,7 @@ Popup
             border.width: 1
             border.color: UISettings.bgStronger
             color: UISettings.bgStrong
+            height: actionsMenuEntries.height
         }
 
     Column
@@ -307,6 +308,7 @@ Popup
             ContextMenuEntry
             {
                 Layout.fillWidth: true
+                Layout.fillHeight: true
                 imgSource: "qrc:/undo.svg"
                 entryText: qsTr("Undo")
                 onEntered: submenuItem = null
@@ -320,6 +322,7 @@ Popup
             ContextMenuEntry
             {
                 Layout.fillWidth: true
+                Layout.fillHeight: true
                 imgSource: "qrc:/redo.svg"
                 entryText: qsTr("Redo")
                 onEntered: submenuItem = null

--- a/qmlui/qml/BeatGeneratorsPanel.qml
+++ b/qmlui/qml/BeatGeneratorsPanel.qml
@@ -154,6 +154,7 @@ Rectangle
         {
             id: keyPadBox
             width: parent.width
+            height: UISettings.iconSizeDefault * 6
             showDMXcontrol: false
             showTapButton: true
             visible: ioManager.beatType === "INTERNAL"

--- a/qmlui/qml/KeyPad.qml
+++ b/qmlui/qml/KeyPad.qml
@@ -34,9 +34,9 @@ Rectangle
 
     property bool showDMXcontrol: true
     property bool showTapButton: false
-    
+
     property alias commandString: commandBox.text
-    property real itemHeight: UISettings.iconSizeDefault - 3
+    property real itemHeight: Math.max(UISettings.iconSizeDefault, keyPadRoot.height / keyPadGrid.rows) - 3
 
     //needed for bpm tapping
     property double tapTimeValue: 0
@@ -109,15 +109,15 @@ Rectangle
                 else
                 {
                     var currTime = new Date().getTime()
-                    
+
                     if (lastTap != 0 && currTime - lastTap < 1500)
                     {
                         var newTime = currTime - lastTap
-                        
+
                         tapHistory.push(newTime)
 
                         tapTimeValue = TimeUtils.calculateBPMByTapIntervals(tapHistory)
-                        
+
                         keyPadRoot.tapTimeChanged(tapTimeValue)
                         tapTimer.interval = tapTimeValue
                         tapTimer.restart()

--- a/qmlui/qml/KeyPad.qml
+++ b/qmlui/qml/KeyPad.qml
@@ -36,7 +36,7 @@ Rectangle
     property bool showTapButton: false
     
     property alias commandString: commandBox.text
-    property real itemHeight: Math.max(UISettings.iconSizeDefault, keyPadRoot.height / keyPadGrid.rows) - 3
+    property real itemHeight: UISettings.iconSizeDefault - 3
 
     //needed for bpm tapping
     property double tapTimeValue: 0

--- a/qmlui/qml/MainView.qml
+++ b/qmlui/qml/MainView.qml
@@ -144,6 +144,7 @@ Rectangle
             MenuBarEntry
             {
                 id: actEntry
+                Layout.alignment: Qt.AlignTop
                 imgSource: "qrc:/qlcplus.svg"
                 entryText: qsTr("Actions")
                 onPressed: actionsMenu.open()
@@ -165,6 +166,7 @@ Rectangle
             {
                 id: fnfEntry
                 property string ctxName: "FIXANDFUNC"
+                Layout.alignment: Qt.AlignTop
                 property string ctxRes: "qrc:/FixturesAndFunctions.qml"
 
                 imgSource: "qrc:/editor.svg"
@@ -180,6 +182,7 @@ Rectangle
             MenuBarEntry
             {
                 id: vcEntry
+                Layout.alignment: Qt.AlignTop
                 property string ctxName: "VC"
                 property string ctxRes: "qrc:/VirtualConsole.qml"
 
@@ -201,6 +204,7 @@ Rectangle
             MenuBarEntry
             {
                 id: sdEntry
+                Layout.alignment: Qt.AlignTop
                 property string ctxName: "SDESK"
                 property string ctxRes: "qrc:/SimpleDesk.qml"
 
@@ -222,6 +226,7 @@ Rectangle
             MenuBarEntry
             {
                 id: smEntry
+                Layout.alignment: Qt.AlignTop
                 property string ctxName: "SHOWMGR"
                 property string ctxRes: "qrc:/ShowManager.qml"
 
@@ -243,6 +248,7 @@ Rectangle
             MenuBarEntry
             {
                 id: ioEntry
+                Layout.alignment: Qt.AlignTop
                 property string ctxName: "IOMGR"
                 property string ctxRes: "qrc:/InputOutputManager.qml"
 
@@ -265,7 +271,7 @@ Rectangle
             {
                 // acts like an horizontal spacer
                 Layout.fillWidth: true
-                height: parent.height
+                implicitHeight: parent.height
                 color: "transparent"
             }
             RobotoText
@@ -273,6 +279,9 @@ Rectangle
                 label: "BPM: " + (ioManager.bpmNumber > 0 ? ioManager.bpmNumber : qsTr("Off"))
                 color: gsMouseArea.containsMouse ? UISettings.bgLight : "transparent"
                 fontSize: UISettings.textSizeDefault
+                Layout.alignment: Qt.AlignTop
+                implicitWidth: width
+                implicitHeight: parent.height
 
                 MouseArea
                 {
@@ -294,8 +303,9 @@ Rectangle
             Rectangle
             {
                 id: beatIndicator
-                width: height
-                height: parent.height * 0.5
+                implicitWidth: height
+                implicitHeight: parent.height * 0.5
+                Layout.alignment: Qt.AlignVCenter
                 radius: height / 2
                 border.width: 2
                 border.color: "#333"
@@ -324,8 +334,9 @@ Rectangle
             IconButton
             {
                 id: stopAllButton
-                width: UISettings.iconSizeDefault
-                height: UISettings.iconSizeDefault
+                implicitWidth: UISettings.iconSizeDefault
+                implicitHeight: UISettings.iconSizeDefault
+                Layout.alignment: Qt.AlignTop
                 enabled: runningCount ? true : false
                 bgColor: "transparent"
                 imgSource: "qrc:/stop.svg"

--- a/qmlui/qml/UISettingsEditor.qml
+++ b/qmlui/qml/UISettingsEditor.qml
@@ -37,7 +37,6 @@ Rectangle
 
     onVisibleChanged:
     {
-        console.log("visibility change");
         origItemHeight = UISettings.listItemHeight
         origIconMedium = UISettings.iconSizeMedium
         origTextSizeDefault = UISettings.textSizeDefault

--- a/qmlui/qml/UISettingsEditor.qml
+++ b/qmlui/qml/UISettingsEditor.qml
@@ -30,13 +30,17 @@ Rectangle
     anchors.fill: parent
     color: "transparent"
 
-    property real origItemHeight: UISettings.listItemHeight
-    property real origIconMedium: UISettings.iconSizeMedium
+    property real origItemHeight: { origItemHeight = UISettings.listItemHeight }
+    property real origIconMedium: { origIconMedium = UISettings.iconSizeMedium }
+    property real origTextSizeDefault: { origTextSizeDefault = UISettings.textSizeDefault}
+    property real origIconDefault: {origIconDefault = UISettings.iconSizeDefault}
 
     onVisibleChanged:
     {
+        console.log("visibility change");
         origItemHeight = UISettings.listItemHeight
         origIconMedium = UISettings.iconSizeMedium
+        origTextSizeDefault = UISettings.textSizeDefault
         sfRestore.origScaleFactor = qlcplus.uiScaleFactor
     }
 
@@ -135,6 +139,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Scaling factor")
         }
         RowLayout
@@ -181,7 +186,9 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Background darker")
+            onHeightChanged: console.log("Row 2 height: " + height);
         }
         Loader
         {
@@ -199,7 +206,9 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Background dark")
+            onHeightChanged: console.log("text height changed " + height)
         }
         Loader
         {
@@ -218,6 +227,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Background medium")
         }
         Loader
@@ -236,6 +246,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Background light")
         }
         Loader
@@ -255,6 +266,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Background lighter")
         }
         Loader
@@ -273,6 +285,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Controls background")
         }
         Loader
@@ -292,6 +305,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Foreground main")
         }
         Loader
@@ -310,6 +324,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Foreground medium")
         }
         Loader
@@ -329,6 +344,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Foreground light")
         }
         Loader
@@ -347,6 +363,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Toolbar gradient start")
         }
         Loader
@@ -366,6 +383,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Sub-toolbar gradient start")
         }
         Loader
@@ -384,6 +402,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Toolbar gradient end")
         }
         Loader
@@ -403,6 +422,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Toolbar hover gradient start")
         }
         Loader
@@ -422,6 +442,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Toolbar hover gradient end")
         }
         Loader
@@ -441,6 +462,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Toolbar selection")
         }
         Loader
@@ -460,6 +482,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Sub-toolbar selection")
         }
         Loader
@@ -479,6 +502,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Section header")
         }
         Loader
@@ -497,6 +521,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Section header divider")
         }
         Loader
@@ -516,6 +541,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Item highlight")
         }
         Loader
@@ -534,6 +560,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Item highlight pressed")
         }
         Loader
@@ -553,6 +580,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Item hover")
         }
         Loader
@@ -571,6 +599,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Item selection")
         }
         Loader
@@ -590,6 +619,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("VC Frame drop area")
         }
         Loader
@@ -608,6 +638,7 @@ Rectangle
         RobotoText
         {
             height: origItemHeight
+            fontSize: origTextSizeDefault
             label: qsTr("Item dark border")
         }
         Loader
@@ -628,6 +659,8 @@ Rectangle
             Layout.columnSpan: 4
             Layout.alignment: Qt.AlignHCenter
             width: origIconMedium * 10
+            height: origIconDefault
+            fontSize: origTextSizeDefault
             label: qsTr("Save to file")
             onClicked:
             {

--- a/qmlui/qml/UISettingsEditor.qml
+++ b/qmlui/qml/UISettingsEditor.qml
@@ -188,7 +188,6 @@ Rectangle
             height: origItemHeight
             fontSize: origTextSizeDefault
             label: qsTr("Background darker")
-            onHeightChanged: console.log("Row 2 height: " + height);
         }
         Loader
         {
@@ -208,7 +207,6 @@ Rectangle
             height: origItemHeight
             fontSize: origTextSizeDefault
             label: qsTr("Background dark")
-            onHeightChanged: console.log("text height changed " + height)
         }
         Loader
         {

--- a/qmlui/qml/UISettingsEditor.qml
+++ b/qmlui/qml/UISettingsEditor.qml
@@ -158,6 +158,7 @@ Rectangle
             RobotoText
             {
                 height: origItemHeight
+                fontSize: origTextSizeDefault
                 label: sfSlider.value.toFixed(2) + "x"
             }
 

--- a/qmlui/qml/popup/PopupAbout.qml
+++ b/qmlui/qml/popup/PopupAbout.qml
@@ -57,6 +57,8 @@ CustomPopupDialog
                       " <a href='https://www.apache.org/licenses/LICENSE-2.0'>" +
                       qsTr("Apache 2.0 license") + "</a>."
                 onLinkActivated: Qt.openUrlExternally(link)
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
 
                 MouseArea
                 {


### PR DESCRIPTION
Fix general UI scaling bugs including

- Top bar elements drift downwards when scale goes under 1.0
- Background for "Actions" bar didn't automatically adjust to rescaled sizing (required second click on "Actions" menu item)
- Prevent BPM "ratchet" issues where scaling up increases keypad button height, but scaling down leaves it at the maximum height scaled to
- Beat Indicator / Stop all button not scaling with UI
- interface jitter in UI Setting editor
- Width of text elements in UI settings editor, but font size changes
- Undo/Redo buttons to layout to scale properly
- Prevent text overflow in about dialog

Current (Beat generator panel has been scaled up, then returned to smaller size):
![pre-pr](https://github.com/mcallegari/qlcplus/assets/42226280/e35f9675-0ddf-488f-9cd5-9b7d561239b2)

Pull Request:
![post-pr](https://github.com/mcallegari/qlcplus/assets/42226280/035795d0-b7ea-429c-bca2-579d6cb1119f)

