### PR TITLE
Tryng to fix 2D left rotation not rotating fixtures preview

### DIFF
--- a/qmlui/mainview2d.cpp
+++ b/qmlui/mainview2d.cpp
@@ -616,6 +616,8 @@ void MainView2D::updateFixtureRotation(quint32 itemID, QVector3D degrees)
             fxItem->setProperty("rotation", degrees.z());
         break;
         case MonitorProperties::LeftSideView:
+            fxItem->setProperty("rotation", -degrees.x());
+        break;
         case MonitorProperties::RightSideView:
             fxItem->setProperty("rotation", degrees.x());
         break;


### PR DESCRIPTION
Hi, hello! I'm new here. I hope I have put the pull-request in the correct way. Otherwise I'm sorry, I promise to do better next time.
Today I was just trying to solve the issue here: https://www.qlcplus.org/forum/viewtopic.php?t=18808 .

`case MonitorProperties::LeftSideView: `
isn't associated to any action. I personally think that it should be followed by

`fxItem->setProperty("rotation", -degrees.x());
break;`

as I think that the rotation to the left should do the opposite to the right rotation.

I've not managed to clone and build the code on my pc, so I have not tested this edited code. Sorry, I will try in the next days.

