### PR TITLE
fixture: fix problems with  Showtec-Giant-XL-LED.qxf

### DIFF
--- a/resources/fixtures/Showtec/Showtec-Giant-XL-LED.qxf
+++ b/resources/fixtures/Showtec/Showtec-Giant-XL-LED.qxf
@@ -132,13 +132,6 @@
   <Channel Number="7">Focus</Channel>
  </Mode>
  <Mode Name="14 Channel">
-  <Physical>
-   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
-   <Dimensions Weight="8.75" Width="240" Height="300" Depth="250"/>
-   <Lens Name="PC" DegreesMin="17" DegreesMax="17"/>
-   <Focus Type="Head" PanMax="540" TiltMax="270"/>
-   <Technical PowerConsumption="102" DmxConnector="3-pin"/>
-  </Physical>
   <Channel Number="0">Pan</Channel>
   <Channel Number="1">Pan Fine</Channel>
   <Channel Number="2">Tilt</Channel>
@@ -155,13 +148,6 @@
   <Channel Number="13">Focus</Channel>
  </Mode>
  <Mode Name="14 Channel (revB)">
-  <Physical>
-   <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
-   <Dimensions Weight="8.75" Width="240" Height="300" Depth="250"/>
-   <Lens Name="PC" DegreesMin="17" DegreesMax="17"/>
-   <Focus Type="Head" PanMax="540" TiltMax="270"/>
-   <Technical PowerConsumption="102" DmxConnector="3-pin"/>
-  </Physical>
   <Channel Number="0">Pan</Channel>
   <Channel Number="1">Tilt</Channel>
   <Channel Number="2">Pan Fine</Channel>


### PR DESCRIPTION
Fixed issues with the current file:
- height specs were wrong, device is 300mm not 350mm (or 325mm)
- the MH had two versions, in the second on the dmx is different for the fine movement channels

## Fixture Information

**Manufacturer:**  ShowTec

**Model:**  GinatXL LED

**Mode(s) included:**  3 (8ch, 14ch, 14ch B)

**Channels used:**  14

## Testing

- [x] Physical data is included 
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly 


## Source(s) of Information

I own a GiantXL, printed manual and testing

## Notes
This PR fixes issues, that appeared when using this fixture with the newer models after a certain year (not quite sure when they changed the addresses), where the pan_fin and tilt_fine channels are not on the right channels.

I did not quite know how to handle this kind of situation since I experienced this issue while programming a show file with my device. The solution I suggested in this PR for the mixed up channels would be a second 14ch Mode which has the proper channel order, since I do know that in the older GiantXL MHs the order, that was in the fixture file is correct. 
If you would rather solve this differently, please do not hesitate to contact me. I am more than happy to rewrite the fixture or find an other way to solve it if that would be preferred on your side. 
Best regards
Liam
