### PR TITLE
macOS: set minimum OS version to 10.13 (Qt5) or 12.0 (Qt6)

### DIFF
--- a/create-dmg-cmake.sh
+++ b/create-dmg-cmake.sh
@@ -18,7 +18,9 @@ fi
 
 # Build
 if [ -n "$QTDIR" ]; then
-    cmake -DCMAKE_PREFIX_PATH="$QTDIR/lib/cmake" ..
+    CMAKE_OSX_DEPLOYMENT_TARGET=12.0
+    [ -d "$QTDIR/lib/cmake/Qt5Core" ] && CMAKE_OSX_DEPLOYMENT_TARGET=10.13
+    cmake -DCMAKE_PREFIX_PATH="$QTDIR/lib/cmake" -DCMAKE_OSX_DEPLOYMENT_TARGET=$CMAKE_OSX_DEPLOYMENT_TARGET ..
 else
     echo "QTDIR not set. Aborting."
     exit 1


### PR DESCRIPTION
macOS: set minimum OS version to 10.13 (Qt5) or 12.0 (Qt6)
    
Without this setting the target macOS version is the version of the host system
So compiling QLC on macOS 15 will stop application from running on earlier macOS systems
**Current 4.14.1 Intel release is not runnable on macOS 11 or earlier
Current 4.14.1 Apple Silicon release is not runnable on macOS 14 or earlier**
Although there is a workaround still: user has to run the binary from terminal specifying
/Applications/QLC+.app/Contents/MacOS/qlcplus
This is not very nice, so this commit fixes it.
    
Tested with xcode 13.4.1 on Intel macOS 12 Monterey. Qt 6.9:
otool -l ~/QLC+.app/Contents/MacOS/qlcplus | grep -C4 LC_BUILD_VERSION
minos 12.0
sdk 12.3
Verified to run on Intel macOS 12 Monterey
    
Qt 5.15:
otool -l ~/QLC+.app/Contents/MacOS/qlcplus | grep -C4 LC_BUILD_VERSION
minos 10.13
sdk 12.3
Verified to run on Intel macOS 10.13 High Sierra
Verified to run on Intel macOS 11 Big Sur

Tested with xcode 15.4 on Apple Silicon macOS 14 Sonoma. Qt 6.9:
otool -l ~/QLC+.app/Contents/MacOS/qlcplus | grep -C4 LC_BUILD_VERSION
 minos 12.0
sdk 14.5
Verified to run on Apple Silicon M1 macOS 12 Monterey
