### PR TITLE
Enable libsndfile clipping to avoid integer overflow

### DIFF
--- a/engine/audio/plugins/sndfile/audiodecoder_sndfile.cpp
+++ b/engine/audio/plugins/sndfile/audiodecoder_sndfile.cpp
@@ -84,6 +84,10 @@ bool AudioDecoderSndFile::initialize(const QString &path)
         sf_command (m_sndfile, SFC_SET_SCALE_FLOAT_INT_READ, NULL, SF_TRUE);
     }
 
+    /* Enable libsndfile clipping correction for MP3 decoding to avoid
+       16-bit PCM wrapping artifacts on sample overflow */
+    sf_command(m_sndfile, SFC_SET_CLIPPING, NULL, SF_TRUE);
+
     AudioFormat pcmFormat = PCM_S16LE;
     switch(snd_info.format & SF_FORMAT_SUBMASK)
     {


### PR DESCRIPTION
Fixes https://github.com/mcallegari/qlcplus/issues/1779

Some mp3's (possibly other formats?) seem to overdrive the signal at
>1.0f or <-1.0f .. during conversion to PCM (16-bit signed integer), by
default no overflow or underflow is detected or corrected. This makes these samples "wrap around" and cause audible "crackle" artifacts. Enabling SFC_SET_CLIPPING = True, enables a different float conversion in libsndfile which clamps the output to the 16-bit signed integer range, avoiding the crackles.