### PR TITLE
Refresh Cue List Widget on Addition or Removal of a Step from Chaser

### DIFF
--- a/engine/src/chaser.cpp
+++ b/engine/src/chaser.cpp
@@ -132,6 +132,7 @@ bool Chaser::addStep(const ChaserStep& step, int index)
         }
 
         emit changed(this->id());
+        emit stepListChange(this->id());
         return true;
     }
     else
@@ -150,6 +151,7 @@ bool Chaser::removeStep(int index)
         }
 
         emit changed(this->id());
+        emit stepListChange(this->id());
         return true;
     }
     else

--- a/engine/src/chaser.h
+++ b/engine/src/chaser.h
@@ -157,6 +157,7 @@ public slots:
 
 signals:
     void stepChanged(int index);
+    void stepListChange(quint32 fid);
 
 protected:
     QList <ChaserStep> m_steps;

--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -488,6 +488,8 @@ void VCCueList::setChaserID(quint32 fid)
                 this, SLOT(slotCurrentStepChanged(int)));
         connect(function, SIGNAL(stepChanged(int)),
                 this, SLOT(slotStepChanged(int)));
+        connect(function, SIGNAL(stepListChange(quint32)),
+                this, SLOT(slotStepListChange(quint32)));
 
         emit chaserIDChanged(fid);
     }
@@ -516,6 +518,11 @@ void VCCueList::slotFunctionRemoved(quint32 fid)
 
         resetIntensityOverrideAttribute();
     }
+}
+
+void VCCueList::slotStepListChange(quint32 fid) {
+    if (fid == m_chaserID)
+        ChaserEditor::updateStepsList(m_doc, chaser(), m_stepsList);
 }
 
 void VCCueList::slotStepChanged(int index)

--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -520,7 +520,8 @@ void VCCueList::slotFunctionRemoved(quint32 fid)
     }
 }
 
-void VCCueList::slotStepListChange(quint32 fid) {
+void VCCueList::slotStepListChange(quint32 fid)
+{
     if (fid == m_chaserID)
         ChaserEditor::updateStepsList(m_doc, chaser(), m_stepsList);
 }

--- a/qmlui/virtualconsole/vccuelist.h
+++ b/qmlui/virtualconsole/vccuelist.h
@@ -188,6 +188,7 @@ private slots:
     void slotFunctionRemoved(quint32 fid);
     void slotFunctionNameChanged(quint32 fid);
     void slotStepChanged(int index);
+    void slotStepListChange(quint32 fid);
 
 private:
     FunctionParent functionParent() const;


### PR DESCRIPTION
- Currently adding or removing a widget is not reflected in the cue list widget unless the project is saved and reopened 
- Also apparent cause of crash at https://www.qlcplus.org/forum/viewtopic.php?t=17147, as the cue list would attempt to access a non-existent index
- This PR reloads the chaser cue list if a function is added or removed from the linked chaser, allowing updates to be seen in real time and preventing the crash