### PR TITLE
allow any serial port device.

### DIFF
--- a/plugins/dmxusb/src/dmxinterface.cpp
+++ b/plugins/dmxusb/src/dmxinterface.cpp
@@ -76,7 +76,7 @@ bool DMXInterface::validInterface(quint16 vendor, quint16 product)
         vendor != DMXInterface::ATMELVID &&
         vendor != DMXInterface::MICROCHIPVID &&
         vendor != DMXInterface::NXPVID)
-            return false;
+            return true;
 
     if (product != DMXInterface::FTDIPID &&
         product != DMXInterface::FTDI2PID &&
@@ -85,8 +85,7 @@ bool DMXInterface::validInterface(quint16 vendor, quint16 product)
         product != DMXInterface::EUROLITEPID &&
         product != DMXInterface::ELECTROTASPID &&
         product != DMXInterface::DMXKINGMAXPID)
-            return false;
-
+            return true;
     return true;
 }
 


### PR DESCRIPTION
Hi,
I'm trying to use an arduino as a dmx adapter. Therefore i would like to make this pull request. I guess i need to change the code a bit. It would be nice that the com port number or path is visible in ui. Is it possible to use just a usb serial converter with an rs485 module?  