### PR TITLE
ui: add support for frame expand/collapse via external input

### DIFF
--- a/ui/src/virtualconsole/vcframe.h
+++ b/ui/src/virtualconsole/vcframe.h
@@ -44,6 +44,7 @@
 #define KXMLQLCVCFrameIsCollapsed       QStringLiteral("Collapsed")
 #define KXMLQLCVCFrameIsDisabled        QStringLiteral("Disabled")
 #define KXMLQLCVCFrameEnableSource      QStringLiteral("Enable")
+#define KXMLQLCVCFrameCollapseSource    QStringLiteral("Collapse")
 #define KXMLQLCVCFrameShowEnableButton  QStringLiteral("ShowEnableButton")
 
 #define KXMLQLCVCFrameMultipage   QStringLiteral("Multipage")
@@ -69,6 +70,7 @@ public:
     static const quint8 nextPageInputSourceId;
     static const quint8 previousPageInputSourceId;
     static const quint8 enableInputSourceId;
+    static const quint8 collpseInputSourceId;
     static const quint8 shortcutsBaseInputSourceId;
 
     /*********************************************************************
@@ -226,6 +228,12 @@ public:
     /** Get the keyboard key combination to enable/disable the frame */
     QKeySequence enableKeySequence() const;
 
+    /** Set the keyboard key combination to collapse/expand the frame */
+    void setCollapseKeySequence(const QKeySequence& keySequence);
+
+    /** Get the keyboard key combination to collapse/expand the frame */
+    QKeySequence collapseKeySequence() const;
+
     /** Set the keyboard key combination for skipping to the next page */
     void setNextPageKeySequence(const QKeySequence& keySequence);
 
@@ -244,6 +252,7 @@ protected slots:
 
 private:
     QKeySequence m_enableKeySequence;
+    QKeySequence m_collapseKeySequence;
     QKeySequence m_nextPageKeySequence;
     QKeySequence m_previousPageKeySequence;
 

--- a/ui/src/virtualconsole/vcframeproperties.cpp
+++ b/ui/src/virtualconsole/vcframeproperties.cpp
@@ -76,6 +76,19 @@ VCFrameProperties::VCFrameProperties(QWidget* parent, VCFrame* frame, Doc *doc)
     m_extEnableLayout->addWidget(m_inputEnableWidget);
 
     /************************************************************************
+     * Collapse frame
+     ************************************************************************/
+
+    m_inputCollapseWidget = new InputSelectionWidget(m_doc, this);
+    m_inputCollapseWidget->setTitle(tr("External Input - Collapse"));
+    m_inputCollapseWidget->setCustomFeedbackVisibility(true);
+    m_inputCollapseWidget->setKeySequence(m_frame->collapseKeySequence());
+    m_inputCollapseWidget->setInputSource(m_frame->inputSource(VCFrame::collpseInputSourceId));
+    m_inputCollapseWidget->setWidgetPage(m_frame->page());
+    m_inputCollapseWidget->show();
+    m_extEnableLayout->addWidget(m_inputCollapseWidget);
+
+    /************************************************************************
      * Previous page
      ************************************************************************/
 
@@ -284,11 +297,13 @@ void VCFrameProperties::accept()
 
     /* Key sequences */
     m_frame->setEnableKeySequence(m_inputEnableWidget->keySequence());
+    m_frame->setCollapseKeySequence(m_inputCollapseWidget->keySequence());
     m_frame->setNextPageKeySequence(m_inputNextPageWidget->keySequence());
     m_frame->setPreviousPageKeySequence(m_inputPrevPageWidget->keySequence());
 
     /* Input sources */
     m_frame->setInputSource(m_inputEnableWidget->inputSource(), VCFrame::enableInputSourceId);
+    m_frame->setInputSource(m_inputCollapseWidget->inputSource(), VCFrame::collpseInputSourceId);
     m_frame->setInputSource(m_inputNextPageWidget->inputSource(), VCFrame::nextPageInputSourceId);
     m_frame->setInputSource(m_inputPrevPageWidget->inputSource(), VCFrame::previousPageInputSourceId);
 

--- a/ui/src/virtualconsole/vcframeproperties.h
+++ b/ui/src/virtualconsole/vcframeproperties.h
@@ -63,6 +63,7 @@ protected:
     VCFrame *m_frame;
     Doc* m_doc;
     InputSelectionWidget *m_inputEnableWidget;
+    InputSelectionWidget *m_inputCollapseWidget;
     InputSelectionWidget *m_inputNextPageWidget;
     InputSelectionWidget *m_inputPrevPageWidget;
     QList<VCFramePageShortcut*> m_shortcuts;


### PR DESCRIPTION
_see https://www.qlcplus.org/forum/viewtopic.php?t=19349_

This PR adds the ability to expand/collapse a VC (solo) frame via a keyboard shortcut or an external input to v4. The already existing code for the “enable” button was used as a reference for the implementation.

Furthermore, some existing code sections have been encapsulated in blocks so that in longer methods, local variables only exists where they are actually used.

Please note that I tested the keyboard shortcut and external input part (using a second QLC+ instance and the OSC plugin on `localhost`). However, I have not been able to test this (or the feedback functionality) on real hardware.