### PR TITLE
Fix bugs in Fixture Search

### DIFF
--- a/qmlui/qml/GenericMultiDragItem.qml
+++ b/qmlui/qml/GenericMultiDragItem.qml
@@ -1,6 +1,6 @@
 /*
   Q Light Controller Plus
-  FunctionDragItem.qml
+  GenericMultiDragItem.qml
 
   Copyright (c) Massimo Callegari
 

--- a/qmlui/qml/TreeNodeDelegate.qml
+++ b/qmlui/qml/TreeNodeDelegate.qml
@@ -103,6 +103,7 @@ Column
                 id: nodeLabel
                 width: nodeBgRect.width - x - 1
                 text: cRef ? cRef.name : textLabel
+                originalText: text
 
                 onTextConfirmed: nodeContainer.pathChanged(nodePath, text)
             }

--- a/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
@@ -132,6 +132,7 @@ Column
                 id: nodeLabel
                 Layout.fillWidth: true
                 text: textLabel
+                originalText: text
 
                 onTextConfirmed:
                 {

--- a/qmlui/qml/fixturesfunctions/LeftPanel.qml
+++ b/qmlui/qml/fixturesfunctions/LeftPanel.qml
@@ -98,8 +98,10 @@ SidePanel
                 autoExclusive: false
                 onToggled:
                 {
-                    if (checked == true)
+                    if (checked == true) {
                         loaderSource = "qrc:/FixtureGroupManager.qml"
+                        fixtureManager.searchFilter = ""
+                    }
                     animatePanel(checked)
                 }
             }

--- a/qmlui/qml/fixturesfunctions/LeftPanel.qml
+++ b/qmlui/qml/fixturesfunctions/LeftPanel.qml
@@ -98,7 +98,8 @@ SidePanel
                 autoExclusive: false
                 onToggled:
                 {
-                    if (checked == true) {
+                    if (checked == true)
+                    {
                         loaderSource = "qrc:/FixtureGroupManager.qml"
                         fixtureManager.searchFilter = ""
                     }

--- a/qmlui/treemodel.cpp
+++ b/qmlui/treemodel.cpp
@@ -202,7 +202,7 @@ TreeModelItem *TreeModel::itemAtPath(QString path)
             return nullptr;
     }
 
-    if(m_itemsPathMap.contains(pathList.at(0)))
+    if (m_itemsPathMap.contains(pathList.at(0)))
         return nullptr;
     TreeModelItem *item = m_itemsPathMap[pathList.at(0)];
     QString subPath = path.mid(path.indexOf(TreeModel::separator()) + 1);
@@ -272,7 +272,7 @@ void TreeModel::setItemRoleData(QString path, const QVariant &value, int role)
     }
     else
     {
-        if(!m_itemsPathMap.contains(pathList.at(0)))
+        if (!m_itemsPathMap.contains(pathList.at(0)))
             return;
         TreeModelItem *item = m_itemsPathMap[pathList.at(0)];
         QString subPath = path.mid(path.indexOf(TreeModel::separator()) + 1);

--- a/qmlui/treemodel.cpp
+++ b/qmlui/treemodel.cpp
@@ -202,6 +202,8 @@ TreeModelItem *TreeModel::itemAtPath(QString path)
             return nullptr;
     }
 
+    if(m_itemsPathMap.contains(pathList.at(0)))
+        return nullptr;
     TreeModelItem *item = m_itemsPathMap[pathList.at(0)];
     QString subPath = path.mid(path.indexOf(TreeModel::separator()) + 1);
     return item->children()->itemAtPath(subPath);
@@ -270,6 +272,8 @@ void TreeModel::setItemRoleData(QString path, const QVariant &value, int role)
     }
     else
     {
+        if(!m_itemsPathMap.contains(pathList.at(0)))
+            return;
         TreeModelItem *item = m_itemsPathMap[pathList.at(0)];
         QString subPath = path.mid(path.indexOf(TreeModel::separator()) + 1);
         item->children()->setItemRoleData(subPath, value, role);


### PR DESCRIPTION
Bugs fixed:
- selecting or deselecting a fixture with Fixture Groups panel open results in a segfault
- Escape erases the names of fixtures and universes
- Switching from Fixture Groups view to another view in the left panel and then switching back to fixture view does not clear filter until the search button is clicked again, without any visual indication that a filter is still active