### PR TITLE
Add missing "Up" and "Left" Buttons to Fixture Group Editor

### DIFF
--- a/ui/src/fixturegroupeditor.cpp
+++ b/ui/src/fixturegroupeditor.cpp
@@ -58,8 +58,12 @@ FixtureGroupEditor::FixtureGroupEditor(FixtureGroup* grp, Doc* doc, QWidget* par
 
     connect(m_rightButton, SIGNAL(clicked()),
             this, SLOT(slotRightClicked()));
+    connect(m_leftButton, SIGNAL(clicked()),
+            this, SLOT(slotLeftClicked()));
     connect(m_downButton, SIGNAL(clicked()),
             this, SLOT(slotDownClicked()));
+    connect(m_upButton, SIGNAL(clicked()),
+            this, SLOT(slotUpClicked())),
     connect(m_removeButton, SIGNAL(clicked()),
             this, SLOT(slotRemoveFixtureClicked()));
 

--- a/ui/src/fixturegroupeditor.cpp
+++ b/ui/src/fixturegroupeditor.cpp
@@ -162,10 +162,21 @@ void FixtureGroupEditor::slotRightClicked()
     addFixtureHeads(Qt::RightArrow);
 }
 
+void FixtureGroupEditor::slotLeftClicked()
+{
+    addFixtureHeads(Qt::LeftArrow);
+}
+
 void FixtureGroupEditor::slotDownClicked()
 {
     addFixtureHeads(Qt::DownArrow);
 }
+
+void FixtureGroupEditor::slotUpClicked()
+{
+    addFixtureHeads(Qt::UpArrow);
+}
+
 
 void FixtureGroupEditor::slotRemoveFixtureClicked()
 {
@@ -267,8 +278,12 @@ void FixtureGroupEditor::addFixtureHeads(Qt::ArrowType direction)
             m_grp->assignHead(QLCPoint(col, row), gh);
             if (direction == Qt::RightArrow)
                 col++;
-            else
+            else if (direction == Qt::DownArrow)
                 row++;
+            else if (direction == Qt::LeftArrow)
+                col--;
+            else if (direction == Qt::UpArrow)
+                row--;
         }
 
         updateTable();

--- a/ui/src/fixturegroupeditor.h
+++ b/ui/src/fixturegroupeditor.h
@@ -49,6 +49,8 @@ private slots:
     void slotYSpinValueChanged(int value);
 
     void slotRightClicked();
+    void slotLeftClicked(); 
+    void slotUpClicked();
     void slotDownClicked();
     void slotRemoveFixtureClicked();
 

--- a/ui/src/fixturegroupeditor.ui
+++ b/ui/src/fixturegroupeditor.ui
@@ -153,7 +153,7 @@
     </widget>
    </item>
    <item row="2" column="6">
-    <widget class="QToolButton" name="m_leftbutton">
+    <widget class="QToolButton" name="m_leftButton">
      <property name="toolTip">
       <string>Add/replace fixtures to current row, going backwards starting from selected cell</string>
      </property>

--- a/ui/src/fixturegroupeditor.ui
+++ b/ui/src/fixturegroupeditor.ui
@@ -52,7 +52,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="6">
+   <item row="5" column="6">
     <widget class="QToolButton" name="m_removeButton">
      <property name="toolTip">
       <string>Remove selected fixture/head</string>
@@ -138,7 +138,7 @@
    <item row="1" column="6">
     <widget class="QToolButton" name="m_rightButton">
      <property name="toolTip">
-      <string>Add/replace fixtures to current row, starting from selected cell</string>
+      <string>Add/replace fixtures to current row, going right starting from selected cell</string>
      </property>
      <property name="icon">
       <iconset resource="qlcui.qrc">
@@ -153,13 +153,47 @@
     </widget>
    </item>
    <item row="2" column="6">
+    <widget class="QToolButton" name="m_leftbutton">
+     <property name="toolTip">
+      <string>Add/replace fixtures to current row, going backwards starting from selected cell</string>
+     </property>
+     <property name="icon">
+      <iconset resource="qlcui.qrc">
+       <normaloff>:/back.png</normaloff>:/back.png</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="6">
     <widget class="QToolButton" name="m_downButton">
      <property name="toolTip">
-      <string>Add/replace fixtures to current column, starting from selected cell</string>
+      <string>Add/replace fixtures to current column, going down starting from selected cell</string>
      </property>
      <property name="icon">
       <iconset resource="qlcui.qrc">
        <normaloff>:/down.png</normaloff>:/down.png</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="6">
+    <widget class="QToolButton" name="m_upButton">
+     <property name="toolTip">
+      <string>Add/replace fixtures to current column, going up starting from selected cell</string>
+     </property>
+     <property name="icon">
+      <iconset resource="qlcui.qrc">
+       <normaloff>:/up.png</normaloff>:/up.png</iconset>
      </property>
      <property name="iconSize">
       <size>


### PR DESCRIPTION
## Overview

This pull request enhances the Fixture Group Editor in QLC+ by adding "Up" and "Left" buttons. These buttons allow users to add fixtures to a group starting from the selected cell in the reverse directions (upwards and leftwards) of the existing "Right" and "Down" buttons.

## Changes Made
### Code Enhancements:

1. Added new slots: slotUpClicked() and slotLeftClicked().
2. Extended addFixtureHeads() to handle Qt::UpArrow and Qt::LeftArrow.

### UI 
4. Added "Left" and "Up" buttons to the layout in fixturegroupeditor.ui.
5. Configured the buttons with an appropriate tooltip and icon (:/back.png, :/up.png).
6. Connected the buttons to slots in the constructor of FixtureGroupEditor.

## Testing:

I have verified the functionality of "Up" and "Left" buttons across various scenarios, ensuring correct behaviour and bounds handling.
