### PR TITLE
bugfix: Have Plasma RGB Script remember its colors

### DIFF
--- a/resources/rgbscripts/plasma.js
+++ b/resources/rgbscripts/plasma.js
@@ -281,11 +281,6 @@ var testAlgo;
       util.initialized = false;
     }
 
-    algo.rgbMapGetColors = function()
-    {
-      return util.colorArray;
-    }
-
     algo.rgbMap = function(width, height, rgb, step)
     {
       if (util.initialized === false)


### PR DESCRIPTION
By removing the rgbMapGetColors function, the colors are not overwritten by the default values. This fix is based on how balls.js works.

The bug is described in this post: https://forum.qlcplus.org/viewtopic.php?p=77014.