### PR TITLE
Adding fixture beamZ BT430

### DIFF
--- a/resources/fixtures/beamZ/beamZ-BT430.qxf
+++ b/resources/fixtures/beamZ/beamZ-BT430.qxf
@@ -69,7 +69,7 @@
  <Channel Name="Dimmer Warm White - Ring 7" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer Warm White - Ring 8" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer Warm White - Ring 9" Preset="IntensityDimmer"/>
- <Mode Name="7-channels">
+ <Mode Name="7 Channel">
   <Channel Number="0">Master Dimmer</Channel>
   <Channel Number="1">Strobe</Channel>
   <Channel Number="2">Warm white</Channel>
@@ -78,7 +78,7 @@
   <Channel Number="5">Macro Run</Channel>
   <Channel Number="6">Macro Run Speed</Channel>
  </Mode>
- <Mode Name="16-channels">
+ <Mode Name="16 Channel">
   <Channel Number="0">Master Dimmer</Channel>
   <Channel Number="1">Strobe</Channel>
   <Channel Number="2">Warm white</Channel>


### PR DESCRIPTION
## Fixture Information

**Manufacturer:**  beamZ
**Model:**   BT430
**Mode(s) included:**  7-channel & 16-channel 
**Channels used:**  16

## Testing

- [X] Physical data is included 
- [X] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [X] Channel modes do not include the word "mode" in them
- [X] Capabilities are labeled and ordered clearly


## Source(s) of Information

Manual: https://www.beamzlighting.com/wp-content/uploads/2025/04/151.341-BT430-PAR-Strobe-CC_WW_QSG_V1.2.pdf

## Notes

I have used this fixture in a theater show, and it works fine with QLC 4.

---

Thank you for improving the QLC+ fixture library.
