### PR TITLE
The QTreeWidget for Slider dialog → Level tab now allows sorting

### DIFF
--- a/ui/src/virtualconsole/vcsliderproperties.cpp
+++ b/ui/src/virtualconsole/vcsliderproperties.cpp
@@ -55,6 +55,7 @@ VCSliderProperties::VCSliderProperties(VCSlider* slider, Doc* doc)
     m_ovrResetSelWidget = NULL;
 
     setupUi(this);
+    m_levelList->sortByColumn(0, Qt::AscendingOrder);
 
     QAction* action = new QAction(this);
     action->setShortcut(QKeySequence(QKeySequence::Close));

--- a/ui/src/virtualconsole/vcsliderproperties.ui
+++ b/ui/src/virtualconsole/vcsliderproperties.ui
@@ -305,6 +305,9 @@
          <property name="selectionMode">
           <enum>QAbstractItemView::SingleSelection</enum>
          </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
          <property name="allColumnsShowFocus">
           <bool>true</bool>
          </property>


### PR DESCRIPTION
This was a feature request in [the forum](
https://forum.qlcplus.org/viewtopic.php?t=18266).