### PR TITLE
Prevent NPE with setEFXInterval(uint) after 'stop all functions' is hit

### DIFF
--- a/ui/src/virtualconsole/vcxypadarea.cpp
+++ b/ui/src/virtualconsole/vcxypadarea.cpp
@@ -265,7 +265,8 @@ void VCXYPadArea::setEFXPolygons(const QPolygonF &pattern, const QVector<QPolygo
 
 void VCXYPadArea::setEFXInterval(uint duration)
 {
-    m_previewArea->draw(duration / m_previewArea->polygonsCount());
+    if (m_previewArea != NULL)
+        m_previewArea->draw(duration / m_previewArea->polygonsCount());
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This was first reported [in the forum](https://forum.qlcplus.org/viewtopic.php?t=18302).