### PR TITLE
fixtures: Stairville: WGF-2000: Fix typos

### DIFF
--- a/resources/fixtures/Stairville/Stairville-WGF-2000.qxf
+++ b/resources/fixtures/Stairville/Stairville-WGF-2000.qxf
@@ -7,7 +7,7 @@
   <Author>CoS2000</Author>
  </Creator>
  <Manufacturer>Stairville</Manufacturer>
- <Model>WGF 2000</Model>
+ <Model>WGF-2000</Model>
  <Type>Smoke</Type>
  <Channel Name="Smoke">
   <Group Byte="0">Intensity</Group>
@@ -15,7 +15,7 @@
  </Channel>
  <Channel Name="Fan">
   <Group Byte="0">Intensity</Group>
-  <Capability Min="0" Max="255">Van Intensity (0%-100%)</Capability>
+  <Capability Min="0" Max="255">Fan Intensity (0%-100%)</Capability>
  </Channel>
  <Channel Name="Program">
   <Group Byte="0">Effect</Group>
@@ -29,7 +29,7 @@
  </Mode>
  <Physical>
   <Bulb Type="" Lumens="0" ColourTemperature="0"/>
-  <Dimensions Weight="1.2" Width="345" Height="360" Depth="785"/>
+  <Dimensions Weight="24" Width="345" Height="360" Depth="785"/>
   <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
   <Technical PowerConsumption="2000" DmxConnector="3-pin"/>


### PR DESCRIPTION
Fix typos in the definition of the Stairville Water Ground Fog 2000:
* Model name is WGF-2000 (as defined by the manual)
* Replace "Van Intensity" with "Fan Intensity"
* Weight is 24 kg (as specified in the manual)
