### PR TITLE
virtualconsole/xypad: fix external input to coarse channels affecting fine channels

### DIFF
--- a/ui/src/virtualconsole/vcxypad.cpp
+++ b/ui/src/virtualconsole/vcxypad.cpp
@@ -1000,7 +1000,7 @@ void VCXYPad::slotInputValueChanged(quint32 universe, quint32 channel,
     {
         if (m_efx == NULL)
         {
-            m_lastPos.setX(value);
+            m_lastPos.moveLeft(value);
             updatePosition();
         }
         else
@@ -1025,7 +1025,7 @@ void VCXYPad::slotInputValueChanged(quint32 universe, quint32 channel,
     {
         if (m_efx == NULL)
         {
-            m_lastPos.setY(value);
+            m_lastPos.moveTop(value);
             updatePosition();
         }
         else


### PR DESCRIPTION
**Steps to Reproduce:**
1. Open QLC+ and add a moving head fixture (tested with “Lixada Mini Wash RGBW”).
2. Switch to the Virtual Console, add a XY pad and add the fixture to it.
3. Connect an external input in absolute mode (default) to the pan and tilt channels, but leave the corresponding fine channels without external input (tested with a HID joystick and with a second QLC+ instance via OSC on localhost).
4. Switch to “Operate” mode, open the DMX monitor and input on the external controls.

**Result:**
The non-fine (coarse) channels move according to `input - 1`, but the values of the fine channels always equal to `255 - coarseValue`.

**Expected result:**
The absolute external input to the coarse channels is output correctly and does not affect the value of the fine channels.

**Problem:**
The `VCXYPad` class internally uses a `QRect` named `m_lastPos` to store the current position:
- `m_lastPos.x()`: pan coarse
- `m_lastPos.y()`: tilt coarse
- `m_lastPos.width()`: pan fine
- `m_lastPos.height()`: tilt fine

However, in the `slotInputValueChanged` function, the coarse values are set using the `setX(int x)` and `setY(int y)` function, which, according to the [documentation](https://doc.qt.io/qt-6/qrect.html#setX), may influence the width and height of the rectangle. Thus, the fine values are changed.

**Solution:**
Replace the `setX(int x)` and `setY(int y)` functions with the `moveLeft(int x)` and `moveTop(int y)` functions, which modify the x and y values without changing the width and height (see [documentation](https://doc.qt.io/qt-6/qrect.html#moveLeft)).