### PR TITLE
Fix endless/binding loops, deprecations, OpenGL

### DIFF
--- a/qmlui/fixturemanager.cpp
+++ b/qmlui/fixturemanager.cpp
@@ -1431,8 +1431,8 @@ QVariantList FixtureManager::fixturesMap()
      * Fixture ID | DMX address | isOdd | channel type (a lookup for icons)
      */
 
-    m_fixturesMap.clear();
-    m_fixtureNamesMap.clear();
+    QVariantList fixturesMap;
+    QVariantList fixtureNamesMap;
 
     QList<Fixture*> origList = m_doc->fixtures();
     // sort the fixture list by address and not by ID
@@ -1449,32 +1449,45 @@ QVariantList FixtureManager::fixturesMap()
         quint32 startAddress = fx->address();
         for (quint32 cn = 0; cn < fx->channels(); cn++)
         {
-            m_fixturesMap.append(fx->id());
-            m_fixturesMap.append(startAddress + cn);
+            fixturesMap.append(fx->id());
+            fixturesMap.append(startAddress + cn);
 
             if (odd)
-                m_fixturesMap.append(1);
+                fixturesMap.append(1);
             else
-                m_fixturesMap.append(0);
+                fixturesMap.append(0);
 
             QLCChannel::Group group = fx->channel(cn)->group();
             if (group == QLCChannel::Intensity)
-                m_fixturesMap.append(fx->channel(cn)->colour());
+                fixturesMap.append(fx->channel(cn)->colour());
             else
-                m_fixturesMap.append(group);
+                fixturesMap.append(group);
         }
         odd = !odd;
 
-        m_fixtureNamesMap.append(fx->id());
-        m_fixtureNamesMap.append(fx->address());
-        m_fixtureNamesMap.append(fx->channels());
-        m_fixtureNamesMap.append(fx->name());
+        fixtureNamesMap.append(fx->id());
+        fixtureNamesMap.append(fx->address());
+        fixtureNamesMap.append(fx->channels());
+        fixtureNamesMap.append(fx->name());
     }
+    setFixturesMap(fixturesMap);
+    setFixtureNamesMap(fixtureNamesMap);
 
+    return fixturesMap;
+}
+
+void FixtureManager::setFixturesMap(QVariantList fixturesMap){
+    if(fixturesMap == m_fixturesMap)
+        return;
+    m_fixturesMap = fixturesMap;
     emit fixturesMapChanged();
-    emit fixtureNamesMapChanged();
+}
 
-    return m_fixturesMap;
+void FixtureManager::setFixtureNamesMap(QVariantList fixtureNamesMap){
+    if(fixtureNamesMap == m_fixtureNamesMap)
+        return;
+    m_fixtureNamesMap = fixtureNamesMap;
+    emit fixtureNamesMapChanged();
 }
 
 int FixtureManager::pasteFromClipboard(QVariantList fixtureIDs)

--- a/qmlui/fixturemanager.h
+++ b/qmlui/fixturemanager.h
@@ -324,12 +324,14 @@ public:
 public:
     /** Returns a list of fixture names for representation in a GridEditor QML component */
     QVariantList fixtureNamesMap();
+    void setFixtureNamesMap(QVariantList fixtureNamesMap);
 
     /** Get a string to be displayed as tooltip for a fixture at $address */
     Q_INVOKABLE QString getTooltip(quint32 address);
 
     /** Returns data for representation in a GridEditor QML component */
     QVariantList fixturesMap();
+    void setFixturesMap(QVariantList fixturesMap);
 
     Q_INVOKABLE int pasteFromClipboard(QVariantList fixtureIDs);
 

--- a/qmlui/js/Math3DView.js
+++ b/qmlui/js/Math3DView.js
@@ -88,6 +88,8 @@ function lookAt(eye, center, up)
 
 function getLightDirection(transform, panTransform, tiltTransform)
 {
+	if (!transform) return Qt.vector3d(0.0,0.0,0.0)
+	
     var m = transform.matrix;
     if (panTransform) {
         m = transform.matrix.times(panTransform.matrix);

--- a/qmlui/main.cpp
+++ b/qmlui/main.cpp
@@ -62,6 +62,11 @@ void printVersion()
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+// Since Qt6, the default rendering backend is Rhi. QLC doesn't support it yet so OpenGL have to be forced.
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGLRhi);
+    qputenv("QT3D_RENDERER", "opengl");
+#endif
 
     QApplication::setOrganizationName("qlcplus");
     QApplication::setOrganizationDomain("org");

--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -109,6 +109,7 @@ Popup
     CustomPopupDialog
     {
         id: saveFirstPopup
+        width: menuRoot.width  // Set width to avoid binding loops on implicit sizes
         title: qsTr("Your project has changes")
         message: qsTr("Do you wish to save the current project first?\nChanges will be lost if you don't save them.")
         standardButtons: Dialog.Yes | Dialog.No | Dialog.Cancel
@@ -581,6 +582,7 @@ Popup
             PopupAbout
             {
                 id: infoPopup
+                width: menuRoot.width	// Set width to avoid binding loops on implicit sizes
             }
         }
     }

--- a/qmlui/qml/CustomComboBox.qml
+++ b/qmlui/qml/CustomComboBox.qml
@@ -113,7 +113,7 @@ ComboBox
     delegate:
         ItemDelegate
         {
-            width: parent.width
+            width: parent?.width
             implicitHeight: delegateHeight
             highlighted: control.highlightedIndex === index
             hoverEnabled: control.hoverEnabled

--- a/qmlui/qml/GenericButton.qml
+++ b/qmlui/qml/GenericButton.qml
@@ -94,7 +94,7 @@ Rectangle
         anchors.fill: parent
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton
-        onClicked: btnRoot.clicked(mouse.button)
+        onClicked: (mouse) => btnRoot.clicked(mouse.button)
         onPressAndHold:
         {
             if (repetition == true)

--- a/qmlui/qml/TreeNodeDelegate.qml
+++ b/qmlui/qml/TreeNodeDelegate.qml
@@ -126,9 +126,9 @@ Column
 
             drag.target: dragItem
 
-            onPressed: nodeContainer.mouseEvent(App.Pressed, cRef ? cRef.id : -1, nodeContainer.itemType,
+            onPressed: (mouse) => nodeContainer.mouseEvent(App.Pressed, cRef ? cRef.id : -1, nodeContainer.itemType,
                                                 nodeContainer, mouse.modifiers)
-            onClicked:
+            onClicked: (mouse) =>
             {
                 nodeLabel.forceActiveFocus()
                 nodeContainer.mouseEvent(App.Clicked, cRef ? cRef.id : -1, nodeContainer.itemType,

--- a/qmlui/qml/fixtureeditor/FixtureEditor.qml
+++ b/qmlui/qml/fixtureeditor/FixtureEditor.qml
@@ -49,7 +49,8 @@ Rectangle
         id: openDialog
         visible: false
         title: qsTr("Open a fixture definition")
-        currentFolder: "file://" + fixtureEditor.workingPath
+        // fixtureEditor may be null on exit
+        currentFolder: "file://" + fixtureEditor?.workingPath
         nameFilters: [ qsTr("Fixture definition files") + " (*.qxf)", qsTr("All files") + " (*)" ]
 
         onAccepted:
@@ -70,7 +71,8 @@ Rectangle
         id: saveDialog
         visible: false
         title: qsTr("Save definition as...")
-        currentFolder: "file://" + fixtureEditor.workingPath
+        // fixtureEditor may be null on exit
+        currentFolder: "file://" + fixtureEditor?.workingPath
         fileMode: FileDialog.SaveFile
         nameFilters: [ qsTr("Fixture definition files") + " (*.qxf)", qsTr("All files") + " (*)" ]
         defaultSuffix: "qxf"
@@ -266,7 +268,7 @@ Rectangle
                 id: editorsRepeater
                 model: fixtureEditor ? fixtureEditor.editorsList : null
 
-                onItemAdded: item.clicked()
+                onItemAdded: (index,item) => item.clicked()
 
                 delegate:
                     MenuBarEntry

--- a/qmlui/qml/fixturesfunctions/2DView.qml
+++ b/qmlui/qml/fixturesfunctions/2DView.qml
@@ -222,7 +222,7 @@ Rectangle
                 property int initialXPos
                 property int initialYPos
 
-                onPressed:
+                onPressed: (mouse) =>
                 {
                     console.log("button: " + mouse.button + ", mods: " + mouse.modifiers)
                     var itemID = View2D.itemIDAtPos(Qt.point(mouse.x, mouse.y))
@@ -256,7 +256,7 @@ Rectangle
                     }
                 }
 
-                onPositionChanged:
+                onPositionChanged: (mouse) =>
                 {
                     if (selectionRect.visible == true)
                     {
@@ -294,7 +294,7 @@ Rectangle
                     }
                 }
 
-                onReleased:
+                onReleased: (mouse) =>
                 {
                     if (selectionRect.visible === true && selectionRect.width && selectionRect.height)
                     {
@@ -317,7 +317,7 @@ Rectangle
                     }
                 }
 
-                onWheel:
+                onWheel: (wheel)=>
                 {
                     //console.log("Wheel delta: " + wheel.angleDelta.y)
                     if (wheel.angleDelta.y > 0)

--- a/qmlui/qml/fixturesfunctions/2DView.qml
+++ b/qmlui/qml/fixturesfunctions/2DView.qml
@@ -353,7 +353,7 @@ Rectangle
                     drag.threshold: 10
                     drag.target: parent
 
-                    onReleased:
+                    onReleased: (mouse) =>
                     {
                         if (drag.active)
                         {

--- a/qmlui/qml/fixturesfunctions/3DView/3DView.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/3DView.qml
@@ -330,7 +330,7 @@ Rectangle
 
                 projectionType: CameraLens.PerspectiveProjection
                 fieldOfView: 45
-                aspectRatio: viewSize.width / viewSize.height
+                aspectRatio: viewCamera.width / viewCamera.height
                 nearPlane: 1.0
                 farPlane: 1000.0
                 position: View3D.cameraPosition
@@ -360,7 +360,7 @@ Rectangle
                 property int selGenericCount: View3D.genericSelectedCount
 
                 sourceDevice: mDevice
-                onPressed:
+                onPressed: (mouse) =>
                 {
                     directionCounter = 0
                     dx = 0
@@ -368,7 +368,7 @@ Rectangle
                     startPoint = Qt.point(mouse.x, mouse.y)
                 }
 
-                onPositionChanged:
+                onPositionChanged: (mouse) =>
                 {
                     if (directionCounter < 3)
                     {
@@ -444,7 +444,7 @@ Rectangle
                         if (!mouse.modifiers || (mouse.modifiers & Qt.ShiftModifier && direction == Qt.Horizontal))
                             viewCamera.panAboutViewCenter(-xDelta, Qt.vector3d(0, 1, 0))
                         if (!mouse.modifiers || (mouse.modifiers & Qt.ShiftModifier && direction == Qt.Vertical))
-                            viewCamera.tiltAboutViewCenter(yDelta, Qt.vector3d(1, 0, 0))
+                            viewCamera.tiltAboutViewCenter(yDelta)
 
                         View3D.cameraPosition = viewCamera.position
                         View3D.cameraUpVector = viewCamera.upVector
@@ -464,7 +464,7 @@ Rectangle
                     startPoint = Qt.point(mouse.x, mouse.y)
                 }
 
-                onWheel:
+                onWheel: (wheel) =>
                 {
                     if (wheel.angleDelta.y > 0)
                         viewCamera.setZoom(-1)

--- a/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
@@ -82,10 +82,11 @@ Entity
     readonly property Layer spotlightScatteringLayer: Layer { }
 
     property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
-    property real coneTopRadius: (0.24023 / 2) * transform.scale3D.x * 0.7 // (diameter / 2) * scale * magic number
+    property real coneTopRadius: !transform ? 0.0 : (0.24023 / 2) * transform.scale3D.x * 0.7 // (diameter / 2) * scale * magic number
 
     property real headLength:
     {
+		if(!transform) return 0.0;
         switch(meshType)
         {
             case MainView3D.NoMeshType: return 0;
@@ -341,7 +342,7 @@ Entity
 
         property var lastPos
 
-        onClicked:
+        onClicked: (pick) =>
         {
             console.log("3D item clicked")
             isSelected = !isSelected

--- a/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
@@ -232,14 +232,14 @@ Entity
     {
         id: panAnim
         running: false
-        easing.type: Easing.Linear
+        easing.type: QQ2.Easing.Linear
     }
 
     QQ2.NumberAnimation on tiltRotation
     {
         id: tiltAnim
         running: false
-        easing.type: Easing.Linear
+        easing.type: QQ2.Easing.Linear
     }
 
     property Texture2D depthTex:
@@ -292,7 +292,7 @@ Entity
         id: goboAnim
         running: false
         duration: 0
-        easing.type: Easing.Linear
+        easing.type: QQ2.Easing.Linear
         from: 0
         to: 360
         loops: QQ2.Animation.Infinite
@@ -323,7 +323,7 @@ Entity
     {
         id: eSceneLoader
 
-        onStatusChanged:
+        onStatusChanged: (status) =>
         {
             if (status === SceneLoader.Ready)
                 View3D.initializeFixture(itemID, fixtureEntity, eSceneLoader)

--- a/qmlui/qml/fixturesfunctions/3DView/RenderShadowMapFilter.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/RenderShadowMapFilter.qml
@@ -39,7 +39,7 @@ LayerFilter
                 RenderPassFilter
                 {
                     id: geometryPass
-                    matchAny: FilterKey { name: "pass"; value: { return fixtureItem.lightIntensity ? "shadows" : "invalid" } }
+                    matchAny: FilterKey { name: "pass"; value: { return fixtureItem && fixtureItem.lightIntensity ? "shadows" : "invalid" } }
 
                     parameters: [
                         Parameter { name: "lightViewMatrix"; value: fixtureItem ? fixtureItem.lightViewMatrix : Qt.matrix4x4() },

--- a/qmlui/qml/fixturesfunctions/3DView/SelectionGeometry.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SelectionGeometry.qml
@@ -70,14 +70,12 @@ GeometryRenderer
     Buffer
     {
         id: vertexBuffer
-        type: Buffer.VertexBuffer
         data: vertexBufferData()
     }
 
     Buffer
     {
         id: indexBuffer
-        type: Buffer.IndexBuffer
         data: indexBufferData()
     }
 

--- a/qmlui/qml/fixturesfunctions/3DView/StageBox.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/StageBox.qml
@@ -37,8 +37,8 @@ Entity
             effect: stage.effect
 
             parameters: [
-                Parameter { name: "diffuse"; value: "lightgray" },
-                Parameter { name: "specular"; value: "black" },
+                Parameter { name: "diffuse"; value: Qt.color("lightgray") },
+                Parameter { name: "specular"; value: Qt.color("black") },
                 Parameter { name: "shininess"; value: 1.0 },
                 Parameter { name: "bloom"; value: 0 }
             ]
@@ -76,7 +76,7 @@ Entity
         ObjectPicker
         {
             id: groundPicker
-            onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+            onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
         }
 
         components: [
@@ -98,7 +98,7 @@ Entity
         ObjectPicker
         {
             id: leftPicker
-            onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+            onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
         }
 
         components: [
@@ -119,7 +119,7 @@ Entity
         ObjectPicker
         {
             id: rightPicker
-            onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+            onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
         }
 
         components: [
@@ -140,7 +140,7 @@ Entity
         ObjectPicker
         {
             id: backPicker
-            onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+            onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
         }
 
         components: [

--- a/qmlui/qml/fixturesfunctions/3DView/StageRock.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/StageRock.qml
@@ -42,8 +42,8 @@ Entity
             effect: stage.effect
 
             parameters: [
-                Parameter { name: "diffuse"; value: "lightgray" },
-                Parameter { name: "specular"; value: "black" },
+                Parameter { name: "diffuse"; value: Qt.color("lightgray") },
+                Parameter { name: "specular"; value: Qt.color("black") },
                 Parameter { name: "shininess"; value: 1.0 },
                 Parameter { name: "bloom"; value: 0 }
             ]
@@ -203,7 +203,7 @@ Entity
         ObjectPicker
         {
             id: stagePicker
-            onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+            onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
         }
 
         components: [

--- a/qmlui/qml/fixturesfunctions/3DView/StageSimple.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/StageSimple.qml
@@ -35,8 +35,8 @@ Entity
         {
             effect: stage.effect
             parameters: [
-                Parameter { name: "diffuse"; value: "lightgray" },
-                Parameter { name: "specular"; value: "black" },
+                Parameter { name: "diffuse"; value: Qt.color("lightgray") },
+                Parameter { name: "specular"; value: Qt.color("black") },
                 Parameter { name: "shininess"; value: 1.0 },
                 Parameter { name: "bloom"; value: 0 }
             ]
@@ -56,7 +56,7 @@ Entity
     ObjectPicker
     {
         id: stagePicker
-        onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+        onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
     }
 
     components: [

--- a/qmlui/qml/fixturesfunctions/3DView/StageTheatre.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/StageTheatre.qml
@@ -45,8 +45,8 @@ Entity
         {
             effect: stage.effect
             parameters: [
-                Parameter { name: "diffuse"; value: "lightgray" },
-                Parameter { name: "specular"; value: "black" },
+                Parameter { name: "diffuse"; value: Qt.color("lightgray") },
+                Parameter { name: "specular"; value: Qt.color("black") },
                 Parameter { name: "shininess"; value: 1.0 },
                 Parameter { name: "bloom"; value: 0 }
             ]
@@ -167,7 +167,7 @@ Entity
         ObjectPicker
         {
             id: stagePicker
-            onClicked: contextManager.setPositionPickPoint(pick.worldIntersection)
+            onClicked: (pick) => contextManager.setPositionPickPoint(pick.worldIntersection)
         }
 
         components: [

--- a/qmlui/qml/fixturesfunctions/Fixture2DItem.qml
+++ b/qmlui/qml/fixturesfunctions/Fixture2DItem.qml
@@ -301,7 +301,7 @@ Rectangle
         onEntered: fixtureLabel.visible = true
         onExited: showLabel ? fixtureLabel.visible = true : fixtureLabel.visible = false
 
-        onPressed:
+        onPressed: (mouse) =>
         {
             // do not accept this event to propagate it to the drag rectangle
             mouse.accepted = false

--- a/qmlui/qml/fixturesfunctions/FixtureBrowser.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureBrowser.qml
@@ -132,7 +132,7 @@ Rectangle
                 width: modelsList.width - (manufScroll.visible ? manufScroll.width : 0)
                 isManufacturer: true
                 textLabel: modelData
-                onMouseEvent:
+                onMouseEvent: (type, iID, iType, qItem, mouseMods) =>
                 {
                     if (type == App.Clicked)
                     {
@@ -239,7 +239,7 @@ Rectangle
                     manufacturer: fixtureBrowser.selectedManufacturer
                     textLabel: modelData
 
-                    onMouseEvent:
+                    onMouseEvent: (type, iID, iType, qItem, mouseMods) =>
                     {
                         if (type == App.Clicked)
                         {

--- a/qmlui/qml/fixturesfunctions/FixtureBrowserDelegate.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureBrowserDelegate.qml
@@ -111,11 +111,11 @@ Item
         id: fxMouseArea
         anchors.fill: parent
         hoverEnabled: true
-        onClicked: fxDraggableItem.mouseEvent(App.Clicked, 0, 0, fxDraggableItem, mouse.modifiers)
+        onClicked: (mouse) => fxDraggableItem.mouseEvent(App.Clicked, 0, 0, fxDraggableItem, mouse.modifiers)
         drag.target: FixtureDragItem { }
         drag.threshold: 30
 
-        onPressed:
+        onPressed: (mouse) =>
         {
             if (fxDraggableItem.isManufacturer == false)
             {
@@ -124,11 +124,15 @@ Item
                 FxDragJS.initProperties()
             }
         }
-        onPositionChanged:
+        onPositionChanged: (mouse) =>
+        {
             if (fxDraggableItem.isManufacturer == false && drag.active == true)
                 FxDragJS.handleDrag(mouse)
-        onReleased:
+        }
+        onReleased: (mouse) =>
+        {
             if (fxDraggableItem.isManufacturer == false && drag.active == true)
                 FxDragJS.endDrag(mouse)
+        }
     }
 }

--- a/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
@@ -305,13 +305,13 @@ Column
 
             drag.target: dragItem
 
-            onPressed: nodeContainer.mouseEvent(App.Pressed, cRef ? cRef.id : -1, -1, nodeContainer, mouse.modifiers)
-            onClicked:
+            onPressed: (mouse) => nodeContainer.mouseEvent(App.Pressed, cRef ? cRef.id : -1, -1, nodeContainer, mouse.modifiers)
+            onClicked: (mouse) => 
             {
                 nodeLabel.forceActiveFocus()
                 nodeContainer.mouseEvent(App.Clicked, itemID, -1, nodeContainer, mouse.modifiers)
             }
-            onDoubleClicked:
+            onDoubleClicked: (mouse) => 
             {
                 nodeContainer.mouseEvent(App.DoubleClicked, itemID, -1, nodeContainer, mouse.modifiers)
                 isExpanded = !isExpanded

--- a/qmlui/qml/fixturesfunctions/FixturesAndFunctions.qml
+++ b/qmlui/qml/fixturesfunctions/FixturesAndFunctions.qml
@@ -213,7 +213,7 @@ Rectangle
                     height: viewToolbar.height - 4
                     anchors.margins: 1
                     model: ioManager.universesListModel
-                    currValue: contextManager.universeFilter
+                    currValue: contextManager?.universeFilter
 
                     onValueChanged:
                     {

--- a/qmlui/qml/fixturesfunctions/LeftPanel.qml
+++ b/qmlui/qml/fixturesfunctions/LeftPanel.qml
@@ -31,7 +31,7 @@ SidePanel
     anchors.leftMargin: 0
     panelAlignment: Qt.AlignLeft
 
-    onContentLoaded:
+    onContentLoaded: (item, ID) =>
     {
         item.width = Qt.binding(function() { return leftSidePanel.width - collapseWidth })
         item.height = Qt.binding(function() { return leftSidePanel.height })
@@ -339,7 +339,7 @@ SidePanel
                 height: iconSize
                 faSource: FontAwesome.fa_bolt
                 tooltip: qsTr("Highlight")
-                counter: contextManager.selectedFixturesCount
+                counter: contextManager?.selectedFixturesCount
                 onClicked: contextManager.highlightFixtureSelection()
             }
 

--- a/qmlui/qml/fixturesfunctions/PaletteManager.qml
+++ b/qmlui/qml/fixturesfunctions/PaletteManager.qml
@@ -224,7 +224,7 @@ Rectangle
                       drag.target: pDragItem
                       drag.threshold: height / 2
 
-                      onPressed:
+                      onPressed: (mouse) =>
                       {
                           if (model.isSelected)
                               return

--- a/qmlui/qml/fixturesfunctions/UniverseGridView.qml
+++ b/qmlui/qml/fixturesfunctions/UniverseGridView.qml
@@ -19,6 +19,7 @@
 
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Controls
 
 import "."
 


### PR DESCRIPTION
- Fix endless loop on Universe View : Getters should not emit change if not changed.
- Force OpenGL for Qt6/QML.
- Fixes some binding loops (QML).
- Fixes some deprecated callback uses (QML).
- Fixes missing namespace (QML).
- Fixes warnings on potential null values (QML).