### PR TITLE
Update m_columnSpin when m_compCombo or m_16bitCheck change

### DIFF
--- a/ui/src/addrgbpanel.h
+++ b/ui/src/addrgbpanel.h
@@ -80,7 +80,7 @@ private:
 
 protected slots:
     void slotUniverseChanged();
-    void slotComponentsChanged(int index);
+    void slotComponentsChanged();
     void slotAddressChanged();
     void slotSizeChanged(int val);
 


### PR DESCRIPTION
We now include the 16bit checkbox in the calculation of the maximum amount of columns.
We also set the value of m_columnSpin to the maximum if its current value is over the new maximum.