### PR TITLE
webaccess: make more strings translatable

### DIFF
--- a/webaccess/src/webaccessauth.cpp
+++ b/webaccess/src/webaccessauth.cpp
@@ -187,18 +187,17 @@ QList<WebAccessUser> WebAccessAuth::getUsers() const
 
 void WebAccessAuth::sendUnauthorizedResponse(QHttpResponse* res) const
 {
-    //TODO: Allow for localization of this
     const static QByteArray text = QString(
-        "<html>"
-            "<head>"
-                "<meta charset=\"utf-8\">"
-                "<title>Unauthorized</title>"
-            "</head>"
-            "<body>"
-                "<h1>401 Unauthorized</h1>"
-                "<p>Access to this resource requires proper authorization"
-                " and you have failed to authenticate.</p>"
-            "</body>"
+        "<!DOCTYPE html>\n"
+        "<html>\n"
+        "    <head>\n"
+        "        <meta charset=\"utf-8\">\n"
+        "        <title>" + QObject::tr("Unauthorized") + "</title>\n"
+        "    </head>\n"
+        "    <body>\n"
+        "        <h1>" + QObject::tr("401 Unauthorized") + "</h1>\n"
+        "        <p>" + QObject::tr("Access to this resource requires proper authorization and you have failed to authenticate.") + "</p>\n"
+        "    </body>\n"
         "</html>"
     ).toUtf8();
 

--- a/webaccess/src/webaccessconfiguration.cpp
+++ b/webaccess/src/webaccessconfiguration.cpp
@@ -238,17 +238,17 @@ QString WebAccessConfiguration::getPasswordsConfigHTML(WebAccessAuth *auth)
 
             html += "<option value=\"" + QString::number(VC_ONLY_LEVEL) + "\"";
             if (level >= VC_ONLY_LEVEL && level < SIMPLE_DESK_AND_VC_LEVEL)
-                html += "selected";
+                html += " selected";
             html += ">" + tr("Only Virtual Console") + "</option>";
 
             html += "<option value=\"" + QString::number(SIMPLE_DESK_AND_VC_LEVEL) + "\"";
             if (level >= SIMPLE_DESK_AND_VC_LEVEL && level < SUPER_ADMIN_LEVEL)
-                html += "selected";
+                html += " selected";
             html += ">" + tr("Virtual Console and Simple Desk") + "</option>";
 
             html += "<option value=\"" + QString::number(SUPER_ADMIN_LEVEL) + "\"";
             if (level >= SUPER_ADMIN_LEVEL)
-                html += "selected";
+                html += " selected";
             html += ">" + tr("Everything") + "</option>";
 
             html += "</select>";

--- a/webaccess/src/webaccessconfiguration.cpp
+++ b/webaccess/src/webaccessconfiguration.cpp
@@ -68,7 +68,7 @@ QString WebAccessConfiguration::getIOConfigHTML(Doc *doc)
     profiles.prepend("None");
 
     html += "<table class=\"hovertable\" style=\"width: 100%;\">\n";
-    html += "<tr><th>Universe</th><th>Input</th><th>Output</th><th>Feedback</th><th>Profile</th></tr>\n";
+    html += "<tr><th>" + tr("Universe") + "</th><th>" + tr("Input") + "</th><th>" + tr("Output") + "</th><th>" + tr("Feedback") + "</th><th>" + tr("Profile") + "</th></tr>\n";
 
     for (quint32 i = 0; i < ioMap->universesCount(); i++)
     {
@@ -148,13 +148,13 @@ QString WebAccessConfiguration::getAudioConfigHTML(Doc *doc)
     QList<AudioDeviceInfo> devList = doc->audioPluginCache()->audioDevicesList();
 
     html += "<table class=\"hovertable\" style=\"width: 100%;\">\n";
-    html += "<tr><th>Input</th><th>Output</th></tr>\n";
+    html += "<tr><th>" + tr("Input") + "</th><th>" + tr("Output") + "</th></tr>\n";
     html += "<tr align=center>";
 
     QString audioInSelect = "<td><select onchange=\"ioChanged('AUDIOIN', this.value);\">\n"
-                            "<option value=\"__qlcplusdefault__\">Default device</option>\n";
+                            "<option value=\"__qlcplusdefault__\">" + tr("Default device") + "</option>\n";
     QString audioOutSelect = "<td><select onchange=\"ioChanged('AUDIOOUT', this.value);\">\n"
-                             "<option value=\"__qlcplusdefault__\">Default device</option>\n";
+                             "<option value=\"__qlcplusdefault__\">" + tr("Default device") + "</option>\n";
 
     QString inputName, outputName;
     QSettings settings;
@@ -193,7 +193,7 @@ QString WebAccessConfiguration::getUserFixturesConfigHTML()
         return "";
 
     html += "<table class=\"hovertable\" style=\"width: 100%;\">\n";
-    html += "<tr><th>File name</th></tr>\n";
+    html += "<tr><th>" + tr("File name") + "</th></tr>\n";
 
     /* Attempt to read all specified files from the given directory */
     QStringListIterator it(userFx.entryList());

--- a/webaccess/src/webaccessconfiguration.cpp
+++ b/webaccess/src/webaccessconfiguration.cpp
@@ -254,9 +254,9 @@ QString WebAccessConfiguration::getPasswordsConfigHTML(WebAccessAuth *auth)
             html += "</select>";
         html += "</td>";
         html += "<td>";
-            html += "<button role=\"button\" onclick=\"authChangeUser('" + username + "')\">"
+            html += "<button onclick=\"authChangeUser('" + username + "')\">"
                  + tr("Change") + "</button>";
-            html += "<button role=\"button\" onclick=\"authDeleteUser('" + username + "')\">"
+            html += "<button onclick=\"authDeleteUser('" + username + "')\">"
                  + tr("Delete user") + "</button>";
         html += "</td>";
         html += "</tr>";
@@ -279,7 +279,7 @@ QString WebAccessConfiguration::getPasswordsConfigHTML(WebAccessAuth *auth)
     html += "</td>";
     html += "<td>";
         // Script will dynamically add rows with users so it needs to know translations
-        html += "<button role=\"button\" onclick=\"authAddUser("
+        html += "<button onclick=\"authAddUser("
                 "'" + tr("Change") + "','" + tr("Delete user") + "'"
                 ",'" + tr("Username and password are required fields.") + "'"
                 ",'" + tr("New password...") + "'"

--- a/webaccess/src/webaccessconfiguration.h
+++ b/webaccess/src/webaccessconfiguration.h
@@ -28,6 +28,7 @@ class WebAccessAuth;
 
 class WebAccessConfiguration : public QObject
 {
+    Q_OBJECT
 public:
     WebAccessConfiguration();
 

--- a/webaccess/src/webaccessnetwork.h
+++ b/webaccess/src/webaccessnetwork.h
@@ -43,6 +43,7 @@ typedef struct
 
 class WebAccessNetwork: public QObject
 {
+    Q_OBJECT
 public:
     WebAccessNetwork(QObject *parent = 0);
 


### PR DESCRIPTION
While working on the German translation a few weeks ago, I noticed some untranslatable strings on the webaccess pages.

This PR fixes this by enabling full translation of the configuration and authentication error page.