### PR TITLE
Add channel address in add fixture dialogue

### DIFF
--- a/ui/src/fixtureselection.cpp
+++ b/ui/src/fixtureselection.cpp
@@ -48,6 +48,7 @@ FixtureSelection::FixtureSelection(QWidget* parent, Doc* doc)
                   FixtureTreeWidget::HeadsNumber |
                   FixtureTreeWidget::Manufacturer |
                   FixtureTreeWidget::Model |
+                  FixtureTreeWidget::AddressRange |
                   FixtureTreeWidget::ShowGroups;
 
     m_tree = new FixtureTreeWidget(m_doc, m_treeFlags, this);


### PR DESCRIPTION
Forum thread: https://www.qlcplus.org/forum/viewtopic.php?t=17674

This pull request is made in response to the above forum thread. When adding a fixture, it can be helpful to have the address available for reference. 

Testing required:
- EFX Editor
- Scene Editor
