### PR TITLE
Fix hanging connections because maxPendingConnections is reached

### DIFF
--- a/webaccess/src/qhttpserver/qhttpserver.cpp
+++ b/webaccess/src/qhttpserver/qhttpserver.cpp
@@ -141,6 +141,4 @@ void CustomTcpServer::incomingConnection(qintptr handle)
             this, SIGNAL(webSocketDataReady(QHttpConnection*,QString)));
     connect(connection, SIGNAL(webSocketConnectionClose(QHttpConnection*)),
             this, SIGNAL(webSocketConnectionClose(QHttpConnection*)));
-
-    addPendingConnection(socket);
 }


### PR DESCRIPTION
The bug in question:
Open QLC+ using `--web`, start a browser and navigate to `http://localhost:9999`, then start refreshing bypassing the browsers cache using CTRL+SHIFT+R. After some attempts you will see that the browser's connection starts hanging.

The reason for this is that every connection is added to the list of "pending connections", and this list is finite. By default, it's 30 positions. So after 30 connections (with every page request using multiple connections), things get clogged up.

The solution:
Since QLC+ doesn't use pending connections in `QHttpServer` (there is no call to `m_tcpServer->nextPendingConnection()`), it is no problem to remove support for that.

Either that, or we should call nextPendingConnection() for every connection we add with addPendingConnection(QTcpSocket*). But I wasn't sure where to do that call.
