### PR TITLE
qmlui: fix more Qt6 warnings

### DIFF
--- a/qmlui/qml/ColorToolFull.qml
+++ b/qmlui/qml/ColorToolFull.qml
@@ -128,8 +128,8 @@ Rectangle
                 toolColorChanged(currentRGB.r, currentRGB.g, currentRGB.b, currentWAUV.r, currentWAUV.g, currentWAUV.b)
             }
 
-            onPressed: setPickedColor(mouse)
-            onPositionChanged: setPickedColor(mouse)
+            onPressed: (mouse) => setPickedColor(mouse)
+            onPositionChanged: (mouse) => setPickedColor(mouse)
             onReleased: rootBox.released()
         }
     }

--- a/qmlui/qml/ColorToolPrimary.qml
+++ b/qmlui/qml/ColorToolPrimary.qml
@@ -116,7 +116,7 @@ Rectangle
             }
 
             onPressed: calculateValue()
-            onPositionChanged:
+            onPositionChanged: (mouse) =>
             {
                 if (!pressed)
                     return

--- a/qmlui/qml/DMXAddressTool.qml
+++ b/qmlui/qml/DMXAddressTool.qml
@@ -45,7 +45,7 @@ GridLayout
         flipHorizontally: toolRoot.flipHorizontally
         flipVertically: toolRoot.flipVertically
         currentValue: toolRoot.value
-        onValueChanged: toolRoot.value = value
+        onValueChanged: (value) => toolRoot.value = value
     }
 
     // row 2

--- a/qmlui/qml/ExternalControlDelegate.qml
+++ b/qmlui/qml/ExternalControlDelegate.qml
@@ -60,7 +60,7 @@ Column
             Layout.fillWidth: true
             height: UISettings.listItemHeight
             currValue: controlID
-            onValueChanged:
+            onValueChanged: (value) =>
             {
                 controlID = value
                 widgetObjRef.updateInputSourceControlID(universe, channel, controlID)

--- a/qmlui/qml/InputChannelDelegate.qml
+++ b/qmlui/qml/InputChannelDelegate.qml
@@ -85,7 +85,7 @@ Rectangle
                 anchors.fill: parent
                 hoverEnabled: true
 
-                onClicked: chDelegate.mouseEvent(App.Clicked, cRef.id, cRef.type, chDelegate, mouse.modifiers)
+                onClicked: (mouse) => chDelegate.mouseEvent(App.Clicked, cRef.id, cRef.type, chDelegate, mouse.modifiers)
                 onDoubleClicked: chDelegate.mouseEvent(App.DoubleClicked, cRef.id, cRef.type, chDelegate, -1)
             }
         }

--- a/qmlui/qml/fixturesfunctions/AudioEditor.qml
+++ b/qmlui/qml/fixturesfunctions/AudioEditor.qml
@@ -45,7 +45,7 @@ Rectangle
         x: rightSidePanel.x - width
         visible: false
 
-        onValueChanged:
+        onValueChanged: (val) =>
         {
             if (speedType == QLCFunction.FadeIn)
                 audioEditor.fadeInSpeed = val

--- a/qmlui/qml/fixturesfunctions/PositionTool.qml
+++ b/qmlui/qml/fixturesfunctions/PositionTool.qml
@@ -322,13 +322,13 @@ Rectangle
             property int initialXPos
             property int initialYPos
 
-            onPressed:
+            onPressed: (mouse) =>
             {
                 // initialize local variables to determine the selection orientation
                 initialXPos = mouse.x
                 initialYPos = mouse.y
             }
-            onPositionChanged:
+            onPositionChanged: (mouse) =>
             {
                 if (Math.abs(mouse.x - initialXPos) > Math.abs(mouse.y - initialYPos))
                 {

--- a/qmlui/qml/fixturesfunctions/SceneEditor.qml
+++ b/qmlui/qml/fixturesfunctions/SceneEditor.qml
@@ -59,7 +59,7 @@ Rectangle
     {
         id: seSelector
         //onItemsCountChanged: console.log("Scene Editor selected items changed!")
-        onItemSelectionChanged:
+        onItemSelectionChanged: (itemIndex, selected) =>
         {
             var item = sfxList.itemAtIndex(itemIndex)
             if (item.itemType === App.FixtureDragItem)
@@ -282,7 +282,7 @@ Rectangle
                             {
                                 anchors.fill: parent
 
-                                onClicked:
+                                onClicked: (mouse) =>
                                 {
                                     if (compDelegate.itemType === App.FixtureDragItem)
                                     {

--- a/qmlui/qml/fixturesfunctions/UniverseGridView.qml
+++ b/qmlui/qml/fixturesfunctions/UniverseGridView.qml
@@ -127,7 +127,7 @@ Flickable
             return fixtureManager.getTooltip(uniAddress)
         }
 
-        onPressed:
+        onPressed: (xPos, yPos, mods) =>
         {
             universeGridView.interactive = false
             var uniAddress = (yPos * gridSize.width) + xPos
@@ -154,7 +154,7 @@ Flickable
             prevFixtureID = currentItemID
         }
 
-        onReleased:
+        onReleased: (xPos, yPos, offset, mods) =>
         {
             universeGridView.interactive = true
 
@@ -165,7 +165,7 @@ Flickable
             fixtureManager.moveFixture(currentItemID, selectionData[0] + offset)
         }
 
-        onDragEntered:
+        onDragEntered: (xPos, yPos, dragEvent) =>
         {
             var channels = dragEvent.source.channels
             console.log("Drag entered. Channels: " + channels)
@@ -182,7 +182,7 @@ Flickable
             setSelectionData(tmp)
         }
 
-        onDragPositionChanged:
+        onDragPositionChanged: (xPos, yPos, offset, dragEvent) =>
         {
             var uniAddress = (yPos * gridSize.width) + xPos
             dragEvent.source.address = uniAddress
@@ -195,7 +195,7 @@ Flickable
                 validSelection = false
         }
 
-        onPositionChanged:
+        onPositionChanged: (xPos, yPos, offset, mods) =>
         {
             var uniAddress = (yPos * gridSize.width) + xPos
             var freeAddr = fixtureBrowser.availableChannel(currentItemID, uniAddress)

--- a/qmlui/qml/popup/PopupAbout.qml
+++ b/qmlui/qml/popup/PopupAbout.qml
@@ -56,7 +56,7 @@ CustomPopupDialog
                       qsTr("This application is licensed under the terms of the") +
                       " <a href='https://www.apache.org/licenses/LICENSE-2.0'>" +
                       qsTr("Apache 2.0 license") + "</a>."
-                onLinkActivated: Qt.openUrlExternally(link)
+                onLinkActivated: (link) => Qt.openUrlExternally(link)
                 Layout.fillWidth: true
                 wrapMode: Text.WordWrap
 


### PR DESCRIPTION
This PR fixes some more QML signal handlers that emit the following warning when called:

```
qrc:/[...] Parameter "[...]" is not declared. Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead.
```