### PR TITLE
Correctly name 'SonicPulse LED Bar 10'

### DIFF
--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -1745,7 +1745,7 @@
     <F n="Stairville-SC250H" m="SC250H"/>
     <F n="Stairville-SF-1500" m="SF-1500"/>
     <F n="Stairville-SonicPulse-LED-Bar-05" m="SonicPulse LED Bar 05"/>
-    <F n="Stairville-SonicPulse-LED-Bar-10" m="SonicPulse LED Bar 05"/>
+    <F n="Stairville-SonicPulse-LED-Bar-10" m="SonicPulse LED Bar 10"/>
     <F n="Stairville-Stage-PAR-CX-2-RGBAW" m="Stage PAR CX-2 RGBAW"/>
     <F n="Stairville-Tri-Flat-PAR-Profile-5x3W-RGB" m="Tri Flat PAR Profile 5x3W RGB"/>
     <F n="Stairville-TRI-LED-Bundle-Complete" m="Stage TRI LED Bundle Complete"/>

--- a/resources/fixtures/Stairville/Stairville-SonicPulse-LED-Bar-10.qxf
+++ b/resources/fixtures/Stairville/Stairville-SonicPulse-LED-Bar-10.qxf
@@ -7,7 +7,7 @@
   <Author>Simeon08 &amp; ReComplexed</Author>
  </Creator>
  <Manufacturer>Stairville</Manufacturer>
- <Model>SonicPulse LED Bar 05</Model>
+ <Model>SonicPulse LED Bar 10</Model>
  <Type>LED Bar (Beams)</Type>
  <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Strobe">


### PR DESCRIPTION
This fixes the warning `bool
QLCFixtureDefCache::addFixtureDef(QLCFixtureDef*) Cache already contains "Stairville SonicPulse LED Bar 05"` and also shows the SonicPulse LED Bar 10 in the fixtures list when adding a fixture.

The fixture in question is [this one](https://www.thomann.de/intl/stairville_sonicpulse_led_bar_10.htm).