### PR TITLE
Do not updateStepColor() with 1-too-high step count

### DIFF
--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -1434,10 +1434,17 @@ void RGBMatrixEditor::slotSaveToSequenceClicked()
 
             sequence->addStep(step);
             currentStep += increment;
-            if (currentStep == totalSteps && m_matrix->runOrder() == RGBMatrix::PingPong)
+            if (currentStep == totalSteps)
             {
-                currentStep = totalSteps - 2;
-                increment = -1;
+                if (m_matrix->runOrder() == RGBMatrix::PingPong)
+                {
+                    currentStep = totalSteps - 2;
+                    increment = -1;
+                }
+                else
+                {
+                    currentStep = 0;
+                }
             }
             m_previewHandler->updateStepColor(currentStep, m_matrix->getColor(0), m_matrix->stepsCount());
         }


### PR DESCRIPTION
During the "RGB Matrix to sequence" logic, while looping through the RGB Matrix, everything is ok. But the last step of the loop will try to set `currentStep` to a value that is 1 too high. This will in turn cause QLC+ to try to set colors to values out of range 0 <= c < 256, causing errors in the console.