### PR TITLE
webaccess: fix regression introduced by PR #1721

### DIFF
--- a/webaccess/res/virtualconsole.css
+++ b/webaccess/res/virtualconsole.css
@@ -522,27 +522,3 @@ input[type="color"].vMatrix {
  cursor: pointer;
  border: solid 1px;
 }
-
-#vc {
- display: flex;
- flex-direction: row;
- width: 100%;
- height: calc(100vh - 40px); /* Minus controlBar height */
-}
-
-#vcScrollContainer {
- overflow: auto;
-}
-
-#vcGM {
- height: calc(100vh - 40px);
- width: 40px;
- background-color: #ccc;
- display: flex;
- flex-direction: column;
- justify-content: space-between;
-}
-
-#vcGM .vcslLabel {
- height: auto;
-}

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -2332,9 +2332,6 @@ void WebAccess::slotGrandMasterValueChanged(uchar value)
 
 QString WebAccess::getGrandMasterSliderHTML()
 {
-    if (!m_vc->properties().grandMasterVisible())
-        return "";
-
     GrandMaster::ValueMode gmValueMode = m_vc->properties().grandMasterValueMode();
     GrandMaster::SliderMode gmSliderMode = m_vc->properties().grandMasterSliderMode();
     uchar gmValue = m_doc->inputOutputMap()->grandMasterValue();
@@ -2350,7 +2347,8 @@ QString WebAccess::getGrandMasterSliderHTML()
         gmDisplayValue = QString("%1%").arg(p, 2, 10, QChar('0'));
     }
 
-    QString str = "<div id=\"vcGM\">";
+    QString str = "<div class=\"vcslider\" style=\"width: 100%; height: 100%;\">\n";
+    str += "<div style=\"height: 100%; display: flex; flex-direction: column; justify-content: space-between; \">";
     str += "<div class=\"vcslLabel\" id=\"vcGMSliderLabel\">"+gmDisplayValue+"</div>\n";
 
     int rotate = gmSliderMode == GrandMaster::SliderMode::Inverted ? 90 : 270;
@@ -2366,6 +2364,7 @@ QString WebAccess::getGrandMasterSliderHTML()
                 "min=\""+QString::number(min)+"\" max=\""+QString::number(max)+"\" "
                 "step=\"1\" value=\"" + QString::number(gmValue) + "\">\n";
     str += "<div class=\"vcslLabel\">GM</div>";
+    str += "</div>\n";
     str += "</div>\n";
 
     connect(m_doc->inputOutputMap(), SIGNAL(grandMasterValueChanged(uchar)),
@@ -2391,7 +2390,7 @@ QString WebAccess::getVCHTML()
 				"<input id=\"submitTrigger\" type=\"submit\"/>\n"
             "</form>\n"
 
-            "<div class=\"controlBar\">\n"
+            "<div class=\"controlBar\" style=\"position: fixed; top: 0; left: 0; z-index: 1;\">\n"
             "<a class=\"button button-blue\" href=\"javascript:document.getElementById('loadTrigger').click();\">\n"
             "<span>" + tr("Load project") + "</span></a>\n"
 
@@ -2402,21 +2401,22 @@ QString WebAccess::getVCHTML()
             "<div class=\"swInfo\">" + QString(APPNAME) + " " + QString(APPVERSION) + "</div>"
             "</div>\n";
 
-    widgetsHTML += "<div id=\"vc\">\n";
-    widgetsHTML += getGrandMasterSliderHTML();
-    widgetsHTML += "<div id=\"vcScrollContainer\">\n";
+    QString mainLeft;
+    if (m_vc->properties().grandMasterVisible())
+    {
+        widgetsHTML += "<div style=\"height: calc(100vh - 60px); position: fixed; top: 40px; left: 0; width: 40px; background-color: #ccc; z-index: 1;\">"+getGrandMasterSliderHTML()+"</div>";
+        mainLeft = "left: 40px;";
+    }
     widgetsHTML += "<div style=\"position: relative; "
             "width: " + QString::number(mfSize.width()) +
             "px; height: " + QString::number(mfSize.height()) + "px; "
-            "background-color: " + mainFrame->backgroundColor().name() + ";\">\n";
+            "background-color: " + mainFrame->backgroundColor().name() + "; top: 40px; " + mainLeft + "\">\n";
 
     widgetsHTML += getChildrenHTML(mainFrame, 0, 0);
 
-    widgetsHTML += "</div>\n";
-    widgetsHTML += "</div>\n";
     m_JScode += "\n</script>\n";
 
-    QString str = HTML_HEADER + m_CSScode + "</head>\n<body>\n" + widgetsHTML + "</div>\n" + m_JScode + "\n</body></html>";
+    QString str = HTML_HEADER + m_CSScode + "</head>\n<body>\n" + widgetsHTML + "</div>\n</body>\n" + m_JScode + "</html>";
     return str;
 }
 


### PR DESCRIPTION
GM master, when visible, occupied 100% of screen width

This PR basically reverts HTML code changes,
and reimplements hiding of GM in a less intrusive way

![qlc_webaccess_good](https://github.com/user-attachments/assets/7ad4219f-b2d2-4998-a9a7-dbea546ad29e)
![qlc_webaccess_bad](https://github.com/user-attachments/assets/2a445ec2-6bd2-4587-bb27-38315d9558da)
