### PR TITLE
[v5] engine/scriptv4: fix conversion of the blackout command

### DIFF
--- a/engine/src/scriptv4.cpp
+++ b/engine/src/scriptv4.cpp
@@ -522,6 +522,22 @@ QString Script::convertLine(const QString& str, bool *ok)
                     value.append("\"");
                 }
             }
+            else if (command == blackoutLegacy)
+            {
+                if (value == "on")
+                {
+                    value = "true";
+                }
+                else if (value == "off")
+                {
+                    value = "false";
+                }
+                else
+                {
+                    value.prepend("\"");
+                    value.append("\"");
+                }
+            }
 
             values << value.trimmed();
         }


### PR DESCRIPTION
**Steps to Reproduce:**
1. Open QLC+ (v4) and add a script function to the empty workspace.
2. Add two commands to this script: `blackout:on` and `blackout:off`.
3. Run the script to verify that it executes correctly – the blackout button should quickly turn on and off.
4. Save the workspace and close QLC+ (v4). Open QLC+ (v5) and load the workspace.
5. The workspace will be automatically converted to v5 format, including converting the script to the new syntax.

**(Expected) Result:**
Most of the script commands (of QLC+ v4) will be converted correctly.
However, the `blackout` command is not (according to the syntax checker inside QLC+ v5):
- Actual result: `blackout:[on/off]` → `Engine.setBlackout([on/off]);`
- Expected result: `blackout:[on/off]` → `Engine.setBlackout([true/false]);`

**Problem:**
In the function `Script::convertLine(…)` (`scriptv4.cpp`), after parsing the old syntax, the parameter of the `blackout` command is inserted directly into the new syntax without any special conversion/substitution.

**Solution:**
Add a special case to the conversion logic to handle the substitution.