### PR TITLE
[WIP] Add Javascript log functions to log from an RGB script

### DIFF
--- a/engine/src/rgbscript.cpp
+++ b/engine/src/rgbscript.cpp
@@ -223,6 +223,9 @@ void RGBScript::initEngine()
         s_engineMutex = new QRecursiveMutex();
 #endif
         s_engine = new QScriptEngine(QCoreApplication::instance());
+
+        QScriptValue logWarnFunction = s_engine->newFunction(logWarn);
+        s_engine->globalObject().setProperty("logWarn", logWarnFunction);
     }
     Q_ASSERT(s_engineMutex != NULL);
     Q_ASSERT(s_engine != NULL);
@@ -264,6 +267,17 @@ int RGBScript::rgbMapStepCount(const QSize& size)
         int ret = value.isNumber() ? value.toInteger() : -1;
         return ret;
     }
+}
+
+QScriptValue RGBScript::logWarn(QScriptContext *context, __attribute__((unused)) QScriptEngine *engine)
+{
+    QScriptValue logLine = context->argument(0);
+    if (logLine.isValid())
+        qWarning() << "[SCRIPT] " << logLine.toString();
+    else
+        qCritical() << "[SCRIPT] calls logWarn(String) without first parameter";
+
+    return QScriptValue();
 }
 
 void RGBScript::rgbMapSetColors(QVector<uint> &colors)

--- a/engine/src/rgbscript.h
+++ b/engine/src/rgbscript.h
@@ -21,6 +21,7 @@
 #define RGBSCRIPT_H
 
 #include <QScriptValue>
+#include <QScriptContext>
 #include <QMutex>
 #include "rgbalgorithm.h"
 #include "rgbscriptproperty.h"
@@ -79,6 +80,9 @@ private:
 private:
     /** Init engine, engine mutex, and scripts map */
     static void initEngine();
+
+    /** Callback function to log a warning from script */
+    static QScriptValue logWarn(QScriptContext *context, __attribute__((unused)) QScriptEngine *engine);
 
     /** Handle an error after evaluate() or call() of a script */
     static void displayError(QScriptValue e, const QString& fileName);


### PR DESCRIPTION
Currently it is a bit of a pain to write RGB scripts. There is [the QLC+ RGB script devtool](https://github.com/mrfratello/qlcplus-rgb-script-devtool/) but that has not been updated for a while and I can not get it to work anymore. It would be handy if developers could add log statements to RGB scripts.

This PR is somewhat of an example on how this could be implemented. Would something along this line be accepted? In that case I'll finish the PR.