### PR TITLE
Introduce keyboard scroll flag in Virtual Console

### DIFF
--- a/ui/src/CMakeLists.txt
+++ b/ui/src/CMakeLists.txt
@@ -141,6 +141,7 @@ add_library(${module_name}
     virtualconsole/vcmatrixproperties.cpp virtualconsole/vcmatrixproperties.h virtualconsole/vcmatrixproperties.ui
     virtualconsole/vcproperties.cpp virtualconsole/vcproperties.h virtualconsole/vcproperties.ui
     virtualconsole/vcpropertieseditor.cpp virtualconsole/vcpropertieseditor.h
+    virtualconsole/vcscrollarea.cpp virtualconsole/vcscrollarea.h
     virtualconsole/vcslider.cpp virtualconsole/vcslider.h
     virtualconsole/vcsliderproperties.cpp virtualconsole/vcsliderproperties.h virtualconsole/vcsliderproperties.ui
     virtualconsole/vcsoloframe.cpp virtualconsole/vcsoloframe.h

--- a/ui/src/assignhotkey.cpp
+++ b/ui/src/assignhotkey.cpp
@@ -30,6 +30,7 @@
 #define SETTINGS_GEOMETRY "assignhotkey/geometry"
 #define SETTINGS_AUTOCLOSE "assignhotkey/autoclose"
 
+
 /*****************************************************************************
  * Initialization
  *****************************************************************************/
@@ -59,11 +60,8 @@ AssignHotKey::AssignHotKey(QWidget* parent, const QKeySequence& keySequence)
     m_infoText->setFocusPolicy(Qt::NoFocus);
     m_buttonBox->setFocusPolicy(Qt::NoFocus);
 
-    m_previewEdit->setReadOnly(true);
-    m_previewEdit->setAlignment(Qt::AlignCenter);
-
     m_keySequence = QKeySequence(keySequence);
-    m_previewEdit->setText(m_keySequence.toString(QKeySequence::NativeText));
+    m_previewLabel->setText(m_keySequence.toString(QKeySequence::NativeText));
 
     QSettings settings;
     m_autoCloseCheckBox->setChecked(settings.value(SETTINGS_AUTOCLOSE).toBool());
@@ -89,13 +87,14 @@ void AssignHotKey::keyPressEvent(QKeyEvent* event)
 {
     int key = event->key();
     if (event->key() == Qt::Key_Control || event->key() == Qt::Key_Alt ||
-        event->key() == Qt::Key_Shift || event->key() == Qt::Key_Meta)
+        event->key() == Qt::Key_Shift || event->key() == Qt::Key_Meta ||
+        event->modifiers() == Qt::ControlModifier)
     {
         key = 0;
     }
 
     m_keySequence = QKeySequence(key | (event->modifiers() & ~Qt::ControlModifier));
-    m_previewEdit->setText(m_keySequence.toString(QKeySequence::NativeText));
+    m_previewLabel->setText(m_keySequence.toString(QKeySequence::NativeText));
 
     if (m_autoCloseCheckBox->isChecked() == true && key != 0)
         accept();

--- a/ui/src/assignhotkey.ui
+++ b/ui/src/assignhotkey.ui
@@ -37,7 +37,7 @@
     <widget class="QTextBrowser" name="m_infoText"/>
    </item>
    <item>
-    <widget class="QLabel" name="m_previewLabel">
+    <widget class="QLabel" name="m_keyCombinationLabel">
      <property name="text">
       <string>Key combination</string>
      </property>
@@ -47,12 +47,27 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="m_previewEdit">
+    <widget class="QLabel" name="m_previewLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="margin">
+      <number>3</number>
      </property>
     </widget>
    </item>

--- a/ui/src/src.pro
+++ b/ui/src/src.pro
@@ -155,6 +155,7 @@ HEADERS += virtualconsole/addvcbuttonmatrix.h \
            virtualconsole/vcmatrixproperties.h \
            virtualconsole/vcproperties.h \
            virtualconsole/vcpropertieseditor.h \
+           virtualconsole/vcscrollarea.h \
            virtualconsole/vcslider.h \
            virtualconsole/vcsliderproperties.h \
            virtualconsole/vcsoloframe.h \
@@ -337,6 +338,7 @@ SOURCES += virtualconsole/addvcbuttonmatrix.cpp \
            virtualconsole/vcmatrixproperties.cpp \
            virtualconsole/vcproperties.cpp \
            virtualconsole/vcpropertieseditor.cpp \
+           virtualconsole/vcscrollarea.cpp \
            virtualconsole/vcslider.cpp \
            virtualconsole/vcsliderproperties.cpp \
            virtualconsole/vcsoloframe.cpp \

--- a/ui/src/virtualconsole/vcproperties.cpp
+++ b/ui/src/virtualconsole/vcproperties.cpp
@@ -33,6 +33,7 @@
 
 VCProperties::VCProperties()
     : m_size(QSize(1920, 1080))
+    , m_keyboardScroll(true)
     , m_gmChannelMode(GrandMaster::Intensity)
     , m_gmValueMode(GrandMaster::Reduce)
     , m_gmSliderMode(GrandMaster::Normal)
@@ -43,6 +44,7 @@ VCProperties::VCProperties()
 
 VCProperties::VCProperties(const VCProperties& properties)
     : m_size(properties.m_size)
+    , m_keyboardScroll(properties.m_keyboardScroll)
     , m_gmChannelMode(properties.m_gmChannelMode)
     , m_gmValueMode(properties.m_gmValueMode)
     , m_gmSliderMode(properties.m_gmSliderMode)
@@ -60,6 +62,7 @@ VCProperties &VCProperties::operator=(const VCProperties &props)
     if (this != &props)
     {
         m_size = props.m_size;
+        m_keyboardScroll = props.m_keyboardScroll;
         m_gmChannelMode = props.m_gmChannelMode;
         m_gmValueMode = props.m_gmValueMode;
         m_gmSliderMode = props.m_gmSliderMode;
@@ -82,6 +85,20 @@ void VCProperties::setSize(const QSize& size)
 QSize VCProperties::size() const
 {
     return m_size;
+}
+
+/*****************************************************************************
+ * Keyboard scrolling
+ *****************************************************************************/
+
+void VCProperties::setKeyboardScroll(const bool enable)
+{
+    m_keyboardScroll = enable;
+}
+
+bool VCProperties::keyboardScroll() const
+{
+    return m_keyboardScroll;
 }
 
 /*****************************************************************************
@@ -166,6 +183,15 @@ bool VCProperties::loadXML(QXmlStreamReader &root)
             /* Set size if both are valid */
             if (sz.isValid() == true)
                 setSize(sz);
+\
+            bool keyboardScroll = true;
+
+            /* Keyboard scrolling */
+            str = root.attributes().value(KXMLQLCVCPropertiesKeyboardScroll).toString();
+            if (str.isEmpty() == false)
+                keyboardScroll = QVariant(str).toBool();
+            setKeyboardScroll(keyboardScroll);
+
             root.skipCurrentElement();
         }
         else if (root.name() == KXMLQLCVCPropertiesGrandMaster)
@@ -224,6 +250,7 @@ bool VCProperties::saveXML(QXmlStreamWriter *doc) const
     doc->writeStartElement(KXMLQLCVCPropertiesSize);
     doc->writeAttribute(KXMLQLCVCPropertiesSizeWidth, QString::number(size().width()));
     doc->writeAttribute(KXMLQLCVCPropertiesSizeHeight, QString::number(size().height()));
+    doc->writeAttribute(KXMLQLCVCPropertiesKeyboardScroll, QVariant(keyboardScroll()).toString());
     doc->writeEndElement();
 
     /***********************

--- a/ui/src/virtualconsole/vcproperties.h
+++ b/ui/src/virtualconsole/vcproperties.h
@@ -37,10 +37,11 @@ class Doc;
 
 #define KXMLQLCVirtualConsole           QString("VirtualConsole")
 
-#define KXMLQLCVCProperties             QString("Properties")
-#define KXMLQLCVCPropertiesSize         QString("Size")
-#define KXMLQLCVCPropertiesSizeWidth    QString("Width")
-#define KXMLQLCVCPropertiesSizeHeight   QString("Height")
+#define KXMLQLCVCProperties               QString("Properties")
+#define KXMLQLCVCPropertiesSize           QString("Size")
+#define KXMLQLCVCPropertiesSizeWidth      QString("Width")
+#define KXMLQLCVCPropertiesSizeHeight     QString("Height")
+#define KXMLQLCVCPropertiesKeyboardScroll QString("KeyboardScroll")
 
 #define KXMLQLCVCPropertiesGrandMaster              QString("GrandMaster")
 #define KXMLQLCVCPropertiesGrandMasterVisible       QString("Visible")
@@ -77,6 +78,19 @@ public:
 
 private:
     QSize m_size;
+
+    /*********************************************************************
+     * Keyboard scrolling
+     *********************************************************************/
+public:
+    /** Set Virtual Console keyboard scrolling */
+    void setKeyboardScroll(const bool enable);
+
+    /** Get Virtual Console keyboard scrolling */
+    bool keyboardScroll() const;
+
+private:
+    bool m_keyboardScroll;
 
     /*************************************************************************
      * Grand Master

--- a/ui/src/virtualconsole/vcproperties.ui
+++ b/ui/src/virtualconsole/vcproperties.ui
@@ -105,6 +105,35 @@
         </widget>
        </item>
        <item row="1" column="0">
+        <widget class="QGroupBox" name="m_scrollGroup">
+         <property name="title">
+          <string>Scrolling</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_1">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="m_enableKeyboardScroll">
+            <property name="text">
+             <string>Use arrow and PgUp/PgDown keys to scroll</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="m_keyboardScrollWarning">
+            <property name="text">
+             <string>Note: enabling keyboard scroll prevents using arrow and PgUp/PgDown keys in Key combinations for console controls.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -820,6 +849,7 @@
  <tabstops>
   <tabstop>m_sizeXSpin</tabstop>
   <tabstop>m_sizeYSpin</tabstop>
+  <tabstop>m_enableKeyboardScroll</tabstop>
   <tabstop>m_buttonWspin</tabstop>
   <tabstop>m_buttonHspin</tabstop>
   <tabstop>m_sliderWspin</tabstop>
@@ -991,6 +1021,22 @@
     <hint type="destinationlabel">
      <x>149</x>
      <y>838</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>m_enableKeyboardScroll</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>VCPropertiesEditor</receiver>
+   <slot>slotKeyboardScrollToggled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>190</x>
+     <y>198</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>190</x>
+     <y>245</y>
     </hint>
    </hints>
   </connection>

--- a/ui/src/virtualconsole/vcpropertieseditor.cpp
+++ b/ui/src/virtualconsole/vcpropertieseditor.cpp
@@ -56,6 +56,7 @@ VCPropertiesEditor::VCPropertiesEditor(QWidget* parent, const VCProperties& prop
     /* General page */
     m_sizeXSpin->setValue(properties.size().width());
     m_sizeYSpin->setValue(properties.size().height());
+    m_enableKeyboardScroll->setChecked(properties.keyboardScroll());
 
     /* Widgets page */
     QSettings settings;
@@ -317,6 +318,11 @@ void VCPropertiesEditor::slotSizeYChanged(int value)
     QSize sz(m_properties.size());
     sz.setHeight(value);
     m_properties.setSize(sz);
+}
+
+void VCPropertiesEditor::slotKeyboardScrollToggled(bool checked)
+{
+    m_properties.setKeyboardScroll(checked);
 }
 
 void VCPropertiesEditor::slotSpeedDialConfirmed()

--- a/ui/src/virtualconsole/vcpropertieseditor.h
+++ b/ui/src/virtualconsole/vcpropertieseditor.h
@@ -84,6 +84,7 @@ private:
 private slots:
     void slotSizeXChanged(int value);
     void slotSizeYChanged(int value);
+    void slotKeyboardScrollToggled(bool checked);
 
     /*************************************************************************
      * Widgets page

--- a/ui/src/virtualconsole/vcscrollarea.cpp
+++ b/ui/src/virtualconsole/vcscrollarea.cpp
@@ -1,0 +1,18 @@
+#include "vcscrollarea.h"
+#include "qevent.h"
+
+VCScrollArea::VCScrollArea(QWidget *parent) : QScrollArea(parent) {
+    // nothing more right now
+}
+
+void VCScrollArea::keyPressEvent(QKeyEvent *ev) {
+    if (m_keyPassthru) {
+        ev->ignore();
+    } else {
+        QScrollArea::keyPressEvent(ev);
+    }
+}
+
+void VCScrollArea::setKeyPassthruEnabled(bool enable) {
+    m_keyPassthru = enable;
+}

--- a/ui/src/virtualconsole/vcscrollarea.h
+++ b/ui/src/virtualconsole/vcscrollarea.h
@@ -1,0 +1,23 @@
+#ifndef VCSCROLLAREA_H
+#define VCSCROLLAREA_H
+
+#include <QObject>
+#include <QScrollArea>
+#include <QWidget>
+
+class VCScrollArea : public QScrollArea
+{
+    Q_OBJECT
+public:
+    explicit VCScrollArea(QWidget *parent = nullptr);
+
+    void setKeyPassthruEnabled(bool enabled);
+
+protected:
+    void keyPressEvent(QKeyEvent *) override;
+
+private:
+    bool m_keyPassthru;
+};
+
+#endif // VCSCROLLAREA_H

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -133,6 +133,7 @@ VirtualConsole::VirtualConsole(QWidget* parent, Doc* doc)
     , m_contents(NULL)
 
     , m_liveEdit(false)
+    , m_keyboardScroll(true)
 {
     Q_ASSERT(s_instance == NULL);
     s_instance = this;
@@ -1583,7 +1584,7 @@ void VirtualConsole::initContents()
 {
     Q_ASSERT(layout() != NULL);
 
-    m_scrollArea = new QScrollArea(this);
+    m_scrollArea = new VCScrollArea(this);
     m_contentsLayout->addWidget(m_scrollArea);
     m_scrollArea->setAlignment(Qt::AlignCenter);
     m_scrollArea->setWidgetResizable(false);
@@ -1707,6 +1708,9 @@ void VirtualConsole::enableEdit()
     m_stackingRaiseAction->setShortcut(QKeySequence("SHIFT+UP"));
     m_stackingLowerAction->setShortcut(QKeySequence("SHIFT+DOWN"));
 
+    // disable key passthru
+    m_scrollArea->setKeyPassthruEnabled(false);
+
     // Show toolbar
     m_toolbar->show();
 }
@@ -1758,6 +1762,10 @@ void VirtualConsole::disableEdit()
 
     m_stackingRaiseAction->setShortcut(QKeySequence());
     m_stackingLowerAction->setShortcut(QKeySequence());
+
+
+    // manage key passthru
+    m_scrollArea->setKeyPassthruEnabled(!m_keyboardScroll);
 
     // Hide toolbar; there's nothing usable there in operate mode
     m_toolbar->hide();
@@ -1821,6 +1829,7 @@ bool VirtualConsole::loadXML(QXmlStreamReader &root)
             QSize size(m_properties.size());
             contents()->resize(size);
             contents()->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
+            m_keyboardScroll = m_properties.keyboardScroll();
         }
         else if (root.name() == KXMLQLCVCFrame)
         {

--- a/ui/src/virtualconsole/virtualconsole.h
+++ b/ui/src/virtualconsole/virtualconsole.h
@@ -26,6 +26,7 @@
 #include <QFrame>
 #include <QList>
 
+#include "vcscrollarea.h"
 #include "vcproperties.h"
 #include "doc.h"
 
@@ -34,7 +35,7 @@ class QXmlStreamWriter;
 class VirtualConsole;
 class QActionGroup;
 class QVBoxLayout;
-class QScrollArea;
+class VCScrollArea;
 class VCDockArea;
 class QKeyEvent;
 class QToolBar;
@@ -336,7 +337,7 @@ protected:
 
 protected:
     QVBoxLayout* m_contentsLayout;
-    QScrollArea* m_scrollArea;
+    VCScrollArea* m_scrollArea;
     VCFrame* m_contents;
     QHash <quint32, VCWidget *> m_widgetsMap;
 
@@ -363,6 +364,7 @@ signals:
      *********************************************************************/
 private:
     bool m_liveEdit;
+    bool m_keyboardScroll;
 
 public:
     /** Toggle Virtual Console live editting */

--- a/ui/test/assignhotkey/assignhotkey_test.cpp
+++ b/ui/test/assignhotkey/assignhotkey_test.cpp
@@ -32,8 +32,7 @@ void AssignHotKey_Test::initial()
     QKeySequence seq(Qt::Key_A | Qt::SHIFT);
     AssignHotKey ahk(NULL, seq);
     QCOMPARE(ahk.keySequence(), seq);
-    QCOMPARE(ahk.m_previewEdit->text(), seq.toString(QKeySequence::NativeText));
-    QCOMPARE(ahk.m_previewEdit->isReadOnly(), true);
+    QCOMPARE(ahk.m_previewLabel->text(), seq.toString(QKeySequence::NativeText));
 }
 
 void AssignHotKey_Test::keyPressEventAuto()


### PR DESCRIPTION
This is the second try to fix #1443, after a first attempt with pull request #1584 that covered only VCButtons.
The approach on this change is completely different: introduce a flag to choose whether or not to use arrow and PgUp/PgDown keys to scroll Virtual Console.
When the flag is disabled, all the keys are available as key combinations on the controls.

Side changes:

- in assignhotkey.ui the former QLineEdit has been replaced by a QLabel to allow capture of all the keys (the QLineEdit consumes at least backspace, delete, home, end, left and right cursor keys)
- the CTRL+key combinations are completely blocked

Closes #1443