### PR TITLE
qmlui/vcclock: prevent underflow/negative time if countdown is started at 00:00:00.0

### DIFF
--- a/qmlui/qml/virtualconsole/VCClockItem.qml
+++ b/qmlui/qml/virtualconsole/VCClockItem.qml
@@ -109,12 +109,15 @@ VCWidgetItem
             {
                 anchors.fill: parent
                 acceptedButtons: Qt.LeftButton | Qt.RightButton
-                onClicked:
+                onClicked: (mouse) =>
                 {
                     if (clockType == VCClock.Stopwatch || clockType == VCClock.Countdown)
                     {
                         if (mouse.button === Qt.LeftButton)
                         {
+                            if (clockType === VCClock.Countdown && timeCounter <= 0)
+                                return;
+
                             clockTimer.running = !clockTimer.running
                             return;
                         }


### PR DESCRIPTION
If a VC clock is started in countdown mode from the time `00:00:00.0` in QLC+ 5, the internal time value is decreased before checking whether it is equal to `0`. As a result, it jumps to a large negative number (underflow) that is counted up.

This PR introduces a check before starting the countdown to prevent the undesirable behaviour described above.