### PR TITLE
Fix warnings about discarded return value

### DIFF
--- a/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp
+++ b/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp
@@ -237,7 +237,7 @@ void QLCFixtureDefCache_Test::storeDef()
 {
     QLCFixtureDef *def = cache.fixtureDef("Futurelight", "CY-200");
     QFile defFile(def->definitionSourceFile());
-    defFile.open(QIODevice::ReadOnly | QIODevice::Text);
+    QVERIFY(defFile.open(QIODevice::ReadOnly | QIODevice::Text));
     QString defBuffer = defFile.readAll();
     defFile.close();
     QVERIFY(cache.storeFixtureDef("storeTest.qxf", defBuffer) == true);

--- a/engine/test/rgbscript/rgbscript_test.cpp
+++ b/engine/test/rgbscript/rgbscript_test.cpp
@@ -94,7 +94,7 @@ void RGBScript_Test::scripts()
     // Prepare check that file is registered for delivery
     QString proFilePath = dir.filePath("rgbscripts.pro");
     QFile proFile(proFilePath);
-    proFile.open(QIODevice::ReadWrite);
+    QVERIFY(proFile.open(QIODevice::ReadWrite));
     QTextStream pro (&proFile);
 
     // Catch syntax / JS engine errors explicitly in the test.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -217,7 +217,11 @@ bool parseArgs()
             QLCArgs::logToFile = true;
             QString logFilename = QDir::homePath() + QDir::separator() + "QLC+.log";
             QLCArgs::logFile.setFileName(logFilename);
-            QLCArgs::logFile.open(QIODevice::Append);
+            if (!QLCArgs::logFile.open(QIODevice::Append))
+            {
+                qWarning() << "Could not open log file!";
+                return false;
+            }
         }
         else if (arg == "-f" || arg == "--fullscreen")
         {


### PR DESCRIPTION
When building QLC+ with Fedora rawhide, we get a few warnings about a discarded return value from a nodiscard function (`QFile::open`).
Let's fix this by evaluating the value with QVERIFY() or by exiting with an error message.

An example of this error is:
```
/builddir/build/BUILD/qlcplus-QLC+_4.14.3-build/qlcplus-QLC-_4.14.3/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp: In member function ‘void QLCFixtureDefCache_Test::storeDef()’:
/builddir/build/BUILD/qlcplus-QLC+_4.14.3-build/qlcplus-QLC-_4.14.3/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp:240:17: error: ignoring return value of ‘virtual bool QFile::open(QIODeviceBase::OpenMode)’, declared with attribute ‘nodiscard’ [-Werror=unused-result]
  240 |     defFile.open(QIODevice::ReadOnly | QIODevice::Text);
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt6/QtCore/qdir.h:11,
                 from /usr/include/qt6/QtCore/QtCore:91,
                 from /usr/include/qt6/QtTest/QtTestDepends:3,
                 from /usr/include/qt6/QtTest/QtTest:3,
                 from /builddir/build/BUILD/qlcplus-QLC+_4.14.3-build/qlcplus-QLC-_4.14.3/engine/test/qlcfixturedefcache/qlcfixturedefcache_test.cpp:20:
/usr/include/qt6/QtCore/qfile.h:291:32: note: declared here
  291 |     QFILE_MAYBE_NODISCARD bool open(OpenMode flags) override;
      |                                ^~~~
cc1plus: all warnings being treated as errors
```
