### PR TITLE
WebAccess: add getWidgetFunction API to expose VC widget → Function association

### DIFF
--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -703,9 +703,12 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
                         VCSlider *slider = qobject_cast<VCSlider*>(widget);
                         if (slider != NULL)
                         {
-                            quint32 candidate = slider->playbackFunction();
-                            if (candidate != Function::invalidId())
-                                fID = candidate;
+                            if (slider->sliderMode() == VCSlider::Playback)
+                            {
+                                quint32 candidate = slider->playbackFunction();
+                                if (candidate != Function::invalidId())
+                                    fID = candidate;
+                            }
                         }
                     }
                     break;


### PR DESCRIPTION
## Description

**Summary of Changes:**

This pull request introduces a new WebAccess WebSocket API command, `QLC+API|getWidgetFunction`, which exposes the Function associated with Virtual Console widgets that operate a single Function.

The new API enables external integrations to reliably correlate VC widgets with the Functions they control, addressing ambiguity caused by duplicate or empty widget captions and improving feedback accuracy and usability.

Supported widget types include:
- VC Button widgets: returns the configured target Function.
- VC Cue List widgets: returns the associated Chaser (which is also a Function).
- VC Slider widgets (Playback mode only): returns the configured playback Function.

Sliders operating in other modes (Level, Submaster, Adjust, etc.) intentionally return no binding information, as they do not have a direct Function association.

The API response format is:

QLC+API|getWidgetFunction|<widgetId>|<functionId>|<functionType>|<functionName>

If the widget does not operate a Function, or the widget is not found, the API returns:

QLC+API|getWidgetFunction|<widgetId>|0|Undefined|

This change is strictly additive and does not modify any existing WebAccess commands or response formats.

**Related Issues:**

This change was motivated by external integration needs and does not currently correspond to an existing tracked issue.

---

## Checklist

- [x] I have read and followed the QLC+ Coding Guidelines (https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or updated documentation as necessary.

---

## Testing

**Test Cases:**

- Verified WebAccess WebSocket connectivity using a Python-based WebSocket client.
- Queried `getWidgetsList` to obtain active VC widget IDs.
- Queried `getWidgetFunction|<widgetId>` for:
  - VC Buttons bound to Scenes, Scripts, and RGB Matrices.
  - VC Cue Lists bound to Chasers.
  - VC Sliders configured in Playback mode.
  - Widgets without Function bindings (Frames, unbound Buttons, non-playback Sliders).

**Test Results:**

- Correct Function ID, type, and name returned for all supported widget types.
- Widgets without a Function binding consistently returned `0|Undefined`.
- No regressions observed in existing WebAccess commands.
- Behavior confirmed against a live QLC+ project with mixed widget types.

---

## Additional Notes

- This API intentionally limits scope to widgets with a single, well-defined Function association.
- Widgets with multiple or indirect associations (e.g. Speed Dial, Clock) are not included to preserve a predictable one-widget-to-one-function contract.
- The API name and response format were chosen to align with existing WebAccess conventions and to minimize client-side round trips.
