### PR TITLE
Prevent crash with rotation stop capability on some fixtures

### DIFF
--- a/qmlui/fixtureutils.cpp
+++ b/qmlui/fixtureutils.cpp
@@ -423,7 +423,8 @@ bool FixtureUtils::goboTiming(const QLCCapability *cap, uchar value, int &speed)
         return true;
     }
 
-    value = SCALE(value, cap->min(), cap->max(), 1, 255);
+    if (cap->preset() != QLCCapability::RotationStop)
+        value = SCALE(value, cap->min(), cap->max(), 1, 255);
 
     switch (cap->preset())
     {


### PR DESCRIPTION
- Currently, activating 3d mode with fixtures that have the same value for minimum and maximum for RotationStop (for example the Robe ColorSpot 250 AT) will cause the application to crash due to division by 0
- This PR skips the calculation (which is never actually used in RotationStop capabilities) to prevent the application crash

Initial Forum Report: https://www.qlcplus.org/forum/viewtopic.php?p=74082