### PR TITLE
ui: fix audio volume adjustment of a video on intensity change

### DIFF
--- a/engine/src/video.cpp
+++ b/engine/src/video.cpp
@@ -333,8 +333,7 @@ int Video::adjustAttribute(qreal fraction, int attributeId)
     {
         case Intensity:
         {
-            int b = -100 - (int)((qreal)-100.0 * getAttributeValue(Intensity));
-            emit requestBrightnessAdjust(b);
+            emit requestBrightnessVolumeAdjust(getAttributeValue(Intensity));
             emit intensityChanged();
         }
         break;

--- a/engine/src/video.h
+++ b/engine/src/video.h
@@ -164,7 +164,7 @@ signals:
     void requestPlayback();
     void requestPause(bool enable);
     void requestStop();
-    void requestBrightnessAdjust(int value);
+    void requestBrightnessVolumeAdjust(qreal value);
 
 private:
     /** URL of the video media source */

--- a/ui/src/videoprovider.cpp
+++ b/ui/src/videoprovider.cpp
@@ -117,8 +117,8 @@ VideoWidget::VideoWidget(Video *video, QObject *parent)
             this, SLOT(slotSetPause(bool)));
     connect(m_video, SIGNAL(requestStop()),
             this, SLOT(slotStopVideo()));
-    connect(m_video, SIGNAL(requestBrightnessAdjust(int)),
-            this, SLOT(slotBrightnessAdjust(int)));
+    connect(m_video, SIGNAL(requestBrightnessVolumeAdjust(qreal)),
+            this, SLOT(slotBrightnessVolumeAdjust(qreal)));
 
     QString sourceURL = m_video->sourceUrl();
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -310,16 +310,19 @@ void VideoWidget::slotStopVideo()
     m_video->stop(functionParent());
 }
 
-void VideoWidget::slotBrightnessAdjust(int value)
+void VideoWidget::slotBrightnessVolumeAdjust(qreal value)
 {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    if (m_videoWidget != NULL)
-        m_videoWidget->setBrightness(value);
+    int brightness = -100 + (int)(qreal(100.0) * value);
+    int volume = 100 * (int)QAudio::convertVolume(value, QtAudio::LogarithmicVolumeScale, QtAudio::LinearVolumeScale);
+    if (m_videoWidget)
+        m_videoWidget->setBrightness(brightness);
     if (m_videoPlayer)
-        m_videoPlayer->setVolume(value + 100);
+        m_videoPlayer->setVolume(volume);
 #else
+    qreal linearVolume = QtAudio::convertVolume(value, QtAudio::LogarithmicVolumeScale, QtAudio::LinearVolumeScale);
     if (m_audioOutput)
-        m_audioOutput->setVolume(value + 100);
+        m_audioOutput->setVolume(linearVolume);
 #endif
 }
 

--- a/ui/src/videoprovider.h
+++ b/ui/src/videoprovider.h
@@ -48,7 +48,7 @@ protected slots:
     void slotPlaybackVideo();
     void slotSetPause(bool enable);
     void slotStopVideo();
-    void slotBrightnessAdjust(int value);
+    void slotBrightnessVolumeAdjust(qreal value);
 
 private:
     int getScreenCount();


### PR DESCRIPTION
_inspired by https://www.qlcplus.org/forum/viewtopic.php?t=18545 (however, the issue described in this forum post is a Qt problem and cannot be easily fixed by QLC+ alone, see c348c2b4ae3967f39db212e6f96b833f98bfecda)_

**Describe the bug / To Reproduce**
1. Start QLC+ (v4, new workspace, compiled with Qt6 (!)) and add a new `Video` function. The selected video does not matter as long as it can be played by QLC+ and contains an audio track.
2. Switch to the `Virtual Console`, add a frame and, within it, a button linked to the `Video` function and a slider in submaster mode.
3. Switch to `Operate` mode and start the video by clicking the button.
4. When changing the slider value, the audio volume does not change unless the slider has a value of `0`, which mutes the audio completely.

**Expected behaviour**
The audio volume should change according to the value of the slider.
(Ideally, the video should also fade out according to the value of the slider, but this feature has been removed with Qt6.)

**Problem Analysis**
In the function [`Video::adjustAttribute`](https://github.com/mcallegari/qlcplus/blob/master/engine/src/video.cpp#L328), the slider value (`[0, 1]`) is mapped to a range of `[-100, 0]`, which is then sent to [`VideoWidget::slotBrightnessAdjust`](https://github.com/mcallegari/qlcplus/blob/master/ui/src/videoprovider.cpp#L313) to adjust, in case of Qt5, the brightness of the video.

However, this `value` has the wrong range for the Qt6 audio volume (`m_audioOutput->setVolume(value + 100)` → range: `[0, 100]`), which requires a value in the range `[0, 1]`.

Furthermore, this value is assumed to be on a linear scale, whereas humans perceive volume on a logarithmic scale. Therefore, the raw slider value needs to be converted to enable smooth volume control. ([source Qt5](https://doc.qt.io/archives/qt-5.15/qmediaplayer.html#volume-prop), [source Qt6](https://doc.qt.io/qt-6/qaudiooutput.html#volume-prop)).

**Proposed Solutions**
Scale the slider value to the correct range and convert it to a linear scale (fixes 2d857c8af552048e4620aab71aaccb730ce58d1b and c348c2b4ae3967f39db212e6f96b833f98bfecda)