### PR TITLE
Fix crash when deleting script runner

### DIFF
--- a/engine/src/scriptv4.cpp
+++ b/engine/src/scriptv4.cpp
@@ -364,7 +364,10 @@ void Script::postRun(MasterTimer* timer, QList<Universe *> universes)
 
 void Script::slotRunnerFinished()
 {
-    delete m_runner;
+    // we can't directly delete m_runner here because the finished() signal of
+    // QThread is fired just before the thread has actually finished executing. This
+    // would crash in ~QThread. deleteLater() ensures the thread is actually done.
+    m_runner->deleteLater();
     m_runner = NULL;
 }
 


### PR DESCRIPTION

## Description

Avoid deleting the script runner immediately in the slot connected to finished() .
QThread is not quite done executing, so this crashed. Using deleteLater() is explicitly mentioned by Qt to avoid this problem and only delete the thread when it's fully done.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS

