### PR TITLE
Add pull_request_template.md to enable selection of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please go the the `Preview` tab and select the appropriate sub-template:
+
+- [New feature or fix](?expand=1&template=feature_or_fix.md)
+- [New QLC+ fixture profile](?expand=1&template=new_fixture.md)


### PR DESCRIPTION
There is a missing piece in the GitHub pull request flow to enable the PR templates added in #1760 to be automatically populated. 

If we don't add this file, the only way to use the templates is to append rubbish to the URL.

The templates themselves are supposed to be selected from a list we maintain in pull_request_template.md. 

You can test this flow by creating a PR in this repo: https://github.com/snamiki1212/example-multiple-pr-templates/compare/main...snamiki1212-patch-1

I've kept the list pretty basic but am open to feedback. 

Further reading:

- https://stackoverflow.com/questions/73771068/multiple-templates-for-pull-requests-on-github/75030350#75030350
- https://graphite.dev/guides/pull-request-templates?utm_source=chatgpt.com
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository