### PR TITLE
Fix Android build error with qt6

### DIFF
--- a/engine/audio/src/src.pro
+++ b/engine/audio/src/src.pro
@@ -22,7 +22,7 @@ HEADERS += audio.h \
            audioplugincache.h
 
 lessThan(QT_MAJOR_VERSION, 5) {
-  unix:!macx:HEADERS += audiorenderer_alsa.h audiocapture_alsa.h
+  unix:!macx:!android:HEADERS += audiorenderer_alsa.h audiocapture_alsa.h
   win32:HEADERS += audiorenderer_waveout.h audiocapture_wavein.h
 }
 lessThan(QT_MAJOR_VERSION, 6) {
@@ -39,7 +39,7 @@ SOURCES += audio.cpp \
            audioplugincache.cpp
 
 lessThan(QT_MAJOR_VERSION, 5) {
-  unix:!macx:SOURCES += audiorenderer_alsa.cpp audiocapture_alsa.cpp
+  unix:!macx:!android:SOURCES += audiorenderer_alsa.cpp audiocapture_alsa.cpp
   win32:SOURCES += audiorenderer_waveout.cpp audiocapture_wavein.cpp
 
   macx {

--- a/engine/src/src.pro
+++ b/engine/src/src.pro
@@ -34,7 +34,13 @@ INCLUDEPATH += ../../hotplugmonitor/src
 LIBS        += -L../../hotplugmonitor/src -lhotplugmonitor
 }
 
-LIBS        += -L../audio/src -lqlcplusaudio
+LIBS        += -L../audio/src
+
+android {
+  LIBS            += -lqlcplusaudio_$${QT_ARCH}
+} else {
+  LIBS            += -lqlcplusaudio
+}
 
 #############################################################################
 # Sources

--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -18,14 +18,14 @@
   limitations under the License.
 -->
 <manifest package="org.qlcplus" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="5.0" android:versionCode="1" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="-- %%INSERT_APP_NAME%% --" android:icon="@drawable/icon">
-        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="unspecified" android:launchMode="singleTop">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt.android.bindings.QtApplication" android:label="-- %%INSERT_APP_NAME%% --" android:icon="@drawable/icon">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt.android.bindings.QtActivity" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="unspecified" android:launchMode="singleTop" android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
-            <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
+            <!-- <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/> -->
             <meta-data android:name="android.app.repository" android:value="default"/>
             <meta-data android:name="android.app.qt_libs_resource_id" android:resource="@array/qt_libs"/>
             <meta-data android:name="android.app.bundled_libs_resource_id" android:resource="@array/bundled_libs"/>
@@ -38,8 +38,8 @@
             <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
             <!--  Messages maps -->
-            <meta-data android:value="@string/ministro_not_found_msg" android:name="android.app.ministro_not_found_msg"/>
-            <meta-data android:value="@string/ministro_needed_msg" android:name="android.app.ministro_needed_msg"/>
+            <!-- <meta-data android:value="@string/ministro_not_found_msg" android:name="android.app.ministro_not_found_msg"/>
+            <meta-data android:value="@string/ministro_needed_msg" android:name="android.app.ministro_needed_msg"/> -->
             <meta-data android:value="@string/fatal_error_msg" android:name="android.app.fatal_error_msg"/>
             <!--  Messages maps -->
 
@@ -55,11 +55,11 @@
                           "applicationStateChanged(Qt::ApplicationSuspended)"
                           signal is sent! -->
             <meta-data android:name="android.app.background_running" android:value="false"/>
-            <meta-data android:value="@string/unsupported_android_version" android:name="android.app.unsupported_android_version"/>
+            <!-- <meta-data android:value="@string/unsupported_android_version" android:name="android.app.unsupported_android_version"/> -->
             <!-- Background running -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="25"/>
+    <uses-sdk android:minSdkVersion="28" android:targetSdkVersion="33"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -1,17 +1,17 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:8.0.0'
     }
 }
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 apply plugin: 'com.android.application'
@@ -33,6 +33,7 @@ android {
      * updated by QtCreator and androiddeployqt tools.
      * Changing them manually might break the compilation!
      *******************************************************/
+    namespace "org.qlcplus"
 
     compileSdkVersion androidCompileSdkVersion.toInteger()
 

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -9,3 +9,4 @@ org.gradle.jvmargs=-Xmx2048m
 # build with the same inputs. However, over time, the cache size will
 # grow. Uncomment the following line to enable it.
 #org.gradle.caching=true
+android.useAndroidX=true

--- a/platforms/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/variables.pri
+++ b/variables.pri
@@ -50,7 +50,7 @@ contains(FORCECONFIG, release) {
  }
  else {
    QMAKE_CXXFLAGS += -Wno-unused-local-typedefs # Fix to build with GCC 4.8
-   QMAKE_CXXFLAGS += -Wno-template-id-cdtor # Fix to build with GCC 14
+   # QMAKE_CXXFLAGS += -Wno-template-id-cdtor # Fix to build with GCC 14
  }
 }
 


### PR DESCRIPTION
Summary of Changes:
  - Update gradle version from 7.0.0 to 8.0.0
  - Update qt version from 5 to 6
  - Remove ministro resource links
  - Update android-sdk version from 25 to 33

Related Issues: https://github.com/mcallegari/qlcplus/issues/1794