### PR TITLE
plugins/artnet: force IPv4 when binding UDP socket

### DIFF
--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -412,7 +412,7 @@ QSharedPointer<QUdpSocket> ArtNetPlugin::getUdpSocket()
     udpSocket = QSharedPointer<QUdpSocket>(new QUdpSocket());
     m_udpSocket = udpSocket.toWeakRef();
 
-    if (udpSocket->bind(ARTNET_PORT, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint))
+    if (udpSocket->bind(QHostAddress::SpecialAddress::AnyIPv4, ARTNET_PORT, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint))
     {
         connect(udpSocket.data(), SIGNAL(readyRead()),
                 this, SLOT(slotReadyRead()));


### PR DESCRIPTION
qlcplus on Ubuntu 22.04 right now when configuring ArtNet input on an IPv4 address seems not to receive UDP packets (see  #1588).
Forcing IPv4 when binding UDP socket solves the issue.

Another more complicated approach is to create a socket for each input address and bind it explicitly to the address