### PR TITLE
engine/audio: fix race condition bug when playing short audio functions

### DIFF
--- a/engine/audio/src/audio.cpp
+++ b/engine/audio/src/audio.cpp
@@ -371,6 +371,7 @@ void Audio::preRun(MasterTimer* timer)
         m_audio_out->adjustIntensity(m_volume * getAttributeValue(Intensity));
         m_audio_out->setFadeIn(elapsed() ? 0 : fadeIn);
         m_audio_out->setLooped(runOrder() == Audio::Loop);
+        m_audio_out->setUserStop(false);
         m_audio_out->start();
     }
 

--- a/engine/audio/src/audiorenderer.cpp
+++ b/engine/audio/src/audiorenderer.cpp
@@ -99,12 +99,18 @@ void AudioRenderer::setFadeOut(uint fadeTime)
 
 void AudioRenderer::stop()
 {
-    m_userStop = true;
+    setUserStop(true);
     while (this->isRunning())
         usleep(10000);
     m_intensity = 1.0;
     m_currentIntensity = 1.0;
 }
+
+void AudioRenderer::setUserStop(bool stop)
+{
+    m_userStop = stop;
+}
+
 
 /*********************************************************************
  * Thread functions
@@ -113,7 +119,6 @@ void AudioRenderer::stop()
 void AudioRenderer::run()
 {
     qint64 audioDataWritten;
-    m_userStop = false;
     audioDataRead = 0;
 
     int sampleSize = m_adec->audioParameters().sampleSize();
@@ -195,7 +200,7 @@ void AudioRenderer::run()
                     usleep(15000);
                 }
                 if (m_currentIntensity <= 0)
-                    m_userStop = true;
+                    setUserStop(true);
             }
             else
             {

--- a/engine/audio/src/audiorenderer.h
+++ b/engine/audio/src/audiorenderer.h
@@ -120,6 +120,7 @@ public:
     virtual void run(); //thread run function
 
     void stop();
+    void setUserStop(bool stop);
 
 protected:
     /** State machine variables */


### PR DESCRIPTION
When a short snippet from an audio file is played, the `Audio` function can no longer be stopped, and any attempt to do so causes QLC+ to freeze/crash.

_I know this PR description is quite long, but I have tried to explain the issue precisely, which in most cases requires some words for such race condition/parallelisation bugs._

**Describe the bug / To Reproduce**
1. Start QLC+ (new workspace, v4/v5 does not matter since this is about the common `engine` code) and add a new `Audio` function. The selected audio file does not matter as long as it can be played by QLC+. To facilitate testing, it should be at least 15 seconds long, but preferably a minute.
2. Switch to `Functions`, add a chaser (single short, forward, default fade in/out speeds, per step duration) and add the audio function with a hold time of less than `30ms`, preferably `0ms`, to that.
3. Start the chaser. The audio will start playing “normally” even though it was limited to a short snippet. Clicking anywhere in the UI closes the `chasereditor`, but neither the chaser nor the audio function will be stopped. Attempting to manually stop the audio by clicking the stop button of the chaser or the global “Stop all functions” button will cause the whole program to freeze.

**Expected behaviour**
The chaser should play without any issue, crash or lock up, despite the nonsensical (*) hold times.

*: Those hold times may seem “absurd” in a final show, but when incrementally building and testing a light show, such times may be accidentally included. In such situations, the program should not lock up or crash under any circumstances.

**Problem Analysis**
There is a race condition bug in the `Audio` or `AudioRenderer` classes, respectively. The `Chaser` in the above example just helps to reliably trigger the issue.

In summary, overriding the `m_userStop` variable at a suboptimal point in time from another thread causes this race condition bug. It manifests itself in the UI locking when attempting to manually stop the `Audio` function, which continues to run beyond the specified hold time.

_Detailed Analysis_
When an `Audio` function is started, the `Audio::preRun` method is executed. Depending on the platform, a subclass of `AudioRenderer` is initialised there, whereby, among other things, the `m_userStop` variable is set to `true`.

At the end, `AudioRenderer::start()` is called, a method inherited from the superclass of `AudioRenderer`, `QThread`. It creates a new thread, which executes the method `AudioRenderer::run()`. At its beginning, the `m_userStop` variable is set to `false`, which indicates that the user/the executing QLC+ function has not yet requested the `Audio` function to stop.

The main part of the aforementioned `run` function consists of a large `while` loop for decoding/preparing the audio. This loop only ends when the `m_userStop` variable to `true` – when either the calling function (e.g. a Chaser) or the user has requested the `Audio` function to stop.

In this scenario, however, before `AudioRenderer::run()` runs, the `Audio` function should already be terminated due to the short hold time specified in the chaser. This is done by calling `AudioRenderer::stop()`, which resets `m_userStop` to `true` and then waits for the thread to actually stop, by busy-waiting for `this->isRunning()` to become `false`. However, `isRunning` is already `true` here since the thread is starting up in the background. Therefore, for now, one of the main threads is stuck in the waiting loop in `AudioRenderer::stop()`.

Meanwhile, the `AudioRenderer` thread has finally started and is executing the `run` function, which, as mentioned earlier, first sets `m_userStop` to `false` to allow the local main loop to run, overriding the user’s request to stop the thread. Hence, this thread now continues to run while the other thread is locked in the loop in `AudioRenderer::stop()`, waiting for the audio thread to exit, which is not going to happen anytime soon.

**Proposed Solution**
Move setting the `m_userStop` variable to `false` from the (asynchronous) `run` method of the `AudioRenderer` thread to the synchronised setup code of `Audio::preRun` via a new `AudioRenderer::userStart()` “enabler” method

_Overriding the method `QThread::start(…)` within the `AudioRenderer` class to integrate setting the variable_ or, _using a custom status `enum` instead of a simple `bool` variable to distinguish the state of the `AudioRenderer` more precisely_, might be better solutions. However, this solution requires only minimal code changes and no changes to the internal program logic of the `Audio` class.

**Related issues**
This issue might be related to #1646. At the time, I was able to reproduce the crash/lock-up described there using QLC+ 4.13.1 on Windows. However, since I was not able to reproduce it with QLC+ 4.14.x, I assumed that it had been fixed somewhere (maybe implicitly by switching to Qt6) and did not look further into it. After investigating this bug, however, I could imagine that it was also the cause of #1646.