### PR TITLE
Fix color picker full mode

### DIFF
--- a/qmlui/qml/ColorToolFull.qml
+++ b/qmlui/qml/ColorToolFull.qml
@@ -125,6 +125,7 @@ Rectangle
                 bSpin.value = b*/
 
                 currentRGB = Qt.rgba(r / 255, g / 255, b / 255, 1.0)
+                colorChanged(currentRGB.r, currentRGB.g, currentRGB.b, currentWAUV.r, currentWAUV.g, currentWAUV.b)
             }
 
             onPressed: setPickedColor(mouse)


### PR DESCRIPTION
This PR fixes a bug where using the "Full" color picker mode doesn't update the color of fixtures or UI color settings.