### PR TITLE
ui: restore brightness adjustment of a video on intensity change

### DIFF
--- a/ui/src/videoprovider.h
+++ b/ui/src/videoprovider.h
@@ -21,6 +21,9 @@
 #define VIDEOPROVIDER_H
 
 #include <QMediaPlayer>
+#include <QGraphicsView>
+#include <QGraphicsVideoItem>
+#include <QGraphicsRectItem>
 #include <QObject>
 #include <QHash>
 
@@ -29,7 +32,7 @@
 class Doc;
 class QVideoWidget;
 
-class VideoWidget: public QObject
+class VideoWidget : public QObject
 {
     Q_OBJECT
 
@@ -51,24 +54,29 @@ protected slots:
     void slotBrightnessVolumeAdjust(qreal value);
 
 private:
-    int getScreenCount();
+    int getScreenCount() const;
 
 protected:
     /** reference to the actual Video Function */
     Video *m_video;
     /** output interface to render video data */
     QMediaPlayer *m_videoPlayer;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    /** Qt widget that actually displays the video */
+    QGraphicsView *m_videoWidget;
+    QGraphicsVideoItem* m_videoItem;
+    QGraphicsRectItem* m_videoOverlay;
+    QAudioOutput *m_audioOutput;
+#else
     /** Qt widget that actually displays the video */
     QVideoWidget *m_videoWidget;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QAudioOutput *m_audioOutput;
 #endif
 
 private:
     FunctionParent functionParent() const;
 };
 
-class VideoProvider: public QObject
+class VideoProvider : public QObject
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
This PR was inspired by https://www.qlcplus.org/forum/viewtopic.php?t=18545 and a previous discussion on this topic can be found at #1888. This PR also fixes the casting issue mentioned over there (see changes to `VideoWidget::slotBrightnessVolumeAdjust` in this PR)

**Describe the bug / To Reproduce**
1. Start QLC+ (v4, new workspace, compiled with Qt6 (!)) and add a new `Video` function. The selected video does not matter as long as it can be played by QLC+.
2. Switch to the `Virtual Console`, add a frame and, within it, a button linked to the `Video` function and a slider in submaster mode.
3. Switch to `Operate` mode and start the video by clicking the button.
4. When changing the slider value, the video brightness does not change.

**Expected behaviour**
The video should fade out according to the value of the slider (`255` = full brightness/no changes, `0` = completely black/no video visible).

**Problem Analysis**
The simple video brightness adjustment from Qt5, which was used by QLC+, has been removed in Qt6. Therefore, it was no longer possible to fade videos in v4.

**Proposed Solutions**
The `QVideoWidget` class has been replaced by a more flexible `QGraphicsView`, to which a `QGraphicsScene` can be added. With the help of this `QGraphicsScene`, which can consist of multiple items (layers), the idea of v5 to use a black overlay with variable opacity can be implemented.

The most challenging part is to scale all objects correctly (or rather, maintain the scaling) since video functions must be able to operate in two modes, “window” and “fullscreen”. These can be switch at program (!) runtime – not while the function is running, but without reinitialising the `QGraphics*` objects.

This has been tested on an Ubuntu system with Qt 6.9.2, but it should better be tested on Windows and macOS systems as well because these graphical topics are probably very platform-dependant.