### PR TITLE
Rename Linux desktop file to be consistent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
           wget -c https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O ./appimagetool-x86_64.AppImage
           chmod a+x ./appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage -v ${INSTALL_ROOT}
-          mv -v Q_Light_Controller_Plus-x86_64.AppImage qlcplus-${{env.TASK}}-${{env.APPVERSION}}-${{env.BUILD_DATE}}-${{env.GIT_REV}}.AppImage
+          mv -v Q_Light_Controller_Plus_-_QLC+-x86_64.AppImage qlcplus-${{env.TASK}}-${{env.APPVERSION}}-${{env.BUILD_DATE}}-${{env.GIT_REV}}.AppImage
 
       - name: Test Load AppImage
         if: ${{ matrix.task == 'compile-qt5qml' }}

--- a/platforms/linux/qlcplus-fixtureeditor.desktop
+++ b/platforms/linux/qlcplus-fixtureeditor.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=QLC+ Fixture Editor
+Name=Fixture Definition Editor - QLC+
 Name[fr]=Éditeur d'appareil QLC+
 GenericName=Edit fixtures
 GenericName[cz]=Editor definicí zařízení

--- a/platforms/linux/qlcplus.desktop
+++ b/platforms/linux/qlcplus.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=QLC+
+Name=Q Light Controller Plus - QLC+
 GenericName=Lighting control
 GenericName[cz]=Řízení světel
 GenericName[de]=Lichtsteuerung

--- a/platforms/linux/qlcplus.desktop
+++ b/platforms/linux/qlcplus.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Q Light Controller Plus
+Name=QLC+
 GenericName=Lighting control
 GenericName[cz]=Řízení světel
 GenericName[de]=Lichtsteuerung


### PR DESCRIPTION
When searching for QLC+ in my app launcher, I think to search for "QLC+", not "Q Light Controller Plus".

This change also makes it consistent with the name of the fixture editor desktop entry, which is "QLC+ Fixture Editor".