### PR TITLE
translations: update German translation for QLC+ 5.2.0

### DIFF
--- a/qmlui/qlcplus_de_DE.ts
+++ b/qmlui/qlcplus_de_DE.ts
@@ -2176,67 +2176,67 @@ Ungespeicherte Änderungen gehen verloren.</translation>
         <translation>Geräte hinzufügen</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="109"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="95"/>
         <source>Fixture Groups</source>
         <translation>Gerätegruppen</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="132"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="118"/>
         <source>Palettes</source>
         <translation>Paletten</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="151"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="137"/>
         <source>Intensity</source>
         <translation>Intensität</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="187"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="173"/>
         <source>Shutter</source>
         <translation>Shutter</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="217"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="203"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="245"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="231"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="277"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="263"/>
         <source>Color Wheel</source>
         <translation>Farbrad</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="307"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="293"/>
         <source>Gobos</source>
         <translation>Gobos</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="337"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="323"/>
         <source>Beam</source>
         <translation>Lichtstrahl</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="373"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="359"/>
         <source>Highlight</source>
         <translation>Hervorhebung</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="390"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="376"/>
         <source>Pick a 3D point</source>
         <translation>3D-Punkt auswählen</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="399"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="385"/>
         <source>Toggle multiple item selection</source>
         <translation>Mehrfachauswahl umschalten</translation>
     </message>
     <message>
-        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="410"/>
+        <location filename="qml/fixturesfunctions/LeftPanel.qml" line="396"/>
         <source>Select/Deselect all fixtures</source>
         <translation>Alle Geräte an-/abwählen</translation>
     </message>
@@ -2696,27 +2696,27 @@ Ungespeicherte Änderungen gehen verloren.</translation>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="209"/>
         <source>The modifier name cannot be empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Name des Modifizierers darf nicht leer sein.</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="216"/>
         <source>Please choose a name other than &quot;None&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitte einen anderen Namen als &quot;Nichts&quot; wählen.</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="224"/>
         <source>You are trying to overwrite a system template! Please choose another name and the template will be saved in your channel modifier&apos;s user folder.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sie versuchen, eine Systemvorlage zu überschreiben! Bitte wählen Sie einen anderen Namen, damit die Vorlage in Ihren Kanalmodifizierer-Benutzerordner gespeichert werden kann.</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="233"/>
         <source>Unable to save the modifier template.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Modifizierer-Vorlage konnte nicht gespeichert werden.</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="250"/>
         <source>New Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Neue Vorlage</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="275"/>
@@ -2741,7 +2741,7 @@ Ungespeicherte Änderungen gehen verloren.</translation>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="326"/>
         <source>Name</source>
-        <translation type="unfinished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="446"/>
@@ -2761,12 +2761,12 @@ Ungespeicherte Änderungen gehen verloren.</translation>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="547"/>
         <source>Error</source>
-        <translation type="unfinished">Fehler</translation>
+        <translation>Fehler</translation>
     </message>
     <message>
         <location filename="qml/popup/PopupChannelModifiers.qml" line="554"/>
         <source>Rename modifier template</source>
-        <translation type="unfinished"></translation>
+        <translation>Modifizierer-Vorlage umbenennen</translation>
     </message>
 </context>
 <context>
@@ -3669,7 +3669,7 @@ Zugriffsrechte:</translation>
     <message>
         <location filename="qml/fixturesfunctions/RGBMatrixEditor.qml" line="228"/>
         <source>Save this matrix to a sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Diese Matrix als Sequenz speichern</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RGBMatrixEditor.qml" line="235"/>
@@ -3912,7 +3912,7 @@ Zugriffsrechte:</translation>
     <message>
         <location filename="rgbmatrixeditor.cpp" line="707"/>
         <source>Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Sequenz</translation>
     </message>
 </context>
 <context>
@@ -4045,7 +4045,7 @@ Zugriffsrechte:</translation>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="237"/>
         <source>Timing Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Timing-Einstellungen</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="257"/>
@@ -4117,7 +4117,7 @@ Bitte einen anderen Namen angeben.</translation>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="420"/>
         <source>Toggle multiple item selection</source>
-        <translation type="unfinished">Mehrfachauswahl umschalten</translation>
+        <translation>Mehrfachauswahl umschalten</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/RightPanel.qml" line="437"/>
@@ -4741,47 +4741,47 @@ eine Funktion auf die Zeitleiste ziehen</translation>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="76"/>
         <source>--</source>
-        <translation type="unfinished"></translation>
+        <translation>--</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="78"/>
         <source>Multiple</source>
-        <translation type="unfinished"></translation>
+        <translation>Mehrere</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="232"/>
         <source>Alignment</source>
-        <translation type="unfinished">Ausrichtung</translation>
+        <translation>Ausrichtung</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="242"/>
         <source>Align start to cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>Anfang an Cursor ausrichten</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="250"/>
         <source>Align end to cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>Ende an Cursor ausrichten</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="275"/>
         <source>Timings</source>
-        <translation type="unfinished"></translation>
+        <translation>Timings</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="394"/>
         <source>Start time</source>
-        <translation type="unfinished">Startzeit</translation>
+        <translation>Startzeit</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="411"/>
         <source>End time</source>
-        <translation type="unfinished"></translation>
+        <translation>Endzeit</translation>
     </message>
     <message>
         <location filename="qml/showmanager/TimingUtils.qml" line="428"/>
         <source>Duration</source>
-        <translation type="unfinished">Dauer</translation>
+        <translation>Dauer</translation>
     </message>
 </context>
 <context>
@@ -6040,12 +6040,12 @@ Entweder ist nicht genug Platz vorhanden oder das Ziel-Universum ist ungültig</
     <message>
         <location filename="qml/virtualconsole/VCSliderProperties.qml" line="419"/>
         <source>External input</source>
-        <translation type="unfinished"></translation>
+        <translation>Externer Eingang</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSliderProperties.qml" line="441"/>
         <source>Catch up with the external controller input value</source>
-        <translation type="unfinished"></translation>
+        <translation>Dem Wert des externen Controller-Eingangs folgen</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSliderProperties.qml" line="449"/>
@@ -6162,7 +6162,7 @@ Entweder ist nicht genug Platz vorhanden oder das Ziel-Universum ist ungültig</
         <location filename="virtualconsole/vcspeeddial.cpp" line="425"/>
         <location filename="virtualconsole/vcspeeddial.cpp" line="483"/>
         <source>Preset: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Voreinstellung: %1</translation>
     </message>
 </context>
 <context>
@@ -6178,39 +6178,39 @@ Entweder ist nicht genug Platz vorhanden oder das Ziel-Universum ist ungültig</
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="90"/>
         <source>Presets</source>
-        <translation type="unfinished"></translation>
+        <translation>Voreinstellungen</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="118"/>
         <source>Preset name</source>
-        <translation type="unfinished"></translation>
+        <translation>Name der Voreinstellung</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="138"/>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="155"/>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="164"/>
         <source>Preset time</source>
-        <translation type="unfinished"></translation>
+        <translation>Dauer der Voreinstellung</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="192"/>
         <source>Add a preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Voreinstellung hinzufügen</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="210"/>
         <source>Remove the selected preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Ausgewählte Voreinstellung entfernen</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="248"/>
         <source>Name</source>
-        <translation type="unfinished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCSpeedDialPresets.qml" line="257"/>
         <source>Time</source>
-        <translation type="unfinished">Zeit</translation>
+        <translation>Zeit</translation>
     </message>
 </context>
 <context>
@@ -6472,7 +6472,7 @@ fallen lassen um die Liste zu füllen</translation>
     <message>
         <location filename="qml/virtualconsole/VCWidgetProperties.qml" line="198"/>
         <source>Presets</source>
-        <translation type="unfinished"></translation>
+        <translation>Voreinstellungen</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCWidgetProperties.qml" line="210"/>
@@ -6527,7 +6527,7 @@ fallen lassen um die Liste zu füllen</translation>
     <message>
         <location filename="qml/virtualconsole/VCWidgetProperties.qml" line="414"/>
         <source>Z-Index</source>
-        <translation type="unfinished"></translation>
+        <translation>Z-Index</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCWidgetProperties.qml" line="434"/>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -2278,151 +2278,151 @@ Changes will be lost if you don&apos;t save them.</source>
     <message>
         <location filename="fixturemanager.cpp" line="865"/>
         <source>Manufacturer</source>
-        <translation type="unfinished">Hersteller</translation>
+        <translation>Hersteller</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="866"/>
         <source>Model</source>
-        <translation type="unfinished">Modell</translation>
+        <translation>Modell</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="867"/>
         <source>Mode</source>
-        <translation type="unfinished">Modus</translation>
+        <translation>Modus</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="868"/>
         <location filename="fixturemanager.cpp" line="945"/>
         <location filename="fixturemanager.cpp" line="971"/>
         <source>Type</source>
-        <translation type="unfinished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="872"/>
         <source>Universe</source>
-        <translation type="unfinished">Universum</translation>
+        <translation>Universum</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="876"/>
         <source>Address Range</source>
-        <translation type="unfinished">Adressbereich</translation>
+        <translation>Adressbereich</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="896"/>
         <source>Binary Address (DIP)</source>
-        <translation type="unfinished"></translation>
+        <translation>Binäre Adresse (DIP)</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="904"/>
         <location filename="fixturemanager.cpp" line="1044"/>
         <source>Channel</source>
-        <translation type="unfinished">Kanal</translation>
+        <translation>Kanal</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="905"/>
         <source>DMX</source>
-        <translation type="unfinished">DMX</translation>
+        <translation>DMX</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="923"/>
         <source>Physical</source>
-        <translation type="unfinished">Abmessungen</translation>
+        <translation>Abmessungen</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="930"/>
         <source>Width</source>
-        <translation type="unfinished">Breite</translation>
+        <translation>Breite</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="932"/>
         <source>Height</source>
-        <translation type="unfinished">Höhe</translation>
+        <translation>Höhe</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="934"/>
         <source>Depth</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiefe</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="936"/>
         <source>Weight</source>
-        <translation type="unfinished"></translation>
+        <translation>Gewicht</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="938"/>
         <source>Power consumption</source>
-        <translation type="unfinished"></translation>
+        <translation>Leistungsaufnahme</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="939"/>
         <source>DMX Connector</source>
-        <translation type="unfinished"></translation>
+        <translation>DMX-Anschluss</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="944"/>
         <source>Bulb</source>
-        <translation type="unfinished"></translation>
+        <translation>Leuchtmittel</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="946"/>
         <source>Luminous Flux</source>
-        <translation type="unfinished"></translation>
+        <translation>Lumen</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="947"/>
         <source>Colour Temperature</source>
-        <translation type="unfinished"></translation>
+        <translation>Farbtemperatur</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="953"/>
         <source>Lens</source>
-        <translation type="unfinished"></translation>
+        <translation>Linse</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="958"/>
         <location filename="fixturemanager.cpp" line="963"/>
         <source>Beam Angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Abstrahlwinkel</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="970"/>
         <source>Head(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Head(s)</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="972"/>
         <source>Pan Range</source>
-        <translation type="unfinished"></translation>
+        <translation>Pan-Bereich</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="973"/>
         <source>Tilt Range</source>
-        <translation type="unfinished"></translation>
+        <translation>Tilt-Bereich</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="976"/>
         <source>Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Anordnung</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="988"/>
         <source>Fixture definition author: </source>
-        <translation type="unfinished"></translation>
+        <translation>Autor der Gerätedefinition: </translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1043"/>
         <source>Fixture</source>
-        <translation type="unfinished">Gerät</translation>
+        <translation>Gerät</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1045"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Beschreibung</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1063"/>
         <source>Channel %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanal %1</translation>
     </message>
     <message>
         <location filename="fixturemanager.cpp" line="1087"/>

--- a/webaccess/src/webaccess_de_DE.ts
+++ b/webaccess/src/webaccess_de_DE.ts
@@ -21,32 +21,32 @@
     <message>
         <location filename="webaccess-qml.cpp" line="218"/>
         <source>Simple Desk</source>
-        <translation type="unfinished">Einfache Arbeitsfläche</translation>
+        <translation>Einfache Arbeitsfläche</translation>
     </message>
     <message>
         <location filename="webaccess-qml.cpp" line="223"/>
         <source>Universe</source>
-        <translation type="unfinished">Universum</translation>
+        <translation>Universum</translation>
     </message>
     <message>
         <location filename="webaccess-qml.cpp" line="237"/>
         <source>Reset universe</source>
-        <translation type="unfinished">Universum zurücksetzen</translation>
+        <translation>Universum zurücksetzen</translation>
     </message>
     <message>
         <location filename="webaccess-qml.cpp" line="239"/>
         <source>Faders</source>
-        <translation type="unfinished"></translation>
+        <translation>Fader</translation>
     </message>
     <message>
         <location filename="webaccess-qml.cpp" line="250"/>
         <source>Page</source>
-        <translation type="unfinished">Seite</translation>
+        <translation>Seite</translation>
     </message>
     <message>
         <location filename="webaccess-qml.cpp" line="258"/>
         <source>Back</source>
-        <translation type="unfinished">Zurück</translation>
+        <translation>Zurück</translation>
     </message>
 </context>
 <context>
@@ -181,63 +181,63 @@
     <message>
         <location filename="webaccessbase.cpp" line="216"/>
         <source>Loading project...</source>
-        <translation type="unfinished">Lade Projekt...</translation>
+        <translation>Lade Projekt...</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="301"/>
         <source>Fixture stored and loaded</source>
-        <translation type="unfinished">Gerät gespeichert und geladen</translation>
+        <translation>Gerät gespeichert und geladen</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="482"/>
         <source>Username and password are required fields.</source>
-        <translation type="unfinished">Benutzername und Passwort sind benötigte Felder.</translation>
+        <translation>Benutzername und Passwort sind erforderlich.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="489"/>
         <location filename="webaccessbase.cpp" line="516"/>
         <source>User level has to be a positive integer.</source>
-        <translation type="unfinished">Benutzerlevel muss eine positive Ganzzahl sein.</translation>
+        <translation>Benutzerlevel muss eine positive Ganzzahl sein.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="509"/>
         <source>Username is required.</source>
-        <translation type="unfinished">Benutzername wird benötigt.</translation>
+        <translation>Benutzername ist erforderlich.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="531"/>
         <source>Error while saving passwords file.</source>
-        <translation type="unfinished">Fehler beim Speichern der Passwortdatei.</translation>
+        <translation>Fehler beim Speichern der Passwortdatei.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="552"/>
         <source>Network configuration changed. Reboot to apply the changes.</source>
-        <translation type="unfinished">Die Netzwerkkonfiguration hat sich geändert. Neustarten, um die Änderungen anzuwenden.</translation>
+        <translation>Die Netzwerkkonfiguration hat sich geändert. Neustarten, um die Änderungen anzuwenden.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="554"/>
         <source>An error occurred while updating the network configuration.</source>
-        <translation type="unfinished">Beim Aktualisieren der Netzwerk-Konfiguration ist ein Fehler aufgetreten.</translation>
+        <translation>Beim Aktualisieren der Netzwerk-Konfiguration ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="571"/>
         <source>Wi-Fi hotspot successfully activated.</source>
-        <translation type="unfinished">Der Wi-Fi-Hotspot wurde erfolgreich aktiviert.</translation>
+        <translation>Der Wi-Fi-Hotspot wurde erfolgreich aktiviert.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="573"/>
         <source>An error occurred while creating a Wi-Fi hotspot.</source>
-        <translation type="unfinished">Beim Erstellen des Wi-Fi-Hotspots ist ein Fehler aufgetreten.</translation>
+        <translation>Beim Erstellen des Wi-Fi-Hotspots ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="578"/>
         <source>Wi-Fi hotspot successfully deactivated.</source>
-        <translation type="unfinished">Der Wi-Fi-Hotspot wurde erfolgreich deaktiviert.</translation>
+        <translation>Der Wi-Fi-Hotspot wurde erfolgreich deaktiviert.</translation>
     </message>
     <message>
         <location filename="webaccessbase.cpp" line="595"/>
         <source>Autostart configuration changed</source>
-        <translation type="unfinished">Autostart-Konfiguration geändert</translation>
+        <translation>Autostart-Konfiguration geändert</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
_Please excuse me for boring everyone again with a language-/translation-related PR; related to [#1945 (comment)](https://github.com/mcallegari/qlcplus/pull/1945#pullrequestreview-3751870659) and f54ff36b5fc50e6310d01db9db4fde2995a6383d_

Added German translations for the new strings introduced since QLC+ 5.1.0.

Most of the translations for the new strings in `qmlui` were taken from the `ui` translation. The changes in the `ui` and `webaccess` directories are almost exclusively due to code being moved around, were automatically found by the `lupdate` tool and have just been un-`unfinished`.

@Loewe111 @kripton @FloEdelmann @ClarkLiam