### PR TITLE
Add merger mode for HIDDMXDevices (DE/FX5/Nodle)

### DIFF
--- a/plugins/hid/HID_ca_ES.ts
+++ b/plugins/hid/HID_ca_ES.ts
@@ -19,7 +19,12 @@
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Actualitzar</translation>
     </message>

--- a/plugins/hid/HID_cz_CZ.ts
+++ b/plugins/hid/HID_cz_CZ.ts
@@ -19,7 +19,12 @@
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Obnovit</translation>
     </message>

--- a/plugins/hid/HID_de_DE.ts
+++ b/plugins/hid/HID_de_DE.ts
@@ -19,7 +19,12 @@
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>

--- a/plugins/hid/HID_es_ES.ts
+++ b/plugins/hid/HID_es_ES.ts
@@ -19,7 +19,12 @@
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>

--- a/plugins/hid/HID_fi_FI.ts
+++ b/plugins/hid/HID_fi_FI.ts
@@ -19,7 +19,12 @@
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation type="unfinished">Päivitä</translation>
     </message>

--- a/plugins/hid/HID_fr_FR.ts
+++ b/plugins/hid/HID_fr_FR.ts
@@ -19,7 +19,12 @@
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Rafraîchir</translation>
     </message>

--- a/plugins/hid/HID_it_IT.ts
+++ b/plugins/hid/HID_it_IT.ts
@@ -19,7 +19,12 @@
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>

--- a/plugins/hid/HID_ja_JP.ts
+++ b/plugins/hid/HID_ja_JP.ts
@@ -19,7 +19,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation type="unfinished">更新</translation>
     </message>

--- a/plugins/hid/HID_nl_NL.ts
+++ b/plugins/hid/HID_nl_NL.ts
@@ -19,7 +19,12 @@
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Ververs</translation>
     </message>

--- a/plugins/hid/HID_pt_BR.ts
+++ b/plugins/hid/HID_pt_BR.ts
@@ -19,7 +19,12 @@
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="configurehid.ui" line="65"/>
+        <location filename="configurehid.ui" line="62"/>
+        <source>Merger Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="configurehid.ui" line="70"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>

--- a/plugins/hid/configurehid.cpp
+++ b/plugins/hid/configurehid.cpp
@@ -104,7 +104,8 @@ void ConfigureHID::refreshList()
         item->setText(KColumnName, dev->name());
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 
-        if (dev->hasMergerMode()) {
+        if (dev->hasMergerMode())
+        {
             QWidget* widget = createMergerModeWidget(dev->isMergerModeEnabled());
             widget->setProperty(PROP_DEV, (qulonglong) dev);
             m_list->setItemWidget(item, KColumnMerger, widget);
@@ -138,10 +139,11 @@ QWidget* ConfigureHID::createMergerModeWidget(bool mergerModeEnabled)
 {
     QCheckBox* checkbox = new QCheckBox;
 
-        if (mergerModeEnabled)
-            checkbox->setCheckState(Qt::Checked);
-        else
-            checkbox->setCheckState(Qt::Unchecked);  
+    if (mergerModeEnabled)
+        checkbox->setCheckState(Qt::Checked);
+    else
+        checkbox->setCheckState(Qt::Unchecked);
+
     connect(checkbox, SIGNAL(stateChanged(int)), this, SLOT(slotMergerModeChanged(int)));
 
     return checkbox;

--- a/plugins/hid/configurehid.cpp
+++ b/plugins/hid/configurehid.cpp
@@ -25,6 +25,7 @@
 #include <QTimer>
 #include <QDebug>
 #include <QSettings>
+#include <QCheckBox>
 
 #include "configurehid.h"
 #include "hiddevice.h"
@@ -32,6 +33,8 @@
 
 #define KColumnNumber  0
 #define KColumnName    1
+#define KColumnMerger 2
+#define PROP_DEV        "dev"
 
 #define SETTINGS_GEOMETRY "configurehid/geometry"
 
@@ -100,6 +103,12 @@ void ConfigureHID::refreshList()
         item->setText(KColumnNumber, s.setNum(i + 1));
         item->setText(KColumnName, dev->name());
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+
+        if (dev->hasMergerMode()) {
+            QWidget* widget = createMergerModeWidget(dev->isMergerModeEnabled());
+            widget->setProperty(PROP_DEV, (qulonglong) dev);
+            m_list->setItemWidget(item, KColumnMerger, widget);
+        }
     }
     m_list->header()->resizeSections(QHeaderView::ResizeToContents);
 }
@@ -123,4 +132,33 @@ void ConfigureHID::slotDeviceRemoved(HIDDevice* device)
             break;
         }
     }
+}
+
+QWidget* ConfigureHID::createMergerModeWidget(bool mergerModeEnabled)
+{
+    QCheckBox* checkbox = new QCheckBox;
+
+        if (mergerModeEnabled)
+            checkbox->setCheckState(Qt::Checked);
+        else
+            checkbox->setCheckState(Qt::Unchecked);  
+    connect(checkbox, SIGNAL(stateChanged(int)), this, SLOT(slotMergerModeChanged(int)));
+
+    return checkbox;
+}
+
+void ConfigureHID::slotMergerModeChanged(int state)
+{
+    QCheckBox* checkbox = qobject_cast<QCheckBox*> (QObject::sender());
+    Q_ASSERT(checkbox != NULL);
+
+    QVariant var = checkbox->property(PROP_DEV);
+    Q_ASSERT(var.isValid() == true);
+
+    HIDDevice* dev = (HIDDevice*) var.toULongLong();
+    Q_ASSERT(dev != NULL);
+
+    bool mergerModeEnabled = (state == Qt::Checked);
+    
+    dev->enableMergerMode(mergerModeEnabled);
 }

--- a/plugins/hid/configurehid.h
+++ b/plugins/hid/configurehid.h
@@ -52,9 +52,15 @@ private slots:
     /** Callback for HIDInput::deviceRemoved() signals. */
     void slotDeviceRemoved(HIDDevice* device);
 
+    /** Change the merger mode. */
+    void slotMergerModeChanged(int state);
+
 private:
     /** Refresh the interface list */
     void refreshList();
+
+    /** Checkbox for merger mode (de-)activation. */
+    QWidget* createMergerModeWidget(bool mergerModeEnabled);
 };
 
 #endif

--- a/plugins/hid/configurehid.ui
+++ b/plugins/hid/configurehid.ui
@@ -57,6 +57,11 @@
        <string>Name</string>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>Merger Mode</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item row="1" column="0">

--- a/plugins/hid/hiddevice.cpp
+++ b/plugins/hid/hiddevice.cpp
@@ -45,6 +45,21 @@ HIDDevice::~HIDDevice()
 /*****************************************************************************
  * File operations
  *****************************************************************************/
+bool HIDDevice::hasMergerMode()
+{
+    return false; //usual HIDDevices don't offer a merger mode
+}
+
+bool HIDDevice::isMergerModeEnabled()
+{
+    return false; //never enabled when not offered
+}
+
+void HIDDevice::enableMergerMode(bool mergerModeEnabled)
+{
+    Q_UNUSED(mergerModeEnabled);
+}
+
 
 bool HIDDevice::openInput()
 {

--- a/plugins/hid/hiddevice.h
+++ b/plugins/hid/hiddevice.h
@@ -42,6 +42,29 @@ public:
      *************************************************************************/
 public:
     /**
+     * Check if the device offers a built-in merger mode.
+     *
+     * Merger mode means that all DMX data from the device's input port is
+     * copied to its output port and - if output from QLC+ is enabled -
+     * merged with this output in a HTP manner on the device itself. 
+     *
+     * @return true if the device offers a merger mode, false otherwise
+     */
+    virtual bool hasMergerMode();
+
+    /**
+     * Check if device's built-in merger mode is enabled.
+     *
+     * @return true if the device's merger mode is enabled, false otherwise
+     */
+    virtual bool isMergerModeEnabled();
+
+    /**
+     * Enable or disable the built-in merger mode.
+     */
+    virtual void enableMergerMode(bool mergerModeEnabled);
+
+    /**
      * Attempt to open the HID device as input in RW mode and fall back
      * to RO if that fails.
      *

--- a/plugins/hid/hiddmxdevice.cpp
+++ b/plugins/hid/hiddmxdevice.cpp
@@ -75,6 +75,18 @@ void HIDDMXDevice::init()
  * File operations
  *****************************************************************************/
 
+bool HIDDMXDevice::isMergerModeEnabled()
+{
+    return (m_mode & DMX_MODE_MERGER);
+}
+
+void HIDDMXDevice::enableMergerMode(bool mergerModeEnabled)
+{
+    if (mergerModeEnabled) m_mode |= DMX_MODE_MERGER;
+    else m_mode &= ~DMX_MODE_MERGER;
+    updateMode();
+}
+
 bool HIDDMXDevice::openInput()
 {
     m_mode |= DMX_MODE_INPUT;
@@ -216,6 +228,8 @@ void HIDDMXDevice::updateMode()
         driver_mode += 2;
     if (m_mode & DMX_MODE_INPUT)
         driver_mode += 4;
+    if (m_mode & DMX_MODE_MERGER)
+        driver_mode += 1;
 
     unsigned char buffer[34];
 

--- a/plugins/hid/hiddmxdevice.cpp
+++ b/plugins/hid/hiddmxdevice.cpp
@@ -82,8 +82,10 @@ bool HIDDMXDevice::isMergerModeEnabled()
 
 void HIDDMXDevice::enableMergerMode(bool mergerModeEnabled)
 {
-    if (mergerModeEnabled) m_mode |= DMX_MODE_MERGER;
-    else m_mode &= ~DMX_MODE_MERGER;
+    if (mergerModeEnabled)
+        m_mode |= DMX_MODE_MERGER;
+    else
+        m_mode &= ~DMX_MODE_MERGER;
     updateMode();
 }
 

--- a/plugins/hid/hiddmxdevice.h
+++ b/plugins/hid/hiddmxdevice.h
@@ -64,10 +64,22 @@ protected:
     /** @reimp */
     bool hasOutput() { return true; }
 
+    /** @reimp */
+    bool hasMergerMode() {
+        return true; //DE, FX5, and Nodle have a merger mode
+    }
+
     /*********************************************************************
      * File operations
      *********************************************************************/
 public:
+
+    /** @reimp */
+    bool isMergerModeEnabled();
+
+    /** @reimp */
+    void enableMergerMode(bool mergerModeEnabled);
+
     /** @reimp */
     bool openInput();
 
@@ -117,7 +129,8 @@ private:
     {
         DMX_MODE_NONE   = 1 << 0,
         DMX_MODE_OUTPUT = 1 << 1,
-        DMX_MODE_INPUT  = 1 << 2
+        DMX_MODE_INPUT  = 1 << 2,
+        DMX_MODE_MERGER  = 1 << 3
     };
 
     /** mode selection function */

--- a/plugins/hid/hiddmxdevice.h
+++ b/plugins/hid/hiddmxdevice.h
@@ -65,9 +65,7 @@ protected:
     bool hasOutput() { return true; }
 
     /** @reimp */
-    bool hasMergerMode() {
-        return true; //DE, FX5, and Nodle have a merger mode
-    }
+    bool hasMergerMode() { return true; /*DE, FX5, and Nodle have a merger mode*/ }
 
     /*********************************************************************
      * File operations
@@ -130,7 +128,7 @@ private:
         DMX_MODE_NONE   = 1 << 0,
         DMX_MODE_OUTPUT = 1 << 1,
         DMX_MODE_INPUT  = 1 << 2,
-        DMX_MODE_MERGER  = 1 << 3
+        DMX_MODE_MERGER = 1 << 3
     };
 
     /** mode selection function */

--- a/resources/docs/html_en_EN/hidplugin.html
+++ b/resources/docs/html_en_EN/hidplugin.html
@@ -39,10 +39,36 @@ supports 2 axes and 4 buttons, they will appear in the input mapping dialogs lik
 </ul>
 </P>
 
+<H2>Nodle USB DMX interface</H2>
+<P>
+The Nodle USB DMX interface is available in two versions: For self-construction it is called
+<EM>Nodle U1</EM> or ready made it is called <EM>Nodle R4S</EM> (ready for show).
+</P>
+
+<P>
+It can output and input DMX data and it has a built-in merger mode. When activated via the configuration
+dialog, the device merges any DMX data coming from QLC+ (if selected as output) with all
+DMX data coming from the device's input in an HTP (Highest Takes Precedence) manner.
+</P>
+
+<P>
+If set, the merger mode persists even when QLC+ is closed as long as the device is powered.
+This way the device is transparent to incoming DMX data and just forwards them.
+</P>
+
+<P>
+The device buffers incoming DMX data. So when the connection at the DMX input is interrupted the last
+DMX data is repeated until the connection is reestablished or the device is reset.
+</P>
+
+<P>
+Check the product manual for further information, connection, and peculiar issues.
+</P>
+
 <H2>FX5 USB DMX</H2>
 <P>
-The <A HREF="https://fx5.de/">FX5 USB DMX</A> adapter is supported either for output and input
-DMX data. Check the product manual for the connection and peculiar issues.
+Although not available anymore. The FX5 USB DMX adapter is still supported either for output and input
+DMX data. It offers the same features as the Nodle USB DMX. Check the product manual for the connection and peculiar issues.
 </P>
 
 </BODY>


### PR DESCRIPTION
Adding the ability to set the DE/FX5/Nodle devices into merger mode as explained in the updated docs.

Tested with two Nodle R4S.