### PR TITLE
scripts: fix QT 6 builds

### DIFF
--- a/engine/src/scriptrunner.cpp
+++ b/engine/src/scriptrunner.cpp
@@ -35,7 +35,7 @@
 ScriptRunner::ScriptRunner(Doc *doc, QString &content, QObject *parent)
     : QThread(parent)
     , m_doc(doc)
-    , m_content(content)
+    , m_content(content + "\n")
     , m_running(false)
     , m_engine(NULL)
     , m_stopOnExit(true)

--- a/engine/src/scriptv4.cpp
+++ b/engine/src/scriptv4.cpp
@@ -522,6 +522,22 @@ QString Script::convertLine(const QString& str, bool *ok)
                     value.append("\"");
                 }
             }
+            else if (command == blackoutLegacy)
+            {
+                if (value == "on")
+                {
+                    value = "true";
+                }
+                else if (value == "off")
+                {
+                    value = "false";
+                }
+                else
+                {
+                    value.prepend("\"");
+                    value.append("\"");
+                }
+            }
 
             values << value.trimmed();
         }

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -233,9 +233,15 @@ void ScriptEditor::slotAddStartFunction()
         {
             Function* function = m_doc->function(id);
             Q_ASSERT(function != NULL);
-            QString cmd = QString("%1:%2 // %3\n").arg(Script::startFunctionCmd)
-                                                   .arg(id)
-                                                   .arg(function->name());
+            QString cmd =
+                #ifdef QT_QML_LIB
+                    QString("%1(%2); // %3\n")
+                #else
+                    QString("%1:%2 // %3\n")
+                #endif
+                .arg(Script::startFunctionCmd)
+                .arg(id)
+                .arg(function->name());
             cursor.insertText(cmd);
             m_editor->moveCursor(QTextCursor::Down);
         }
@@ -255,9 +261,15 @@ void ScriptEditor::slotAddStopFunction()
         {
             Function* function = m_doc->function(id);
             Q_ASSERT(function != NULL);
-            QString cmd = QString("%1:%2 // %3\n").arg(Script::stopFunctionCmd)
-                                                  .arg(id)
-                                                  .arg(function->name());
+            QString cmd =
+                #ifdef QT_QML_LIB
+                    QString("%1(%2); // %3\n")
+                #else
+                    QString("%1:%2 // %3\n")
+                #endif
+                .arg(Script::stopFunctionCmd)
+                .arg(id)
+                .arg(function->name());
             cursor.insertText(cmd);
             m_editor->moveCursor(QTextCursor::Down);
         }
@@ -285,9 +297,15 @@ void ScriptEditor::slotAddBlackout()
     if (dialog.exec() == QDialog::Accepted)
     {
         m_editor->moveCursor(QTextCursor::StartOfLine);
-        m_editor->textCursor().insertText(QString("%1:%2\n")
-                              .arg(Script::blackoutCmd)
-                              .arg(cb->isChecked() ? Script::blackoutOn : Script::blackoutOff));
+        m_editor->textCursor().insertText(
+            #ifdef QT_QML_LIB
+                QString("%1(%2);\n").arg(Script::blackoutCmd)
+                                    .arg(cb->isChecked() ? "true" : "false")
+            #else
+                QString("%1:%2\n").arg(Script::blackoutCmd)
+                                  .arg(cb->isChecked() ? Script::blackoutOn : Script::blackoutOff)
+            #endif
+        );
     }
 }
 
@@ -317,8 +335,14 @@ void ScriptEditor::slotAddWait()
     if (dialog.exec() == QDialog::Accepted)
     {
         m_editor->moveCursor(QTextCursor::StartOfLine);
-        m_editor->textCursor().insertText(QString("%1:%2\n")
-                              .arg(Script::waitCmd).arg(Function::speedToString(sd->value())));
+        m_editor->textCursor().insertText(
+            #ifdef QT_QML_LIB
+                QString("%1(\"%2\");\n")
+            #else
+                QString("%1:%2\n")
+            #endif
+                .arg(Script::waitCmd)
+                .arg(Function::speedToString(sd->value())));
     }
 }
 
@@ -362,10 +386,15 @@ void ScriptEditor::slotAddSetFixture()
         {
             const QLCChannel* channel = fxi->channel(sv.channel);
             m_editor->moveCursor(QTextCursor::StartOfLine);
-            m_editor->textCursor().insertText(QString("%1:%2 ch:%3 val:0 // %4, %5\n")
-                                                .arg(Script::setFixtureCmd)
-                                                .arg(fxi->id()).arg(sv.channel)
-                                                .arg(fxi->name()).arg(channel->name()));
+            m_editor->textCursor().insertText(
+            #ifdef QT_QML_LIB
+                QString("%1(%2,%3,0); // %4, %5\n")
+            #else
+                QString("%1:%2 ch:%3 val:0 // %4, %5\n")
+            #endif
+                .arg(Script::setFixtureCmd)
+                .arg(fxi->id()).arg(sv.channel)
+                .arg(fxi->name()).arg(channel->name()));
             m_editor->moveCursor(QTextCursor::Down);
         }
     }
@@ -394,13 +423,26 @@ void ScriptEditor::slotAddSystemCommand()
     QString formattedArgs;
     foreach (QString arg, argsList)
     {
-        formattedArgs.append(QString("arg:%1 ").arg(arg));
+        formattedArgs.append(
+            #ifdef QT_QML_LIB
+                QString("%1 ")
+            #else
+                QString("arg:%1 ")
+            #endif
+        .arg(arg));
     }
+    if (formattedArgs.endsWith(' '))
+        formattedArgs = formattedArgs.left(formattedArgs.length()-1);
 
     m_editor->moveCursor(QTextCursor::StartOfLine);
-    m_editor->textCursor().insertText(QString("%1:%2 %3\n")
-                                        .arg(Script::systemCmd)
-                                        .arg(fn).arg(formattedArgs));
+    m_editor->textCursor().insertText(
+        #ifdef QT_QML_LIB
+            QString("%1(\"%2 %3\");\n")
+        #else
+            QString("%1:%2 %3\n")
+        #endif
+            .arg(Script::systemCmd)
+            .arg(fn).arg(formattedArgs));
     m_editor->moveCursor(QTextCursor::Down);
 }
 
@@ -444,8 +486,13 @@ void ScriptEditor::slotAddRandom()
     if (dialog.exec() == QDialog::Accepted)
     {
         m_editor->moveCursor(QTextCursor::StartOfLine);
-        m_editor->textCursor().insertText(QString("random(%1,%2)")
-                              .arg(minSB->value()).arg(maxSB->value()));
+        m_editor->textCursor().insertText(
+            #ifdef QT_QML_LIB
+                QString("Engine.random(%1,%2)")
+            #else
+                QString("random(%1,%2)")
+            #endif
+                .arg(minSB->value()).arg(maxSB->value()));
         m_editor->moveCursor(QTextCursor::EndOfLine);
     }
 }

--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -35,7 +35,7 @@
 #include "scripteditor.h"
 #include "mastertimer.h"
 #include "speeddial.h"
-#include "script.h"
+#include "scriptwrapper.h"
 #include "doc.h"
 
 ScriptEditor::ScriptEditor(QWidget* parent, Script* script, Doc* doc)
@@ -468,18 +468,28 @@ void ScriptEditor::slotCheckSyntax()
     QString errResult;
     QString scriptText = m_document->toPlainText();
     m_script->setData(scriptText);
+
+#ifdef QT_QML_LIB
+    QStringList errLines = m_script->syntaxErrorsLines();
+#else
     QList<int> errLines = m_script->syntaxErrorsLines();
+#endif
+
     if (errLines.isEmpty())
     {
         errResult.append(tr("No syntax errors found in the script"));
     }
     else
     {
+    #ifdef QT_QML_LIB
+        errResult.append(errLines.join("\n"));
+    #else
         QStringList lines = scriptText.split(QRegularExpression("(\\r\\n|\\n\\r|\\r|\\n)"));
         foreach (int line, errLines)
         {
             errResult.append(tr("Syntax error at line %1:\n%2\n\n").arg(line).arg(lines.at(line - 1)));
         }
+    #endif
     }
     QMessageBox::information(this, tr("Script check results"), errResult);
 }


### PR DESCRIPTION
Reported: https://www.qlcplus.org/forum/viewtopic.php?t=18149

I could reproduce the described behaviour when building QLC+ with QT 6 on an up-to-date Ubuntu 24.10 machine.

- When build with QT 6, QLC+ uses the “new” script style, based on JavaScript, while builds with QT 5 still utilize the “old” custom syntax scripts (see [here](https://github.com/mcallegari/qlcplus/blob/master/engine/src/src.pro#L191)).
- However, the `scripteditor` [always includes](https://github.com/mcallegari/qlcplus/blob/master/ui/src/scripteditor.cpp#L38) the `script.h` (old scripts), from which it uses the `QList<int> Script::syntaxErrorsLines()` function to check the script syntax (see [here](https://github.com/mcallegari/qlcplus/blob/master/ui/src/scripteditor.cpp#L471) and [here](https://github.com/mcallegari/qlcplus/blob/master/engine/src/script.h#L117)).
That is why, when compiling the `ScriptEditor` class, the compiler assumes getting a `QList<int>` from that function call, but later, it is linked against `QStringList Script::syntaxErrorsLines()` from `scriptv4.cpp` (see [here](https://github.com/mcallegari/qlcplus/blob/master/engine/src/scriptv4.cpp#L225)), resulting in strange output or crashes when [its values are later used as an index into another list](https://github.com/mcallegari/qlcplus/blob/master/ui/src/scripteditor.cpp#L481).
- When opening a workspace created by a QLC+ version built with QT 5, scripts are [automatically converted into the new syntax](https://github.com/mcallegari/qlcplus/blob/master/engine/src/scriptv4.cpp#L392). However, the conversion of the `setBlackout` command seems to be wrong:
is: `blackout:[on/off]` -> `Engine.setBlackout([on/off]);`
should: `blackout:[on/off]` -> `Engine.setBlackout([true/false]);`.
- When adding commands via the UI buttons to a script in a QT 6 based QLC+ build, the old syntax is used. Also, the `waitkey`, `sethtp` and `setltp` commands have been ignored as they had been marked `not supported yet` ever since the initial import of QLC+ and because they have no equivalent implementation in the “new” script syntax.
- It seems as if the “new” scripts need to have a newline at the end in order to run (correctly). Since I did not want to introduce code modifying existing workspaces, the corresponding commit always simply appends a newline on the fly to given script code before execution. Therefore, it is guaranteed that a script can run, even if it does not end with a newline.
- [TODO] In QLC+ versions built with QT 5, scripts terminate when all of their commands have been executed, releasing all of the channel “overrides”. On QT 6 builds, a script just stays on the last command until it is manually stopped.