### PR TITLE
Let cursor keys and PgUp/PgDown work as key combination on VCButtons

### DIFF
--- a/ui/src/CMakeLists.txt
+++ b/ui/src/CMakeLists.txt
@@ -141,6 +141,7 @@ add_library(${module_name}
     virtualconsole/vcmatrixproperties.cpp virtualconsole/vcmatrixproperties.h virtualconsole/vcmatrixproperties.ui
     virtualconsole/vcproperties.cpp virtualconsole/vcproperties.h virtualconsole/vcproperties.ui
     virtualconsole/vcpropertieseditor.cpp virtualconsole/vcpropertieseditor.h
+    virtualconsole/vcscrollarea.cpp virtualconsole/vcscrollarea.h
     virtualconsole/vcslider.cpp virtualconsole/vcslider.h
     virtualconsole/vcsliderproperties.cpp virtualconsole/vcsliderproperties.h virtualconsole/vcsliderproperties.ui
     virtualconsole/vcsoloframe.cpp virtualconsole/vcsoloframe.h

--- a/ui/src/src.pro
+++ b/ui/src/src.pro
@@ -155,6 +155,7 @@ HEADERS += virtualconsole/addvcbuttonmatrix.h \
            virtualconsole/vcmatrixproperties.h \
            virtualconsole/vcproperties.h \
            virtualconsole/vcpropertieseditor.h \
+           virtualconsole/vcscrollarea.h \
            virtualconsole/vcslider.h \
            virtualconsole/vcsliderproperties.h \
            virtualconsole/vcsoloframe.h \
@@ -337,6 +338,7 @@ SOURCES += virtualconsole/addvcbuttonmatrix.cpp \
            virtualconsole/vcmatrixproperties.cpp \
            virtualconsole/vcproperties.cpp \
            virtualconsole/vcpropertieseditor.cpp \
+           virtualconsole/vcscrollarea.cpp \
            virtualconsole/vcslider.cpp \
            virtualconsole/vcsliderproperties.cpp \
            virtualconsole/vcsoloframe.cpp \

--- a/ui/src/virtualconsole/vcscrollarea.cpp
+++ b/ui/src/virtualconsole/vcscrollarea.cpp
@@ -1,0 +1,43 @@
+#include "vcscrollarea.h"
+#include "qevent.h"
+
+#include <QDebug>
+
+VCScrollArea::VCScrollArea(QWidget *parent) : QScrollArea(parent) {
+    // nothing more right now
+}
+
+void VCScrollArea::keyPressEvent(QKeyEvent *ev) {
+    unsigned int keyCode = ev->key() | ev->modifiers();
+    QList<unsigned int>::const_iterator it = std::find(m_overriddenKeyCodes.constBegin(), m_overriddenKeyCodes.constEnd(), keyCode);
+    if (it != m_overriddenKeyCodes.constEnd()) {
+        ev->ignore();
+    } else {
+        QScrollArea::keyPressEvent(ev);
+    }
+}
+
+bool VCScrollArea::needsOverride(const QKeySequence& ks) {
+    return ks == QKeySequence::MoveToPreviousPage
+           || ks == QKeySequence::MoveToNextPage
+           || ks == QKeySequence(Qt::Key_Up)
+           || ks == QKeySequence(Qt::Key_Down)
+           || ks == QKeySequence(Qt::Key_Left)
+           || ks == QKeySequence(Qt::Key_Right);
+}
+
+void VCScrollArea::setKeyOverrides(const QList<QKeySequence> &keyOverrides) {
+    m_overriddenKeyCodes.clear();
+    for (QList<QKeySequence>::const_iterator it = keyOverrides.constBegin();
+         it != keyOverrides.constEnd(); ++it) {
+        if (needsOverride(*it)) {
+            // all our key sequences have only one key
+            unsigned int keyCode = (*it)[0];
+            m_overriddenKeyCodes.append(keyCode);
+        }
+    }
+}
+
+void VCScrollArea::clearKeyOverrides() {
+    m_overriddenKeyCodes.clear();
+}

--- a/ui/src/virtualconsole/vcscrollarea.cpp
+++ b/ui/src/virtualconsole/vcscrollarea.cpp
@@ -10,9 +10,12 @@ VCScrollArea::VCScrollArea(QWidget *parent) : QScrollArea(parent) {
 void VCScrollArea::keyPressEvent(QKeyEvent *ev) {
     unsigned int keyCode = ev->key() | ev->modifiers();
     QList<unsigned int>::const_iterator it = std::find(m_overriddenKeyCodes.constBegin(), m_overriddenKeyCodes.constEnd(), keyCode);
-    if (it != m_overriddenKeyCodes.constEnd()) {
+    if (it != m_overriddenKeyCodes.constEnd())
+    {
         ev->ignore();
-    } else {
+    }
+    else
+    {
         QScrollArea::keyPressEvent(ev);
     }
 }
@@ -29,8 +32,10 @@ bool VCScrollArea::needsOverride(const QKeySequence& ks) {
 void VCScrollArea::setKeyOverrides(const QList<QKeySequence> &keyOverrides) {
     m_overriddenKeyCodes.clear();
     for (QList<QKeySequence>::const_iterator it = keyOverrides.constBegin();
-         it != keyOverrides.constEnd(); ++it) {
-        if (needsOverride(*it)) {
+         it != keyOverrides.constEnd(); ++it)
+    {
+        if (needsOverride(*it))
+        {
             // all our key sequences have only one key
             unsigned int keyCode = (*it)[0];
             m_overriddenKeyCodes.append(keyCode);

--- a/ui/src/virtualconsole/vcscrollarea.h
+++ b/ui/src/virtualconsole/vcscrollarea.h
@@ -1,0 +1,26 @@
+#ifndef VCSCROLLAREA_H
+#define VCSCROLLAREA_H
+
+#include <QObject>
+#include <QScrollArea>
+#include <QWidget>
+
+class VCScrollArea : public QScrollArea
+{
+    Q_OBJECT
+public:
+    explicit VCScrollArea(QWidget *parent = nullptr);
+
+    static bool needsOverride(const QKeySequence& keySequence);
+
+    void setKeyOverrides(const QList<QKeySequence> &keyOverrides);
+    void clearKeyOverrides();
+
+protected:
+    void keyPressEvent(QKeyEvent *) override;
+
+private:
+    QList<unsigned int> m_overriddenKeyCodes;
+};
+
+#endif // VCSCROLLAREA_H

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1583,7 +1583,7 @@ void VirtualConsole::initContents()
 {
     Q_ASSERT(layout() != NULL);
 
-    m_scrollArea = new QScrollArea(this);
+    m_scrollArea = new VCScrollArea(this);
     m_contentsLayout->addWidget(m_scrollArea);
     m_scrollArea->setAlignment(Qt::AlignCenter);
     m_scrollArea->setWidgetResizable(false);
@@ -1661,6 +1661,8 @@ bool VirtualConsole::liveEdit() const
 
 void VirtualConsole::enableEdit()
 {
+    disableKeyOverrides();
+
     // Allow editing and adding in design mode
     m_toolsSettingsAction->setEnabled(true);
     m_editActionGroup->setEnabled(true);
@@ -1759,6 +1761,8 @@ void VirtualConsole::disableEdit()
     m_stackingRaiseAction->setShortcut(QKeySequence());
     m_stackingLowerAction->setShortcut(QKeySequence());
 
+    enableKeyOverrides();
+
     // Hide toolbar; there's nothing usable there in operate mode
     m_toolbar->hide();
 
@@ -1766,6 +1770,24 @@ void VirtualConsole::disableEdit()
     // Without this, key combinations don't work unless
     // the user clicks on some VC area
     m_contents->setFocus();
+}
+
+void VirtualConsole::enableKeyOverrides() {
+    QList<QKeySequence> keySequencesToOverride;
+
+    for (QHash<quint32, VCWidget *>::const_iterator it = m_widgetsMap.constBegin();
+         it != m_widgetsMap.constEnd();
+         ++it) {
+        VCButton *btn = qobject_cast<VCButton*>(*it);
+        if (btn) {
+            keySequencesToOverride.append(btn->keySequence());
+        }
+    }
+    m_scrollArea->setKeyOverrides(keySequencesToOverride);
+}
+
+void VirtualConsole::disableKeyOverrides() {
+    m_scrollArea->clearKeyOverrides();
 }
 
 void VirtualConsole::slotModeChanged(Doc::Mode mode)

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1776,10 +1776,11 @@ void VirtualConsole::enableKeyOverrides() {
     QList<QKeySequence> keySequencesToOverride;
 
     for (QHash<quint32, VCWidget *>::const_iterator it = m_widgetsMap.constBegin();
-         it != m_widgetsMap.constEnd();
-         ++it) {
+         it != m_widgetsMap.constEnd(); ++it)
+    {
         VCButton *btn = qobject_cast<VCButton*>(*it);
-        if (btn) {
+        if (btn)
+        {
             keySequencesToOverride.append(btn->keySequence());
         }
     }

--- a/ui/src/virtualconsole/virtualconsole.h
+++ b/ui/src/virtualconsole/virtualconsole.h
@@ -26,6 +26,7 @@
 #include <QFrame>
 #include <QList>
 
+#include "vcscrollarea.h"
 #include "vcproperties.h"
 #include "doc.h"
 
@@ -34,7 +35,7 @@ class QXmlStreamWriter;
 class VirtualConsole;
 class QActionGroup;
 class QVBoxLayout;
-class QScrollArea;
+class VCScrollArea;
 class VCDockArea;
 class QKeyEvent;
 class QToolBar;
@@ -336,13 +337,16 @@ protected:
 
 protected:
     QVBoxLayout* m_contentsLayout;
-    QScrollArea* m_scrollArea;
+    VCScrollArea* m_scrollArea;
     VCFrame* m_contents;
     QHash <quint32, VCWidget *> m_widgetsMap;
 
     /*********************************************************************
      * Key press handler
      *********************************************************************/
+private:
+    void enableKeyOverrides();
+    void disableKeyOverrides();
 
 protected:
     /** Handler for keyboard key presse events */


### PR DESCRIPTION
As stated on #1443, PgUp, PgDown and cursor keys do not work when configured as key combination on VCButtons.
This happens because the QScrollArea hosting the controls intercepts these keys to move around the scroll area.

This change lets the mentioned keys pass through to the buttons when the user chooses them, but, of course, the keys chosen as key combinations will not be used to move around on the scroll area, since it would be way confusing to keep both functions.

Closes #1443 