### PR TITLE
Refresh Grand Master slider mode on new/load document

### DIFF
--- a/ui/src/virtualconsole/vcproperties.cpp
+++ b/ui/src/virtualconsole/vcproperties.cpp
@@ -113,7 +113,7 @@ void VCProperties::setGrandMasterSliderMode(GrandMaster::SliderMode mode)
     m_gmSliderMode = mode;
 }
 
-GrandMaster::SliderMode VCProperties::grandMasterSlideMode() const
+GrandMaster::SliderMode VCProperties::grandMasterSliderMode() const
 {
     return m_gmSliderMode;
 }

--- a/ui/src/virtualconsole/vcproperties.h
+++ b/ui/src/virtualconsole/vcproperties.h
@@ -89,7 +89,7 @@ public:
     GrandMaster::ValueMode grandMasterValueMode() const;
 
     void setGrandMasterSliderMode(GrandMaster::SliderMode mode);
-    GrandMaster::SliderMode grandMasterSlideMode() const;
+    GrandMaster::SliderMode grandMasterSliderMode() const;
 
     void setGrandMasterInputSource(quint32 universe, quint32 channel);
     quint32 grandMasterInputUniverse() const;

--- a/ui/src/virtualconsole/vcpropertieseditor.cpp
+++ b/ui/src/virtualconsole/vcpropertieseditor.cpp
@@ -218,7 +218,7 @@ VCPropertiesEditor::VCPropertiesEditor(QWidget* parent, const VCProperties& prop
         break;
     }
 
-    switch (properties.grandMasterSlideMode())
+    switch (properties.grandMasterSliderMode())
     {
     default:
     case GrandMaster::Normal:

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1010,7 +1010,7 @@ void VirtualConsole::slotToolsSettings()
         m_doc->inputOutputMap()->setGrandMasterChannelMode(m_properties.grandMasterChannelMode());
         m_doc->inputOutputMap()->setGrandMasterValueMode(m_properties.grandMasterValueMode());
         if (m_dockArea != NULL)
-            m_dockArea->setGrandMasterInvertedAppearance(m_properties.grandMasterSlideMode());
+            m_dockArea->setGrandMasterInvertedAppearance(m_properties.grandMasterSliderMode());
 
         QSettings settings;
         settings.setValue(SETTINGS_BUTTON_SIZE, vcpe.buttonSize());

--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1537,9 +1537,12 @@ void VirtualConsole::resetContents()
     updateActions();
 
     /* Reset all properties but size */
+    m_properties.setGrandMasterSliderMode(GrandMaster::Normal);
     m_properties.setGrandMasterChannelMode(GrandMaster::Intensity);
     m_properties.setGrandMasterValueMode(GrandMaster::Reduce);
     m_properties.setGrandMasterInputSource(InputOutputMap::invalidUniverse(), QLCChannel::invalid());
+
+    m_dockArea->setGrandMasterInvertedAppearance(m_properties.grandMasterSliderMode());
 }
 
 void VirtualConsole::addWidgetInMap(VCWidget* widget)
@@ -1924,6 +1927,8 @@ void VirtualConsole::postLoad()
     }
     foreach (VCWidget *widget, invalidWidgetsList)
         addWidgetInMap(widget);
+
+    m_dockArea->setGrandMasterInvertedAppearance(m_properties.grandMasterSliderMode());
 
     m_contents->setFocus();
 

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -2332,7 +2332,7 @@ void WebAccess::slotGrandMasterValueChanged(uchar value)
 QString WebAccess::getGrandMasterSliderHTML()
 {
     GrandMaster::ValueMode gmValueMode = m_vc->properties().grandMasterValueMode();
-    GrandMaster::SliderMode gmSliderMode = m_vc->properties().grandMasterSlideMode();
+    GrandMaster::SliderMode gmSliderMode = m_vc->properties().grandMasterSliderMode();
     uchar gmValue = m_doc->inputOutputMap()->grandMasterValue();
 
     QString gmDisplayValue;


### PR DESCRIPTION
The slider mode is stored in the XML file, but is not refreshed when a document is loaded (or a new document is created). This PR fixes that.