### PR TITLE
ui/virtualconsole: fix background colour issues

### DIFF
--- a/ui/src/virtualconsole/virtualconsole.cpp
+++ b/ui/src/virtualconsole/virtualconsole.cpp
@@ -1257,6 +1257,7 @@ void VirtualConsole::slotBackgroundColor()
     {
         if (m_selectedWidgets.isEmpty() == true)
         {
+            contents()->setAutoFillBackground(true);
             contents()->setBackgroundColor(color);
         }
         else
@@ -1287,6 +1288,7 @@ void VirtualConsole::slotBackgroundImage()
     {
         if (m_selectedWidgets.isEmpty() == true)
         {
+            contents()->setAutoFillBackground(true);
             contents()->setBackgroundImage(path);
         }
         else
@@ -1304,6 +1306,7 @@ void VirtualConsole::slotBackgroundNone()
 
     if (m_selectedWidgets.isEmpty() == true)
     {
+        contents()->setAutoFillBackground(true);
         contents()->resetBackgroundColor();
     }
     else
@@ -1609,6 +1612,7 @@ void VirtualConsole::initContents()
     m_contentsLayout->addWidget(m_scrollArea);
     m_scrollArea->setAlignment(Qt::AlignCenter);
     m_scrollArea->setWidgetResizable(false);
+    m_scrollArea->setAutoFillBackground(true);
 
     resetContents();
 }


### PR DESCRIPTION
_Reported at https://www.qlcplus.org/forum/viewtopic.php?t=19491, fixes #1986_

**Describe the bug / To Reproduce**
QLC+ 4.14.4 unintentionally introduced breaking changes to the background colour/background image of the `Virtual Console` (see forum or linked issue for details).

**Expected behaviour**
The existing functionality of QLC+ 4.14.3 and earlier versions should not be changed (see forum or linked issue for details).

**Problem Analysis**
Since there have been no changes to the relevant parts of the QLC+ source code, the breaking changes are likely located in the Qt framework.

The following versions/platforms seem to be affected: 
- official QLC 4.14.4 on Windows (11) / Qt 6.10.2
- current `master` branch build on Ubuntu 25.04 (Qt 6.8.3), 25.10 (Qt 6.9.2) and 26.04 beta (Qt 6.10.2)

The following versions/platforms do NOT seem to be affected:
- official QLC 4.14.3 on Windows / Qt 6.8.1
- current `master` branch build on Ubuntu 22.04 (Qt 5.15.3)

**Proposed Solutions**
As described in [this](https://wiki.qt.io/How_to_Change_the_Background_Color_of_QWidget#Using_the_Palette) Qt example, the [autoFillBackground](https://doc.qt.io/qt-6/qwidget.html#autoFillBackground-prop) property of `QWidget` seems to be important for a solid background colour to be drawn.
Although the constructor of `VCWidget` also sets this to the correct value (`true`), this property is reset to `false` for the VC main `VCFrame` called `m_contents` at some point after initialisation.
To be honest, I could not find the exact cause of this, but re-setting it to `true` when a new colour or image is set, as well as setting this property for the parent widget (`m_scrollArea`) when it is created ([source for this idea](https://stackoverflow.com/questions/79532988/how-to-make-a-qscrollarea-inherit-its-color-scheme-in-a-qtabwidget-as-if-it-was)), fixes the issues and restores the previous behaviour.

For (Linux) Qt5 builds (which were not affected anyway), this changes nothing.

Please note that I only developed this on Linux, so it still needs to be tested on Windows and macOS builds.

When this PR is merged, the [Qt version of Linux v4 builds in the GitHub Actions](https://github.com/mcallegari/qlcplus/blob/master/.github/workflows/build.yml#L72) can be bumped to `6.10.2` again to match the other platforms.