### PR TITLE
Save XML tags in determinicstic order (better when using a VCS)

### DIFF
--- a/engine/src/cue.cpp
+++ b/engine/src/cue.cpp
@@ -32,7 +32,7 @@ Cue::Cue(const QString& name)
 {
 }
 
-Cue::Cue(const QHash <uint,uchar> values)
+Cue::Cue(const QMap <uint,uchar> values)
     : m_name(QString())
     , m_values(values)
     , m_fadeInSpeed(0)
@@ -105,7 +105,7 @@ uchar Cue::value(uint channel) const
         return 0;
 }
 
-QHash <uint,uchar> Cue::values() const
+QMap <uint,uchar> Cue::values() const
 {
     return m_values;
 }
@@ -191,7 +191,7 @@ bool Cue::saveXML(QXmlStreamWriter *doc) const
     doc->writeStartElement(KXMLQLCCue);
     doc->writeAttribute(KXMLQLCCueName, name());
 
-    QHashIterator <uint,uchar> it(values());
+    QMapIterator <uint,uchar> it(values());
     while (it.hasNext() == true)
     {
         it.next();

--- a/engine/src/cue.h
+++ b/engine/src/cue.h
@@ -22,7 +22,7 @@
 #define CUE_H
 
 #include <QString>
-#include <QHash>
+#include <QMap>
 
 #include "scenevalue.h"
 
@@ -47,7 +47,7 @@ class Cue
 {
 public:
     Cue(const QString& name = QString());
-    Cue(const QHash <uint,uchar> values);
+    Cue(const QMap <uint,uchar> values);
     Cue(const Cue& cue);
     ~Cue();
 
@@ -71,10 +71,10 @@ public:
     void unsetValue(uint channel);
     uchar value(uint channel) const;
 
-    QHash <uint,uchar> values() const;
+    QMap <uint,uchar> values() const;
 
 private:
-    QHash <uint,uchar> m_values;
+    QMap <uint,uchar> m_values;
 
     /************************************************************************
      * Speed

--- a/engine/src/cuestack.cpp
+++ b/engine/src/cuestack.cpp
@@ -22,7 +22,6 @@
 #include <QXmlStreamWriter>
 #include <qmath.h>
 #include <QDebug>
-#include <QHash>
 
 #include "genericfader.h"
 #include "fadechannel.h"
@@ -445,7 +444,7 @@ void CueStack::writeDMX(MasterTimer *timer, QList<Universe*> ua)
     {
         if (m_fadersMap.isEmpty())
         {
-            QHashIterator <uint,uchar> it(m_cues.first().values());
+            QMapIterator <uint,uchar> it(m_cues.first().values());
             while (it.hasNext() == true)
             {
                 it.next();
@@ -649,7 +648,7 @@ void CueStack::switchCue(int from, int to, const QList<Universe *> ua)
     }
 
     // Fade out the HTP channels of the previous cue
-    QHashIterator <uint,uchar> oldit(oldCue.values());
+    QMapIterator <uint,uchar> oldit(oldCue.values());
     while (oldit.hasNext() == true)
     {
         oldit.next();
@@ -662,7 +661,7 @@ void CueStack::switchCue(int from, int to, const QList<Universe *> ua)
     }
 
     // Fade in all channels of the new cue
-    QHashIterator <uint,uchar> newit(newCue.values());
+    QMapIterator <uint,uchar> newit(newCue.values());
     while (newit.hasNext() == true)
     {
         newit.next();

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -1430,7 +1430,7 @@ bool Fixture::saveXML(QXmlStreamWriter *doc) const
 
     if (m_channelModifiers.isEmpty() == false)
     {
-        QHashIterator<quint32, ChannelModifier *> it(m_channelModifiers);
+        QMapIterator<quint32, ChannelModifier *> it(m_channelModifiers);
         while (it.hasNext())
         {
             it.next();

--- a/engine/src/fixture.h
+++ b/engine/src/fixture.h
@@ -25,7 +25,7 @@
 #include <QMutex>
 #include <QList>
 #include <QIcon>
-#include <QHash>
+#include <QMap>
 
 #include "qlcchannel.h"
 #include "qlcfixturedef.h"
@@ -353,7 +353,7 @@ protected:
     /** Hash holding the pair <channel index, modifier pointer>
      *  This is basically the place to store them to be saved/loaded
      *  on the project XML file */
-    QHash<quint32, ChannelModifier*> m_channelModifiers;
+    QMap<quint32, ChannelModifier*> m_channelModifiers;
 
     /*********************************************************************
      * Channel info

--- a/engine/src/rgbmatrix.cpp
+++ b/engine/src/rgbmatrix.cpp
@@ -230,7 +230,7 @@ void RGBMatrix::setAlgorithm(RGBAlgorithm *algo)
         if (m_algorithm != NULL && m_algorithm->type() == RGBAlgorithm::Script)
         {
             RGBScript *script = static_cast<RGBScript*> (m_algorithm);
-            QHashIterator<QString, QString> it(m_properties);
+            QMapIterator<QString, QString> it(m_properties);
             while (it.hasNext())
             {
                 it.next();
@@ -531,7 +531,7 @@ bool RGBMatrix::saveXML(QXmlStreamWriter *doc)
     doc->writeTextElement(KXMLQLCRGBMatrixFixtureGroup, QString::number(fixtureGroup()));
 
     /* Properties */
-    QHashIterator<QString, QString> it(m_properties);
+    QMapIterator<QString, QString> it(m_properties);
     while (it.hasNext())
     {
         it.next();
@@ -604,7 +604,7 @@ void RGBMatrix::preRun(MasterTimer *timer)
             if (m_runAlgorithm->type() == RGBAlgorithm::Script)
             {
                 RGBScript *script = static_cast<RGBScript*> (m_runAlgorithm);
-                QHashIterator<QString, QString> it(m_properties);
+                QMapIterator<QString, QString> it(m_properties);
                 while (it.hasNext())
                 {
                     it.next();

--- a/engine/src/rgbmatrix.h
+++ b/engine/src/rgbmatrix.h
@@ -26,7 +26,6 @@
 #include <QList>
 #include <QSize>
 #include <QPair>
-#include <QHash>
 #include <QMap>
 #include <QMutex>
 
@@ -218,7 +217,7 @@ public:
 
 private:
     /** A map of the custom properties for this matrix */
-    QHash<QString, QString>m_properties;
+    QMap<QString, QString>m_properties;
 
     /************************************************************************
      * Load & Save

--- a/engine/test/cue/cue_test.cpp
+++ b/engine/test/cue/cue_test.cpp
@@ -38,7 +38,7 @@ void Cue_Test::initial()
     QCOMPARE(cue.name(), QString("Foo"));
     QCOMPARE(cue.values().size(), 0);
 
-    QHash <uint,uchar> values;
+    QMap <uint,uchar> values;
     values[0] = 14;
     values[932] = 5;
     values[5] = 255;

--- a/ui/src/simpledeskengine.cpp
+++ b/ui/src/simpledeskengine.cpp
@@ -122,7 +122,7 @@ void SimpleDeskEngine::resetUniverse(int universe)
 
     // remove values previously set on universe
     QMutexLocker locker(&m_mutex);
-    QHashIterator <uint,uchar> it(m_values);
+    QMapIterator <uint,uchar> it(m_values);
     while (it.hasNext() == true)
     {
         it.next();
@@ -374,7 +374,7 @@ void SimpleDeskEngine::writeDMX(MasterTimer *timer, QList<Universe *> ua)
 
     if (hasChanged())
     {
-        QHashIterator <uint,uchar> it(m_values);
+        QMapIterator <uint,uchar> it(m_values);
         while (it.hasNext() == true)
         {
             it.next();

--- a/ui/src/simpledeskengine.h
+++ b/ui/src/simpledeskengine.h
@@ -94,7 +94,7 @@ public:
 private:
     /** A map of channel absolute addresses and their values.
       * Note that only channels overridden by Simple Desk are here */
-    QHash <uint,uchar> m_values;
+    QMap <uint,uchar> m_values;
 
     /** A list of commands to be executed on writeDMX.
      *  This is used to sync reset requests with mastertimer ticks */

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -843,7 +843,7 @@ void VCMatrix::slotUpdate()
                 algorithmName == control->m_resource)
             {
                 on = true;
-                for (QHash<QString, QString>::const_iterator it = control->m_properties.begin();
+                for (QMap<QString, QString>::const_iterator it = control->m_properties.begin();
                         it != control->m_properties.end(); ++it)
                 {
                     if (algorithmProperties.value(it.key(), QString()) != it.value())
@@ -1004,7 +1004,7 @@ void VCMatrix::addCustomControl(VCMatrixControl const& control)
         if (!control.m_properties.isEmpty())
         {
             btnLabel += " (";
-            QHashIterator<QString, QString> it(control.m_properties);
+            QMapIterator<QString, QString> it(control.m_properties);
             while (it.hasNext())
             {
                 it.next();
@@ -1241,7 +1241,7 @@ void VCMatrix::slotCustomControlClicked()
             if (!control->m_properties.isEmpty())
             {
                 RGBScript *script = static_cast<RGBScript*> (algo);
-                QHashIterator<QString, QString> it(control->m_properties);
+                QMapIterator<QString, QString> it(control->m_properties);
                 while (it.hasNext())
                 {
                     it.next();

--- a/ui/src/virtualconsole/vcmatrix.h
+++ b/ui/src/virtualconsole/vcmatrix.h
@@ -24,7 +24,7 @@
 #include <QToolButton>
 #include <QComboBox>
 #include <QLabel>
-#include <QHash>
+#include <QMap>
 
 #include "vcwidget.h"
 #include "vcmatrixcontrol.h"

--- a/ui/src/virtualconsole/vcmatrixcontrol.cpp
+++ b/ui/src/virtualconsole/vcmatrixcontrol.cpp
@@ -270,7 +270,7 @@ bool VCMatrixControl::saveXML(QXmlStreamWriter *doc)
 
     if (!m_properties.isEmpty())
     {
-        QHashIterator<QString, QString> it(m_properties);
+        QMapIterator<QString, QString> it(m_properties);
         while (it.hasNext())
         {
             it.next();

--- a/ui/src/virtualconsole/vcmatrixcontrol.h
+++ b/ui/src/virtualconsole/vcmatrixcontrol.h
@@ -23,7 +23,7 @@
 #include <QSharedPointer>
 #include <QKeySequence>
 #include <QColor>
-#include <QHash>
+#include <QMap>
 
 #include "qlcinputsource.h"
 
@@ -131,7 +131,7 @@ public:
     QString m_resource;
 
     /** A map holding the requested script properties */
-    QHash<QString, QString> m_properties;
+    QMap<QString, QString> m_properties;
 
     QSharedPointer<QLCInputSource> m_inputSource;
     QKeySequence m_keySequence;

--- a/ui/src/virtualconsole/vcmatrixpresetselection.cpp
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.cpp
@@ -224,7 +224,7 @@ QString VCMatrixPresetSelection::selectedPreset()
     return m_presetCombo->currentText();
 }
 
-QHash<QString, QString> VCMatrixPresetSelection::customizedProperties()
+QMap<QString, QString> VCMatrixPresetSelection::customizedProperties()
 {
     return m_properties;
 }

--- a/ui/src/virtualconsole/vcmatrixpresetselection.h
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.h
@@ -21,6 +21,7 @@
 #define VCMATRIXPRESETSELECTION_H
 
 #include <QDialog>
+#include <QMap>
 
 #include "ui_vcmatrixpresetselection.h"
 
@@ -37,7 +38,7 @@ public:
 
     QString selectedPreset();
 
-    QHash<QString, QString> customizedProperties();
+    QMap<QString, QString> customizedProperties();
 
 protected slots:
     void slotUpdatePresetProperties();
@@ -55,7 +56,7 @@ private:
     Doc *m_doc;
 
     /** A map holding the customized script properties */
-    QHash<QString, QString> m_properties;
+    QMap<QString, QString> m_properties;
 };
 
 #endif // VCMATRIXPRESETSELECTION_H

--- a/ui/src/virtualconsole/vcmatrixproperties.cpp
+++ b/ui/src/virtualconsole/vcmatrixproperties.cpp
@@ -20,6 +20,7 @@
 #include <QColorDialog>
 #include <QInputDialog>
 #include <QTreeWidget>
+#include <QMap>
 
 #include "vcmatrixpresetselection.h"
 #include "inputselectionwidget.h"
@@ -313,7 +314,7 @@ void VCMatrixProperties::updateTree()
                 if (!control->m_properties.isEmpty())
                 {
                     presetName += " (";
-                    QHashIterator<QString, QString> it(control->m_properties);
+                    QMapIterator<QString, QString> it(control->m_properties);
                     while (it.hasNext())
                     {
                         it.next();

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -20,6 +20,7 @@
 #include <QDebug>
 #include <QProcess>
 #include <QSettings>
+#include <QMap>
 #include <qmath.h>
 
 #include "webaccess.h"
@@ -2158,7 +2159,7 @@ QString WebAccess::getMatrixHTML(VCMatrix *matrix)
                 if (!control->m_properties.isEmpty())
                 {
                         btnLabel += " (";
-                        QHashIterator<QString, QString> it(control->m_properties);
+                        QMapIterator<QString, QString> it(control->m_properties);
                         while (it.hasNext())
                         {
                             it.next();


### PR DESCRIPTION
Use QMap instead of QHash while saving XML. This way the tags in the resulting XML are always in the same order. When storing XML files in a version control system such as Git, this circumvents false differences between revisions.