### PR TITLE
webaccess: show page names of multi-page (solo-) frames

### DIFF
--- a/variables.pri
+++ b/variables.pri
@@ -216,7 +216,7 @@ macx:USERRGBSCRIPTDIR       = $$USERDATADIR/RGBScripts
 android:USERRGBSCRIPTDIR    = $$USERDATADIR/rgbscripts
 ios:USERRGBSCRIPTDIR        = $$USERDATADIR/RGBScripts
 
-# RGB Scripts
+# Web Files
 win32:WEBFILESDIR      = Web
 unix:!macx:WEBFILESDIR = $$DATADIR/web
 macx:WEBFILESDIR       = $$DATADIR/Web

--- a/webaccess/res/virtualconsole.js
+++ b/webaccess/res/virtualconsole.js
@@ -259,10 +259,11 @@ var framesTotalPages = new Array();
 var framesCurrentPage = new Array();
 var frameDisableState = new Array();
 var frameCaption = new Array();
+var framesPageNames = new Array();
 
 function updateFrameLabel(id) {
   var framePageObj = document.getElementById("fr" + id + "Page");
-  var newLabel = "Page " + (framesCurrentPage[id] + 1);
+  var newLabel = framesPageNames[id][framesCurrentPage[id]];
   framePageObj.innerHTML = newLabel;
 
   var frameCaptionObj = document.getElementById("fr" + id + "Caption");


### PR DESCRIPTION
Instead of the untranslated "Page: %1", the web virtual console now displays the page names that were set in the local QLC+ virtual console.
"Page: %1" is now only used as a backup and can be translated.

This PR also fixes a bug where it was not possible to change the page of a frame via the web interface.
To reproduce this issue, the frame name needs to contain a `"` or end on a `\`, as these strings were not escaped before being inserted into the JavaScript code.