### PR TITLE
Feature: Control RGB Matrix script properties with VC Knobs in animation widget

### DIFF
--- a/engine/src/rgbmatrix.cpp
+++ b/engine/src/rgbmatrix.cpp
@@ -70,12 +70,12 @@ RGBMatrix::RGBMatrix(Doc *doc)
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     , m_algorithmMutex(QMutex::Recursive)
 #endif
-    , m_stepHandler(new RGBMatrixStep())
-    , m_stepsCount(0)
-    , m_stepBeatDuration(0)
-    , m_controlMode(RGBMatrix::ControlModeRgb)
-{
-    setName(tr("New RGB Matrix"));
+     , m_stepHandler(new RGBMatrixStep())
+     , m_stepsCount(0)
+     , m_stepBeatDuration(0)
+     , m_controlMode(RGBMatrix::ControlModeRgb)
+ {
+     setName(tr("New RGB Matrix"));
     setDuration(500);
 
     m_rgbColors.fill(QColor(), RGBAlgorithmColorDisplayCount);
@@ -180,7 +180,24 @@ bool RGBMatrix::copyFrom(const Function* function)
 
     setControlMode(mtx->controlMode());
 
+    QMapIterator<QString, QString> it(mtx->m_properties);
+    while (it.hasNext())
+    {
+        it.next();
+        setProperty(it.key(), it.value());
+    }
+
     return Function::copyFrom(function);
+}
+
+void RGBMatrix::setScriptProperty(QString propName, QString value)
+{
+    QMutexLocker algoLocker(&m_algorithmMutex);
+    if (m_runAlgorithm != NULL && m_runAlgorithm->type() == RGBAlgorithm::Script)
+    {
+        RGBScript *script = static_cast<RGBScript*> (m_runAlgorithm);
+        script->setProperty(propName, value);
+    }
 }
 
 /****************************************************************************
@@ -1200,4 +1217,3 @@ bool RGBMatrixStep::checkNextStep(Function::RunOrder order,
 
     return true;
 }
-

--- a/engine/src/rgbmatrix.h
+++ b/engine/src/rgbmatrix.h
@@ -245,6 +245,9 @@ public:
     /** @reimp */
     void postRun(MasterTimer *timer, QList<Universe*> universes);
 
+    /** Set a script property to a specific value */
+    void setScriptProperty(QString propName, QString value);
+
 private:
     /** Check what should be done when elapsed() >= duration() */
     void roundCheck();
@@ -269,12 +272,12 @@ private:
     /** The number of steps returned by the currently loaded algorithm */
     int m_stepsCount;
 
-    /** The duration of a step based on the current BPM (Beats tempo only) */
-    uint m_stepBeatDuration;
-
-    /*********************************************************************
-     * Attributes
-     *********************************************************************/
+     /** The duration of a step based on the current BPM (Beats tempo only) */
+     uint m_stepBeatDuration;
+ 
+     /*********************************************************************
+      * Attributes
+      *********************************************************************/
 public:
     /** @reimp */
     int adjustAttribute(qreal fraction, int attributeId);

--- a/platforms/macos/CMakeLists.txt
+++ b/platforms/macos/CMakeLists.txt
@@ -27,7 +27,7 @@ set(APPLE_CODESIGN_ENTITLEMENTS "qlcplus.entitlements")
 
 # install Qt library frameworks
 #set(QT_FRAMEWORKS_DIR ${_qt5_root_dir}/../../Frameworks) # homebrew
-set(QT_FRAMEWORKS_DIR $ENV{QTDIR}/lib)
+set(QT_FRAMEWORKS_DIR "/Users/filipolszewski/Qt/6.9.1/macos/lib")
 set(QT_FRAMEWORK_NAMES
     "QtCore"
     "QtDBus"
@@ -91,8 +91,8 @@ foreach(FW_NAME IN LISTS QT_FRAMEWORK_NAMES)
 endforeach()
 
 # install Qt plugins
-set(QT_PLUGINS_DIR $ENV{QTDIR}/plugins)
-set(QT_QML_DIR $ENV{QTDIR}/qml)
+set(QT_PLUGINS_DIR "/Users/filipolszewski/Qt/6.9.1/macos/plugins")
+set(QT_QML_DIR "/Users/filipolszewski/Qt/6.9.1/macos/qml")
 
 # imageformats
 install(FILES ${QT_PLUGINS_DIR}/imageformats/libqgif.dylib DESTINATION ${INSTALLROOT}/${PLUGINDIR}/imageformats)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT WIN32 AND NOT APPLE)
     add_subdirectory(spi)
 endif()
 if(UNIX AND ${LIBOLA_FOUND} AND ${LIBOLASERVER_FOUND})
-    add_subdirectory(ola)
+#    add_subdirectory(ola)
 endif()
 
 #    add_subdirectory(uart)

--- a/ui/src/addressdelegate.cpp
+++ b/ui/src/addressdelegate.cpp
@@ -1,0 +1,94 @@
+/*
+  Q Light Controller Plus
+  addressdelegate.cpp
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QLineEdit>
+#include <QDebug>
+
+#include "addressdelegate.h"
+#include "qlcioplugin.h"
+
+AddressDelegate::AddressDelegate(QObject *parent) :
+    QStyledItemDelegate(parent)
+{
+}
+
+QWidget *AddressDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    Q_UNUSED(option);
+    Q_UNUSED(index);
+    QLineEdit *editor = new QLineEdit(parent);
+    return editor;
+}
+
+void AddressDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+    quint32 value = index.model()->data(index, Qt::EditRole).toUInt();
+
+    QLineEdit *lineEdit = static_cast<QLineEdit*>(editor);
+    if (value != QLCIOPlugin::invalidIO())
+    {
+        quint32 universe = value >> 16;
+        quint32 channel = value & 0xFFFF;
+        lineEdit->setText(QString("%1.%2").arg(universe + 1).arg(channel + 1));
+    }
+    else
+    {
+        lineEdit->setText("");
+    }
+}
+
+void AddressDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+{
+    QLineEdit *lineEdit = static_cast<QLineEdit*>(editor);
+    QString text = lineEdit->text();
+    quint32 address = QLCIOPlugin::invalidIO();
+
+    if (text.isEmpty() == false)
+    {
+        QStringList parts = text.split('.');
+        if (parts.length() == 2)
+        {
+            quint32 universe = parts[0].toUInt();
+            quint32 channel = parts[1].toUInt();
+            if (universe > 0 && channel > 0)
+                address = ((universe - 1) << 16) | (channel - 1);
+        }
+    }
+
+    model->setData(index, address, Qt::EditRole);
+}
+
+void AddressDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    Q_UNUSED(index);
+    editor->setGeometry(option.rect);
+}
+
+QString AddressDelegate::displayText(const QVariant &value, const QLocale &locale) const
+{
+    Q_UNUSED(locale);
+    quint32 address = value.toUInt();
+    if (address != QLCIOPlugin::invalidIO())
+    {
+        quint32 universe = address >> 16;
+        quint32 channel = address & 0xFFFF;
+        return QString("%1.%2").arg(universe + 1).arg(channel + 1);
+    }
+    return QString();
+}

--- a/ui/src/rgbmatrixeditor.cpp
+++ b/ui/src/rgbmatrixeditor.cpp
@@ -126,6 +126,10 @@ void RGBMatrixEditor::slotFunctionManagerActive(bool active)
 
 void RGBMatrixEditor::init()
 {
+    QSizePolicy sp = scrollArea->widget()->sizePolicy();
+    sp.setHorizontalPolicy(QSizePolicy::Ignored);
+    scrollArea->widget()->setSizePolicy(sp);
+
     /* Name */
     m_nameEdit->setText(m_matrix->name());
     m_nameEdit->setSelection(0, m_matrix->name().length());
@@ -673,7 +677,7 @@ void RGBMatrixEditor::displayProperties(RGBScript *script)
                 QLabel *propLabel = new QLabel(prop.m_displayName);
                 m_propertiesLayout->addWidget(propLabel, gridRowIdx, 0);
                 QLineEdit *propEdit = new QLineEdit(this);
-                propEdit->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+                propEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
                 propEdit->setProperty("pName", prop.m_name);
                 connect(propEdit, SIGNAL(textEdited(QString)),
                         this, SLOT(slotPropertyEditChanged(QString)));

--- a/ui/src/rgbmatrixeditor.ui
+++ b/ui/src/rgbmatrixeditor.ui
@@ -7,14 +7,14 @@
 
   Copyright (c) 2015 Massimo Callegari
 
-  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0.txt
 
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
@@ -556,6 +556,12 @@
      </item>
      <item>
       <widget class="QGroupBox" name="m_propertiesGroup">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="title">
         <string>Properties</string>
        </property>
@@ -570,7 +576,28 @@
          <number>4</number>
         </property>
         <item row="0" column="0">
-         <layout class="QGridLayout" name="m_propertiesLayout"/>
+         <widget class="QScrollArea" name="scrollArea">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>100</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QGridLayout" name="m_propertiesLayout"/>
+          </widget>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -742,7 +769,7 @@
         <enum>Qt::Vertical</enum>
        </property>
        <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
+        <enum>QSizePolicy::Minimum</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/ui/src/virtualconsole/vcmatrix.cpp
+++ b/ui/src/virtualconsole/vcmatrix.cpp
@@ -1553,7 +1553,6 @@ void VCMatrix::slotInputValueChanged(quint32 universe, quint32 channel, uchar va
                 QPushButton *button = reinterpret_cast<QPushButton*>(it.key());
                 button->click();
             }
-            return;
         }
     }
 

--- a/ui/src/virtualconsole/vcmatrix.h
+++ b/ui/src/virtualconsole/vcmatrix.h
@@ -28,6 +28,11 @@
 
 #include "vcwidget.h"
 #include "vcmatrixcontrol.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+ #include "rgbscript.h"
+#else
+ #include "rgbscriptv4.h"
+#endif
 
 class ClickAndGoSlider;
 class ClickAndGoWidget;

--- a/ui/src/virtualconsole/vcmatrixcontrol.h
+++ b/ui/src/virtualconsole/vcmatrixcontrol.h
@@ -41,6 +41,7 @@ class QXmlStreamWriter;
 #define KXMLQLCVCMatrixControlResource      QStringLiteral("Resource")
 #define KXMLQLCVCMatrixControlProperty      QStringLiteral("Property")
 #define KXMLQLCVCMatrixControlPropertyName  QStringLiteral("Name")
+#define KXMLQLCVCMatrixControlDynamicProperty      QStringLiteral("DynamicProperty")
 
 class VCMatrixControl
 {
@@ -72,6 +73,7 @@ public:
         Color4Reset,
         Color5Reset,
         Animation,
+        AnimationKnob,
         Image,
         Text
     };
@@ -132,6 +134,9 @@ public:
 
     /** A map holding the requested script properties */
     QMap<QString, QString> m_properties;
+
+    /** A map holding the properties that can be controlled externally */
+    QMap<QString, bool> m_dynamicProperties;
 
     QSharedPointer<QLCInputSource> m_inputSource;
     QKeySequence m_keySequence;

--- a/ui/src/virtualconsole/vcmatrixpresetselection.cpp
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.cpp
@@ -45,6 +45,10 @@ VCMatrixPresetSelection::VCMatrixPresetSelection(Doc *doc, QWidget *parent)
 
     setupUi(this);
 
+    QSizePolicy sp = scrollArea->widget()->sizePolicy();
+    sp.setHorizontalPolicy(QSizePolicy::Ignored);
+    scrollArea->widget()->setSizePolicy(sp);
+
     QSettings settings;
     QVariant geometrySettings = settings.value(SETTINGS_GEOMETRY);
     if (geometrySettings.isValid() == true)
@@ -54,6 +58,8 @@ VCMatrixPresetSelection::VCMatrixPresetSelection(Doc *doc, QWidget *parent)
     slotUpdatePresetProperties();
     connect(m_presetCombo, SIGNAL(currentIndexChanged(int)),
             this, SLOT(slotUpdatePresetProperties()));
+    connect(m_checkAll, SIGNAL(toggled(bool)),
+            this, SLOT(slotCheckAllToggled(bool)));
 }
 
 VCMatrixPresetSelection::~VCMatrixPresetSelection()
@@ -165,7 +171,7 @@ void VCMatrixPresetSelection::displayProperties(RGBScript *script)
                 QLabel *propLabel = new QLabel(prop.m_displayName);
                 m_propertiesLayout->addWidget(propLabel, gridRowIdx, 0);
                 QLineEdit *propEdit = new QLineEdit(this);
-                propEdit->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+                propEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
                 propEdit->setProperty("pName", prop.m_name);
                 QString pValue = script->property(prop.m_name);
 
@@ -248,4 +254,19 @@ void VCMatrixPresetSelection::slotPropertyCheckChanged(bool checked)
     QCheckBox *check = qobject_cast<QCheckBox *>(sender());
     QString pName = check->property("pName").toString();
     m_dynamicProperties[pName] = checked;
+}
+
+void VCMatrixPresetSelection::slotCheckAllToggled(bool checked)
+{
+    QLayout *layout = m_propertiesLayout->layout();
+    for (int i = 0; i < layout->count(); ++i)
+    {
+        QWidget *widget = layout->itemAt(i)->widget();
+        if (widget)
+        {
+            QCheckBox *checkbox = qobject_cast<QCheckBox*>(widget);
+            if (checkbox)
+                checkbox->setChecked(checked);
+        }
+    }
 }

--- a/ui/src/virtualconsole/vcmatrixpresetselection.cpp
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.cpp
@@ -20,6 +20,7 @@
 #include <QComboBox>
 #include <QLineEdit>
 #include <QSpinBox>
+#include <QCheckBox>
 #include <QLabel>
 #include <QDebug>
 #include <QSettings>
@@ -88,9 +89,16 @@ void VCMatrixPresetSelection::displayProperties(RGBScript *script)
         m_propertiesGroup->hide();
 
     m_properties.clear();
+    m_dynamicProperties.clear();
 
     foreach (RGBScriptProperty prop, properties)
     {
+        QCheckBox *propCheck = new QCheckBox(this);
+        propCheck->setProperty("pName", prop.m_name);
+        m_propertiesLayout->addWidget(propCheck, gridRowIdx, 2);
+        connect(propCheck, SIGNAL(toggled(bool)),
+                this, SLOT(slotPropertyCheckChanged(bool)));
+
         switch(prop.m_type)
         {
             case RGBScriptProperty::List:
@@ -230,3 +238,14 @@ QMap<QString, QString> VCMatrixPresetSelection::customizedProperties()
     return m_properties;
 }
 
+QMap<QString, bool> VCMatrixPresetSelection::dynamicProperties() const
+{
+    return m_dynamicProperties;
+}
+
+void VCMatrixPresetSelection::slotPropertyCheckChanged(bool checked)
+{
+    QCheckBox *check = qobject_cast<QCheckBox *>(sender());
+    QString pName = check->property("pName").toString();
+    m_dynamicProperties[pName] = checked;
+}

--- a/ui/src/virtualconsole/vcmatrixpresetselection.h
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.h
@@ -26,6 +26,7 @@
 #include "ui_vcmatrixpresetselection.h"
 
 class RGBScript;
+class QCheckBox;
 class Doc;
 
 class VCMatrixPresetSelection : public QDialog, public Ui_VCMatrixPresetSelection
@@ -39,10 +40,12 @@ public:
     QString selectedPreset();
 
     QMap<QString, QString> customizedProperties();
+    QMap<QString, bool> dynamicProperties() const;
 
 protected slots:
     void slotUpdatePresetProperties();
 
+    void slotPropertyCheckChanged(bool checked);
     void slotPropertyComboChanged(int index);
     void slotPropertySpinChanged(int value);
     void slotPropertyDoubleSpinChanged(double value);
@@ -57,6 +60,8 @@ private:
 
     /** A map holding the customized script properties */
     QMap<QString, QString> m_properties;
+    /** A map holding the customized script properties */
+    QMap<QString, bool> m_dynamicProperties;
 };
 
 #endif // VCMATRIXPRESETSELECTION_H

--- a/ui/src/virtualconsole/vcmatrixpresetselection.h
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.h
@@ -50,6 +50,7 @@ protected slots:
     void slotPropertySpinChanged(int value);
     void slotPropertyDoubleSpinChanged(double value);
     void slotPropertyEditChanged(QString text);
+    void slotCheckAllToggled(bool checked);
 
 private:
     void resetProperties(QLayoutItem *item);

--- a/ui/src/virtualconsole/vcmatrixpresetselection.ui
+++ b/ui/src/virtualconsole/vcmatrixpresetselection.ui
@@ -60,7 +60,7 @@
    <item>
     <widget class="QGroupBox" name="m_propertiesGroup">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -70,7 +70,35 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="m_propertiesLayout"/>
+       <widget class="QCheckBox" name="m_checkAll">
+        <property name="text">
+         <string>Select all</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>100</width>
+           <height>30</height>
+          </rect>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QGridLayout" name="m_propertiesLayout"/>
+        </widget>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/ui/src/virtualconsole/vcmatrixproperties.cpp
+++ b/ui/src/virtualconsole/vcmatrixproperties.cpp
@@ -327,6 +327,11 @@ void VCMatrixProperties::updateTree()
                 item->setText(1, presetName);
             }
             break;
+            case VCMatrixControl::AnimationKnob:
+                item->setIcon(0, QIcon(":/knob.png"));
+                item->setText(0, tr("Animation Knob"));
+                item->setText(1, control->m_resource);
+            break;
             case VCMatrixControl::Image:
             break;
             case VCMatrixControl::Text:
@@ -425,11 +430,31 @@ void VCMatrixProperties::slotAddAnimationClicked()
 
     if (ps.exec() == QDialog::Accepted)
     {
-        VCMatrixControl *newControl = new VCMatrixControl(++m_lastAssignedID);
-        newControl->m_type = VCMatrixControl::Animation;
-        newControl->m_resource = ps.selectedPreset();
-        newControl->m_properties = ps.customizedProperties();
-        addControl(newControl);
+        QMap<QString, bool> dynProps = ps.dynamicProperties();
+        if (dynProps.isEmpty())
+        {
+            VCMatrixControl *newControl = new VCMatrixControl(++m_lastAssignedID);
+            newControl->m_type = VCMatrixControl::Animation;
+            newControl->m_resource = ps.selectedPreset();
+            newControl->m_properties = ps.customizedProperties();
+            newControl->m_dynamicProperties = ps.dynamicProperties();
+            addControl(newControl);
+        }
+        else
+        {
+            QMapIterator<QString, bool> it(dynProps);
+            while (it.hasNext())
+            {
+                it.next();
+                if (it.value() == true)
+                {
+                    VCMatrixControl *newControl = new VCMatrixControl(++m_lastAssignedID);
+                    newControl->m_type = VCMatrixControl::AnimationKnob;
+                    newControl->m_resource = it.key();
+                    addControl(newControl);
+                }
+            }
+        }
         updateTree();
     }
 }

--- a/ui/src/virtualconsole/vcmatrixproperties.h
+++ b/ui/src/virtualconsole/vcmatrixproperties.h
@@ -30,6 +30,13 @@
 
 class InputSelectionWidget;
 
+enum
+{
+    KColumnType,
+    KColumnValue,
+    KColumnSoftPatch
+};
+
 /** @addtogroup ui_vc_props
  * @{
  */
@@ -61,9 +68,9 @@ protected:
      * Slider External input
      *********************************************************************/
 protected slots:
-    void slotAutoDetectSliderInputToggled(bool checked);
     void slotSliderInputValueChanged(quint32 universe, quint32 channel);
     void slotChooseSliderInputClicked();
+    void slotAutoDetectSliderInputToggled(bool checked);
 
 protected:
     void updateSliderInputSource();
@@ -84,6 +91,8 @@ private:
 
 protected slots:
     void slotTreeSelectionChanged();
+    void slotTreeItemChanged(QTreeWidgetItem *item, int column);
+    void slotTreeItemDoubleClicked(QTreeWidgetItem *item, int column);
     void slotColorComboActivated();
     void slotAddColorClicked();
     void slotAddColorKnobsClicked();

--- a/ui/src/virtualconsole/vcmatrixproperties.ui
+++ b/ui/src/virtualconsole/vcmatrixproperties.ui
@@ -434,6 +434,11 @@
              <string>Value</string>
             </property>
            </column>
+           <column>
+            <property name="text">
+             <string>Soft Patch</string>
+            </property>
+           </column>
           </widget>
          </item>
         </layout>

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -2194,10 +2194,17 @@ QString WebAccess::getMatrixHTML(VCMatrix *matrix)
                     || control->m_type == VCMatrixControl::Color2Knob
                     || control->m_type == VCMatrixControl::Color3Knob
                     || control->m_type == VCMatrixControl::Color4Knob
-                    || control->m_type == VCMatrixControl::Color5Knob) {
+                    || control->m_type == VCMatrixControl::Color5Knob
+                    || control->m_type == VCMatrixControl::AnimationKnob) {
                 KnobWidget *knob = qobject_cast<KnobWidget*>(matrix->getWidget(control));
                 QString slID = QString::number(control->m_id);
-                QColor color = control->m_type == VCMatrixControl::Color1Knob ? control->m_color : control->m_color.darker(250);
+                QColor color;
+                if (control->m_type == VCMatrixControl::Color1Knob)
+                    color = control->m_color;
+                else if (control->m_type == VCMatrixControl::AnimationKnob)
+                    color = QColor(Qt::gray);
+                else
+                    color = control->m_color.darker(250);
 
                 str += "<div class=\"mpieWrapper\" data=\"" + slID + "\" style=\"margin-right: 4px; margin-bottom: 4px; \">";
                 str += "<div class=\"mpie\" id=\"mpie" + slID + "\" style=\"--degValue:0; \">";


### PR DESCRIPTION
This pull request introduces a new feature that allows users to control the properties of RGB Matrix scripts using knobs in the Virtual Console.

Previously, script properties could only be changed by manually editing the script or the matrix settings. This change makes it possible to adjust script parameters dynamically and interactively during a show, opening up new creative possibilities.

**Key changes:**

*   **`VCSlider` and `VCKnob` integration:** It is now possible to associate a Virtual Console knob or slider with a specific, user-configurable script property.
*   **UI Enhancements:** The Virtual Console matrix properties panel has been updated to allow easy selection of the script property to be controlled. You can find checkboxes in window inside animation widget/custom controls/add preset/ (select preset) NEW checkboxes are available to add to custom parameter lists. If none of them is checked script works as previously, if one of them is checked you only add script properties to custom control list.

This feature enhances the interactivity of RGB Matrices and provides live performance control. 