### PR TITLE
e131controller.h: Fix QT includes

### DIFF
--- a/plugins/E1.31/e131controller.h
+++ b/plugins/E1.31/e131controller.h
@@ -22,8 +22,10 @@
 
 #if defined(ANDROID)
 #include <QScopedPointer>
-#include <QSharedPointer>
 #endif
+#include <QByteArray>
+#include <QMap>
+#include <QSharedPointer>
 #include <QNetworkInterface>
 #include <QHostAddress>
 #include <QUdpSocket>


### PR DESCRIPTION
A compile error was observed on Fedora Rawhide (see #1709), which showed a few missing includes.
This was likely caused by some changes in a recent QT release.

Fixes #1709