### PR TITLE
ui/clickandgowidget: fix scaling issues on high-DPI screens

### DIFF
--- a/ui/src/clickandgowidget.h
+++ b/ui/src/clickandgowidget.h
@@ -62,7 +62,7 @@ public:
     /**
      * Returns the widget type
      */
-    int getType();
+    int getType() const;
 
     /** Set the low limits from the fader as a preset filter */
     void setLevelLowLimit(int min);
@@ -74,20 +74,25 @@ public:
      * Returns the color at pos position.
      * Used with primary colors linear gradient
      */
-    QColor getColorAt(uchar pos);
+    QColor getColorAt(uchar pos) const;
 
     /**
      * Return a QImage to be displayed on a Click & Go button
      *
      * @param value the slider position value
      */
-    QImage getImageFromValue(uchar value);
+    QImage getImageFromValue(uchar value) const;
 
     /** Returns a human readable string of a Click And Go type */
     static QString clickAndGoTypeToString(ClickAndGoWidget::ClickAndGo type);
 
     /** Returns a Click And Go type from the given string */
     static ClickAndGoWidget::ClickAndGo stringToClickAndGoType(QString str);
+
+private:
+    QImage getDPIAwareImage(int width, int height) const;
+
+    static QImage getDPIAwareImageStatic(const ClickAndGoWidget* parent, int width, int height);
 
 protected:
     /**
@@ -119,12 +124,12 @@ protected:
      * PresetResource Class
      *************************************************************************/
 private:
-    class PresetResource
+    class PresetResource final
     {
     public:
-        PresetResource(QString path, QString text, uchar min, uchar max);
-        PresetResource(QColor color1, QColor color2, QString text, uchar min, uchar max);
-        PresetResource(int index, QString text, uchar min, uchar max);
+        PresetResource(const ClickAndGoWidget* parent, QString path, QString text, uchar min, uchar max);
+        PresetResource(const ClickAndGoWidget* parent, QColor color1, QColor color2, QString text, uchar min, uchar max);
+        PresetResource(const ClickAndGoWidget* parent, int index, QString text, uchar min, uchar max);
 
     public:
         QImage m_thumbnail;


### PR DESCRIPTION
**Describe the bug / To Reproduce**
1. Start QLC+ (v4, compiled with Qt6 (!), new workspace) on a system with a scaled screen (Windows: set the display scaling in the Settings app `> 100%`, Ubuntu/Linux: `QT_SCALE_FACTOR=1.5 qlcplus …`)
2. Add a fixture with preset channels (for example a moving head, I used the `Tomshine Mini Gobo Moving Head`) and switch to the `Simple Desk`.
3. Click on the icon at the top of the “Colour wheel” or “Gobo wheel” channel slider.
4. Both the text labels as well as the images/icons look badly scaled.

**Expected behaviour**
Regardless of the resolution or scaling, all text labels and icons should be drawn sharply, with the possible exception of raster images, which have a low resolution to begin with.

**Problem Analysis**
With the switch from Qt5 to Qt6, many settings related to a high-dpi resolution were changed from “opt-in” to “enabled by default” or “always enabled”. For example, the `Qt::ApplicationAttribute` enum no longer contains the properties `Qt::AA_EnableHighDpiScaling` and `Qt::AA_DisableHighDpiScaling` (sources: [Qt5]( https://doc.qt.io/archives/qt-5.15/qt.html#ApplicationAttribute-enum), [Qt6](https://doc.qt.io/qt-6/qt.html#ApplicationAttribute-enum)), which can be used to control the scaling behaviour for the entire application.

However, most standard Qt UI elements handle this well by default, details can be found in this [documentation page](https://doc.qt.io/qt-6/highdpi.html).
On the other hand, custom elements such as `QImage` and `QPixmap` do not handle this (correctly) by default (see [here](https://doc.qt.io/qt-6/qpainter.html#drawing-high-resolution-versions-of-pixmaps-and-images)).

In QLC+, those elements are used to render the text labels and images/icons in the `ClickAndGoWidget` class.

**Proposed Solution**
A practical example of how to solve this issue can be found [here](https://stackoverflow.com/questions/78537946/why-qpixmap-looks-ugly-on-laptop-when-dpi-is-set-to-125#78542375).
However, as indicated [here](https://stackoverflow.com/questions/42011410/qt-drawing-high-dpi-qpixmaps#47182640), using the global/application-wide `devicePixelRatio` may not be the ideal solution, since users may be using multiple different screens.

Furthermore, the academically clean solution would be to create a subclass of `QImage` and override the `paintEvent` method with a custom one, which takes DPI-related scaling into account.
Since QLC+ is only affected in one place by this, I chose the more practical approach, writing a “factory method” for `QImage` that sets all necessary parameters based on the values of the underlying parent `QWidget`.
The static variant of this method is used by the inner class `ClickAndGoWidget::PresetResource` and helps to centralise the code additions, resulting in minimal changes in existing code.

I also took the opportunity to apply the recent “initialisation list”, “final class” and “const methods” refactorings to the `ClickAndGoWidget` class.