### PR TITLE
[v4/Qt6] Cue Stack: fix marker of currently active cue

### DIFF
--- a/engine/src/cuestack.cpp
+++ b/engine/src/cuestack.cpp
@@ -513,7 +513,8 @@ void CueStack::write(QList<Universe*> ua)
         int to = previous();
         switchCue(from, to, ua);
         m_previous = false;
-        emit currentCueChanged(m_currentIndex);
+        emit currentCueChanged(from);
+        emit currentCueChanged(to);
     }
     else if (m_next == true)
     {
@@ -523,7 +524,8 @@ void CueStack::write(QList<Universe*> ua)
         int to = next();
         switchCue(from, to, ua);
         m_next = false;
-        emit currentCueChanged(m_currentIndex);
+        emit currentCueChanged(from);
+        emit currentCueChanged(to);
     }
 /*
     else if (m_elapsed >= duration())

--- a/ui/src/cuestackmodel.cpp
+++ b/ui/src/cuestackmodel.cpp
@@ -226,7 +226,7 @@ QVariant CueStackModel::data(const QModelIndex& index, int role) const
     return var;
 }
 
-QStringList CueStackModel::mimeTypes () const
+QStringList CueStackModel::mimeTypes() const
 {
     return QStringList() << QString("text/plain");
 }

--- a/ui/src/cuestackmodel.h
+++ b/ui/src/cuestackmodel.h
@@ -74,7 +74,7 @@ public:
     int rowCount(const QModelIndex& parent = QModelIndex()) const;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
 
-    QStringList mimeTypes () const;
+    QStringList mimeTypes() const;
     Qt::DropActions supportedDropActions() const;
     Qt::ItemFlags flags(const QModelIndex &index) const;
 


### PR DESCRIPTION
**Disclaimer:**
- This issue was neither discovered nor reported by me, but via the [QLC+ forum]( https://www.qlcplus.org/forum/viewtopic.php?t=18592).
- I have never used the “cue stack” feature of QLC+ myself. Furthermore, since scenes and chasers are the better option in most cases, it is not going to be available in QLC+ v5. Therefore, it might already be considered “deprecated” in v4.

**Steps to Reproduce:**

0. _Note: If QLC+ uses Qt5, this issue does not occur. It only seems to happen on Qt6 QLC+ builds._
1. Open a new QLC+ workspace.
2. On the “Simple Desk” page, add at least three cues in the same cue stack.
3. Use the arrow buttons to play the cues forwards or backwards, respectively.

**Result:**
Every cue played since the last “stop” is marked with a small triangle.

**Expected result:**
Only the currently active cue should be marked, and the mark should move when the active cue changes.

**Problem:**
After clicking the “Next Cue” button, the execution finally reaches [`void CueStack::nextCue()`](https://github.com/mcallegari/qlcplus/blob/master/engine/src/cuestack.cpp#L290), which sets `m_next` to `true`.
Then, the next time [`void CueStack::write(QList<Universe*> ua)`](https://github.com/mcallegari/qlcplus/blob/master/engine/src/cuestack.cpp#L503) is called, the cues are switched (and everything is set correctly in the “backend”), but the `currentCueChanged` signal is only emitted for the newly active cue.
That is why, the row of the previously active cue is not immediately redrawn and the marker is only removed when the cursor is moved over it or when the user minimizes the window, for example.

The same applies to the “previous cue” button.

**Solution:**
Within `void CueStack::write(QList<Universe*> ua)`, signals for both the “previously” and “newly” active cues should be emitted using the variables set before the transition. This way, this code does not have to handle the overflow of cue numbers (jumping from the last cue in a stack to the first and vice versa) and does not need to know which internal function in this code section modifies the `m_currentIndex` variable and when during the transition it points to which cue.