### PR TITLE
Build option+ui fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(qlcplus VERSION 4.13.1 LANGUAGES C CXX)
 
+option(qmlui "Build for QLC+ 5 QML UI" OFF)
+
 # Set Release build type by default
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)

--- a/qmlui/qml/popup/CustomPopupDialog.qml
+++ b/qmlui/qml/popup/CustomPopupDialog.qml
@@ -95,7 +95,7 @@ Dialog
 
             contentItem.implicitHeight: UISettings.iconSizeDefault
 
-            onClicked:
+            onClicked: function(button)
             {
                 if (button === standardButton(Dialog.Yes))
                     control.clicked(Dialog.Yes)

--- a/qmlui/qml/popup/PopupDisclaimer.qml
+++ b/qmlui/qml/popup/PopupDisclaimer.qml
@@ -62,6 +62,8 @@ CustomPopupDialog
                       "Reports of what is marked as 'Work in progress' or 'Missing'<br>" +
                       " will be ignored. You've been warned."
                 onLinkActivated: Qt.openUrlExternally(link)
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
 
                 MouseArea
                 {


### PR DESCRIPTION
Add a compile option to build for QLC5.
Remove qml slot depreciation.
Adapt disclaimer text size to content.