### PR TITLE
fixtures: Add Cameo P2 T

### DIFF
--- a/resources/fixtures/Cameo/Cameo-P2-T.qxf
+++ b/resources/fixtures/Cameo/Cameo-P2-T.qxf
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.14.3</Version>
+  <Author>Christoph Müllner</Author>
+ </Creator>
+ <Manufacturer>Cameo</Manufacturer>
+ <Model>P2 T</Model>
+ <Type>Dimmer</Type>
+ <Channel Name="Dimmer" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Dimmer fine" Preset="IntensityMasterDimmerFine"/>
+ <Channel Name="Strobe Functions">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="5" Preset="ShutterOpen">Strobe open</Capability>
+  <Capability Min="6" Max="10" Preset="ShutterClose">Strobe closed</Capability>
+  <Capability Min="11" Max="33">Pulse random, slow to fast</Capability>
+  <Capability Min="34" Max="56">Ramp up random, slow to fast</Capability>
+  <Capability Min="57" Max="79">Ramp down random, slow to fast</Capability>
+  <Capability Min="80" Max="102" Preset="StrobeRandomSlowToFast">Random strobe effect, slow to fast</Capability>
+  <Capability Min="103" Max="127">Strobe break effect, 5s...1s (short burst with break)</Capability>
+  <Capability Min="128" Max="250" Preset="StrobeFreqRange" Res1="1" Res2="20">Strobe slow to fast &lt; 1Hz - 20Hz</Capability>
+  <Capability Min="251" Max="255" Preset="ShutterOpen">Strobe open</Capability>
+ </Channel>
+ <Channel Name="Dimmer Response">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="5">No function</Capability>
+  <Capability Min="6" Max="127">Dimmer response LED (hold 5s)</Capability>
+  <Capability Min="128" Max="191">Dimmer response Halogen (hold 5s)</Capability>
+  <Capability Min="192" Max="255">No function</Capability>
+ </Channel>
+ <Channel Name="Dimmer Curve">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="5">No function</Capability>
+  <Capability Min="6" Max="63">Linear dimmer curve</Capability>
+  <Capability Min="64" Max="127">Exponential dimmer curve</Capability>
+  <Capability Min="128" Max="191">Logarithmic dimmer curve</Capability>
+  <Capability Min="192" Max="255">S-Curve dimmer curve</Capability>
+ </Channel>
+ <Channel Name="Device Settings">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="5">No function</Capability>
+  <Capability Min="6" Max="127">Dimmer response LED (hold 5s)</Capability>
+  <Capability Min="128" Max="191">Dimmer response Halogen (hold 5s)</Capability>
+  <Capability Min="192" Max="196">Fan auto (hold 5s)</Capability>
+  <Capability Min="197" Max="201">Fan off (hold 5s)</Capability>
+  <Capability Min="202" Max="206">Fan constant low (hold 5s)</Capability>
+  <Capability Min="207" Max="211">Fan constant medium (hold 5s)</Capability>
+  <Capability Min="212" Max="218">Fan constant high (hold 5s)</Capability>
+  <Capability Min="219" Max="223">PWM Frequency 800 Hz (hold 5s)</Capability>
+  <Capability Min="224" Max="228">PWM Frequency 1200 Hz (hold 5s)</Capability>
+  <Capability Min="229" Max="233">PWM Frequency 2000 Hz (hold 5s)</Capability>
+  <Capability Min="234" Max="238">PWM Frequency 3600 Hz (hold 5s)</Capability>
+  <Capability Min="239" Max="242">PWM Frequency 12 kHz (hold 5s)</Capability>
+  <Capability Min="243" Max="245">PWM Frequency 18.9 kHz (hold 5s)</Capability>
+  <Capability Min="246" Max="249">PWM Frequency 25 kHz (hold 5s)</Capability>
+  <Capability Min="250" Max="255">No function</Capability>
+ </Channel>
+ <Mode Name="1 Channel">
+  <Channel Number="0">Dimmer</Channel>
+ </Mode>
+ <Mode Name="2 Channel 16-bit">
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Dimmer fine</Channel>
+ </Mode>
+ <Mode Name="2 Channel Strobe">
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Strobe Functions</Channel>
+ </Mode>
+ <Mode Name="3 Channel Device">
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Dimmer fine</Channel>
+  <Channel Number="2">Strobe Functions</Channel>
+ </Mode>
+ <Mode Name="4 Channel">
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Strobe Functions</Channel>
+  <Channel Number="2">Dimmer Curve</Channel>
+  <Channel Number="3">Device Settings</Channel>
+ </Mode>
+ <Mode Name="5 Channel">
+  <Channel Number="0">Dimmer</Channel>
+  <Channel Number="1">Dimmer fine</Channel>
+  <Channel Number="2">Strobe Functions</Channel>
+  <Channel Number="3">Dimmer Curve</Channel>
+  <Channel Number="4">Device Settings</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="14000" ColourTemperature="3200"/>
+  <Dimensions Weight="10.5" Width="245" Height="202" Depth="462"/>
+  <Lens Name="Other" DegreesMin="25" DegreesMax="50"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical PowerConsumption="220" DmxConnector="5-pin"/>
+ </Physical>
+</FixtureDefinition>

--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -396,6 +396,7 @@
     <F n="Cameo-Multi-PAR-3" m="Multi Par 3"/>
     <F n="Cameo-NanoBeam-300" m="NanoBeam 300"/>
     <F n="Cameo-P2-FC" m="P2 FC"/>
+    <F n="Cameo-P2-T" m="P2 T"/>
     <F n="Cameo-Pixbar-600-PRO" m="Pixbar 600 PRO"/>
     <F n="Cameo-Q-Spot-15-RGBW" m="Q-Spot 15 RGBW"/>
     <F n="Cameo-Q-Spot-40-RGBW" m="Q-Spot 40 RGBW"/>


### PR DESCRIPTION
The Cameo P2 T has 6 different modes.
This patch adds support for all of them.
The physical properties of this device are very similar to those of the Cameo P2 FC.

## Fixture Information

**Manufacturer:**  Cameo
**Model:**  P2 T
**Mode(s) included:**  all
**Channels used:**  6 in total / up to 5 used (depending on mode)

## Testing

- [x] Physical data is included 
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly


## Source(s) of Information

User manual andn DMX Control Table documents are linked on the vendor homepage: https://portal.adamhall.com/downloadcenter/products?article=CLP2T