### PR TITLE
Handle the case when `make_chip_iter()` throws exception

### DIFF
--- a/plugins/gpio/gpioplugin.cpp
+++ b/plugins/gpio/gpioplugin.cpp
@@ -58,15 +58,23 @@ void GPIOPlugin::init()
     else
     {
         // autodetect chips and use first
-        for (auto& it: ::gpiod::make_chip_iter())
+        try
         {
-            qDebug() << "GPIO chip found" << QString::fromStdString(it.name());
-            if (m_chipName.empty())
-                m_chipName = it.name();
+            for (auto& it: ::gpiod::make_chip_iter())
+            {
+                qDebug() << "GPIO chip found: " << QString::fromStdString(it.name());
+                if (m_chipName.empty())
+                    m_chipName = it.name();
+                else
+                	qWarning() << "Multiple GPIO chips found, skipping chip: " << QString::fromStdString(it.name());
+            }
+        } catch (const std::system_error& e) {
+            qWarning() << "Error while scanning GPIO chips: " << e.what() << " - GPIO plugin not initialized.";
         }
     }
 
-    updateLinesList();
+    if (!m_chipName.empty())
+        updateLinesList();
 }
 
 QString GPIOPlugin::name()


### PR DESCRIPTION
I use Podman+QEmu to test my Raspberry Pi QLC+ images on my development machine. It's a much faster development cycle. But there are no GPIO chips on my development machine, and the Raspberry Pi QLC+ image obviously has that plugin enabled. Previously I resorted to a hacky "delete GPIO plugin when running inside QEmu"-script, but this PR ensures that the situation is handled gracefully.

For anyone interested in running the Raspberry Pi QLC+ image on a non-arm64 Debian machine, the global steps are:
- `sudo apt install podman qemu-user-static`
- Extract rootfs from QLC+ `.img` file to `somedir/root`
- `sudo podman run -it --rootfs somedir/root bash`