### PR TITLE
fix spelling mistakes

### DIFF
--- a/check-licenses.sh
+++ b/check-licenses.sh
@@ -23,11 +23,11 @@
 LICENSECHECK_BIN="$(which licensecheck 2> /dev/null)"
 #regex for ignore
 FILE_REGEX=""
-#array with file extentions to check
+#array with file extensions to check
 FILE_EXT[0]=""
 
 ##config
-#file extentions
+#file extensions
 FILE_EXT[0]="cpp"
 FILE_EXT[1]="c"
 FILE_EXT[2]="h"
@@ -37,7 +37,7 @@ FILE_EXT[5]="ui"
 #FILE_EXT[6]="xml"
 
 ##Functions
-#Join file extentions to group
+#Join file extensions to group
 function generate_regex {
  TMP_IFS="$IFS"
  local IFS="|"

--- a/engine/src/chaserstep.h
+++ b/engine/src/chaserstep.h
@@ -77,7 +77,7 @@ public:
      ***********************************************************************/
 public:
     /** Load ChaserStep contents from $root and return step index in $stepNumber.
-      * $doc is used to check fixture existance. If NULL the check is skipped */
+      * $doc is used to check fixture existence. If NULL the check is skipped */
     bool loadXML(QXmlStreamReader &root, int& stepNumber, Doc *doc);
 
     /** Save ChaserStep contents to $doc, with $stepNumber */

--- a/engine/src/doc.h
+++ b/engine/src/doc.h
@@ -268,7 +268,7 @@ public:
     /**
      * Replace the whole fixtures list with a new one.
      * This is done by remapping. Note that no signal is emitted to
-     * avoid loosing scenes and all the stuff connected to fixtures.
+     * avoid losing scenes and all the stuff connected to fixtures.
      * The caller must be aware on this and reassign all the QLC+ project
      * data previously created.
      *
@@ -537,7 +537,7 @@ public:
     quint32 nextFunctionID();
 
     /**
-     * Set the ID of a function to start everytime QLC+ goes
+     * Set the ID of a function to start every time QLC+ goes
      * in operate mode
      *
      * @param fid The ID of the function

--- a/engine/src/efxfixture.cpp
+++ b/engine/src/efxfixture.cpp
@@ -194,7 +194,7 @@ void EFXFixture::durationChanged()
             float(0), float(m_parent->loopDuration()));
 
     // Serial or Asymmetric propagation mode:
-    // we must substract the offset from the current position
+    // we must subtract the offset from the current position
     if (timeOffset())
     {
         if (m_elapsed < timeOffset())

--- a/engine/src/function.h
+++ b/engine/src/function.h
@@ -821,7 +821,7 @@ public:
      * actually stopped. To prevent deadlocks the function only waits for 2s.
      *
      * @return true if the function was stopped. false if the function did not
-     *              stop withing two seconds
+     *              stop within two seconds
      */
     bool stopAndWait();
 

--- a/engine/src/mastertimer-unix.cpp
+++ b/engine/src/mastertimer-unix.cpp
@@ -93,7 +93,7 @@ void MasterTimerPrivate::run()
     int nsTickTime = 1000000000L / mt->frequency();
 
     /* Allocate this from stack here so that GCC doesn't have
-       to do it everytime implicitly when gettimeofday() is called */
+       to do it every time implicitly when gettimeofday() is called */
     int ret = 0;
 
     /* Allocate all the memory at the start so we don't waste any time */

--- a/engine/src/mastertimer.h
+++ b/engine/src/mastertimer.h
@@ -240,7 +240,7 @@ private:
     bool m_beatRequested;
     /** The reference of a platform dependent timer to measure precise elapsed time */
     QElapsedTimer *m_beatTimer;
-    /** Time offset in milliseconds when the last beat occured */
+    /** Time offset in milliseconds when the last beat occurred */
     int m_lastBeatOffset;
 };
 

--- a/engine/src/scriptrunner.cpp
+++ b/engine/src/scriptrunner.cpp
@@ -172,7 +172,7 @@ bool ScriptRunner::write(MasterTimer *timer, QList<Universe *> universes)
             fc->setReady(false);
         }
     }
-    // if we don't have to wait and there are some funtions in the queue
+    // if we don't have to wait and there are some functions in the queue
     if (m_waitFunctionId == Function::invalidId() && m_functionQueue.count())
     {
         while (!m_functionQueue.isEmpty())

--- a/plugins/artnet/src/artnetplugin.cpp
+++ b/plugins/artnet/src/artnetplugin.cpp
@@ -452,7 +452,7 @@ void ArtNetPlugin::handlePacket(QByteArray const& datagram, QHostAddress const& 
             return;
         }
     }
-    // Packet comming from another subnet. This is an unusual case.
+    // Packet coming from another subnet. This is an unusual case.
     // We stop at the first controller that handles this packet.
     foreach (ArtNetIO io, m_IOmapping)
     {

--- a/plugins/dmxusb/src/dmxinterface.h
+++ b/plugins/dmxusb/src/dmxinterface.h
@@ -165,7 +165,7 @@ public:
     /**
      * Set the widget in "low latency mode". Some DMX controllers send DMX
      * frames at a much higher rate than the specified value. USB widget may
-     * have difficulties to read independant frames in this case and need
+     * have difficulties to read independent frames in this case and need
      * some configuration.
      *
      * @param lowLatency true for low latency, false otherwise

--- a/plugins/dummy/dummyplugin.cpp
+++ b/plugins/dummy/dummyplugin.cpp
@@ -139,7 +139,7 @@ void DummyPlugin::writeUniverse(quint32 universe, quint32 output, const QByteArr
      * data transmission. It is called at the rate of the QLC+ MasterTimer clock
      * and it should never block for more than 20ms.
      * If this plugin cannot predict the duration of a universe transmission,
-     * it is then safer to exchange data with a thread, running indipendently
+     * it is then safer to exchange data with a thread, running independently
      * and not risking to hang QLC+
      */
 }

--- a/plugins/interfaces/qlcioplugin.h
+++ b/plugins/interfaces/qlcioplugin.h
@@ -366,7 +366,7 @@ protected:
 
     /**
      * Remove a line from the universe map. If a universe has no lines at all
-     * it is removed completely from the map (thus loosing the custom parameters
+     * it is removed completely from the map (thus losing the custom parameters
      * as well)
      *
      * @param universe The QLC+ universe index of the patched $line

--- a/plugins/midi/src/common/midiplugin.cpp
+++ b/plugins/midi/src/common/midiplugin.cpp
@@ -383,7 +383,7 @@ void MidiPlugin::configure()
                     QLCIOPlugin::unSetParameter(universe, inLine, Input, MIDI_INITMESSAGE);
             }
             else
-                qDebug() << "[MIDI] coudln't find device for line:" << inLine;
+                qDebug() << "[MIDI] couldn't find device for line:" << inLine;
         }
 
         m_universesMap[universe].outputParameters.clear();
@@ -406,7 +406,7 @@ void MidiPlugin::configure()
                                               MIDI_INITMESSAGE, dev->midiTemplateName());
             }
             else
-                qDebug() << "[MIDI] coudln't find device for line:" << outLine;
+                qDebug() << "[MIDI] couldn't find device for line:" << outLine;
         }
     }
 }

--- a/plugins/ola/olaoutthread.cpp
+++ b/plugins/ola/olaoutthread.cpp
@@ -52,7 +52,7 @@ OlaOutThread::~OlaOutThread()
 /*
  * Start the OLA thread
  *
- * @return true if sucessfull, false otherwise
+ * @return true if successful, false otherwise
  */
 bool OlaOutThread::start(Priority priority)
 {

--- a/plugins/peperoni/unix/peperonidevice.cpp
+++ b/plugins/peperoni/unix/peperonidevice.cpp
@@ -568,7 +568,7 @@ void PeperoniDevice::outputDMX(quint32 line, const QByteArray& universe)
         /** universe number: Rodins only support index 0, DMX21 supports 0 and 1 */
         m_bulkBuffer.append(char(line - m_baseLine));
 
-        m_bulkBuffer.append(char(0x07)); /** lenght of data stage (512 + 7 bytes), LSB */
+        m_bulkBuffer.append(char(0x07)); /** length of data stage (512 + 7 bytes), LSB */
         m_bulkBuffer.append(char(0x02)); /** length of data state (512 + 7 bytes), MSB */
         m_bulkBuffer.append(char(PEPERONI_NEW_BULK_CONFIG_BLOCK      /** transmitter configuration: block while transmitter is busy */
                                | PEPERONI_NEW_BULK_CONFIG_FORCETX)); /** transmitter configuration: force transmission */

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -75,7 +75,7 @@ typedef struct
 {
     /** Reference to the fixture root item, for hierarchy walk and function calls */
     QEntity *m_rootItem;
-    /** Reference to the root item tranform component, to perform translations/rotations */
+    /** Reference to the root item transform component, to perform translations/rotations */
     Qt3DCore::QTransform *m_rootTransform;
     /** Reference to the arm entity used by moving heads */
     QEntity *m_armItem;

--- a/qmlui/palettemanager.cpp
+++ b/qmlui/palettemanager.cpp
@@ -169,7 +169,7 @@ void PaletteManager::deletePalettes(QVariantList list)
 
 void PaletteManager::addPaletteToNewScene(quint32 id, QString sceneName)
 {
-    // check for palette existance
+    // check for palette existence
     if (m_doc->palette(id) == nullptr)
         return;
 

--- a/qmlui/previewcontext.h
+++ b/qmlui/previewcontext.h
@@ -108,7 +108,7 @@ signals:
 protected:
     /** Reference to the current view window.
      *  If the context is not detached, this is equal to $m_mainView,
-     *  otherwise this is an indipendent view */
+     *  otherwise this is an independent view */
     QQuickView *m_view;
 
     /** Reference to the root QML view */

--- a/qmlui/showmanager.h
+++ b/qmlui/showmanager.h
@@ -307,7 +307,7 @@ private:
     /** Holds the currently selected Show items */
     QList<SelectedShowItem> m_selectedItems;
 
-    /** Holds the item currenly ready for pasting */
+    /** Holds the item currently ready for pasting */
     QList<SelectedShowItem> m_clipboard;
 };
 

--- a/qmlui/tardis/simplecrypt.h
+++ b/qmlui/tardis/simplecrypt.h
@@ -50,7 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   If you do not provide a key, or if something else is wrong, the encryption and
   decryption function will return an empty string or will return a string containing nonsense.
-  lastError() will return a value indicating if the method was succesful, and if not, why not.
+  lastError() will return a value indicating if the method was successful, and if not, why not.
 
   SimpleCrypt is prepared for the case that the encryption and decryption
   algorithm is changed in a later version, by prepending a version identifier to the cypertext.
@@ -81,7 +81,7 @@ public:
         ProtectionHash     /*!< A cryptographic hash is used to verify the integrity of the data. This method produces a much stronger, but longer check */
     };
     /**
-      Error describes the type of error that occured.
+      Error describes the type of error that occurred.
       */
     enum Error {
         ErrorNoError,         /*!< No error occurred. */
@@ -174,7 +174,7 @@ public:
       Decrypts a cyphertext string encrypted with this class with the set key back to the
       plain text version.
 
-      If an error occured, such as non-matching keys between encryption and decryption,
+      If an error occurred, such as non-matching keys between encryption and decryption,
       an empty string or a string containing nonsense may be returned.
       */
     QString decryptToString(const QString& cyphertext) ;
@@ -182,7 +182,7 @@ public:
       Decrypts a cyphertext string encrypted with this class with the set key back to the
       plain text version.
 
-      If an error occured, such as non-matching keys between encryption and decryption,
+      If an error occurred, such as non-matching keys between encryption and decryption,
       an empty string or a string containing nonsense may be returned.
       */
     QByteArray decryptToByteArray(const QString& cyphertext) ;
@@ -190,7 +190,7 @@ public:
       Decrypts a cyphertext binary encrypted with this class with the set key back to the
       plain text version.
 
-      If an error occured, such as non-matching keys between encryption and decryption,
+      If an error occurred, such as non-matching keys between encryption and decryption,
       an empty string or a string containing nonsense may be returned.
       */
     QString decryptToString(QByteArray cypher) ;
@@ -198,7 +198,7 @@ public:
       Decrypts a cyphertext binary encrypted with this class with the set key back to the
       plain text version.
 
-      If an error occured, such as non-matching keys between encryption and decryption,
+      If an error occurred, such as non-matching keys between encryption and decryption,
       an empty string or a string containing nonsense may be returned.
       */
     QByteArray decryptToByteArray(QByteArray cypher) ;

--- a/qmlui/virtualconsole/vcspeeddial.h
+++ b/qmlui/virtualconsole/vcspeeddial.h
@@ -145,7 +145,7 @@ private:
      * Dial absolute time
      *********************************************************************/
 public:
-    /* Get/Set the time range minumum value */
+    /* Get/Set the time range minimum value */
     uint timeMinimumValue() const;
     void setTimeMinimumValue(uint newTimeMinimumValue);
 

--- a/qmlui/virtualconsole/vcwidget.h
+++ b/qmlui/virtualconsole/vcwidget.h
@@ -610,7 +610,7 @@ protected:
      * @param h Loaded h position
      * @param visible Loaded visible status
      *
-     * @return true if succesful, otherwise false
+     * @return true if successful, otherwise false
      */
     bool loadXMLWindowState(QXmlStreamReader &root, int* x, int* y,
                             int* w, int* h, bool* visible);

--- a/qmlui/virtualconsole/virtualconsole.h
+++ b/qmlui/virtualconsole/virtualconsole.h
@@ -145,7 +145,7 @@ public:
     Q_INVOKABLE void setPageScale(qreal factor);
 
 signals:
-    /** Notify the listeners that the currenly selected VC page has changed */
+    /** Notify the listeners that the currently selected VC page has changed */
     void selectedPageChanged(int selectedPage);
 
     /** Notify the listener that some page names have changed */
@@ -209,7 +209,7 @@ public:
     Q_INVOKABLE QString widgetIcon(int type);
 
 signals:
-    /** Notify the listeners that the currenly selected VC widget has changed */
+    /** Notify the listeners that the currently selected VC widget has changed */
     void selectedWidgetChanged();
 
     void selectedWidgetsCountChanged();

--- a/resources/docs/html_en_EN/dmxdump.html
+++ b/resources/docs/html_en_EN/dmxdump.html
@@ -12,7 +12,7 @@
 <P>
 The DMX Dump functionality allows you to save the current DMX values that are being sent to the output universes
 at a particular moment. Basically it takes a "snapshot" of DMX channels and saves them for a later use.<br>
-DMX Dump can save values to a new <A HREF="concept.html#Scene">Scene</A> or overwite the values of an existing
+DMX Dump can save values to a new <A HREF="concept.html#Scene">Scene</A> or overwrite the values of an existing
 Scene. The "dumped" Scene can also be added to an existing
 <A HREF="concept.html#Chaser">Chaser</A>, Virtual Console <A HREF="vcbutton.html">button</A>
 or <A HREF="vcslider.html">slider</A><br><br>

--- a/resources/docs/html_en_EN/fixturedefinitioneditor.html
+++ b/resources/docs/html_en_EN/fixturedefinitioneditor.html
@@ -38,7 +38,7 @@ You are recommended to save them in the user fixtures folder. To find it, please
  </TR>
  <TR>
   <TD><IMG SRC="qrc:/fileopen.png"/></TD>
-  <TD>Open an existing fixture definiton. Opens the fixture definition in a Fixture Editor window.</TD>
+  <TD>Open an existing fixture definition. Opens the fixture definition in a Fixture Editor window.</TD>
  </TR>
  <TR>
   <TD><IMG SRC="qrc:/filesave.png"/></TD>

--- a/resources/docs/html_en_EN/fixturemonitor.html
+++ b/resources/docs/html_en_EN/fixturemonitor.html
@@ -240,7 +240,7 @@ Gray dots show PAN/TILT ranges. Zero (middle of the range) is at the bottom.
 </P>
 
 <P>
-In the folowing picture PAN range is 660 degrees and tilt range is 300 degrees. Pan is at counter-clockwise end (-330 deg) and tilt is at -150 deg.
+In the following picture PAN range is 660 degrees and tilt range is 300 degrees. Pan is at counter-clockwise end (-330 deg) and tilt is at -150 deg.
 </P>
 
 <IMG src="../images/pan-tilt.png" />

--- a/resources/docs/html_en_EN/howto-input-profiles.html
+++ b/resources/docs/html_en_EN/howto-input-profiles.html
@@ -162,7 +162,7 @@ QLC+ will adjust the heads from their current positions. The direction will depe
 from your external controller. The relative movement will stop when the external controller
 will return to its origin. Joysticks have a spring for that.<br>
 In addition to this, the Input Profile Editor Relative setting allows you to set a <b>Sensitivity</b>
-parameter that will instruct QLC+ about the strenght of your external controller movements.
+parameter that will instruct QLC+ about the strength of your external controller movements.
 The higher this value is, the slower the movements will occur. The lower, the faster.
 </P>
 <HR>

--- a/resources/docs/html_en_EN/midiplugin.html
+++ b/resources/docs/html_en_EN/midiplugin.html
@@ -46,7 +46,7 @@ Each line has three options that can be changed depending on your needs:
       </li>
      </ul>
  </li>
- <li><b>Initialization message</b>: This is a list of presets (templates) containing the intialization message
+ <li><b>Initialization message</b>: This is a list of presets (templates) containing the initialization message
         that QLC+ will send when opening a MIDI device before using it. A detailed explanation of this functionality
         is written below.
  </li>

--- a/resources/docs/html_en_EN/scripteditor.html
+++ b/resources/docs/html_en_EN/scripteditor.html
@@ -89,7 +89,7 @@ Each line of a script will be executed by QLC+ in a sequential order.
     </LI>
     <LI><IMG SRC="qrc:/fileopen.png" width=24 align="absmiddle"> <B>File Path</B>: Open a file dialog
       to select a file. The absolute path and the file name will be insterted at the editor current position.<br>
-      If a path contains spaces, it will be writen within quotes
+      If a path contains spaces, it will be written within quotes
     </LI>
    </UL>
   </TD>

--- a/resources/docs/html_en_EN/showmanager.html
+++ b/resources/docs/html_en_EN/showmanager.html
@@ -302,6 +302,6 @@ depending on your needs.<br>
 
 <H2>And finally...play! <IMG SRC="qrc:/player_play.png"></H2>
 When a complete show has finally been created, it can be played just by clicking on the Play icon.<br>
-Playback always starts from the current cursor postion. The cursor position can be changed by clicking on the time line.
+Playback always starts from the current cursor position. The cursor position can be changed by clicking on the time line.
 </BODY>
 </HTML>

--- a/resources/docs/html_ja_JP/howto-input-profiles.html
+++ b/resources/docs/html_ja_JP/howto-input-profiles.html
@@ -162,7 +162,7 @@ QLC+ will adjust the heads from their current positions. The direction will depe
 from your external controller. The relative movement will stop when the external controller
 will return to its origin. Joysticks have a spring for that.<br>
 In addition to this, the Input Profile Editor Relative setting allows you to set a <b>Sensitivity</b>
-parameter that will instruct QLC+ about the strenght of your external controller movements.
+parameter that will instruct QLC+ about the strength of your external controller movements.
 The higher this value is, the slower the movements will occur. The lower, the faster.
 </P>
 <HR>

--- a/resources/fixtures/American_DJ/American-DJ-COB-Cannon-Wash-ST.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-COB-Cannon-Wash-ST.qxf
@@ -108,7 +108,7 @@
   <Capability Min="101" Max="120">Stage 2</Capability>
   <Capability Min="121" Max="255">Default to unit setting</Capability>
  </Channel>
- <Channel Name="Program Selction Mode">
+ <Channel Name="Program Selection Mode">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="51">Standard Dim</Capability>
   <Capability Min="52" Max="102">Color Macro</Capability>
@@ -196,7 +196,7 @@
   <Channel Number="4">Shutter / Strobe</Channel>
   <Channel Number="5">Master dimmer</Channel>
   <Channel Number="6">Master dimmer fine</Channel>
-  <Channel Number="7">Program Selction Mode</Channel>
+  <Channel Number="7">Program Selection Mode</Channel>
   <Channel Number="8">Color Jump/Color Dream/Sound Active</Channel>
   <Channel Number="9">Speed / Sensitivity</Channel>
  </Mode>
@@ -208,7 +208,7 @@
   <Channel Number="4">Shutter / Strobe</Channel>
   <Channel Number="5">Master dimmer</Channel>
   <Channel Number="6">Master dimmer fine</Channel>
-  <Channel Number="7">Program Selction Mode</Channel>
+  <Channel Number="7">Program Selection Mode</Channel>
   <Channel Number="8">Color Jump/Color Dream/Sound Active</Channel>
   <Channel Number="9">Speed / Sensitivity</Channel>
   <Channel Number="10">Dimming Modes</Channel>

--- a/resources/fixtures/Cameo/Cameo-Storm.qxf
+++ b/resources/fixtures/Cameo/Cameo-Storm.qxf
@@ -97,9 +97,9 @@
  </Channel>
  <Channel Name="Laser pattern and rotation">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="4" Preset="RotationStop">No movment</Capability>
+  <Capability Min="0" Max="4" Preset="RotationStop">No movement</Capability>
   <Capability Min="5" Max="127" Preset="RotationClockwiseFastToSlow">Rotation forward fast-slow</Capability>
-  <Capability Min="128" Max="133" Preset="RotationStop">No movment</Capability>
+  <Capability Min="128" Max="133" Preset="RotationStop">No movement</Capability>
   <Capability Min="134" Max="255" Preset="RotationCounterClockwiseSlowToFast">Rotation reverse slow-fast</Capability>
  </Channel>
  <Channel Name="Auto Mode">

--- a/resources/fixtures/Cameo/Cameo-TS-40-WW.qxf
+++ b/resources/fixtures/Cameo/Cameo-TS-40-WW.qxf
@@ -21,7 +21,7 @@
   <Capability Min="0" Max="5">No function</Capability>
   <Capability Min="6" Max="63">Linear dimmer curve</Capability>
   <Capability Min="64" Max="127">Exponential dimmer curve</Capability>
-  <Capability Min="128" Max="191">Logarythmic dimmer curve</Capability>
+  <Capability Min="128" Max="191">Logarithmic dimmer curve</Capability>
   <Capability Min="192" Max="255">S-curve dimmer curve</Capability>
  </Channel>
  <Channel Name="Device Settings">

--- a/resources/fixtures/Cameo/Cameo-TS-60-RGBW.qxf
+++ b/resources/fixtures/Cameo/Cameo-TS-60-RGBW.qxf
@@ -61,7 +61,7 @@
   <Capability Min="0" Max="5">No function</Capability>
   <Capability Min="6" Max="63">Linear dimmer curve</Capability>
   <Capability Min="64" Max="127">Exponential dimmer curve</Capability>
-  <Capability Min="128" Max="191">Logarythmic dimmer curve</Capability>
+  <Capability Min="128" Max="191">Logarithmic dimmer curve</Capability>
   <Capability Min="192" Max="255">S-curve dimmer curve</Capability>
  </Channel>
  <Channel Name="Device Settings">

--- a/resources/fixtures/Chauvet/Chauvet-SlimPAR-Pro-H-USB.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-SlimPAR-Pro-H-USB.qxf
@@ -15,7 +15,7 @@
  <Channel Name="UV" Preset="IntensityUV"/>
  <Channel Name="Color Macros">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="15">No funtion</Capability>
+  <Capability Min="0" Max="15">No function</Capability>
   <Capability Min="16" Max="255">Color macros</Capability>
  </Channel>
  <Channel Name="Speed/Sensitivity">

--- a/resources/fixtures/Chauvet/Chauvet-SlimPAR-Q12-USB.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-SlimPAR-Q12-USB.qxf
@@ -15,7 +15,7 @@
  <Channel Name="Amber" Preset="IntensityAmber"/>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="15">No funtion</Capability>
+  <Capability Min="0" Max="15">No function</Capability>
   <Capability Min="16" Max="255">Color macros</Capability>
  </Channel>
  <Channel Name="Strobe/Speed/Sensitivity">

--- a/resources/fixtures/Chauvet/Chauvet-SlimPAR-QUV12-USB.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-SlimPAR-QUV12-USB.qxf
@@ -15,7 +15,7 @@
  <Channel Name="UV" Preset="IntensityUV"/>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="15">No funtion</Capability>
+  <Capability Min="0" Max="15">No function</Capability>
   <Capability Min="16" Max="255">Color macros</Capability>
  </Channel>
  <Channel Name="Strobe/Speed/Sensitivity">

--- a/resources/fixtures/Chauvet/Chauvet-SlimPAR-T6-USB.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-SlimPAR-T6-USB.qxf
@@ -14,7 +14,7 @@
  <Channel Name="Blue" Preset="IntensityBlue"/>
  <Channel Name="Color Macro">
   <Group Byte="0">Colour</Group>
-  <Capability Min="0" Max="15">No funtion</Capability>
+  <Capability Min="0" Max="15">No function</Capability>
   <Capability Min="16" Max="255">Color macros</Capability>
  </Channel>
  <Channel Name="Mode">

--- a/resources/fixtures/Coemar/Coemar-LEDko-FullSpectrum-6.qxf
+++ b/resources/fixtures/Coemar/Coemar-LEDko-FullSpectrum-6.qxf
@@ -106,7 +106,7 @@
   <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
   <Capability Min="0" Max="9">no effect</Capability>
-  <Capability Min="10" Max="123">exalts the green color in the mixing ans diminishes the presence of magenta</Capability>
+  <Capability Min="10" Max="123">exalts the green color in the mixing and diminishes the presence of magenta</Capability>
   <Capability Min="124" Max="132">no effect</Capability>
   <Capability Min="133" Max="246">diminishes the presence of green in the mixing and exalts the magenta color</Capability>
   <Capability Min="247" Max="255">no effect</Capability>

--- a/resources/fixtures/Elation/Elation-E-Spot-III.qxf
+++ b/resources/fixtures/Elation/Elation-E-Spot-III.qxf
@@ -108,7 +108,7 @@
   <Group Byte="0">Speed</Group>
   <Capability Min="0" Max="225">Max to min speed</Capability>
   <Capability Min="226" Max="235">Blackout with pan and tilt movement</Capability>
-  <Capability Min="236" Max="245">Blackout whith all wheel movement</Capability>
+  <Capability Min="236" Max="245">Blackout with all wheel movement</Capability>
   <Capability Min="246" Max="255">No function</Capability>
  </Channel>
  <Channel Name="Special Functions">

--- a/resources/fixtures/Elation/Elation-Vision-250.qxf
+++ b/resources/fixtures/Elation/Elation-Vision-250.qxf
@@ -74,7 +74,7 @@
   <Capability Min="127" Max="128">No rotation</Capability>
   <Capability Min="129" Max="255">Backwards rotation from slow to fast</Capability>
  </Channel>
- <Channel Name="Rotating gobos; continous rotation">
+ <Channel Name="Rotating gobos; continuous rotation">
   <Group Byte="0">Gobo</Group>
   <Capability Min="0" Max="31">Open</Capability>
   <Capability Min="32" Max="63">Rotation gobo 1 (dichroic)</Capability>
@@ -118,7 +118,7 @@
   <Channel Number="7">No function</Channel>
   <Channel Number="8">Frost, correction filters, 3-facet prism, Macros</Channel>
   <Channel Number="9">3-facet prism rotation control</Channel>
-  <Channel Number="10">Rotating gobos; continous rotation</Channel>
+  <Channel Number="10">Rotating gobos; continuous rotation</Channel>
   <Channel Number="11">Rotating gobo indexing, rotating gobo rotation</Channel>
   <Channel Number="12">No function 2</Channel>
   <Channel Number="13">Focus</Channel>

--- a/resources/fixtures/GTD/GTD-LM150-Spot.qxf
+++ b/resources/fixtures/GTD/GTD-LM150-Spot.qxf
@@ -63,9 +63,9 @@
  <Channel Name="Prism Rotation">
   <Group Byte="0">Prism</Group>
   <Capability Min="0" Max="127" Preset="RotationIndexed">Prism Indexed</Capability>
-  <Capability Min="128" Max="187" Preset="RotationClockwiseFastToSlow">Prism continous rotation CW from slow to fast</Capability>
+  <Capability Min="128" Max="187" Preset="RotationClockwiseFastToSlow">Prism continuous rotation CW from slow to fast</Capability>
   <Capability Min="188" Max="195" Preset="RotationStop">Stop</Capability>
-  <Capability Min="196" Max="255" Preset="RotationCounterClockwiseSlowToFast">Prism continous rotation CCW from slow to fast</Capability>
+  <Capability Min="196" Max="255" Preset="RotationCounterClockwiseSlowToFast">Prism continuous rotation CCW from slow to fast</Capability>
  </Channel>
  <Channel Name="Pan" Preset="PositionPan"/>
  <Channel Name="Tilt" Preset="PositionTilt"/>

--- a/resources/fixtures/KOOLlight/KOOLlight-3D-RGB-Laser.qxf
+++ b/resources/fixtures/KOOLlight/KOOLlight-3D-RGB-Laser.qxf
@@ -203,10 +203,10 @@
   <Capability Min="0" Max="10">Without change</Capability>
   <Capability Min="11" Max="74">Manual adjust rotation</Capability>
   <Capability Min="75" Max="104">Auto drawing (add)</Capability>
-  <Capability Min="105" Max="144">Auto drawing (substract)</Capability>
+  <Capability Min="105" Max="144">Auto drawing (subtract)</Capability>
   <Capability Min="145" Max="184">Auto drawing (cycle)</Capability>
   <Capability Min="185" Max="224">Auto end to end drawing (add)</Capability>
-  <Capability Min="225" Max="255">Auto end to end drawing (substract)</Capability>
+  <Capability Min="225" Max="255">Auto end to end drawing (subtract)</Capability>
  </Channel>
  <Channel Name="Waving">
   <Group Byte="0">Effect</Group>

--- a/resources/fixtures/Robe/Robe-ParFect-150.qxf
+++ b/resources/fixtures/Robe/Robe-ParFect-150.qxf
@@ -124,7 +124,7 @@
  <Channel Name="Color mix control" Default="255">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="9">virtual color weel has priority</Capability>
-  <Capability Min="10" Max="19">MAX mode higest value has priority</Capability>
+  <Capability Min="10" Max="19">MAX mode highest value has priority</Capability>
   <Capability Min="20" Max="29">LOW mode lowest value has priority</Capability>
   <Capability Min="30" Max="39">multiply mode</Capability>
   <Capability Min="40" Max="49">addition mode</Capability>

--- a/resources/fixtures/Showtec/Showtec-Acrobat.qxf
+++ b/resources/fixtures/Showtec/Showtec-Acrobat.qxf
@@ -76,14 +76,14 @@
  <Channel Name="Channel Functions">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="7">No function</Capability>
-  <Capability Min="8" Max="15">Blackout during Pan / Tilt movment</Capability>
-  <Capability Min="16" Max="23">Disable Blackout during Pan / Tilt movment</Capability>
-  <Capability Min="24" Max="31">Blackout during Colourwheel movment</Capability>
-  <Capability Min="32" Max="39">Disable Blackout during Colourwheel movment</Capability>
-  <Capability Min="40" Max="47">Blackout during Static, Gobowheel movment</Capability>
-  <Capability Min="48" Max="55">Disable Blackout during Static, Gobowheel movment</Capability>
+  <Capability Min="8" Max="15">Blackout during Pan / Tilt movement</Capability>
+  <Capability Min="16" Max="23">Disable Blackout during Pan / Tilt movement</Capability>
+  <Capability Min="24" Max="31">Blackout during Colourwheel movement</Capability>
+  <Capability Min="32" Max="39">Disable Blackout during Colourwheel movement</Capability>
+  <Capability Min="40" Max="47">Blackout during Static, Gobowheel movement</Capability>
+  <Capability Min="48" Max="55">Disable Blackout during Static, Gobowheel movement</Capability>
   <Capability Min="56" Max="87">No function</Capability>
-  <Capability Min="88" Max="95">Disable Blackout during all movment actions</Capability>
+  <Capability Min="88" Max="95">Disable Blackout during all movement actions</Capability>
   <Capability Min="96" Max="103">Reset Pan / Tilt after 5 seconds</Capability>
   <Capability Min="104" Max="111">No function</Capability>
   <Capability Min="112" Max="119">Reset Colourwheel after 5 seconds</Capability>

--- a/resources/fixtures/Stairville/StairVille-MH-z720.qxf
+++ b/resources/fixtures/Stairville/StairVille-MH-z720.qxf
@@ -71,7 +71,7 @@
  <Channel Name="Special Settings">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="9">Without function</Capability>
-  <Capability Min="10" Max="14">Blackout during Pan or Tilt movment</Capability>
+  <Capability Min="10" Max="14">Blackout during Pan or Tilt movement</Capability>
   <Capability Min="15" Max="49">Without function</Capability>
   <Capability Min="50" Max="54">Rotation position reset</Capability>
   <Capability Min="55" Max="59">Inclination position reset</Capability>
@@ -173,7 +173,7 @@
   <Capability Min="208" Max="229">Gradual colour change in descending order, fash to slow</Capability>
   <Capability Min="230" Max="234">Dark</Capability>
   <Capability Min="235" Max="249">Stepped colour change in ascending order, fast to slow</Capability>
-  <Capability Min="250" Max="255">Sound controled colour changing</Capability>
+  <Capability Min="250" Max="255">Sound controlled colour changing</Capability>
  </Channel>
  <Mode Name="14 Channel">
   <Channel Number="0">Rotation</Channel>

--- a/resources/fixtures/Stairville/Stairville-Quad-Par-Profile-RGBW-5x8W.qxf
+++ b/resources/fixtures/Stairville/Stairville-Quad-Par-Profile-RGBW-5x8W.qxf
@@ -17,7 +17,7 @@
  <Channel Name="Macro">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="0">Manual mode</Capability>
-  <Capability Min="1" Max="24">Constant color controled by Ch. 7</Capability>
+  <Capability Min="1" Max="24">Constant color controlled by Ch. 7</Capability>
   <Capability Min="25" Max="49">Automatic show 1</Capability>
   <Capability Min="50" Max="74">Automatic show 2</Capability>
   <Capability Min="75" Max="99">Automatic show 3</Capability>

--- a/resources/fixtures/Varytec/Varytec-Hero-Wash-300-FC.qxf
+++ b/resources/fixtures/Varytec/Varytec-Hero-Wash-300-FC.qxf
@@ -156,14 +156,14 @@
  </Channel>
  <Channel Name="Segment pattern 1 to 18 (1 to 6 static, 7 to 18 dynamic)">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="5">No fucntion</Capability>
+  <Capability Min="0" Max="5">No function</Capability>
   <Capability Min="6" Max="15">Static segment pattern 1</Capability>
   <Capability Min="16" Max="25">Static segment pattern 2</Capability>
   <Capability Min="26" Max="35">Static segment pattern 3</Capability>
   <Capability Min="36" Max="45">Static segment pattern 4</Capability>
   <Capability Min="46" Max="55">Static segment pattern 5</Capability>
   <Capability Min="56" Max="65">Static segment pattern 6</Capability>
-  <Capability Min="66" Max="75">No Fucntion</Capability>
+  <Capability Min="66" Max="75">No function</Capability>
   <Capability Min="76" Max="90">Dynamic segment pattern 7</Capability>
   <Capability Min="91" Max="105">Dynamic segment pattern 8</Capability>
   <Capability Min="106" Max="120">Dynamic segment pattern 9</Capability>

--- a/resources/fixtures/scripts/update-fixture-map.rb
+++ b/resources/fixtures/scripts/update-fixture-map.rb
@@ -4,7 +4,7 @@
 # Run it every time some fixtures are added to this folder.
 # The packages 'ruby' and 'ruby-libxml' are required to run this
 
-# When invoked with addtional parameter (filename), it will create
+# When invoked with additional parameter (filename), it will create
 # HTML overview of the fixtures e.g. ./update-fixtures-map.rb index.html
 
 # rubocop: disable Style/Documentation, Metrics/MethodLength

--- a/ui/src/rdmmanager.ui
+++ b/ui/src/rdmmanager.ui
@@ -172,7 +172,7 @@
         <item row="0" column="1">
          <widget class="QLineEdit" name="m_pidEdit">
           <property name="toolTip">
-           <string extracomment="Enter a PID eiter in hex or decimal format"/>
+           <string extracomment="Enter a PID either in hex or decimal format"/>
           </property>
          </widget>
         </item>

--- a/ui/src/showmanager/trackitem.h
+++ b/ui/src/showmanager/trackitem.h
@@ -61,7 +61,7 @@ public:
     /** Set the track name */
     void setName(QString name);
 
-    /** Enable/disable active state which higlight the left bar */
+    /** Enable/disable active state which highlights the left bar */
     void setActive(bool flag);
 
     /** Return if this track is active or not */

--- a/ui/src/virtualconsole/vcpropertieseditor.h
+++ b/ui/src/virtualconsole/vcpropertieseditor.h
@@ -95,7 +95,7 @@ protected slots:
      * Grand Master page
      *************************************************************************/
 private slots:
-    void slotGrandMasterVisibleToggled(bool checkeck);
+    void slotGrandMasterVisibleToggled(bool checked);
     void slotGrandMasterIntensityToggled(bool checked);
     void slotGrandMasterReduceToggled(bool checked);
     void slotGrandMasterSliderNormalToggled(bool checked);

--- a/ui/src/virtualconsole/vcwidget.h
+++ b/ui/src/virtualconsole/vcwidget.h
@@ -547,7 +547,7 @@ protected:
      *
      * @param doc A QXmlStreamReader to save the tag to
      *
-     * @return true if succesful, otherwise false
+     * @return true if successful, otherwise false
      */
     bool saveXMLWindowState(QXmlStreamWriter *doc);
 
@@ -561,7 +561,7 @@ protected:
      * @param h Loaded h position
      * @param visible Loaded visible status
      *
-     * @return true if succesful, otherwise false
+     * @return true if successful, otherwise false
      */
     bool loadXMLWindowState(QXmlStreamReader &tag, int* x, int* y,
                             int* w, int* h, bool* visible);

--- a/ui/src/virtualconsole/vcxypadproperties.cpp
+++ b/ui/src/virtualconsole/vcxypadproperties.cpp
@@ -884,7 +884,7 @@ void VCXYPadProperties::slotMoveUpPresetClicked()
     quint8 newID = moveUpPreset(ctlID);
     updatePresetsTree();
 
-    //select item on new position. User can make multiple move up/down without need to select item everytime.
+    //select item on new position. User can make multiple move up/down without need to select item every time.
     selectItemOnPresetsTree(newID);
 }
 
@@ -897,7 +897,7 @@ void VCXYPadProperties::slotMoveDownPresetClicked()
     quint8 newID =moveDownPreset(ctlID);
     updatePresetsTree();
 
-    //select item on new position. User can make multiple move up/down without need to select item everytime.
+    //select item on new position. User can make multiple move up/down without need to select item every time.
     selectItemOnPresetsTree(newID);
 }
 

--- a/webaccess/res/keypad.html
+++ b/webaccess/res/keypad.html
@@ -244,7 +244,7 @@ function chans_vals(c)
   // Main function. Split command at "AT" string.
   // Left part are single channel number, a range of channels and optionally a step value.
   // Right part are a single value, a range of values and optionally a step value.
-  // Calls to chval fucntion to evaluate channels numbers and values.
+  // Calls to chval function to evaluate channels numbers and values.
   // Arrange it on an array used later to assign channels values
   // calling setChannel function in a loop
     //console.log(c);

--- a/webaccess/src/qhttpserver/http_parser.c
+++ b/webaccess/src/qhttpserver/http_parser.c
@@ -1850,7 +1850,7 @@ reexecute:
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
          * will interpret that as saying that this message has no body. This
-         * is needed for the annoying case of recieving a response to a HEAD
+         * is needed for the annoying case of receiving a response to a HEAD
          * request.
          *
          * We'd like to use CALLBACK_NOTIFY_NOADVANCE() here but we cannot, so

--- a/webaccess/src/qhttpserver/qhttpconnection.cpp
+++ b/webaccess/src/qhttpserver/qhttpconnection.cpp
@@ -403,7 +403,7 @@ void QHttpConnection::slotWebSocketPollTimeout()
 
 void QHttpConnection::webSocketWrite(const QString &message)
 {
-    qDebug() << "[webSocketWrite] message lenght:" << message.size() << "message:" << message;
+    qDebug() << "[webSocketWrite] message length:" << message.size() << "message:" << message;
 
     if (m_webSocket)
         m_webSocket->sendTextMessage(message);

--- a/webaccess/src/webaccessnetwork.cpp
+++ b/webaccess/src/webaccessnetwork.cpp
@@ -195,7 +195,7 @@ void WebAccessNetwork::refreshConnectionsList()
     m_interfaces.clear();
     resetInterface(&currInterface);
 
-    // execute "nmcli -t device status" to list all avilable devices
+    // execute "nmcli -t device status" to list all available devices
     QStringList devStatusOutput = getNmcliOutput(QStringList() << "-t" << "device" << "status");
 
     foreach (QString dLine, devStatusOutput)


### PR DESCRIPTION
While reading the changes of the recent #1721, I noticed [this typo](https://github.com/mcallegari/qlcplus/pull/1721/files#diff-104f7c3a29fcb24a8470b91c92858cdd48ddb83602a70f6793418afd149f666c) in one of the header files and took the opportunity to check the entire source code tree for common English spelling mistakes.

Therefore, this PR does not contain any cool new features, but just helps to make the source code a little more readable.