### PR TITLE
ui/sceneeditor: improve switching between view modes

### DIFF
--- a/ui/src/sceneeditor.h
+++ b/ui/src/sceneeditor.h
@@ -213,6 +213,10 @@ private:
     /** Flag to indicate if some fixture channels were
      *  manually selected and copied to clipboard */
     bool m_copyFromSelection;
+
+    /** tab mode: UI_STATE_ALL_FIXTURES: false, UI_STATE_TABBED_FIXTURES: true */
+    bool tabMode() const;
+    void setTabMode(bool tabbed);
 };
 
 /** @} */


### PR DESCRIPTION
**BUG A**

**Describe the bug / To Reproduce**
1. Start QLC+ (v4, new workspace), add a fixture and add this fixture to a new scene.
2. In the `General` tab, click on the “Fixtures used in this scene” list to deselect (!) all fixtures.
3. Click on the folder icon to switch between view modes.
4. All fixture tabs disappear, regardless of which view mode is finally selected.

**Expected behaviour**
The fixture tabs displayed should not depend on the fixtures selected in the list, but only on the fixtures added to the scene.
(If this is the desired behaviour, please let me know. Personally, I would find it counterintuitive.)

**Problem Analysis**
In the `SceneEditor::slotViewModeChanged` function, the fixtures to be added when creating the views depend on the list returned by `SceneEditor::selectedFixtures()` which – as the name suggests – only returns the fixtures currently selected in the list.

**Proposed Solution** _(first commit of this PR)_
Add an optional parameter of type `bool` to the `SceneEditor::selectedFixtures()` function to retrieve the complete fixture list without major code changes.


**BUG B**

**Describe the bug / To Reproduce**
1. Start QLC+ (v4, new workspace), add some fixtures and add these fixtures to a new scene.
2. In the scene editor, click on the folder icon to switch to “All fixtures” view mode.
3. Remove one of the fixtures from the `General` tab.
→ After removal, the fixture will still appear in the `All fixtures` tab. (1)
4. Close the scene editor and reopen it to reinitialise the controls.
5. Add the fixture you just removed from the `General` tab.
→ After adding, a new tab will be created for the fixture instead of adding it to the `All fixtures` tab/page. (2)

**Expected behaviour**
(1) is annoying because the fixture will be added to the scene again, if you accidentally use the remaining fader to change the channel value.
Regarding (2), one could argue that this is a feature to inform the user about the newly added fixtures. However, I do not agree with this, and it is not mentioned in the documentation either. Therefore, I consider it a bug.

**Problem Analysis**
The corresponding functions `SceneEditor::addFixtureTab` and `SceneEditor::removeFixtureTab` do not differentiate between view modes and always assume the “tabbed fixture” mode.
For this reason, these functions do not work properly in “All fixtures” mode.

**Proposed Solution** _(second commit of this PR)_
The simple solution would have been to always call `SceneEditor::slotViewModeChanged` at the end of `SceneEditor::addFixtureTab` and `SceneEditor::removeFixtureTab`, which would have completely regenerated all fixture tabs and therefore correctly reflected the changes.
However, this would be computationally very expensive, especially for small changes (removing one fixture) to a large scene (with many fixtures).

For this reason, I implemented the more efficient solution, where only what needs to be changed is changed. To do this, I used code snippets from the existing methods `SceneEditor::addFixtureTab`, `SceneEditor::removeFixtureTab` and `SceneEditor::slotViewModeChanged`.

The resulting code duplication is not ideal, but I could not find a clean way to refactor this, as there are small differences in the control flows of the above functions.