### PR TITLE
use initializer list

### DIFF
--- a/engine/src/bus.cpp
+++ b/engine/src/bus.cpp
@@ -48,8 +48,8 @@ class BusEntry final
 {
 public:
     BusEntry()
+        : value(0)
     {
-        value = 0;
     }
 
     ~BusEntry()
@@ -57,9 +57,9 @@ public:
     }
 
     BusEntry(const BusEntry& entry)
+        : name(entry.name)
+        , value(entry.value)
     {
-        name = entry.name;
-        value = entry.value;
     }
 
     QString name;

--- a/engine/src/channelmodifier.cpp
+++ b/engine/src/channelmodifier.cpp
@@ -24,10 +24,10 @@
 #include "qlcfile.h"
 
 ChannelModifier::ChannelModifier()
+    : m_name(QString())
+    , m_type(Type::UserTemplate)
 {
     m_values.fill(0, 256);
-    m_name = QString();
-    m_type = UserTemplate;
 }
 
 void ChannelModifier::setName(QString name)

--- a/engine/src/channelsgroup.cpp
+++ b/engine/src/channelsgroup.cpp
@@ -37,11 +37,11 @@
 
 ChannelsGroup::ChannelsGroup(Doc* doc)
     : QObject(doc)
+    , m_doc(doc)
     , m_id(ChannelsGroup::invalidId())
     , m_masterValue(0)
 {
     setName(tr("New Group"));
-    m_doc = doc;
 
     init();
 }

--- a/engine/src/dmxdumpfactoryproperties.cpp
+++ b/engine/src/dmxdumpfactoryproperties.cpp
@@ -20,11 +20,11 @@
 #include "dmxdumpfactoryproperties.h"
 
 DmxDumpFactoryProperties::DmxDumpFactoryProperties(int universes)
-    : m_dumpAllChannels(true)
+    : m_channelsMask(QByteArray(universes * 512, 0))
+    , m_dumpAllChannels(true)
     , m_dumpNonZeroValues(false)
-    , m_selectedTarget(Chaser)
+    , m_selectedTarget(TargetType::Chaser)
 {
-    m_channelsMask = QByteArray(universes * 512, 0);
 }
 
 bool DmxDumpFactoryProperties::dumpChannelsMode()
@@ -87,4 +87,3 @@ DmxDumpFactoryProperties::TargetType DmxDumpFactoryProperties::selectedTarget()
 {
     return m_selectedTarget;
 }
-

--- a/engine/src/qlcphysical.cpp
+++ b/engine/src/qlcphysical.cpp
@@ -37,17 +37,16 @@ QLCPhysical::QLCPhysical()
     , m_width(0)
     , m_height(0)
     , m_depth(0)
+    , m_lensName("Other")
     , m_lensDegreesMin(0)
     , m_lensDegreesMax(0)
+    , m_focusType("Fixed")
     , m_focusPanMax(0)
     , m_focusTiltMax(0)
     , m_layout(QSize(1, 1))
     , m_powerConsumption(0)
-
+    , m_dmxConnector("5-pin")
 {
-    m_lensName = "Other";
-    m_focusType = "Fixed";
-    m_dmxConnector = "5-pin";
 }
 
 QLCPhysical::~QLCPhysical()

--- a/engine/src/rgbscriptproperty.h
+++ b/engine/src/rgbscriptproperty.h
@@ -26,15 +26,15 @@ class RGBScriptProperty final
 {
 public:
     RGBScriptProperty()
+        : m_name(QString())
+        , m_displayName(QString())
+        , m_type(ValueType::None)
+        , m_listValues(QStringList())
+        , m_rangeMinValue(0)
+        , m_rangeMaxValue(0)
+        , m_readMethod(QString())
+        , m_writeMethod(QString())
     {
-        m_name = QString();
-        m_displayName = QString();
-        m_type = None;
-        m_listValues = QStringList();
-        m_rangeMinValue = 0;
-        m_rangeMaxValue = 0;
-        m_readMethod = QString();
-        m_writeMethod = QString();
     }
 
     ~RGBScriptProperty() { /* NOP */ }

--- a/plugins/enttecwing/src/wing.cpp
+++ b/plugins/enttecwing/src/wing.cpp
@@ -34,11 +34,11 @@ const int Wing::UDPPort = 3330;
 
 Wing::Wing(QObject* parent, const QHostAddress& address, const QByteArray& data)
     : QObject(parent)
+    , m_address(address)
+    , m_type(resolveType(data))
+    , m_firmware(resolveFirmware(data))
+    , m_page(WING_PAGE_MIN)
 {
-    m_address = address;
-    m_type = resolveType(data);
-    m_firmware = resolveFirmware(data);
-    m_page = WING_PAGE_MIN;
 }
 
 Wing::~Wing()

--- a/plugins/uart/uartwidget.cpp
+++ b/plugins/uart/uartwidget.cpp
@@ -29,12 +29,12 @@
 #define DMX_MAB 16
 #define DMX_BREAK 110
 
-UARTWidget::UARTWidget(QSerialPortInfo &info, QObject *parent)
+UARTWidget::UARTWidget(const QSerialPortInfo &info, QObject *parent)
     : QThread(parent)
     , m_running(false)
     , m_granularity(Unknown)
+    , m_serialInfo(info)
 {
-    m_serialInfo = info;
 }
 
 UARTWidget::~UARTWidget()

--- a/plugins/uart/uartwidget.h
+++ b/plugins/uart/uartwidget.h
@@ -40,7 +40,7 @@ public:
      * @param info the serial port descriptor
      * @param parent The owner of this object
      */
-    UARTWidget(QSerialPortInfo &info, QObject* parent = 0);
+    UARTWidget(const QSerialPortInfo &info, QObject* parent = 0);
 
     /** Destructor */
     virtual ~UARTWidget();

--- a/ui/src/audiobar.cpp
+++ b/ui/src/audiobar.cpp
@@ -28,21 +28,21 @@
 #include "vccuelist.h"
 #include "virtualconsole.h"
 
-AudioBar::AudioBar(int t, uchar v, quint32 parentId)
+AudioBar::AudioBar(int type, uchar value, quint32 parentId)
+    : m_type(type)
+    , m_parentId(parentId)
+    , m_value(value)
+    , m_tapped(false)
+    , m_dmxChannels(QList<SceneValue>())
+    , m_absDmxChannels(QList<int>())
+    , m_function(NULL)
+    , m_widgetID(VCWidget::invalidId())
+    , m_minThreshold(51) // 20%
+    , m_maxThreshold(204) // 80%
+    , m_divisor(1)
+    , m_skippedBeats(0)
+    , m_widget(NULL)
 {
-    m_parentId = parentId;
-    m_type = t;
-    m_value = v;
-    m_tapped = false;
-    m_dmxChannels.clear();
-    m_absDmxChannels.clear();
-    m_function = NULL;
-    m_widget = NULL;
-    m_widgetID = VCWidget::invalidId();
-    m_minThreshold = 51; // 20%
-    m_maxThreshold = 204; // 80%
-    m_divisor = 1;
-    m_skippedBeats = 0;
 }
 
 AudioBar *AudioBar::createCopy()

--- a/ui/src/audiobar.h
+++ b/ui/src/audiobar.h
@@ -46,7 +46,7 @@ class AudioBar final
 {
 public:
     /** Normal constructor */
-    AudioBar(int t = 0, uchar v = 0, quint32 parentId = quint32(-1));
+    AudioBar(int type = 0, uchar value = 0, quint32 parentId = quint32(-1));
 
     /** Destructor */
     ~AudioBar() { }

--- a/ui/src/virtualconsole/vcwidgetproperties.cpp
+++ b/ui/src/virtualconsole/vcwidgetproperties.cpp
@@ -25,23 +25,23 @@
 #include "vcwidgetproperties.h"
 
 VCWidgetProperties::VCWidgetProperties()
+    : m_state(Qt::WindowNoState)
+    , m_visible(false)
+    , m_x(100)
+    , m_y(100)
+    , m_width(0)
+    , m_height(0)
 {
-    m_state = Qt::WindowNoState;
-    m_visible = false;
-    m_x = 100;
-    m_y = 100;
-    m_width = 0;
-    m_height = 0;
 }
 
 VCWidgetProperties::VCWidgetProperties(const VCWidgetProperties& properties)
+    : m_state(properties.m_state)
+    , m_visible(properties.m_visible)
+    , m_x(properties.m_x)
+    , m_y(properties.m_y)
+    , m_width(properties.m_width)
+    , m_height(properties.m_height)
 {
-    m_state = properties.m_state;
-    m_visible = properties.m_visible;
-    m_x = properties.m_x;
-    m_y = properties.m_y;
-    m_width = properties.m_width;
-    m_height = properties.m_height;
 }
 
 VCWidgetProperties::~VCWidgetProperties()

--- a/webaccess/src/webaccessauth.cpp
+++ b/webaccess/src/webaccessauth.cpp
@@ -39,8 +39,8 @@
 WebAccessAuth::WebAccessAuth(const QString& realm)
     : m_passwords()
     , m_realm(realm)
+    , m_passwordsFile(QString("%1/%2/%3").arg(getenv("HOME")).arg(USERQLCPLUSDIR).arg(DEFAULT_PASSWORD_FILE))
 {
-    m_passwordsFile = QString("%1/%2/%3").arg(getenv("HOME")).arg(USERQLCPLUSDIR).arg(DEFAULT_PASSWORD_FILE);
 }
 
 bool WebAccessAuth::loadPasswordsFile(const QString& filePath)


### PR DESCRIPTION
This PR improves the C++ code quality and performance by using the constructor’s initializer list wherever possible, rather than assigning variables within the constructor body.