### PR TITLE
Fix: Highlight the searchbar when first opening the addfixture dialogue.

### DIFF
--- a/ui/src/addfixture.cpp
+++ b/ui/src/addfixture.cpp
@@ -146,6 +146,9 @@ AddFixture::AddFixture(QWidget* parent, const Doc* doc, const Fixture* fxi)
     if (var.isValid() == true)
         restoreGeometry(var.toByteArray());
     AppUtil::ensureWidgetIsVisible(this);
+
+    // Set focus on the search bar
+    m_searchEdit->setFocus();
 }
 
 AddFixture::~AddFixture()


### PR DESCRIPTION
No forum post as this is a very small change.

When you want to add a fixture, you first search for the fixture, not rename the default dimmer option.

This pull request automatically brings the cursor to the search bar, so the user can immediately begin searching for the fixture they wish to add.