### PR TITLE
Starting m_tapTickTimer with a 0ms interval makes for a busy-wait loop

### DIFF
--- a/ui/src/speeddial.cpp
+++ b/ui/src/speeddial.cpp
@@ -286,7 +286,9 @@ void SpeedDial::updateTapTimer()
             m_tapTickElapseTimer->setInterval(200);
         else
             m_tapTickElapseTimer->setInterval(m_value / 3);
-        m_tapTickTimer->start();
+
+        if (m_tapTickTimer->interval() > 0)
+            m_tapTickTimer->start();
     }
 }
 


### PR DESCRIPTION
If you do, dialogs (Save As, QColorPicker, etc) do not show anymore. Probably the main event loop is "a little busy" with the timer.

To reproduce:
- build using Qt5,
- add SpeedDial widget (default value is 0ms, leave it at that)
- save workspace
- load workspace (causing VCSpeedDial::loadXML(QXmlStreamReader &root) → SpeedDial::setValue(int ms, bool emitValue) →
SpeedDial::updateTapTimer()
- try to open a Save As dialog or a color picker