### PR TITLE
ui/sceneeditor: fix duplicate tabs when adding all fixtures

### DIFF
--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -1288,11 +1288,14 @@ void SceneEditor::slotAddFixtureClicked()
             Fixture *fixture = m_doc->fixture(it.next());
             Q_ASSERT(fixture != NULL);
 
-            addFixtureItem(fixture);
-            addFixtureTab(fixture);
+            if (!m_scene->fixtures().contains(fixture->id()))
+            {
+                addFixtureItem(fixture);
+                addFixtureTab(fixture);
 
-            // Add fixture in scene
-            m_scene->addFixture(fixture->id());
+                // Add fixture in scene
+                m_scene->addFixture(fixture->id());
+            }
         }
     }
 }


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behaviour:

1. Open QLC+.
2. Add at least one fixture.
3. Switch to Functions.
4. Add a scene.
5. To add the fixtures, click on the green plus button, select an item from the list and type `CTRL+A` to select all fixtures.
6. Two tabs are created for each fixture.

**Expected behaviour**
Only one tab should be created per fixture.

This is particularly annoying since the tabs are obviously not synchronised and the last change always overwrites the previous value without being able to see it, if it was set on the other tab of the fixture.

I think the reason for this behaviour is that after typing `CTRL+A`, both the root element (e.g. the universe) and the individual fixtures are selected in the dialogue, and therefore the `QListIterator` contains each fixture twice.