### PR TITLE
[v5] fix script functions not terminating after execution

### DIFF
--- a/engine/src/scriptrunner.cpp
+++ b/engine/src/scriptrunner.cpp
@@ -279,10 +279,6 @@ void ScriptRunner::run()
     }
 
     qDebug() << "[ScriptRunner] Code executed";
-
-    // this thread is done. Wait for the calling Script to stop
-    while (m_running)
-        msleep(50);
 }
 
 /************************************************************************

--- a/engine/src/scriptv4.cpp
+++ b/engine/src/scriptv4.cpp
@@ -366,6 +366,8 @@ void Script::slotRunnerFinished()
 {
     delete m_runner;
     m_runner = NULL;
+
+    stop(FunctionParent::master());
 }
 
 quint32 Script::getValueFromString(QString str, bool *ok)


### PR DESCRIPTION
_fixes #1827_

**Describe the bug / To Reproduce / Expected behaviour**
see linked issue

**Problem Analysis / Proposed Solutions**
This issue consists of two parts.

_Part A_
When a _Script_ function is started in QLC+ v5, the `Script::preRun` (from `scriptv4.cpp`) is executed, which initialises and starts a `ScriptRunner` (a subclass of `QThread`) for the specific script. This sets `ScriptRunner.m_running` to `true`.
At the end of the main `ScriptRunner` function `run`, after the content of the script has been run, there is a `while` loop waiting for `m_running` to become `false`. However, this does never happen, since the script only stops _after_ its `ScriptRunner` has. Hence, waiting for the opposite to happen is fruitless and the `while` loop is an endless loop.
Removing the endless loop lets the `run` function return, which then internally sends a `finished` signal. This is connected to `Script::slotRunnerFinished`, where the `ScriptRunner` is deleted and thereby deconstructed. Inside the `ScriptRunner` destructor, `ScriptRunner::stop` is called and it properly resets all DMX values.
To summarize, by removing an endless loop in `ScriptRunner::run`, the script terminates itself after execution.

_Part B_
However, it does not properly clean up after terminating itself.
The global “running functions” counter is not reset/decremented, for example. To achieve this, the function `Function::stop(…)` from `Script`’s superclass `Function` is explicitly called after deleting the `ScriptRunner` in `Script::slotRunnerFinished`.

The only thing which is still odd is that the `function preview` button stays enabled after the script has finished. However, the same behaviour can be seen when a `single-shot` chaser has finished. Therefore, this is nothing this PR should fix – if it is even considered unwanted behaviour at all.