### PR TITLE
CMake: Set UDEVRULESDIR instead of using the hardcoded /etc/udev/rules.d

### DIFF
--- a/variables.cmake
+++ b/variables.cmake
@@ -427,10 +427,11 @@ endif ()
 
 # udev rules
 if(UNIX AND NOT APPLE)
-    if (${INSTALL_ROOT} STREQUAL "/")
+    if (NOT UDEVRULESDIR)
         set(UDEVRULESDIR "/etc/udev/rules.d")
-    else()
-        set(UDEVRULESDIR "${INSTALL_ROOT}/etc/udev/rules.d")
+    endif()
+    if (NOT ${INSTALL_ROOT} STREQUAL "/")
+        set(UDEVRULESDIR "${INSTALL_ROOT}${UDEVRULESDIR}")
     endif()
 endif()
 


### PR DESCRIPTION
## Description

Linux packages should generally not use /etc/udev/rules.d for files not intended to be edited by users. platforms/linux/qlcplus.spec thus has to hack the qmake build rules, and we would need the same for cmake.

Instead, make it possible to make a compliant build with cmake without hacking the build system by building like:

    cmake -DUDEVRULESDIR:PATH=/usr/lib/udev/rules.d

## Checklist

- [x ] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [ x] My code adheres to the project's coding style, including:
  - [ ] Placing opening braces `{` on a new line for functions and class definitions.
  - [ x] Consistent use of spaces and indentation.
- [ x] I have tested my changes on the following platforms:
  - [ x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

Built rpm using this feature and tested on Fedora.

