### PR TITLE
correct fixture types, part 2: single color fixtures (also set to typ…

### DIFF
--- a/resources/fixtures/American_DJ/American-DJ-Encore-FR150z.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Encore-FR150z.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>American DJ</Manufacturer>
  <Model>Encore FR150z</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Master Dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Strobe" Default="40">
   <Group Byte="0">Shutter</Group>

--- a/resources/fixtures/American_DJ/American-DJ-Encore-FR50z.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Encore-FR50z.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>American DJ</Manufacturer>
  <Model>Encore FR50z</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Master Dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Strobe" Default="40">
   <Group Byte="0">Shutter</Group>

--- a/resources/fixtures/Briteq/Briteq-BT-Theatre-250EZ-Mk3.qxf
+++ b/resources/fixtures/Briteq/Briteq-BT-Theatre-250EZ-Mk3.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Briteq</Manufacturer>
  <Model>BT Theatre 250EZ Mk3</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer fine" Preset="IntensityDimmerFine"/>
  <Channel Name="WW" Preset="IntensityWhite"/>

--- a/resources/fixtures/Briteq/Briteq-BT-Theatre-250EZ.qxf
+++ b/resources/fixtures/Briteq/Briteq-BT-Theatre-250EZ.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Briteq</Manufacturer>
  <Model>BT Theatre 250EZ (and 250EZ Mk2)</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer fine" Preset="IntensityDimmerFine"/>
  <Channel Name="Strobe">

--- a/resources/fixtures/Cameo/Cameo-F2-T-PO.qxf
+++ b/resources/fixtures/Cameo/Cameo-F2-T-PO.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Cameo</Manufacturer>
  <Model>F2 T PO</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Dimmer fine" Preset="IntensityMasterDimmerFine"/>
  <Channel Name="Multifunctional Strobe">

--- a/resources/fixtures/Cameo/Cameo-P2-T.qxf
+++ b/resources/fixtures/Cameo/Cameo-P2-T.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Cameo</Manufacturer>
  <Model>P2 T</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Dimmer fine" Preset="IntensityMasterDimmerFine"/>
  <Channel Name="Strobe Functions">

--- a/resources/fixtures/Chauvet/Chauvet-Ovation-H-105WW.qxf
+++ b/resources/fixtures/Chauvet/Chauvet-Ovation-H-105WW.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Chauvet</Manufacturer>
  <Model>Ovation H-105WW</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Fine Dimmer" Preset="IntensityMasterDimmerFine"/>
  <Channel Name="Strobe Speed">

--- a/resources/fixtures/Pro-Lights/Pro-Lights-EVO90F.qxf
+++ b/resources/fixtures/Pro-Lights/Pro-Lights-EVO90F.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Pro-Lights</Manufacturer>
  <Model>EVO90F</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer fine" Preset="IntensityDimmerFine"/>
  <Channel Name="Strobe">

--- a/resources/fixtures/RVE/RVE-Sereniled-EVO2.qxf
+++ b/resources/fixtures/RVE/RVE-Sereniled-EVO2.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>RVE</Manufacturer>
  <Model>Sereniled EVO2</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer Fine" Preset="IntensityDimmerFine"/>
  <Mode Name="8 Bit">

--- a/resources/fixtures/RVE/RVE-Sereniled-Plus.qxf
+++ b/resources/fixtures/RVE/RVE-Sereniled-Plus.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>RVE</Manufacturer>
  <Model>Sereniled Plus</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer Fine" Preset="IntensityDimmerFine"/>
  <Mode Name="8 Bit">

--- a/resources/fixtures/RVE/RVE-Twinled-EVO2.qxf
+++ b/resources/fixtures/RVE/RVE-Twinled-EVO2.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>RVE</Manufacturer>
  <Model>Twinled EVO2</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Channel Name="Dimmer Fine" Preset="IntensityDimmerFine"/>
  <Mode Name="8 Bit">

--- a/resources/fixtures/Robert_Juliat/Robert-Juliat-DArtagnan-934SNX.qxf
+++ b/resources/fixtures/Robert_Juliat/Robert-Juliat-DArtagnan-934SNX.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Robert Juliat</Manufacturer>
  <Model>D'Artagnan 934SNX</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Lamp">
   <Group Byte="0">Maintenance</Group>
   <Capability Min="0" Max="255">Lamp On</Capability>

--- a/resources/fixtures/Showtec/Showtec-LED-Blinder-2-COB.qxf
+++ b/resources/fixtures/Showtec/Showtec-LED-Blinder-2-COB.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Showtec</Manufacturer>
  <Model>LED Blinder 2 COB</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer intensity (Left COB LED)">
   <Group Byte="0">Intensity</Group>
   <Capability Min="0" Max="255">Gradual adjustment, from dark to brightest 0-100%</Capability>

--- a/resources/fixtures/Showtec/Showtec-Par-64-100W-COB-UV.qxf
+++ b/resources/fixtures/Showtec/Showtec-Par-64-100W-COB-UV.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>Showtec</Manufacturer>
  <Model>Par 64 100W COB UV</Model>
- <Type>Dimmer</Type>
+ <Type>Color Changer</Type>
  <Channel Name="Dimmer" Preset="IntensityDimmer"/>
  <Mode Name="8 Bit">
   <Channel Number="0">Dimmer</Channel>


### PR DESCRIPTION
…e Color Changer as this seems to be common sense)

OK, I've looked at how some other single color LED fixtures like e.g. Cameo TS (40, 100 and 200 WW variants) are done, and it seems to be the widely accepted and preferred way to go.
So I changed the remaining items on my list and set them all to type "Color Changer" now.

This fixes the 2D/3D fixture rendering as discussed in the forum thread mentioned in my previous "part 1" PR.

