### PR TITLE
ui/virtualconsole: fix sorting in the level tab of the slider dialog

### DIFF
--- a/ui/src/CMakeLists.txt
+++ b/ui/src/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(${module_name}
     simpledeskengine.cpp simpledeskengine.h
     speeddial.cpp speeddial.h
     speeddialwidget.cpp speeddialwidget.h
+    treewidgetitem.cpp treewidgetitem.h
     universeitemwidget.cpp universeitemwidget.h
     videoeditor.cpp videoeditor.h videoeditor.ui
     videoprovider.cpp videoprovider.h

--- a/ui/src/treewidgetitem.cpp
+++ b/ui/src/treewidgetitem.cpp
@@ -1,0 +1,25 @@
+#include "treewidgetitem.h"
+#include "vcsliderproperties.h"
+
+
+TreeWidgetItem::TreeWidgetItem(QTreeWidget* parent)
+    : QTreeWidgetItem(parent)
+{
+}
+
+
+TreeWidgetItem::TreeWidgetItem(QTreeWidgetItem* parent)
+    : QTreeWidgetItem(parent)
+{
+}
+
+
+bool TreeWidgetItem::operator<(const QTreeWidgetItem &rhs) const
+{
+    int column = treeWidget()->sortColumn();
+
+    if (column == KColumnName)
+        return this->text(KColumnID).toUInt() < rhs.text(KColumnID).toUInt();
+
+    return QTreeWidgetItem::operator<(rhs);
+}

--- a/ui/src/treewidgetitem.h
+++ b/ui/src/treewidgetitem.h
@@ -1,0 +1,16 @@
+#ifndef TREEWIDGETITEM_H
+#define TREEWIDGETITEM_H
+
+#include <QTreeWidgetItem>
+
+class TreeWidgetItem : public QTreeWidgetItem
+{
+public:
+    TreeWidgetItem(QTreeWidget*);
+    TreeWidgetItem(QTreeWidgetItem*);
+
+private:
+    bool operator<(const QTreeWidgetItem&) const;
+};
+
+#endif

--- a/ui/src/virtualconsole/vcsliderproperties.cpp
+++ b/ui/src/virtualconsole/vcsliderproperties.cpp
@@ -39,11 +39,7 @@
 #include "vcslider.h"
 #include "fixture.h"
 #include "doc.h"
-
-#define KColumnName  0
-#define KColumnType  1
-#define KColumnRange 2
-#define KColumnID    3
+#include "treewidgetitem.h"
 
 VCSliderProperties::VCSliderProperties(VCSlider* slider, Doc* doc)
     : QDialog(slider)
@@ -55,7 +51,7 @@ VCSliderProperties::VCSliderProperties(VCSlider* slider, Doc* doc)
     m_ovrResetSelWidget = NULL;
 
     setupUi(this);
-    m_levelList->sortByColumn(0, Qt::AscendingOrder);
+    m_levelList->sortByColumn(KColumnName, Qt::AscendingOrder);
 
     QAction* action = new QAction(this);
     action->setShortcut(QKeySequence(QKeySequence::Close));
@@ -424,7 +420,7 @@ void VCSliderProperties::levelUpdateChannelNode(QTreeWidgetItem* parent,
     QTreeWidgetItem* item = levelChannelNode(parent, ch);
     if (item == NULL)
     {
-        item = new QTreeWidgetItem(parent);
+        item = new TreeWidgetItem(parent);
         item->setText(KColumnID, QString::number(ch));
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         item->setCheckState(KColumnName, Qt::Unchecked);

--- a/ui/src/virtualconsole/vcsliderproperties.h
+++ b/ui/src/virtualconsole/vcsliderproperties.h
@@ -20,6 +20,11 @@
 #ifndef VCSLIDERPROPERTIES_H
 #define VCSLIDERPROPERTIES_H
 
+#define KColumnName  0
+#define KColumnType  1
+#define KColumnRange 2
+#define KColumnID    3
+
 #include <QDialog>
 
 #include "ui_vcsliderproperties.h"


### PR DESCRIPTION
#1722 (or 4bbba7ba85716ce3076739db013a25633a9dcaac, respectively) introduced the possibility to sort the fixture-channel-list on the `Level` page of Virtual Console Slider properties dialog.

However, this was done by comparing the channel names as a string and thus introduced known "sorting anomalies": Channel 1 - Channel 10 - Channel 11 - Channel 2 - ... (tested with the `Lixada Mini Gobo Moving Head` fixture).

In my opinion, this is particularly unintuitive for non-programmer users of QLC+.

This PR attempts to fix this problem by basing the sort on the numeric channel id instead of the string name.

(I am not very familiar with Qt Framework and its internals, so if there is a better solution, please treat this PR as an issue report and ignore my code.)