### PR TITLE
qmlui,ui: improve nested submasters

### DIFF
--- a/qmlui/virtualconsole/vcframe.h
+++ b/qmlui/virtualconsole/vcframe.h
@@ -290,8 +290,15 @@ protected slots:
     /*********************************************************************
      * Submasters
      *********************************************************************/
+public:
+    /** @reimp */
+    void adjustIntensity(qreal intensity) override;
+
 protected slots:
-    void slotSubmasterValueChanged(qreal value);
+    void slotSubmasterValueChanged(qreal submasterValue);
+
+private:
+    qreal m_submasterValue;
 
     /*********************************************************************
      * External input

--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -660,7 +660,7 @@ void VCFrame::slotSubmasterValueChanged(qreal value)
     while (it.hasNext() == true)
     {
         VCWidget *child = it.next();
-        if (child->parent() == this && child != submaster)
+        if (child != NULL && child->parent() == this && child != submaster)
             child->adjustIntensity(value);
     }
 }
@@ -671,10 +671,10 @@ void VCFrame::updateSubmasterValue()
     while (it.hasNext() == true)
     {
         VCWidget* child = it.next();
-        if (child->parent() == this && child->type() == SliderWidget)
+        if (child != NULL && child->parent() == this && child->type() == SliderWidget)
         {
             VCSlider* slider = reinterpret_cast<VCSlider*>(child);
-            if (slider->sliderMode() == VCSlider::Submaster)
+            if (slider != NULL && slider->sliderMode() == VCSlider::Submaster)
                 slider->emitSubmasterValue();
         }
     }
@@ -691,9 +691,11 @@ void VCFrame::adjustIntensity(qreal val)
     while (it.hasNext() == true)
     {
         VCWidget *child = it.next();
-        if (child->parent() == this)
+        if (child != NULL && child->parent() == this)
             child->adjustIntensity(val);
     }
+
+    updateSubmasterValue();
 }
 
 /*****************************************************************************


### PR DESCRIPTION
_fixes #1810_

**Describe the bug / To Reproduce / Expected behaviour**
see linked issue

**Problem Analysis / Proposed Solutions**
This issue affects both v4 (`ui`) and v5 (`qmlui`). However, nested submasters work for the most part in v4, whereas they do not work at all in v5.

_For the following explanation, I am assuming that the workspace from the linked issue is being used, or at least the same Virtual Console setup. “Inner” submaster refers to the one inside the frame widget, while “outer” submaster describes the one directly on the Virtual Console._

**`ui` (v4)**
Most of the code to make nested submaster work is already in place. Therefore, the only issue is the edge case that an outer submaster slider can override inner ones.

This can be easily fixed by calling the method `void VCFrame::updateSubmasterValue()` at the end of `void VCFrame::adjustIntensity(qreal val)` (method inherited from `VCWidget` that is used from outside the `VCFrame` class/by other `VCFrame` objects to set the intensity of that object) to restore the restrictions already set by inner submasters.

While at it, some `NULL`-pointer checks were added for additional safety (regarding pointer dereferences).

**`qmlui` (v5)**
To implement this functionality in v5, a new property was added to the `VCFrame` class: `m_submasterValue`, which holds the latest value of a submaster _inside_ the corresponding frame and is set to `1` (neutral element of multiplication of real numbers) by default. The existing `intensity` property (inherited from `VCWidget`) contains the value set for the frame by an _outer_ submaster.

By storing both of those values separately, the intensity value to be set on widgets contained within the frame can be recalculated at any time. This would not be possible if one of the values changes and only the “combined” value (product of those two values) would have been stored.

To catch an intensity change from outside the frame, the method `VCFrame::adjustIntensity(qreal intensity)` is added, which overrides the `void VCWidget::adjustIntensity(qreal val)` method inherited from `VCWidget`. It is similar to the method of the same name in `ui`, but removes the call to `VCFrame::updateSubmasterValue()` and uses the modern `nullptr` instead of `NULL` to check for null-pointers. Furthermore, a filter similar to the one of `ui/VCFrame::updateSubmasterValue()` (which skips all submaster sliders) is added, since setting intensity values on submaster sliders limits their value range and thereby causes unwanted side effects.

The existing `void VCFrame::slotSubmasterValueChanged(qreal)` method is changed accordingly to store new `submaster` values and to use this information when calculating the actual intensity value.