### PR TITLE
engine: fix 3 memory leaks

### DIFF
--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -116,6 +116,9 @@ Doc::~Doc()
 
     delete m_fixtureDefCache;
     m_fixtureDefCache = NULL;
+
+    delete m_rgbScriptsCache;
+    m_rgbScriptsCache = NULL;
 }
 
 void Doc::clearContents()

--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -62,6 +62,7 @@ InputOutputMap::~InputOutputMap()
     removeAllUniverses();
     delete m_grandMaster;
     delete m_beatTime;
+    qDeleteAll(m_profiles);
 }
 
 Doc* InputOutputMap::doc() const

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -30,8 +30,8 @@
 
 class QXmlStreamReader;
 class QXmlStreamWriter;
-class QLCInputSource;
 class QElapsedTimer;
+class QLCInputSource;
 class QLCIOPlugin;
 class OutputPatch;
 class InputPatch;

--- a/engine/src/qlcinputprofile.cpp
+++ b/engine/src/qlcinputprofile.cpp
@@ -298,7 +298,7 @@ bool QLCInputProfile::remapChannel(QLCInputChannel* ich, quint32 number)
     quint32 old = channelNumber(ich);
     if (old != QLCChannel::invalid() && m_channels.contains(number) == false)
     {
-        m_channels.take(old);
+        m_channels.remove(old);
         insertChannel(number, ich);
         return true;
     }
@@ -310,10 +310,7 @@ bool QLCInputProfile::remapChannel(QLCInputChannel* ich, quint32 number)
 
 QLCInputChannel* QLCInputProfile::channel(quint32 channel) const
 {
-    if (m_channels.contains(channel) == true)
-        return m_channels[channel];
-    else
-        return NULL;
+    return m_channels.value(channel, NULL);
 }
 
 quint32 QLCInputProfile::channelNumber(const QLCInputChannel* channel) const

--- a/engine/src/qlcmodifierscache.cpp
+++ b/engine/src/qlcmodifierscache.cpp
@@ -28,6 +28,11 @@ QLCModifiersCache::QLCModifiersCache()
 {
 }
 
+QLCModifiersCache::~QLCModifiersCache()
+{
+    qDeleteAll(m_modifiers);
+}
+
 bool QLCModifiersCache::addModifier(ChannelModifier *modifier)
 {
     if (m_modifiers.contains(modifier->name()))
@@ -45,10 +50,7 @@ QList<QString> QLCModifiersCache::templateNames()
 
 ChannelModifier *QLCModifiersCache::modifier(QString name)
 {
-    if (m_modifiers.contains(name))
-        return m_modifiers[name];
-
-    return NULL;
+    return m_modifiers.value(name, NULL);
 }
 
 QDir QLCModifiersCache::systemTemplateDirectory()

--- a/engine/src/qlcmodifierscache.h
+++ b/engine/src/qlcmodifierscache.h
@@ -33,6 +33,7 @@ class QLCModifiersCache
 {
 public:
     QLCModifiersCache();
+    ~QLCModifiersCache();
 
     /**
      * Add a channel modifier to the modifiers map.


### PR DESCRIPTION
as reported by address sanitizer

Direct leak of 1200 byte(s) in 15 object(s) allocated from:
    #0 0x7f16cdef5778 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7f16cca921da in QLCModifiersCache::load(QDir const&, bool) engine/src/qlcmodifierscache.cpp:86

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f16cdef5778 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7f16cc801e73 in Doc::Doc(QObject*, int) engine/src/doc.cpp:70

Indirect leak of 291744 byte(s) in 4052 object(s) allocated from:
    #0 0x7f16cdef5778 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7f16cca7ac52 in QLCInputProfile::loadXML(QXmlStreamReader&) engine/src/qlcinputprofile.cpp:543