### PR TITLE
ui/audioeditor, ui/videoeditor: fix name field not updating after changing input file

### DIFF
--- a/ui/src/audioeditor.cpp
+++ b/ui/src/audioeditor.cpp
@@ -178,6 +178,8 @@ void AudioEditor::slotSourceFileClicked()
         m_audio->stopAndWait();
 
     m_audio->setSourceFileName(fn);
+    m_nameEdit->setText(m_audio->name());
+    m_nameEdit->setSelection(0, m_nameEdit->text().length());
     m_filenameLabel->setText(m_audio->getSourceFileName());
 
     AudioDecoder *adec = m_audio->getAudioDecoder();

--- a/ui/src/videoeditor.cpp
+++ b/ui/src/videoeditor.cpp
@@ -148,6 +148,8 @@ void VideoEditor::slotSourceFileClicked()
     m_video->stopAndWait();
 
     m_video->setSourceUrl(fn);
+    m_nameEdit->setText(m_video->name());
+    m_nameEdit->setSelection(0, m_nameEdit->text().length());
     m_filenameLabel->setText(m_video->sourceUrl());
     m_durationLabel->setText(Function::speedToString(m_video->totalDuration()));
 }
@@ -162,6 +164,8 @@ void VideoEditor::slotSourceUrlClicked()
     if (ok == true)
     {
         m_video->setSourceUrl(videoURL);
+        m_nameEdit->setText(m_video->name());
+        m_nameEdit->setSelection(0, m_nameEdit->text().length());
         m_filenameLabel->setText(m_video->sourceUrl());
     }
 }


### PR DESCRIPTION
When changing the input file/url of an existing audio or video function, the name field is not updated.
It only shows the change after closing and reopening the properties "window".

This PR fixes this by immediately setting the new value to the text field using code from the corresponding constructor.