### PR TITLE
cmake: Make hotplugmonitor a static lib

### DIFF
--- a/hotplugmonitor/src/CMakeLists.txt
+++ b/hotplugmonitor/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(hotplugmonitor
+    STATIC
     hotplugmonitor.cpp hotplugmonitor.h
 )
 set_property(TARGET hotplugmonitor PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
hotplugmonitor is not hooked up to be installed as dynamic library, and hotplugmonitor/src/src.pro declares it as staticlib . It seems like it was the intent that the cmake build system should do the same.