### PR TITLE
Adding fixture Eurolite Silent PAR 6

### DIFF
--- a/resources/fixtures/Eurolite/Eurolite-LED-Silent-PAR6.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-Silent-PAR6.qxf
@@ -80,10 +80,10 @@
   <Capability Min="131" Max="160" Preset="SilentModeAutomatic">Switching colors, R, G, B</Capability>
   <Capability Min="161" Max="190" Preset="Alias">Switching colors, C, M, Y</Capability>
   <Capability Min="191" Max="220" Preset="Alias">Sound controlled strobe effect
-   <Alias Mode="11-channels" Channel="Speed internal programs" With="Microphone sensitivity"/>
+   <Alias Mode="11 Channel" Channel="Speed internal programs" With="Microphone sensitivity"/>
   </Capability>
   <Capability Min="221" Max="255" Preset="Alias">Sound controlled color change
-   <Alias Mode="11-channels" Channel="Speed internal programs" With="Microphone sensitivity"/>
+   <Alias Mode="11 Channel" Channel="Speed internal programs" With="Microphone sensitivity"/>
   </Capability>
  </Channel>
  <Channel Name="Speed internal programs">
@@ -100,7 +100,7 @@
   <Capability Min="101" Max="255">no function</Capability>
  </Channel>
  <Channel Name="Microphone sensitivity" Preset="IntensityValue"/>
- <Mode Name="6-channels">
+ <Mode Name="6 Channel">
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
@@ -108,7 +108,7 @@
   <Channel Number="4">Dimmer</Channel>
   <Channel Number="5">Strobe (simple)</Channel>
  </Mode>
- <Mode Name="11-channels">
+ <Mode Name="11 Channel">
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>


### PR DESCRIPTION
Manual:

## Fixture Information

**Manufacturer:**  Eurolite
**Model:**  Silent PAR 6
**Mode(s) included:**  6-channel and 1-channel
**Channels used:**  11

## Testing

- [X] Physical data is included 
- [X] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [X] Channel modes do not include the word "mode" in them
- [X] Capabilities are labeled and ordered clearly

## Source(s) of Information
Manual identical to the hard copy I have:
https://www.steinigke.de/download/51915340-Manual-143272-1.0000-eurolite-led-silent-par-6-qcl-floor-bk-de_en.pdf

## Notes

I have used this fixture for a show with QLC 4.It's not the besst of lights but it works very well with QLC :-)


Thank you for improving the QLC+ fixture library.
