### PR TITLE
ui/scripteditor: improve systemcommand helper

### DIFF
--- a/ui/src/scripteditor.cpp
+++ b/ui/src/scripteditor.cpp
@@ -396,6 +396,7 @@ void ScriptEditor::slotAddSystemCommand()
     {
         formattedArgs.append(QString("arg:%1 ").arg(arg));
     }
+    formattedArgs = formattedArgs.trimmed();
 
     m_editor->moveCursor(QTextCursor::StartOfLine);
     m_editor->textCursor().insertText(QString("%1:%2 %3\n")


### PR DESCRIPTION
_by-product of #1889_

**Describe the bug / To Reproduce**
1. Start QLC+ (v4, new workspace).
2. Add a new `Script` function, click the “+” button and select “System Command”. Select some executable (i.e. `/usr/bin/true`) and (important!) add some arguments (i.e. `abcd`). Click `OK` to insert the command.
3. Click on the check mark to have QLC+ check the syntax of the script. A syntax error is found in the newly added `systemcommand` line.

**Expected behaviour**
Commands inserted by internal helpers must not contain any syntax errors.

**Problem Analysis**
In the [`ScriptEditor::slotAddSystemCommand()` function](https://github.com/mcallegari/qlcplus/blob/master/ui/src/scripteditor.cpp#L374), all arguments specified in the dialogue box are structured into one line using the format string `"arg:%1 "`. However, the space after the last argument (at the end of the line) is not removed and the syntax checker complains about it.

**Proposed Solution**
`Trim` the final `formattedArgs` string