### PR TITLE
Fix ambiguous QBuffer

### DIFF
--- a/qmlui/tardis/tardis.cpp
+++ b/qmlui/tardis/tardis.cpp
@@ -319,7 +319,7 @@ void Tardis::run()
 
 QByteArray Tardis::actionToByteArray(int code, quint32 objID, QVariant data)
 {
-    QBuffer buffer;
+    ::QBuffer buffer;
     buffer.open(QIODevice::WriteOnly | QIODevice::Text);
     QXmlStreamWriter xmlWriter(&buffer);
 
@@ -421,7 +421,7 @@ bool Tardis::processBufferedAction(int action, quint32 objID, QVariant &value)
         return false;
     }
 
-    QBuffer buffer;
+    ::QBuffer buffer;
     buffer.setData(value.toByteArray());
     buffer.open(QIODevice::ReadOnly | QIODevice::Text);
     QXmlStreamReader xmlReader(&buffer);


### PR DESCRIPTION
```
/Users/leanderSchulten/git_projekte/qlcplus/qmlui/tardis/tardis.cpp:322:5: error: reference to 'QBuffer' is ambiguous
  322 |     QBuffer buffer;
      |     ^
/Users/leanderSchulten/Qt/6.7.2/macos/lib/QtCore.framework/Headers/qbuffer.h:15:21: note: candidate found by name lookup is 'QBuffer'
   15 | class Q_CORE_EXPORT QBuffer : public QIODevice
      |                     ^
/Users/leanderSchulten/Qt/6.7.2/macos/lib/Qt3DCore.framework/Headers/qbuffer.h:18:29: note: candidate found by name lookup is 'Qt3DCore::QBuffer'
   18 | class Q_3DCORESHARED_EXPORT QBuffer : public Qt3DCore::QNode
```