### PR TITLE
Proposal of a rework of HID device names

### DIFF
--- a/plugins/hid/hidjsdevice.cpp
+++ b/plugins/hid/hidjsdevice.cpp
@@ -39,8 +39,9 @@ static QString assembleDevicesName(struct hid_device_info *info)
     if (name_part.trimmed().isEmpty())
     {
         //use the vendor and product_id combination if name is empty
-        name_part = QString::number(info->vendor_id, 16) + ":" +
-                    QString::number(info->product_id, 16);
+        name_part = "HID Input Device (" +
+                    QString::number(info->vendor_id, 16).toUpper() + ":" +
+                    QString::number(info->product_id, 16).toUpper() + ")";
     }
 
     QString serial_number_part = QString::fromWCharArray(info->serial_number);

--- a/plugins/hid/hidjsdevice.cpp
+++ b/plugins/hid/hidjsdevice.cpp
@@ -29,7 +29,8 @@
 HIDJsDevice::HIDJsDevice(HIDPlugin* parent, quint32 line, struct hid_device_info *info)
     : HIDDevice(parent, line,
                 QString::fromWCharArray(info->manufacturer_string) + " " +
-                QString::fromWCharArray(info->product_string),
+                QString::fromWCharArray(info->product_string) + " (" +
+                QString::fromWCharArray(info->serial_number) + ")" ,
                 QString(info->path))
 {
     m_dev_info = (struct hid_device_info*) malloc (sizeof(struct hid_device_info));

--- a/plugins/hid/hidjsdevice.cpp
+++ b/plugins/hid/hidjsdevice.cpp
@@ -26,11 +26,37 @@
 #include "hidjsdevice.h"
 #include "hidplugin.h"
 
+/**
+* Helper for constructing the name from the device info delivered by info
+* (e.g. manufacturer name, product name, PID, VID, or serial number)
+*/
+static QString assembleDevicesName(struct hid_device_info *info)
+{
+
+    QString name_part = QString::fromWCharArray(info->manufacturer_string) + " " +
+                        QString::fromWCharArray(info->product_string);
+                    
+    if (name_part.trimmed().isEmpty())
+    {
+        //use the vendor and product_id combination if name is empty
+        name_part = QString::number(info->vendor_id, 16) + ":" +
+                    QString::number(info->product_id, 16);
+    }
+
+    QString serial_number_part = QString::fromWCharArray(info->serial_number);
+
+    if (!serial_number_part.isEmpty())
+    {
+        //use serial number in parenthesis, if available
+        serial_number_part = " (" + serial_number_part + ")";
+    }
+
+    return name_part + serial_number_part;
+}
+
 HIDJsDevice::HIDJsDevice(HIDPlugin* parent, quint32 line, struct hid_device_info *info)
     : HIDDevice(parent, line,
-                QString::fromWCharArray(info->manufacturer_string) + " " +
-                QString::fromWCharArray(info->product_string) + " (" +
-                QString::fromWCharArray(info->serial_number) + ")" ,
+                assembleDevicesName(info),
                 QString(info->path))
 {
     m_dev_info = (struct hid_device_info*) malloc (sizeof(struct hid_device_info));

--- a/plugins/hid/hidplugin.cpp
+++ b/plugins/hid/hidplugin.cpp
@@ -277,7 +277,8 @@ void HIDPlugin::rescanDevices()
             /* Device is a USB DMX Interface, add it */
             dev = new HIDDMXDevice(this, line++,
                                    QString::fromWCharArray(cur_dev->manufacturer_string) + " " +
-                                   QString::fromWCharArray(cur_dev->product_string),
+                                   QString::fromWCharArray(cur_dev->product_string) + " " +
+                                   "(" + QString::fromWCharArray(cur_dev->serial_number) + ")",
                                    QString(cur_dev->path));
             addDevice(dev);
         }


### PR DESCRIPTION
Hi,

this is a proposal for a more detailed and more robust naming of HID devices.

It covers:
1. HIDDMXDevices always have a serial number, thus it is appended in parenthesis to be able to distinguish several connected devices.
2. Those HIDJSDevices that expose a serial number append it in parenthesis as well.
3. HIDJSDevices not exposing _any_ product or manufacturer name use VID:PID as a naming scheme instead. (Previously those had a completely empty name.)

I'm open to changes of course.