### PR TITLE
ui/dmxmonitor: update gel color immediately

### DIFF
--- a/ui/src/monitor/monitorfixtureitem.h
+++ b/ui/src/monitor/monitorfixtureitem.h
@@ -86,6 +86,8 @@ class MonitorFixtureItem : public QObject, public QGraphicsItem
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
 
+    friend class MonitorFixturePropertiesEditor;
+
 public:
     MonitorFixtureItem(Doc *doc, quint32 fid);
 
@@ -98,19 +100,19 @@ public:
     void setRealPosition(QPointF pos) { m_realPos = pos; }
 
     /** Return the position of this fixture express in the monitor measure units */
-    QPointF realPosition() { return m_realPos; }
+    QPointF realPosition() const { return m_realPos; }
 
     /** Sets the dimension of this fixture */
     void setSize(QSize size);
 
     void setGelColor(QColor color) { m_gelColor = color; }
-    QColor getColor() { return m_gelColor; }
+    QColor getColor() const { return m_gelColor; }
 
     /** Return the fixture ID associated to this item */
-    quint32 fixtureID() { return m_fid; }
+    quint32 fixtureID() const { return m_fid; }
 
     /** Return the number of heads represented by this item */
-    int headsCount() { return m_heads.count(); }
+    int headsCount() const { return m_heads.count(); }
 
     /** Show/hide this fixture item label */
     void showLabel(bool visible);

--- a/ui/src/monitor/monitorfixturepropertieseditor.cpp
+++ b/ui/src/monitor/monitorfixturepropertieseditor.cpp
@@ -107,6 +107,7 @@ void MonitorFixturePropertiesEditor::slotGelColorClicked()
         QPixmap pm(28, 28);
         pm.fill(newColor);
         m_gelColorButton->setIcon(QIcon(pm));
+        m_fxItem->slotUpdateValues();
     }
 }
 
@@ -115,5 +116,6 @@ void MonitorFixturePropertiesEditor::slotGelResetClicked()
     m_gelColorButton->setIcon(QIcon());
     m_fxItem->setGelColor(QColor());
     m_props->setFixtureGelColor(m_fxItem->fixtureID(), 0, 0, QColor());
+    m_fxItem->slotUpdateValues();
 }
 


### PR DESCRIPTION
**Describe the bug / To Reproduce**
1. Start QLC+ (v4, new workspace).
2. Add a `generic dimmer`, switch to the `Simple Desk` page and set the dimmer channel to `255`.
3. Open the `DMX Monitor`, switch to the `2D View` and add the fixture.
4. In the DMX monitor, click on the added fixture to open the properties sub-window.
5. a) Click on the `Gel color` colour picker, choose a colour other than white and click `OK`.
or
b) If a colour (other than white) has been chosen, click the `X` button to reset it to white/no gel colour.

**Expected behaviour**
In the `2D View`, the gel colour should updated immediately. Currently, however, it only changes after modifying the intensity channel value (e.g. via the `Simple Desk`).

**Problem Analysis**
When clicking the gel colour picker or the reset button, `MonitorFixturePropertiesEditor::slotGelColorClicked()` or `MonitorFixturePropertiesEditor::slotGelResetClicked()` is called, respectively.
There, the `m_getColor` attribute of the corresponding `MonitorFixtureItem` is set correctly.
However, this change is not immediately displayed because `MonitorFixtureItem::slotUpdateValues()` is only called when the DMX value changes, not when the gel colour is modified.

**Proposed Solutions**
Once all variables have been set correctly, call `MonitorFixtureItem::slotUpdateValues()` from `MonitorFixturePropertiesEditor::slotGelColorClicked()` and `MonitorFixturePropertiesEditor::slotGelResetClicked()`.

The problem with this is that `slotUpdateValues()` is private within `MonitorFixtureItem`.
Instead of declaring this method public for all classes, `MonitorFixturePropertiesEditor` was declared a friend class of `MonitorFixtureItem`, giving it access to all private members of `MonitorFixtureItem`.