### PR TITLE
Speed up many foreach-based iterations over QMap

### DIFF
--- a/engine/audio/src/audioplugincache.cpp
+++ b/engine/audio/src/audioplugincache.cpp
@@ -103,7 +103,7 @@ void AudioPluginCache::load(const QDir &dir)
 QStringList AudioPluginCache::getSupportedFormats()
 {
     QStringList caps;
-    foreach (QString path, m_pluginsMap.values())
+    foreach (QString path, m_pluginsMap)
     {
         QPluginLoader loader(path, this);
         AudioDecoder* ptr = qobject_cast<AudioDecoder*> (loader.instance());
@@ -124,7 +124,7 @@ AudioDecoder *AudioPluginCache::getDecoderForFile(const QString &filename)
     if (fn.exists() == false)
         return NULL;
 
-    foreach (QString path, m_pluginsMap.values())
+    foreach (QString path, m_pluginsMap)
     {
         QPluginLoader loader(path, this);
         AudioDecoder* ptr = qobject_cast<AudioDecoder*> (loader.instance());

--- a/engine/src/cue.cpp
+++ b/engine/src/cue.cpp
@@ -93,16 +93,12 @@ void Cue::setValue(uint channel, uchar value)
 
 void Cue::unsetValue(uint channel)
 {
-    if (m_values.contains(channel) == true)
-        m_values.remove(channel);
+    m_values.remove(channel);
 }
 
 uchar Cue::value(uint channel) const
 {
-    if (m_values.contains(channel) == true)
-        return m_values[channel];
-    else
-        return 0;
+    return m_values.value(channel, 0);
 }
 
 QMap <uint,uchar> Cue::values() const

--- a/engine/src/cuestack.cpp
+++ b/engine/src/cuestack.cpp
@@ -402,7 +402,7 @@ void CueStack::adjustIntensity(qreal fraction)
 {
     m_intensity = fraction;
 
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->adjustIntensity(fraction);
@@ -562,7 +562,7 @@ void CueStack::postRun(MasterTimer* timer, QList<Universe *> ua)
     }
     else
     {
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->setFadeOut(true, fadeOutSpeed());

--- a/engine/src/dmxdumpfactoryproperties.cpp
+++ b/engine/src/dmxdumpfactoryproperties.cpp
@@ -70,8 +70,7 @@ void DmxDumpFactoryProperties::addChaserID(quint32 id)
 
 void DmxDumpFactoryProperties::removeChaserID(quint32 id)
 {
-    if (m_selectedChaserIDs.contains(id) == true)
-        m_selectedChaserIDs.removeAll(id);
+    m_selectedChaserIDs.removeAll(id);
 }
 
 bool DmxDumpFactoryProperties::isChaserSelected(quint32 id)

--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -803,10 +803,7 @@ bool Doc::deleteFixtureGroup(quint32 id)
 
 FixtureGroup* Doc::fixtureGroup(quint32 id) const
 {
-    if (m_fixtureGroups.contains(id) == true)
-        return m_fixtureGroups[id];
-    else
-        return NULL;
+    return m_fixtureGroups.value(id, NULL);
 }
 
 QList <FixtureGroup*> Doc::fixtureGroups() const
@@ -901,10 +898,7 @@ bool Doc::moveChannelGroup(quint32 id, int direction)
 
 ChannelsGroup* Doc::channelsGroup(quint32 id) const
 {
-    if (m_channelsGroups.contains(id) == true)
-        return m_channelsGroups[id];
-    else
-        return NULL;
+    return m_channelsGroups.value(id, NULL);
 }
 
 QList <ChannelsGroup*> Doc::channelsGroups() const
@@ -980,10 +974,7 @@ bool Doc::deletePalette(quint32 id)
 
 QLCPalette *Doc::palette(quint32 id) const
 {
-    if (m_palettes.contains(id) == true)
-        return m_palettes[id];
-    else
-        return NULL;
+    return m_palettes.value(id, NULL);
 }
 
 QList<QLCPalette *> Doc::palettes() const
@@ -1107,10 +1098,7 @@ bool Doc::deleteFunction(quint32 id)
 
 Function* Doc::function(quint32 id) const
 {
-    if (m_functions.contains(id) == true)
-        return m_functions[id];
-    else
-        return NULL;
+    return m_functions.value(id, NULL);
 }
 
 quint32 Doc::nextFunctionID()

--- a/engine/src/efx.cpp
+++ b/engine/src/efx.cpp
@@ -1173,7 +1173,7 @@ int EFX::adjustAttribute(qreal fraction, int attributeId)
     {
         case Intensity:
         {
-            foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+            foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
             {
                 if (!fader.isNull())
                     fader->adjustIntensity(getAttributeValue(Function::Intensity));
@@ -1202,7 +1202,7 @@ void EFX::setBlendMode(Universe::BlendMode mode)
     if (mode == blendMode())
         return;
 
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->setBlendMode(mode);

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -557,10 +557,7 @@ void Fixture::setChannelModifier(quint32 idx, ChannelModifier *mod)
 
 ChannelModifier *Fixture::channelModifier(quint32 idx)
 {
-    if (m_channelModifiers.contains(idx))
-        return m_channelModifiers[idx];
-
-    return NULL;
+    return m_channelModifiers.value(idx, NULL);
 }
 
 /*********************************************************************
@@ -1428,7 +1425,6 @@ bool Fixture::saveXML(QXmlStreamWriter *doc) const
         doc->writeTextElement(KXMLFixtureForcedLTP, list);
     }
 
-    if (m_channelModifiers.isEmpty() == false)
     {
         QMapIterator<quint32, ChannelModifier *> it(m_channelModifiers);
         while (it.hasNext())

--- a/engine/src/fixturegroup.cpp
+++ b/engine/src/fixturegroup.cpp
@@ -192,16 +192,11 @@ void FixtureGroup::resignFixture(quint32 id)
 
 bool FixtureGroup::resignHead(const QLCPoint& pt)
 {
-    if (m_heads.contains(pt) == true)
-    {
-        m_heads.remove(pt);
+    const int removed = m_heads.remove(pt);
+    if (removed)
         emit changed(this->id());
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+
+    return removed;
 }
 
 void FixtureGroup::swap(const QLCPoint& a, const QLCPoint& b)
@@ -246,7 +241,8 @@ QMap<QLCPoint, GroupHead> FixtureGroup::headsMap() const
 QList <quint32> FixtureGroup::fixtureList() const
 {
     QList <quint32> list;
-    foreach (GroupHead head, headList())
+
+    foreach (GroupHead head, m_heads)
     {
         if (list.contains(head.fxi) == false)
             list << head.fxi;

--- a/engine/src/function.cpp
+++ b/engine/src/function.cpp
@@ -1410,7 +1410,7 @@ void Function::calculateOverrideValue(int attributeIndex)
     if (origAttr.m_flags & Multiply)
         finalValue = origAttr.m_value;
 
-    foreach (AttributeOverride attr, m_overrideMap.values())
+    foreach (AttributeOverride attr, m_overrideMap)
     {
         if (attr.m_attrIndex != attributeIndex)
             continue;

--- a/engine/src/genericdmxsource.cpp
+++ b/engine/src/genericdmxsource.cpp
@@ -38,7 +38,7 @@ GenericDMXSource::GenericDMXSource(Doc* doc)
 
 GenericDMXSource::~GenericDMXSource()
 {
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->requestDelete();

--- a/engine/src/qlcfixturemode.cpp
+++ b/engine/src/qlcfixturemode.cpp
@@ -264,11 +264,10 @@ quint32 QLCFixtureMode::channelActsOn(quint32 chIndex)
 
 void QLCFixtureMode::setChannelActsOn(quint32 chIndex, quint32 actsOnIndex)
 {
-    if (m_actsOnMap.contains(chIndex))
-        m_actsOnMap.remove(chIndex);
-
     if (actsOnIndex != QLCChannel::invalid())
         m_actsOnMap[chIndex] = actsOnIndex;
+    else
+        m_actsOnMap.remove(chIndex);
 }
 
 /*****************************************************************************

--- a/engine/src/qlcfixturemode.h
+++ b/engine/src/qlcfixturemode.h
@@ -320,7 +320,6 @@ public:
 
     /** Save a mode to an XML document */
     bool saveXML(QXmlStreamWriter *doc);
-    QHash<QLCChannel *, QLCChannel *> actsOnChannelsList() const;
 };
 
 /** @} */

--- a/engine/src/rgbmatrix.cpp
+++ b/engine/src/rgbmatrix.cpp
@@ -722,7 +722,7 @@ void RGBMatrix::postRun(MasterTimer *timer, QList<Universe *> universes)
         if (tempoType() == Beats)
             fadeout = beatsToTime(fadeout, timer->beatTimeDuration());
 
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->setFadeOut(true, fadeout);
@@ -928,7 +928,7 @@ int RGBMatrix::adjustAttribute(qreal fraction, int attributeId)
 
     if (attrIndex == Intensity)
     {
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->adjustIntensity(getAttributeValue(Function::Intensity));
@@ -947,7 +947,7 @@ void RGBMatrix::setBlendMode(Universe::BlendMode mode)
     if (mode == blendMode())
         return;
 
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->setBlendMode(mode);

--- a/engine/src/scene.cpp
+++ b/engine/src/scene.cpp
@@ -795,7 +795,7 @@ void Scene::handleFadersEnd(MasterTimer *timer)
         if (tempoType() == Beats)
             fadeout = beatsToTime(fadeout, timer->beatTimeDuration());
 
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->setFadeOut(true, fadeout);
@@ -864,7 +864,7 @@ void Scene::setPause(bool enable)
     if (!isRunning())
         return;
 
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->setPaused(enable);
@@ -882,7 +882,7 @@ int Scene::adjustAttribute(qreal fraction, int attributeId)
 
     if (attrIndex == Intensity)
     {
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->adjustIntensity(getAttributeValue(Function::Intensity));
@@ -890,7 +890,7 @@ int Scene::adjustAttribute(qreal fraction, int attributeId)
     }
     else if (attrIndex == ParentIntensity)
     {
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->setParentIntensity(getAttributeValue(ParentIntensity));
@@ -911,7 +911,7 @@ void Scene::setBlendMode(Universe::BlendMode mode)
 
     qDebug() << "Scene" << name() << "blend mode set to" << Universe::blendModeToString(mode);
 
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->setBlendMode(mode);
@@ -930,7 +930,7 @@ void Scene::setBlendFunctionID(quint32 fid)
     m_blendFunctionID = fid;
     if (isRunning() && fid == Function::invalidId())
     {
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->resetCrossfade();

--- a/engine/src/scriptrunner.cpp
+++ b/engine/src/scriptrunner.cpp
@@ -83,7 +83,7 @@ void ScriptRunner::stop()
     m_startedFunctions.clear();
 
     // request to delete all the active faders
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->requestDelete();

--- a/engine/src/show.cpp
+++ b/engine/src/show.cpp
@@ -65,7 +65,7 @@ quint32 Show::totalDuration()
 {
     quint32 totalDuration = 0;
 
-    foreach (Track *track, tracks())
+    foreach (Track *track, m_tracks)
     {
         foreach (ShowFunction *sf, track->showFunctions())
         {
@@ -257,10 +257,7 @@ bool Show::removeTrack(quint32 id)
 
 Track* Show::track(quint32 id) const
 {
-    if (m_tracks.contains(id) == true)
-        return m_tracks[id];
-    else
-        return NULL;
+    return m_tracks.value(id, NULL);
 }
 
 Track* Show::getTrackFromSceneID(quint32 id)
@@ -478,7 +475,7 @@ void Show::preRun(MasterTimer* timer)
 
     m_runner = new ShowRunner(doc(), this->id(), elapsed());
     int i = 0;
-    foreach (Track *track, m_tracks.values())
+    foreach (Track *track, m_tracks)
         m_runner->adjustIntensity(getAttributeValue(i++), track);
 
     connect(m_runner, SIGNAL(timeChanged(quint32)), this, SIGNAL(timeChanged(quint32)));

--- a/plugins/E1.31/e131controller.cpp
+++ b/plugins/E1.31/e131controller.cpp
@@ -315,7 +315,7 @@ UniverseInfo *E131Controller::getUniverseInfo(quint32 universe)
 E131Controller::Type E131Controller::type()
 {
     int type = Unknown;
-    foreach (UniverseInfo info, m_universeMap.values())
+    foreach (UniverseInfo info, m_universeMap)
     {
         type |= info.type;
     }

--- a/plugins/artnet/src/artnetcontroller.cpp
+++ b/plugins/artnet/src/artnetcontroller.cpp
@@ -69,7 +69,7 @@ ArtNetController::~ArtNetController()
 ArtNetController::Type ArtNetController::type()
 {
     int type = Unknown;
-    foreach (UniverseInfo info, m_universeMap.values())
+    foreach (UniverseInfo info, m_universeMap)
     {
         type |= info.type;
     }

--- a/plugins/osc/osccontroller.cpp
+++ b/plugins/osc/osccontroller.cpp
@@ -199,7 +199,7 @@ UniverseInfo* OSCController::getUniverseInfo(quint32 universe)
 OSCController::Type OSCController::type() const
 {
     int type = Unknown;
-    foreach (UniverseInfo info, m_universeMap.values())
+    foreach (UniverseInfo info, m_universeMap)
     {
         type |= info.type;
     }

--- a/plugins/peperoni/unix/peperoni.cpp
+++ b/plugins/peperoni/unix/peperoni.cpp
@@ -80,8 +80,7 @@ QStringList Peperoni::outputs()
     QStringList list;
     int i = 0;
 
-    QList <PeperoniDevice*> devList = m_devices.values();
-    foreach (PeperoniDevice* dev, devList)
+    foreach (PeperoniDevice* dev, m_devices)
         list << dev->name(i++);
 
     return list;
@@ -174,8 +173,7 @@ QStringList Peperoni::inputs()
     QStringList list;
     int i = 0;
 
-    QList <PeperoniDevice*> devList = m_devices.values();
-    foreach (PeperoniDevice* dev, devList)
+    foreach (PeperoniDevice* dev, m_devices)
         list << dev->name(i++);
 
     return list;
@@ -288,7 +286,7 @@ void Peperoni::rescanDevices()
 
 bool Peperoni::device(struct libusb_device* usbdev)
 {
-    foreach (PeperoniDevice* dev, m_devices.values())
+    foreach (PeperoniDevice* dev, m_devices)
     {
         if (dev->device() == usbdev)
             return true;

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -579,7 +579,7 @@ void VCSlider::setSearchFilter(QString searchFilter)
 
 void VCSlider::removeActiveFaders()
 {
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->requestDelete();

--- a/qmlui/virtualconsole/virtualconsole.cpp
+++ b/qmlui/virtualconsole/virtualconsole.cpp
@@ -545,7 +545,7 @@ void VirtualConsole::setWidgetSelection(quint32 wID, QQuickItem *item, bool enab
 
 void VirtualConsole::resetWidgetSelection()
 {
-    foreach (QQuickItem *widget, m_itemsMap.values())
+    foreach (QQuickItem *widget, m_itemsMap)
         widget->setProperty("isSelected", false);
     m_itemsMap.clear();
 
@@ -576,7 +576,7 @@ QStringList VirtualConsole::selectedWidgetNames()
 
 int VirtualConsole::selectedWidgetsCount() const
 {
-    return m_itemsMap.keys().count();
+    return m_itemsMap.count();
 }
 
 QVariantList VirtualConsole::selectedWidgetIDs()

--- a/ui/src/monitor/monitorgraphicsview.cpp
+++ b/ui/src/monitor/monitorgraphicsview.cpp
@@ -97,7 +97,7 @@ void MonitorGraphicsView::setFixtureRotation(quint32 id, ushort degrees)
 
 void MonitorGraphicsView::showFixturesLabels(bool visible)
 {
-    foreach (MonitorFixtureItem *item, m_fixtures.values())
+    foreach (MonitorFixtureItem *item, m_fixtures)
         item->showLabel(visible);
 }
 
@@ -220,7 +220,7 @@ bool MonitorGraphicsView::removeFixture(quint32 id)
 
 void MonitorGraphicsView::clearFixtures()
 {
-    foreach (MonitorFixtureItem *item, m_fixtures.values())
+    foreach (MonitorFixtureItem *item, m_fixtures)
         delete item;
     m_fixtures.clear();
 }

--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -456,7 +456,7 @@ void SceneEditor::slotEnableCurrent()
     }
     else
     {
-        foreach (FixtureConsole *fc, m_consoleList.values())
+        foreach (FixtureConsole *fc, m_consoleList)
         {
             if (fc == NULL)
                 continue;
@@ -476,7 +476,7 @@ void SceneEditor::slotDisableCurrent()
     }
     else
     {
-        foreach (FixtureConsole *fc, m_consoleList.values())
+        foreach (FixtureConsole *fc, m_consoleList)
         {
             if (fc == NULL)
                 continue;
@@ -497,10 +497,7 @@ void SceneEditor::slotCopy()
         if (fc != NULL)
         {
             copyList = fc->values();
-            if (fc->hasSelections())
-                m_copyFromSelection = true;
-            else
-                m_copyFromSelection = false;
+            m_copyFromSelection = fc->hasSelections();
             clipboard->copyContent(m_scene->id(), copyList);
         }
     }
@@ -508,7 +505,7 @@ void SceneEditor::slotCopy()
     {
         bool oneHasSelection = false;
         QList <SceneValue> selectedOnlyList;
-        foreach (FixtureConsole *fc, m_consoleList.values())
+        foreach (FixtureConsole *fc, m_consoleList)
         {
             if (fc == NULL)
                 continue;
@@ -544,7 +541,7 @@ void SceneEditor::slotPaste()
     }
     else
     {
-        foreach (FixtureConsole *fc, m_consoleList.values())
+        foreach (FixtureConsole *fc, m_consoleList)
         {
             if (fc == NULL)
                 continue;
@@ -1330,7 +1327,7 @@ void SceneEditor::slotRemoveFixtureClicked()
 
 void SceneEditor::slotEnableAll()
 {
-    foreach (FixtureConsole* fc, m_consoleList.values())
+    foreach (FixtureConsole* fc, m_consoleList)
     {
         if (fc != NULL)
             fc->setChecked(true);
@@ -1339,7 +1336,7 @@ void SceneEditor::slotEnableAll()
 
 void SceneEditor::slotDisableAll()
 {
-    foreach (FixtureConsole* fc, m_consoleList.values())
+    foreach (FixtureConsole* fc, m_consoleList)
     {
         if (fc != NULL)
             fc->setChecked(false);

--- a/ui/src/simpledesk.cpp
+++ b/ui/src/simpledesk.cpp
@@ -1010,7 +1010,7 @@ void SimpleDesk::slotUniverseWritten(quint32 idx, const QByteArray& universeData
     }
     else
     {
-        foreach (FixtureConsole *fc, m_consoleList.values())
+        foreach (FixtureConsole *fc, m_consoleList)
         {
             if (fc == NULL)
                 continue;

--- a/ui/src/simpledeskengine.cpp
+++ b/ui/src/simpledeskengine.cpp
@@ -60,14 +60,14 @@ void SimpleDeskEngine::clearContents()
     qDebug() << Q_FUNC_INFO;
 
     // Stop all cuestacks and wait for each of them to stop
-    foreach (CueStack* cs, m_cueStacks.values())
+    foreach (CueStack* cs, m_cueStacks)
     {
         cs->stop();
         while (cs->isStarted() == true) { /* NOP */ }
     }
 
     QMutexLocker locker(&m_mutex);
-    foreach (CueStack* cs, m_cueStacks.values())
+    foreach (CueStack* cs, m_cueStacks)
         delete cs;
     m_cueStacks.clear();
     m_values.clear();

--- a/ui/src/virtualconsole/vcaudiotriggers.cpp
+++ b/ui/src/virtualconsole/vcaudiotriggers.cpp
@@ -480,7 +480,7 @@ void VCAudioTriggers::slotModeChanged(Doc::Mode mode)
         m_doc->masterTimer()->unregisterDMXSource(this);
 
         // request to delete all the active faders
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->requestDelete();

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -1158,7 +1158,7 @@ QMap<quint32,QString> VCMatrix::customControlsMap() const
 {
     QMap<quint32,QString> map;
 
-    foreach (VCMatrixControl *control, m_controls.values())
+    foreach (VCMatrixControl *control, m_controls)
         map.insert(control->m_id, VCMatrixControl::typeToString(control->m_type));
 
     return map;

--- a/ui/src/virtualconsole/vcslider.cpp
+++ b/ui/src/virtualconsole/vcslider.cpp
@@ -217,7 +217,7 @@ VCSlider::~VCSlider()
     m_doc->masterTimer()->unregisterDMXSource(this);
 
     // request to delete all the active faders
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->requestDelete();
@@ -361,7 +361,7 @@ void VCSlider::slotModeChanged(Doc::Mode mode)
         {
             m_doc->masterTimer()->unregisterDMXSource(this);
             // request to delete all the active faders
-            foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+            foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
             {
                 if (!fader.isNull())
                     fader->requestDelete();
@@ -876,7 +876,7 @@ void VCSlider::slotResetButtonClicked()
                                  .arg(m_slider->palette().window().color().name()));
 
     // request to delete all the active fader channels
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->removeAll();
@@ -1619,7 +1619,7 @@ void VCSlider::adjustIntensity(qreal val)
     }
     else if (sliderMode() == Level)
     {
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->adjustIntensity(val);

--- a/ui/src/virtualconsole/vcwidget.cpp
+++ b/ui/src/virtualconsole/vcwidget.cpp
@@ -734,7 +734,7 @@ void VCWidget::slotInputProfileChanged(quint32 universe, const QString &profileN
 
     QLCInputProfile *profile = m_doc->inputOutputMap()->profile(profileName);
 
-    foreach (QSharedPointer<QLCInputSource> const& source, m_inputs.values())
+    foreach (QSharedPointer<QLCInputSource> const& source, m_inputs)
     {
         if (!source.isNull() && source->universe() == universe)
         {

--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -182,7 +182,7 @@ VCXYPad::VCXYPad(QWidget* parent, Doc* doc) : VCWidget(parent, doc)
 VCXYPad::~VCXYPad()
 {
     m_doc->masterTimer()->unregisterDMXSource(this);
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->requestDelete();
@@ -593,7 +593,7 @@ void VCXYPad::slotUniverseWritten(quint32 idx, const QByteArray &universeData)
             fxMap[sc.m_fixture] = QPointF(x, y);
         }
 
-        foreach (QPointF pt, fxMap.values())
+        foreach (QPointF pt, fxMap)
         {
             if (invertedAppearance())
                 pt.setY(256 - pt.y());
@@ -696,7 +696,7 @@ QMap<quint32,QString> VCXYPad::presetsMap() const
 {
     QMap<quint32,QString> map;
 
-    foreach (VCXYPadPreset *control, m_presets.values())
+    foreach (VCXYPadPreset *control, m_presets)
         map.insert(control->m_id, VCXYPadPreset::typeToString(control->m_type));
 
     return map;
@@ -730,7 +730,7 @@ void VCXYPad::slotPresetClicked(bool checked)
     {
         m_scene->stop(functionParent());
         m_scene = NULL;
-        foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+        foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
         {
             if (!fader.isNull())
                 fader->requestDelete();

--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -227,7 +227,7 @@ VCXYPadProperties::~VCXYPadProperties()
     QSettings settings;
     settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
     m_doc->masterTimer()->unregisterDMXSource(this);
-    foreach (QSharedPointer<GenericFader> fader, m_fadersMap.values())
+    foreach (QSharedPointer<GenericFader> fader, m_fadersMap)
     {
         if (!fader.isNull())
             fader->requestDelete();


### PR DESCRIPTION
foreach(X x, map.values()) is semantically the same as foreach(X x, map) but does not create temporary list containter

from https://doc.qt.io/qt-6/foreach-keyword.html : With QMap and QHash, foreach accesses the value component of the (key, value) pairs automatically,
so you should not call values() on the container
(it would generate an unnecessary copy, see below).

also optimize few other obvious things:
use value(key, defaultValue) instead of calling contains() this way map is iterated just once (not twice)

call removeAll without calling contains() to reduce number of map iterations from 2 to 1. if map doesn't contain the key, removeAll() does not crash or puts everything on fire, it only iterates through the map, just like contains() would do