### PR TITLE
fixtureeditor,ui: make keyboard shortcuts non-translatable

### DIFF
--- a/fixtureeditor/app.cpp
+++ b/fixtureeditor/app.cpp
@@ -243,38 +243,38 @@ void App::initActions()
     /* File actions */
     m_fileNewAction = new QAction(QIcon(":/filenew.png"),
                                   tr("&New"), this);
-    m_fileNewAction->setShortcut(QKeySequence(tr("CTRL+N", "File|New")));
+    m_fileNewAction->setShortcut(QKeySequence("CTRL+N"));
     connect(m_fileNewAction, SIGNAL(triggered(bool)),
             this, SLOT(slotFileNew()));
 
     m_fileOpenAction = new QAction(QIcon(":/fileopen.png"),
                                    tr("&Open"), this);
-    m_fileOpenAction->setShortcut(QKeySequence(tr("CTRL+O", "File|Open")));
+    m_fileOpenAction->setShortcut(QKeySequence("CTRL+O"));
     connect(m_fileOpenAction, SIGNAL(triggered(bool)),
             this, SLOT(slotFileOpen()));
 
     m_fileSaveAction = new QAction(QIcon(":/filesave.png"),
                                    tr("&Save"), this);
-    m_fileSaveAction->setShortcut(QKeySequence(tr("CTRL+S", "File|Save")));
+    m_fileSaveAction->setShortcut(QKeySequence("CTRL+S"));
     connect(m_fileSaveAction, SIGNAL(triggered(bool)),
             this, SLOT(slotFileSave()));
 
     m_fileSaveAsAction = new QAction(QIcon(":/filesaveas.png"),
                                      tr("Save &As..."), this);
-    m_fileSaveAsAction->setShortcut(QKeySequence(tr("CTRL+SHIFT+S", "File|Save As...")));
+    m_fileSaveAsAction->setShortcut(QKeySequence("CTRL+SHIFT+S"));
     connect(m_fileSaveAsAction, SIGNAL(triggered(bool)),
             this, SLOT(slotFileSaveAs()));
 
     m_fileQuitAction = new QAction(QIcon(":/exit.png"),
                                    tr("&Quit"), this);
-    m_fileQuitAction->setShortcut(QKeySequence(tr("CTRL+Q", "File|Quit")));
+    m_fileQuitAction->setShortcut(QKeySequence("CTRL+Q"));
     connect(m_fileQuitAction, SIGNAL(triggered(bool)),
             this, SLOT(slotFileQuit()));
 
     /* Help actions */
     m_helpIndexAction = new QAction(QIcon(":/help.png"),
                                     tr("Index"), this);
-    m_helpIndexAction->setShortcut(QKeySequence(tr("SHIFT+F1", "Help|Index")));
+    m_helpIndexAction->setShortcut(QKeySequence("SHIFT+F1"));
     connect(m_helpIndexAction, SIGNAL(triggered(bool)),
             this, SLOT(slotHelpIndex()));
 

--- a/fixtureeditor/fixtureeditor_ca_ES.ts
+++ b/fixtureeditor/fixtureeditor_ca_ES.ts
@@ -48,10 +48,9 @@
         <translation>&amp;Nou</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="251"/>
@@ -59,10 +58,9 @@
         <translation>&amp;Obrir</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="252"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -70,10 +68,9 @@
         <translation>&amp;Desar</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="263"/>
@@ -81,10 +78,9 @@
         <translation>Desar &amp;com...</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="264"/>
         <source>CTRL+SHIFT+S</source>
         <comment>File|Save As...</comment>
-        <translation>CTRL+SHIFT+S</translation>
+        <translation type="vanished">CTRL+SHIFT+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -92,10 +88,9 @@
         <translation>&amp;Sortir</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
         <source>CTRL+Q</source>
         <comment>File|Quit</comment>
-        <translation>CTRL+Q</translation>
+        <translation type="vanished">CTRL+Q</translation>
     </message>
     <message>
         <location filename="app.cpp" line="276"/>
@@ -103,10 +98,9 @@
         <translation>Índex</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="277"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_cz_CZ.ts
+++ b/fixtureeditor/fixtureeditor_cz_CZ.ts
@@ -49,10 +49,9 @@
         <translation>&amp;Nový</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="251"/>
@@ -60,10 +59,9 @@
         <translation>&amp;Otevřít</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="252"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,10 +69,9 @@
         <translation>&amp;Uložit</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="263"/>
@@ -82,10 +79,9 @@
         <translation>Uložit &amp;Jako...</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="264"/>
         <source>CTRL+SHIFT+S</source>
         <comment>File|Save As...</comment>
-        <translation>CTRL+SHIFT+S</translation>
+        <translation type="vanished">CTRL+SHIFT+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,10 +89,9 @@
         <translation>&amp;Quit</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
         <source>CTRL+Q</source>
         <comment>File|Quit</comment>
-        <translation>CTRL+Q</translation>
+        <translation type="vanished">CTRL+Q</translation>
     </message>
     <message>
         <location filename="app.cpp" line="276"/>
@@ -104,10 +99,9 @@
         <translation>Obsah</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="277"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_de_DE.ts
+++ b/fixtureeditor/fixtureeditor_de_DE.ts
@@ -72,10 +72,9 @@
         <translation>&amp;Neu</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="251"/>
@@ -83,10 +82,9 @@
         <translation>&amp;Öffnen</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="252"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -94,10 +92,9 @@
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="263"/>
@@ -106,10 +103,9 @@
         <translation>Speichern &amp;unter…</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="264"/>
         <source>CTRL+SHIFT+S</source>
         <comment>File|Save As...</comment>
-        <translation>CTRL+SHIFT+S</translation>
+        <translation type="vanished">CTRL+SHIFT+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -117,10 +113,9 @@
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
         <source>CTRL+Q</source>
         <comment>File|Quit</comment>
-        <translation>CTRL+Q</translation>
+        <translation type="vanished">CTRL+Q</translation>
     </message>
     <message>
         <location filename="app.cpp" line="276"/>
@@ -128,10 +123,9 @@
         <translation>Handbuch</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="277"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>F1</translation>
+        <translation type="vanished">F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_es_ES.ts
+++ b/fixtureeditor/fixtureeditor_es_ES.ts
@@ -49,21 +49,9 @@
         <translation>&amp;Nuevo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="251"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="252"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,21 +59,9 @@
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="263"/>
         <source>Save &amp;As...</source>
         <translation>Guardar &amp;como...</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="264"/>
-        <source>CTRL+SHIFT+S</source>
-        <comment>File|Save As...</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,21 +69,9 @@
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
-        <source>CTRL+Q</source>
-        <comment>File|Quit</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="276"/>
         <source>Index</source>
         <translation>Índice</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="277"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_fi_FI.ts
+++ b/fixtureeditor/fixtureeditor_fi_FI.ts
@@ -49,21 +49,9 @@
         <translation>&amp;Uusi</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="251"/>
         <source>&amp;Open</source>
         <translation>A&amp;vaa</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="252"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,21 +59,9 @@
         <translation>&amp;Tallenna</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="263"/>
         <source>Save &amp;As...</source>
         <translation>Tallenna nimellä...</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="264"/>
-        <source>CTRL+SHIFT+S</source>
-        <comment>File|Save As...</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,21 +69,9 @@
         <translation>&amp;Poistu</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
-        <source>CTRL+Q</source>
-        <comment>File|Quit</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="276"/>
         <source>Index</source>
         <translation>Hakemisto</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="277"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_fr_FR.ts
+++ b/fixtureeditor/fixtureeditor_fr_FR.ts
@@ -49,21 +49,9 @@
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="251"/>
         <source>&amp;Open</source>
         <translation>&amp;Ouvrir</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="252"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,21 +59,9 @@
         <translation>Enregistrer (&amp;S)</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="263"/>
         <source>Save &amp;As...</source>
         <translation>Enregistrer sous... (&amp;A)</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="264"/>
-        <source>CTRL+SHIFT+S</source>
-        <comment>File|Save As...</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,21 +69,9 @@
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
-        <source>CTRL+Q</source>
-        <comment>File|Quit</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="276"/>
         <source>Index</source>
         <translation>Aide</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="277"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_it_IT.ts
+++ b/fixtureeditor/fixtureeditor_it_IT.ts
@@ -49,21 +49,9 @@
         <translation>&amp;Nuovo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="251"/>
         <source>&amp;Open</source>
         <translation>&amp;Apri</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="252"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,21 +59,9 @@
         <translation>&amp;Salvare</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="263"/>
         <source>Save &amp;As...</source>
         <translation>Salva &amp;Con Nome...</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="264"/>
-        <source>CTRL+SHIFT+S</source>
-        <comment>File|Save As...</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,21 +69,9 @@
         <translation>&amp;Quit</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
-        <source>CTRL+Q</source>
-        <comment>File|Quit</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="276"/>
         <source>Index</source>
         <translation>Indice</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="277"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_ja_JP.ts
+++ b/fixtureeditor/fixtureeditor_ja_JP.ts
@@ -49,21 +49,9 @@
         <translation>新規</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="251"/>
         <source>&amp;Open</source>
         <translation>開く</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="252"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,21 +59,9 @@
         <translation>上書き保存</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="263"/>
         <source>Save &amp;As...</source>
         <translation>名前を付けて保存</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="264"/>
-        <source>CTRL+SHIFT+S</source>
-        <comment>File|Save As...</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,21 +69,9 @@
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
-        <source>CTRL+Q</source>
-        <comment>File|Quit</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="276"/>
         <source>Index</source>
         <translation>ヘルプ</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="277"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_nl_NL.ts
+++ b/fixtureeditor/fixtureeditor_nl_NL.ts
@@ -49,11 +49,10 @@
         <translation>&amp;Nieuw</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
         <translatorcomment>Bestand|Nieuw</translatorcomment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="251"/>
@@ -61,11 +60,10 @@
         <translation>&amp;Open</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="252"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
         <translatorcomment>Bestand|Openen</translatorcomment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -73,11 +71,10 @@
         <translation>Op&amp;slaan</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
         <translatorcomment>Bestand|Opslaan</translatorcomment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="263"/>
@@ -85,11 +82,10 @@
         <translation>Opslaan &amp;Als...</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="264"/>
         <source>CTRL+SHIFT+S</source>
         <comment>File|Save As...</comment>
         <translatorcomment>Bestand|Opslaan als...</translatorcomment>
-        <translation>CTRL+SHIFT+S</translation>
+        <translation type="vanished">CTRL+SHIFT+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -97,11 +93,10 @@
         <translation>S&amp;luiten</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
         <source>CTRL+Q</source>
         <comment>File|Quit</comment>
         <translatorcomment>Bestand|Sluiten</translatorcomment>
-        <translation>CTRL+L</translation>
+        <translation type="vanished">CTRL+L</translation>
     </message>
     <message>
         <location filename="app.cpp" line="276"/>
@@ -109,11 +104,10 @@
         <translation>Index</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="277"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
         <translatorcomment>Help|Index</translatorcomment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/fixtureeditor/fixtureeditor_pt_BR.ts
+++ b/fixtureeditor/fixtureeditor_pt_BR.ts
@@ -49,10 +49,9 @@
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="246"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="251"/>
@@ -60,10 +59,9 @@
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="252"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="257"/>
@@ -71,10 +69,9 @@
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="258"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="263"/>
@@ -82,10 +79,9 @@
         <translation>Guardar &amp;como...</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="264"/>
         <source>CTRL+SHIFT+S</source>
         <comment>File|Save As...</comment>
-        <translation>CTRL+SHIFT+S</translation>
+        <translation type="vanished">CTRL+SHIFT+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="269"/>
@@ -93,10 +89,9 @@
         <translation>&amp;Sair</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="270"/>
         <source>CTRL+Q</source>
         <comment>File|Quit</comment>
-        <translation>CTRL+Q</translation>
+        <translation type="vanished">CTRL+Q</translation>
     </message>
     <message>
         <location filename="app.cpp" line="276"/>
@@ -104,10 +99,9 @@
         <translation>Índice</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="277"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="282"/>

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -680,15 +680,15 @@ void App::initActions()
 {
     /* File actions */
     m_fileNewAction = new QAction(QIcon(":/filenew.png"), tr("&New"), this);
-    m_fileNewAction->setShortcut(QKeySequence(tr("CTRL+N", "File|New")));
+    m_fileNewAction->setShortcut(QKeySequence("CTRL+N"));
     connect(m_fileNewAction, SIGNAL(triggered(bool)), this, SLOT(slotFileNew()));
 
     m_fileOpenAction = new QAction(QIcon(":/fileopen.png"), tr("&Open"), this);
-    m_fileOpenAction->setShortcut(QKeySequence(tr("CTRL+O", "File|Open")));
+    m_fileOpenAction->setShortcut(QKeySequence("CTRL+O"));
     connect(m_fileOpenAction, SIGNAL(triggered(bool)), this, SLOT(slotFileOpen()));
 
     m_fileSaveAction = new QAction(QIcon(":/filesave.png"), tr("&Save"), this);
-    m_fileSaveAction->setShortcut(QKeySequence(tr("CTRL+S", "File|Save")));
+    m_fileSaveAction->setShortcut(QKeySequence("CTRL+S"));
     connect(m_fileSaveAction, SIGNAL(triggered(bool)), this, SLOT(slotFileSave()));
 
     m_fileSaveAsAction = new QAction(QIcon(":/filesaveas.png"), tr("Save &As..."), this);
@@ -697,11 +697,11 @@ void App::initActions()
     /* Control actions */
     m_modeToggleAction = new QAction(QIcon(":/operate.png"), tr("&Operate"), this);
     m_modeToggleAction->setToolTip(tr("Switch to operate mode"));
-    m_modeToggleAction->setShortcut(QKeySequence(tr("CTRL+F12", "Control|Toggle operate/design mode")));
+    m_modeToggleAction->setShortcut(QKeySequence("CTRL+F12"));
     connect(m_modeToggleAction, SIGNAL(triggered(bool)), this, SLOT(slotModeToggle()));
 
     m_controlMonitorAction = new QAction(QIcon(":/monitor.png"), tr("&Monitor"), this);
-    m_controlMonitorAction->setShortcut(QKeySequence(tr("CTRL+M", "Control|Monitor")));
+    m_controlMonitorAction->setShortcut(QKeySequence("CTRL+M"));
     connect(m_controlMonitorAction, SIGNAL(triggered(bool)), this, SLOT(slotControlMonitor()));
 
     m_addressToolAction = new QAction(QIcon(":/diptool.png"), tr("Address Tool"), this);
@@ -722,7 +722,7 @@ void App::initActions()
     m_liveEditVirtualConsoleAction->setEnabled(false);
 
     m_dumpDmxAction = new QAction(QIcon(":/add_dump.png"), tr("Dump DMX values to a function"), this);
-    m_dumpDmxAction->setShortcut(QKeySequence(tr("CTRL+D", "Control|Dump DMX")));
+    m_dumpDmxAction->setShortcut(QKeySequence("CTRL+D"));
     connect(m_dumpDmxAction, SIGNAL(triggered()), this, SLOT(slotDumpDmxIntoFunction()));
 
     m_controlPanicAction = new QAction(QIcon(":/panic.png"), tr("Stop ALL functions!"), this);
@@ -754,12 +754,12 @@ void App::initActions()
 
     m_controlFullScreenAction = new QAction(QIcon(":/fullscreen.png"), tr("Toggle Full Screen"), this);
     m_controlFullScreenAction->setCheckable(true);
-    m_controlFullScreenAction->setShortcut(QKeySequence(tr("CTRL+F11", "Control|Toggle Full Screen")));
+    m_controlFullScreenAction->setShortcut(QKeySequence("CTRL+F11"));
     connect(m_controlFullScreenAction, SIGNAL(triggered(bool)), this, SLOT(slotControlFullScreen()));
 
     /* Help actions */
     m_helpIndexAction = new QAction(QIcon(":/help.png"), tr("&Index"), this);
-    m_helpIndexAction->setShortcut(QKeySequence(tr("SHIFT+F1", "Help|Index")));
+    m_helpIndexAction->setShortcut(QKeySequence("SHIFT+F1"));
     connect(m_helpIndexAction, SIGNAL(triggered(bool)), this, SLOT(slotHelpIndex()));
 
     m_helpAboutAction = new QAction(QIcon(":/qlcplus.png"), tr("&About QLC+"), this);

--- a/ui/src/qlcplus_ca_ES.ts
+++ b/ui/src/qlcplus_ca_ES.ts
@@ -640,10 +640,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>&amp;Nou</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="686"/>
@@ -651,10 +650,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>&amp;Obrir</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -662,10 +660,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>&amp;Desar</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -678,10 +675,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>&amp;Operació</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
         <source>CTRL+F12</source>
         <comment>Control|Toggle operate/design mode</comment>
-        <translation>CTRL+F12</translation>
+        <translation type="vanished">CTRL+F12</translation>
     </message>
     <message>
         <location filename="app.cpp" line="703"/>
@@ -689,10 +685,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>&amp;Monitor</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="704"/>
         <source>CTRL+M</source>
         <comment>Control|Monitor</comment>
-        <translation>CTRL+M</translation>
+        <translation type="vanished">CTRL+M</translation>
     </message>
     <message>
         <location filename="app.cpp" line="707"/>
@@ -720,10 +715,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>Bolcar valors DMX a una funció</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>CTRL+D</translation>
+        <translation type="vanished">CTRL+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>
@@ -757,10 +751,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>Canviar a Pantalla Completa</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
         <source>CTRL+F11</source>
         <comment>Control|Toggle Full Screen</comment>
-        <translation>CTRL+F11</translation>
+        <translation type="vanished">CTRL+F11</translation>
     </message>
     <message>
         <location filename="app.cpp" line="761"/>
@@ -768,10 +761,9 @@ Voleu aturar-les i tornar a Mode Disseny?</translation>
         <translation>&amp;Index</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="762"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>

--- a/ui/src/qlcplus_cz_CZ.ts
+++ b/ui/src/qlcplus_cz_CZ.ts
@@ -643,10 +643,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>&amp;Nový</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="686"/>
@@ -654,10 +653,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>&amp;Otevřít</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -665,10 +663,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>&amp;Uložit</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -681,10 +678,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>&amp;Provoz</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
         <source>CTRL+F12</source>
         <comment>Control|Toggle operate/design mode</comment>
-        <translation>CTRL+F12</translation>
+        <translation type="vanished">CTRL+F12</translation>
     </message>
     <message>
         <location filename="app.cpp" line="703"/>
@@ -692,10 +688,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>&amp;Monitor</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="704"/>
         <source>CTRL+M</source>
         <comment>Control|Monitor</comment>
-        <translation>CTRL+M</translation>
+        <translation type="vanished">CTRL+M</translation>
     </message>
     <message>
         <location filename="app.cpp" line="707"/>
@@ -723,10 +718,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>Zachytit DMX hodnoty do funkce</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>CTRL+D</translation>
+        <translation type="vanished">CTRL+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>
@@ -759,10 +753,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>Přepnout na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
         <source>CTRL+F11</source>
         <comment>Control|Toggle Full Screen</comment>
-        <translation>CTRL+F11</translation>
+        <translation type="vanished">CTRL+F11</translation>
     </message>
     <message>
         <location filename="app.cpp" line="761"/>
@@ -770,10 +763,9 @@ Opravdu si přejete běžící funkce zastavit a přejít zpět do režimu Návr
         <translation>&amp;Index</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="762"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -623,10 +623,9 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
         <translation>&amp;Neu</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>STRG+N</translation>
+        <translation type="vanished">STRG+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="686"/>
@@ -634,10 +633,9 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
         <translation>Ö&amp;ffnen</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>STRG+O</translation>
+        <translation type="vanished">STRG+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -645,10 +643,9 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>STRG+S</translation>
+        <translation type="vanished">STRG+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -661,10 +658,9 @@ Willst du die wirklich stoppen und in den Entwicklungsmodus wechseln?</translati
         <translation>&amp;Betrieb</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
         <source>CTRL+F12</source>
         <comment>Control|Toggle operate/design mode</comment>
-        <translation>STRG+F12</translation>
+        <translation type="vanished">STRG+F12</translation>
     </message>
     <message>
         <location filename="app.cpp" line="719"/>
@@ -730,10 +726,9 @@ Die ausgewählte Datei wurde verschoben oder gelöscht.</translation>
         <translation>&amp;Monitor</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="704"/>
         <source>CTRL+M</source>
         <comment>Control|Monitor</comment>
-        <translation>STRG+M</translation>
+        <translation type="vanished">STRG+M</translation>
     </message>
     <message>
         <location filename="app.cpp" line="755"/>
@@ -741,10 +736,9 @@ Die ausgewählte Datei wurde verschoben oder gelöscht.</translation>
         <translation>Vollbildmodus umschalten</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
         <source>CTRL+F11</source>
         <comment>Control|Toggle Full Screen</comment>
-        <translation>STRG+F11</translation>
+        <translation type="vanished">STRG+F11</translation>
     </message>
     <message>
         <location filename="app.cpp" line="761"/>
@@ -752,10 +746,9 @@ Die ausgewählte Datei wurde verschoben oder gelöscht.</translation>
         <translation>&amp;Handbuch</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="762"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -799,10 +792,9 @@ Die ausgewählte Datei wurde verschoben oder gelöscht.</translation>
         <translation>Abbild (Dump) der DMX-Werte in einer Funktion</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>STRG+D</translation>
+        <translation type="vanished">STRG+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>

--- a/ui/src/qlcplus_es_ES.ts
+++ b/ui/src/qlcplus_es_ES.ts
@@ -599,21 +599,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>&amp;Nuevo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="686"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="687"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -621,10 +609,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -647,18 +634,6 @@ Really stop them and switch back to Design mode?</source>
         <translation>Activar/Desactivar &amp;Blackout</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
-        <source>CTRL+F12</source>
-        <comment>Control|Toggle operate/design mode</comment>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="704"/>
-        <source>CTRL+M</source>
-        <comment>Control|Monitor</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="715"/>
         <source>Live edit a function</source>
         <translation>Edita una función en vivo</translation>
@@ -669,21 +644,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>Cambiar a Pantalla Completa</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
-        <source>CTRL+F11</source>
-        <comment>Control|Toggle Full Screen</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="761"/>
         <source>&amp;Index</source>
         <translation>&amp;Indice</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="762"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -750,12 +713,6 @@ Really stop them and switch back to Design mode?</source>
         <location filename="app.cpp" line="724"/>
         <source>Dump DMX values to a function</source>
         <translation>Volcar valores DMX a una función</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="725"/>
-        <source>CTRL+D</source>
-        <comment>Control|Dump DMX</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>

--- a/ui/src/qlcplus_fi_FI.ts
+++ b/ui/src/qlcplus_fi_FI.ts
@@ -599,32 +599,14 @@ Haluatko varmasti pysäyttää ne ja vaihtaa takaisin Suunnittelutilaan?</transl
         <translation>&amp;Uusi</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="686"/>
         <source>&amp;Open</source>
         <translation>&amp;Avaa</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="690"/>
         <source>&amp;Save</source>
         <translation>&amp;Tallenna</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="691"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -647,18 +629,6 @@ Haluatko varmasti pysäyttää ne ja vaihtaa takaisin Suunnittelutilaan?</transl
         <translation type="unfinished">Kytke &amp;Pimennys</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
-        <source>CTRL+F12</source>
-        <comment>Control|Toggle operate/design mode</comment>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="704"/>
-        <source>CTRL+M</source>
-        <comment>Control|Monitor</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="715"/>
         <source>Live edit a function</source>
         <translation type="unfinished"></translation>
@@ -669,21 +639,9 @@ Haluatko varmasti pysäyttää ne ja vaihtaa takaisin Suunnittelutilaan?</transl
         <translation>Kytke koko näyttö</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
-        <source>CTRL+F11</source>
-        <comment>Control|Toggle Full Screen</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="761"/>
         <source>&amp;Index</source>
         <translation>&amp;Hakemisto</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="762"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -749,12 +707,6 @@ Haluatko varmasti pysäyttää ne ja vaihtaa takaisin Suunnittelutilaan?</transl
     <message>
         <location filename="app.cpp" line="724"/>
         <source>Dump DMX values to a function</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="725"/>
-        <source>CTRL+D</source>
-        <comment>Control|Dump DMX</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/src/qlcplus_fr_FR.ts
+++ b/ui/src/qlcplus_fr_FR.ts
@@ -599,32 +599,14 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création&#xa0;?</tra
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="686"/>
         <source>&amp;Open</source>
         <translation>&amp;Ouvrir</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="690"/>
         <source>&amp;Save</source>
         <translation>Enregi&amp;strer</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="691"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -647,18 +629,6 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création&#xa0;?</tra
         <translation>&amp;Blackout</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
-        <source>CTRL+F12</source>
-        <comment>Control|Toggle operate/design mode</comment>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="704"/>
-        <source>CTRL+M</source>
-        <comment>Control|Monitor</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="715"/>
         <source>Live edit a function</source>
         <translation>Éditer une fonction en direct</translation>
@@ -669,21 +639,9 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création&#xa0;?</tra
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
-        <source>CTRL+F11</source>
-        <comment>Control|Toggle Full Screen</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="761"/>
         <source>&amp;Index</source>
         <translation>A&amp;ide</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="762"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -752,10 +710,9 @@ Voulez-vous vraiment les arrêter et basculer vers le mode Création&#xa0;?</tra
         <translation>Capturer les valeurs DMX vers une fonction</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>CTRL+D</translation>
+        <translation type="vanished">CTRL+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>

--- a/ui/src/qlcplus_it_IT.ts
+++ b/ui/src/qlcplus_it_IT.ts
@@ -599,32 +599,14 @@ Vuoi veramente fermarle e ritornare in modalità Design?</translation>
         <translation>&amp;Nuovo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="686"/>
         <source>&amp;Open</source>
         <translation>&amp;Apri</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="690"/>
         <source>&amp;Save</source>
         <translation>&amp;Salva</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="691"/>
-        <source>CTRL+S</source>
-        <comment>File|Save</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -647,18 +629,6 @@ Vuoi veramente fermarle e ritornare in modalità Design?</translation>
         <translation>&amp;Blackout On/Off</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
-        <source>CTRL+F12</source>
-        <comment>Control|Toggle operate/design mode</comment>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="704"/>
-        <source>CTRL+M</source>
-        <comment>Control|Monitor</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="715"/>
         <source>Live edit a function</source>
         <translation>Modifica una funzione in modalità live</translation>
@@ -669,21 +639,9 @@ Vuoi veramente fermarle e ritornare in modalità Design?</translation>
         <translation>Passa in modalità schermo intero</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
-        <source>CTRL+F11</source>
-        <comment>Control|Toggle Full Screen</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="761"/>
         <source>&amp;Index</source>
         <translation>&amp;Indice</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="762"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -752,10 +710,9 @@ Vuoi veramente fermarle e ritornare in modalità Design?</translation>
         <translation>Salva i valori DMX su una funzione</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>CTRL+D</translation>
+        <translation type="vanished">CTRL+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>

--- a/ui/src/qlcplus_ja_JP.ts
+++ b/ui/src/qlcplus_ja_JP.ts
@@ -594,10 +594,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>新規</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="686"/>
@@ -605,10 +604,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -616,10 +614,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>上書き保存</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -642,16 +639,14 @@ Really stop them and switch back to Design mode?</source>
         <translation>暗転</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
         <source>CTRL+F12</source>
         <comment>Control|Toggle operate/design mode</comment>
-        <translation>CTRL+F12</translation>
+        <translation type="vanished">CTRL+F12</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="704"/>
         <source>CTRL+M</source>
         <comment>Control|Monitor</comment>
-        <translation>CTRL+M</translation>
+        <translation type="vanished">CTRL+M</translation>
     </message>
     <message>
         <location filename="app.cpp" line="715"/>
@@ -664,10 +659,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>フルスクリーン</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
         <source>CTRL+F11</source>
         <comment>Control|Toggle Full Screen</comment>
-        <translation>CTRL+F11</translation>
+        <translation type="vanished">CTRL+F11</translation>
     </message>
     <message>
         <location filename="app.cpp" line="761"/>
@@ -675,10 +669,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="762"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -747,10 +740,9 @@ Really stop them and switch back to Design mode?</source>
         <translation>現在のDMX値をシーンにする</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>CTRL+D</translation>
+        <translation type="vanished">CTRL+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>

--- a/ui/src/qlcplus_nl_NL.ts
+++ b/ui/src/qlcplus_nl_NL.ts
@@ -642,10 +642,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>&amp;Nieuw</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
         <source>CTRL+N</source>
         <comment>File|New</comment>
-        <translation>CTRL+N</translation>
+        <translation type="vanished">CTRL+N</translation>
     </message>
     <message>
         <location filename="app.cpp" line="686"/>
@@ -653,10 +652,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>&amp;Open</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="687"/>
         <source>CTRL+O</source>
         <comment>File|Open</comment>
-        <translation>CTRL+O</translation>
+        <translation type="vanished">CTRL+O</translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -664,10 +662,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>Op&amp;slaan</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -680,10 +677,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>&amp;Operate</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
         <source>CTRL+F12</source>
         <comment>Control|Toggle operate/design mode</comment>
-        <translation>CTRL+F12</translation>
+        <translation type="vanished">CTRL+F12</translation>
     </message>
     <message>
         <location filename="app.cpp" line="703"/>
@@ -691,10 +687,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>&amp;Monitor</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="704"/>
         <source>CTRL+M</source>
         <comment>Control|Monitor</comment>
-        <translation>CTRL+M</translation>
+        <translation type="vanished">CTRL+M</translation>
     </message>
     <message>
         <location filename="app.cpp" line="707"/>
@@ -722,10 +717,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>Dump DMX waarden naar een functie</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="725"/>
         <source>CTRL+D</source>
         <comment>Control|Dump DMX</comment>
-        <translation>CTRL+D</translation>
+        <translation type="vanished">CTRL+D</translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>
@@ -758,10 +752,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>Volledig scherm aan/uit</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
         <source>CTRL+F11</source>
         <comment>Control|Toggle Full Screen</comment>
-        <translation>CTRL+F11</translation>
+        <translation type="vanished">CTRL+F11</translation>
     </message>
     <message>
         <location filename="app.cpp" line="761"/>
@@ -769,10 +762,9 @@ Wil je deze stoppen en naar Design Mode gaan?</translation>
         <translation>&amp;Index</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="762"/>
         <source>SHIFT+F1</source>
         <comment>Help|Index</comment>
-        <translation>SHIFT+F1</translation>
+        <translation type="vanished">SHIFT+F1</translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>

--- a/ui/src/qlcplus_pt_BR.ts
+++ b/ui/src/qlcplus_pt_BR.ts
@@ -599,21 +599,9 @@ Deseja parar e voltar ao Modo Edição?</translation>
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="683"/>
-        <source>CTRL+N</source>
-        <comment>File|New</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="686"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="687"/>
-        <source>CTRL+O</source>
-        <comment>File|Open</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="690"/>
@@ -621,10 +609,9 @@ Deseja parar e voltar ao Modo Edição?</translation>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="691"/>
         <source>CTRL+S</source>
         <comment>File|Save</comment>
-        <translation>CTRL+S</translation>
+        <translation type="vanished">CTRL+S</translation>
     </message>
     <message>
         <location filename="app.cpp" line="694"/>
@@ -647,18 +634,6 @@ Deseja parar e voltar ao Modo Edição?</translation>
         <translation>Activar/Desactivar &amp;Blackout</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="700"/>
-        <source>CTRL+F12</source>
-        <comment>Control|Toggle operate/design mode</comment>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="704"/>
-        <source>CTRL+M</source>
-        <comment>Control|Monitor</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="715"/>
         <source>Live edit a function</source>
         <translation>Editar função ao vivo</translation>
@@ -669,21 +644,9 @@ Deseja parar e voltar ao Modo Edição?</translation>
         <translation>Alterar para Ecrã Completo</translation>
     </message>
     <message>
-        <location filename="app.cpp" line="757"/>
-        <source>CTRL+F11</source>
-        <comment>Control|Toggle Full Screen</comment>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="app.cpp" line="761"/>
         <source>&amp;Index</source>
         <translation>&amp;Indice</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="762"/>
-        <source>SHIFT+F1</source>
-        <comment>Help|Index</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="765"/>
@@ -750,12 +713,6 @@ Deseja parar e voltar ao Modo Edição?</translation>
         <location filename="app.cpp" line="724"/>
         <source>Dump DMX values to a function</source>
         <translation>Atribuirvalores DMX a uma função</translation>
-    </message>
-    <message>
-        <location filename="app.cpp" line="725"/>
-        <source>CTRL+D</source>
-        <comment>Control|Dump DMX</comment>
-        <translation></translation>
     </message>
     <message>
         <location filename="app.cpp" line="728"/>


### PR DESCRIPTION
_fixes #1886_

This PR removes all translation code (`tr(...)`) from the `setShortcut` calls in [`fixtureeditor::App::initActions()`](https://github.com/mcallegari/qlcplus/blob/master/fixtureeditor/app.cpp#L241) and [`ui::App::initActions()`](https://github.com/mcallegari/qlcplus/blob/master/ui/src/app.cpp#L679) and hardcodes the key sequence strings.

It also cleans up the translation files.