### PR TITLE
QML UI: implement mass fixture profile substitution

### DIFF
--- a/engine/src/CMakeLists.txt
+++ b/engine/src/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${module_name} SHARED
     fadechannel.cpp fadechannel.h
     fixture.cpp fixture.h
     fixturegroup.cpp fixturegroup.h
+    fixtureremap.cpp fixtureremap.h
     function.cpp function.h
     genericdmxsource.cpp genericdmxsource.h
     genericfader.cpp genericfader.h

--- a/engine/src/fixtureremap.cpp
+++ b/engine/src/fixtureremap.cpp
@@ -1,0 +1,212 @@
+/*
+  Q Light Controller Plus
+  fixtureremap.cpp
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "fixtureremap.h"
+
+#include <QDebug>
+
+#include "qlcfixturedefcache.h"
+#include "qlcfixturedef.h"
+#include "qlcfixturemode.h"
+#include "qlccapability.h"
+#include "qlcchannel.h"
+#include "fixture.h"
+#include "scene.h"
+#include "doc.h"
+
+#include "monitorproperties.h"
+
+FixtureRemap::FixtureRemap(Doc *doc)
+    : m_doc(doc)
+{
+}
+
+QMap<SceneValue, SceneValue> FixtureRemap::replaceProfiles(QList<quint32> fixtureIDs, const QString& manufacturer,
+                                                            const QString& model, const QString& mode)
+{
+    QMap<SceneValue, SceneValue> channelRemap;
+
+    if (fixtureIDs.isEmpty())
+        return channelRemap;
+
+    QLCFixtureDef *newDef = m_doc->fixtureDefCache()->fixtureDef(manufacturer, model);
+    if (newDef == nullptr)
+    {
+        qWarning() << "[FixtureRemap] Cannot find fixture definition for" << manufacturer << model;
+        return channelRemap;
+    }
+    QLCFixtureMode *newMode = newDef->mode(mode);
+    if (newMode == nullptr)
+    {
+        qWarning() << "[FixtureRemap] Cannot find mode" << mode << "for definition" << manufacturer << model;
+        return channelRemap;
+    }
+
+    struct FxPatch { quint32 id; quint32 addr; quint32 uni; };
+    QList<FxPatch> backup;
+
+    // 1. "Park" all fixtures in an imaginary universe to avoid overlaps/crashes during definition change
+    for (int i = 0; i < fixtureIDs.count(); i++)
+    {
+        quint32 fxID = fixtureIDs.at(i);
+        Fixture *oldFix = m_doc->fixture(fxID);
+        if (oldFix == nullptr) continue;
+
+        backup.append({fxID, oldFix->address(), oldFix->universe()});
+        // Use a safe universe range (100+) to avoid conflicting with existing fixtures
+        // and avoid extremely high values that might cause issues.
+        oldFix->setUniverse(100 + i);
+        oldFix->setAddress(0);
+    }
+
+    QMap<quint32, quint32> fixtureRemap;
+
+    // 2. Build channel remapping and apply new definitions
+    for (const FxPatch& patch : backup)
+    {
+        Fixture *fxi = m_doc->fixture(patch.id);
+        if (fxi == nullptr) continue;
+
+        // Build channel remapping for this fixture
+        for (quint32 s = 0; s < fxi->channels(); s++)
+        {
+            const QLCChannel *srcCh = fxi->channel(s);
+            if (srcCh == nullptr) continue;
+
+            for (int t = 0; t < newMode->channels().count(); t++)
+            {
+                const QLCChannel *tgtCh = newMode->channel(t);
+
+                if ((tgtCh->group() == srcCh->group()) &&
+                    (tgtCh->controlByte() == srcCh->controlByte()))
+                {
+                    if (tgtCh->group() == QLCChannel::Intensity &&
+                        tgtCh->colour() != srcCh->colour())
+                            continue;
+
+                    channelRemap[SceneValue(patch.id, s)] = SceneValue(patch.id, (quint32)t);
+                    break;
+                }
+            }
+        }
+
+        fxi->setFixtureDefinition(newDef, newMode);
+        fixtureRemap[patch.id] = patch.id;
+    }
+
+    // 3. Safe Repatch: try to restore original address or find next available
+    for (const FxPatch& patch : backup)
+    {
+        Fixture *fxi = m_doc->fixture(patch.id);
+        if (fxi == nullptr) continue;
+
+        int requested = (int)patch.addr;
+        int channels = (int)fxi->channels();
+        bool found = false;
+
+        // Ensure we find a place where this fixture fits without overlaps
+        while (requested <= 512 - channels)
+        {
+            bool free = true;
+            for (int i = 0; i < channels; i++)
+            {
+                // Check if address is free (ignoring current fixture because it's parked)
+                if (m_doc->fixtureForAddress((patch.uni << 9) | (quint32)(requested + i)) != Fixture::invalidId())
+                {
+                    free = false;
+                    break;
+                }
+            }
+
+            if (free)
+            {
+                // Set address first while still in parked universe
+                fxi->setAddress((quint32)requested);
+                // Then move back to target universe
+                fxi->setUniverse(patch.uni);
+                found = true;
+                break;
+            }
+            requested++;
+        }
+
+        if (!found)
+        {
+            qWarning() << "[FixtureRemap] Could not find a free address for fixture" << patch.id << "starting from" << patch.addr << ". Keeping it parked.";
+        }
+    }
+
+    // 4. Remap Scenes
+    remapScenes(channelRemap);
+
+    // 5. Remap Monitor Properties
+    remapMonitorProperties(fixtureRemap);
+
+    m_doc->setModified();
+
+    return channelRemap;
+}
+
+void FixtureRemap::remapScenes(const QMap<SceneValue, SceneValue>& remapMap)
+{
+    for (Function *func : m_doc->functions())
+    {
+        if (func->type() == Function::SceneType)
+        {
+            Scene *scene = qobject_cast<Scene*>(func);
+            QList<SceneValue> oldValues = scene->values();
+
+            for (const SceneValue& val : oldValues)
+            {
+                SceneValue key(val.fxi, val.channel);
+                if (remapMap.contains(key))
+                {
+                    SceneValue newVal = remapMap.value(key);
+                    newVal.value = val.value;
+                    if (newVal.channel != val.channel)
+                    {
+                        scene->unsetValue(val.fxi, val.channel);
+                        scene->setValue(newVal);
+                    }
+                }
+                else
+                {
+                    // If the fixture is part of the remapping but this channel has no match, unset it
+                    bool fixtureFound = false;
+                    QMapIterator<SceneValue, SceneValue> it(remapMap);
+                    while (it.hasNext()) {
+                        it.next();
+                        if (it.key().fxi == val.fxi) {
+                            fixtureFound = true;
+                            break;
+                        }
+                    }
+                    if (fixtureFound)
+                        scene->unsetValue(val.fxi, val.channel);
+                }
+            }
+        }
+    }
+}
+
+void FixtureRemap::remapMonitorProperties(const QMap<quint32, quint32>& fixtureRemapMap)
+{
+    Q_UNUSED(fixtureRemapMap);
+    // In-place replacement doesn't need to change monitor positions as IDs are the same
+}

--- a/engine/src/fixtureremap.h
+++ b/engine/src/fixtureremap.h
@@ -1,0 +1,56 @@
+/*
+  Q Light Controller Plus
+  fixtureremap.h
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef FIXTUREREMAP_H
+#define FIXTUREREMAP_H
+
+#include <QList>
+#include <QMap>
+
+#include "scenevalue.h"
+
+class Doc;
+
+/**
+ * Helper class to perform fixture remapping (changing fixture profiles
+ * while attempting to preserve programming).
+ */
+class FixtureRemap
+{
+public:
+    FixtureRemap(Doc *doc);
+
+    /**
+     * Replaces the profile of the fixtures in $fixtureIDs with the new $manufacturer, $model and $mode.
+     * Returns a map of the remapped channels (Source -> Target).
+     */
+    QMap<SceneValue, SceneValue> replaceProfiles(QList<quint32> fixtureIDs, const QString& manufacturer,
+                                                  const QString& model, const QString& mode);
+
+private:
+    /** Remap all Scene functions */
+    void remapScenes(const QMap<SceneValue, SceneValue>& remapMap);
+
+    /** Remap 2D monitor properties */
+    void remapMonitorProperties(const QMap<quint32, quint32>& fixtureRemapMap);
+
+    Doc *m_doc;
+};
+
+#endif // FIXTUREREMAP_H

--- a/engine/test/fixture/CMakeLists.txt
+++ b/engine/test/fixture/CMakeLists.txt
@@ -14,6 +14,22 @@ target_link_libraries(fixture_test PRIVATE
     qlcplusengine
 )
 
+add_executable(fixtureremap_test WIN32
+    ../common/resource_paths.h
+    fixtureremap_test.cpp fixtureremap_test.h
+)
+target_include_directories(fixtureremap_test PRIVATE
+    ../../../plugins/interfaces
+    ../../src
+)
+
+target_link_libraries(fixtureremap_test PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Gui
+    Qt${QT_MAJOR_VERSION}::Test
+    qlcplusengine
+)
+
 # Consider using qt_generate_deploy_app_script() for app deployment if
 # the project can use Qt 6.3. In that case rerun qmake2cmake with
 # --min-qt-version=6.3.

--- a/engine/test/fixture/fixtureremap_test.cpp
+++ b/engine/test/fixture/fixtureremap_test.cpp
@@ -1,0 +1,106 @@
+/*
+  Q Light Controller Plus - Unit test
+  fixtureremap_test.cpp
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QtTest>
+
+#include "fixtureremap_test.h"
+#include "qlcfixturedefcache.h"
+#include "qlcfixturedef.h"
+#include "qlcfixturemode.h"
+#include "fixtureremap.h"
+#include "qlcfile.h"
+#include "fixture.h"
+#include "scene.h"
+#include "doc.h"
+
+#include "../common/resource_paths.h"
+
+void FixtureRemap_Test::initTestCase()
+{
+    m_doc = new Doc(this);
+
+    QDir dir(INTERNAL_FIXTUREDIR);
+    dir.setFilter(QDir::Files);
+    dir.setNameFilters(QStringList() << QString("*%1").arg(KExtFixture));
+    QVERIFY(m_doc->fixtureDefCache()->loadMap(dir) == true);
+}
+
+void FixtureRemap_Test::cleanupTestCase()
+{
+    delete m_doc;
+}
+
+void FixtureRemap_Test::replaceProfiles()
+{
+    // 1. Create a source fixture (Generic RGB)
+    QLCFixtureDef *rgbDef = m_doc->fixtureDefCache()->fixtureDef("Generic", "Generic RGB");
+    QVERIFY(rgbDef != nullptr);
+    QLCFixtureMode *rgbMode = rgbDef->modes().first();
+    QVERIFY(rgbMode != nullptr);
+
+    Fixture *fxi = new Fixture(m_doc);
+    fxi->setFixtureDefinition(rgbDef, rgbMode);
+    m_doc->addFixture(fxi);
+    quint32 fid = fxi->id();
+
+    // 2. Create a scene using this fixture
+    Scene *s = new Scene(m_doc);
+    s->setValue(fid, 0, 255); // Red
+    s->setValue(fid, 1, 128); // Green
+    s->setValue(fid, 2, 64);  // Blue
+    m_doc->addFunction(s);
+
+    // 3. Remap to Generic RGBW
+    QLCFixtureDef *rgbwDef = m_doc->fixtureDefCache()->fixtureDef("Generic", "Generic RGBW");
+    QVERIFY(rgbwDef != nullptr);
+    QLCFixtureMode *rgbwMode = rgbwDef->modes().first();
+
+    FixtureRemap remap(m_doc);
+    QMap<SceneValue, SceneValue> res = remap.replaceProfiles(QList<quint32>() << fid, "Generic", "Generic RGBW", rgbwMode->name());
+
+    // Generic RGB has Red(0), Green(1), Blue(2).
+    // Generic RGBW has Red(0), Green(1), Blue(2), White(3).
+    // Our logic matches by Group AND Color.
+    // So Red(0)->Red(0), Green(1)->Green(1), Blue(2)->Blue(2).
+
+    // Let's verify results.
+    QCOMPARE(fxi->fixtureDef()->model(), QString("Generic RGBW"));
+
+    // Scene values for RGB should be preserved and remapped
+    QCOMPARE(s->values().count(), 3);
+    QCOMPARE(s->values().at(0).value, (uchar)255);
+    QCOMPARE(s->values().at(0).channel, (quint32)0); // Red
+    QCOMPARE(s->values().at(1).value, (uchar)128);
+    QCOMPARE(s->values().at(1).channel, (quint32)1); // Green
+    QCOMPARE(s->values().at(2).value, (uchar)64);
+    QCOMPARE(s->values().at(2).channel, (quint32)2); // Blue
+
+    // Now let's try RGB to RGB (same definition)
+    fxi->setFixtureDefinition(rgbDef, rgbMode);
+    s->clear();
+    s->setValue(fid, 0, 200);
+    QCOMPARE(s->values().count(), 1);
+
+    res = remap.replaceProfiles(QList<quint32>() << fid, "Generic", "Generic RGB", rgbMode->name());
+    QCOMPARE(s->values().count(), 1);
+    QCOMPARE(s->values().first().value, (uchar)200);
+    QCOMPARE(s->values().first().channel, (quint32)0);
+}
+
+QTEST_MAIN(FixtureRemap_Test)

--- a/engine/test/fixture/fixtureremap_test.h
+++ b/engine/test/fixture/fixtureremap_test.h
@@ -1,0 +1,41 @@
+/*
+  Q Light Controller Plus - Unit test
+  fixtureremap_test.h
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef FIXTUREREMAP_TEST_H
+#define FIXTUREREMAP_TEST_H
+
+#include <QObject>
+
+class Doc;
+
+class FixtureRemap_Test final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void replaceProfiles();
+
+private:
+    Doc* m_doc;
+};
+
+#endif

--- a/qmlui/fixturemanager.cpp
+++ b/qmlui/fixturemanager.cpp
@@ -37,6 +37,9 @@
 #include "qlcconfig.h"
 #include "qlcfile.h"
 #include "qlcmodifierscache.h"
+#include "virtualconsole.h"
+#include "fixtureremap.h"
+#include "vcwidget.h"
 #include "fixture.h"
 #include "tardis.h"
 #include "doc.h"
@@ -446,6 +449,40 @@ bool FixtureManager::renameFixture(quint32 itemID, QString newName)
     fixture->setName(newName);
 
     return true;
+}
+
+bool FixtureManager::replaceFixturesProfile(QVariantList fixtureIDList, QString manufacturer, QString model, QString mode)
+{
+    qDebug() << "[replaceFixturesProfile]" << fixtureIDList << manufacturer << model << mode;
+
+    QList<quint32> idList;
+    for (const QVariant &vID : fixtureIDList)
+        idList.append(vID.toUInt());
+
+    FixtureRemap remap(m_doc);
+    QMap<SceneValue, SceneValue> channelRemap = remap.replaceProfiles(idList, manufacturer, model, mode);
+
+    if (channelRemap.isEmpty() == false || idList.isEmpty() == false)
+    {
+        /* Remap Virtual Console widgets */
+        VirtualConsole *vc = qobject_cast<App *>(m_view)->virtualConsole();
+        if (vc != nullptr)
+        {
+            QVariantList widgets = vc->widgetsList();
+            for (const QVariant& vWidget : widgets)
+            {
+                VCWidget *widget = vWidget.value<VCWidget*>();
+                if (widget != nullptr)
+                    widget->remapChannels(channelRemap);
+            }
+        }
+
+        updateGroupsTree(m_doc, m_fixtureTree);
+        emit fixturesMapChanged();
+        return true;
+    }
+
+    return false;
 }
 
 int FixtureManager::fixturesCount()

--- a/qmlui/fixturemanager.h
+++ b/qmlui/fixturemanager.h
@@ -176,6 +176,9 @@ public:
     /** Rename the Fixture with the provided $itemID to $newName */
     Q_INVOKABLE bool renameFixture(quint32 itemID, QString newName);
 
+    /** Change the profile of the fixtures in $fixtureIDList to the provided $manufacturer, $model and $mode */
+    Q_INVOKABLE bool replaceFixturesProfile(QVariantList fixtureIDList, QString manufacturer, QString model, QString mode);
+
     /** Returns the number of fixtures currently loaded in the project */
     int fixturesCount();
 

--- a/qmlui/qml/fixturesfunctions/DMXView.qml
+++ b/qmlui/qml/fixturesfunctions/DMXView.qml
@@ -41,6 +41,34 @@ Rectangle
         dmxSettings.visible = show
     }
 
+    function showFixtureBrowser(show)
+    {
+        if (show)
+        {
+            fixtureAndFunctions.leftPanel.resetSelection()
+            fixtureAndFunctions.leftPanel.loaderSource = "qrc:/FixtureSubstitutionPanel.qml"
+            fixtureAndFunctions.leftPanel.animatePanel(true)
+        }
+        else
+        {
+            fixtureAndFunctions.leftPanel.animatePanel(false)
+        }
+    }
+
+    Connections
+    {
+        target: fixtureAndFunctions.leftPanel
+        function onContentLoaded(item, ID)
+        {
+            if (fixtureAndFunctions.leftPanel.loaderSource === "qrc:/FixtureSubstitutionPanel.qml")
+            {
+                item.closed.connect(function() {
+                    fixtureAndFunctions.leftPanel.animatePanel(false)
+                })
+            }
+        }
+    }
+
     ChannelToolLoader
     {
         id: channelToolLoader

--- a/qmlui/qml/fixturesfunctions/FixtureProperties.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureProperties.qml
@@ -207,8 +207,9 @@ Rectangle
                         Layout.fillWidth: true
                         textRole: ""
                         model: fixtureBrowser.modesList
-                        onModelChanged: currentIndex = 0
-                        onDisplayTextChanged: fixtureBrowser.selectedMode = displayText
+                        currentIndex: -1
+                        onModelChanged: currentIndex = -1
+                        onDisplayTextChanged: if (displayText !== "") fixtureBrowser.selectedMode = displayText
                     }
                     IconButton
                     {

--- a/qmlui/qml/fixturesfunctions/FixtureSubstitutionPanel.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureSubstitutionPanel.qml
@@ -1,0 +1,113 @@
+/*
+  Q Light Controller Plus
+  FixtureSubstitutionPanel.qml
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+
+import org.qlcplus.classes 1.0
+import "."
+
+Rectangle
+{
+    id: subPanelRoot
+    anchors.fill: parent
+    color: UISettings.bgStrong
+
+    signal closed()
+
+    Component.onCompleted:
+    {
+        fixtureBrowser.selectedManufacturer = ""
+        fixtureBrowser.selectedModel = ""
+        fixtureBrowser.selectedMode = ""
+        fixtureBrowser.searchFilter = ""
+    }
+
+    ColumnLayout
+    {
+        anchors.fill: parent
+        anchors.margins: 2
+        spacing: 2
+
+        Rectangle
+        {
+            height: UISettings.listItemHeight
+            Layout.fillWidth: true
+            color: UISettings.sectionHeader
+
+            RobotoText
+            {
+                anchors.centerIn: parent
+                label: qsTr("Substitute Profile")
+            }
+        }
+
+        Item
+        {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            FixtureBrowser
+            {
+                id: fxBrowser
+                // O FixtureBrowser.qml tem anchors.fill: parent,
+                // então ele vai preencher este Item.
+            }
+        }
+
+        RowLayout
+        {
+            Layout.fillWidth: true
+            Layout.preferredHeight: UISettings.listItemHeight
+            Layout.margins: 4
+            spacing: 5
+
+            GenericButton
+            {
+                Layout.fillWidth: true
+                Layout.preferredHeight: UISettings.listItemHeight
+                label: qsTr("Cancel")
+                onClicked: subPanelRoot.closed()
+            }
+
+            GenericButton
+            {
+                Layout.fillWidth: true
+                Layout.preferredHeight: UISettings.listItemHeight
+                label: qsTr("Confirm")
+                // Usando a instância global fixtureBrowser para garantir a leitura dos dados
+                enabled: fixtureBrowser.selectedModel !== "" && fixtureBrowser.selectedMode !== ""
+                onClicked:
+                {
+                    console.log("Substituindo para: " + fixtureBrowser.selectedManufacturer + " " + fixtureBrowser.selectedModel + " (" + fixtureBrowser.selectedMode + ")")
+                    var selectedIDs = contextManager.selectedFixtureIDVariantList()
+                    if (fixtureManager.replaceFixturesProfile(selectedIDs,
+                                                             fixtureBrowser.selectedManufacturer,
+                                                             fixtureBrowser.selectedModel,
+                                                             fixtureBrowser.selectedMode))
+                    {
+                        subPanelRoot.closed()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qmlui/qml/fixturesfunctions/FixturesAndFunctions.qml
+++ b/qmlui/qml/fixturesfunctions/FixturesAndFunctions.qml
@@ -37,6 +37,8 @@ Rectangle
     // for dynamic items creation
     property string currentView: contextManager.currentSubContext
 
+    property alias leftPanel: leftPanel
+
     Component.onCompleted:
     {
         switch (contextManager.currentSubContext)

--- a/qmlui/qml/fixturesfunctions/LeftPanel.qml
+++ b/qmlui/qml/fixturesfunctions/LeftPanel.qml
@@ -37,6 +37,12 @@ SidePanel
         item.height = Qt.binding(function() { return leftSidePanel.height })
     }
 
+    function resetSelection()
+    {
+        fxManagerGroup.checkedButton = null
+        capabilitiesGroup.checkedButton = null
+    }
+
     Rectangle
     {
         id: sideBar

--- a/qmlui/qml/fixturesfunctions/SettingsViewDMX.qml
+++ b/qmlui/qml/fixturesfunctions/SettingsViewDMX.qml
@@ -79,5 +79,19 @@ Rectangle
             checked: relativeAddresses
             onToggled: ViewDMX.relativeAddresses = checked
         }
+
+        // row 3
+        RobotoText { label: qsTr("Change profile") }
+        IconButton
+        {
+            id: changeProfileButton
+            implicitHeight: UISettings.listItemHeight
+            implicitWidth: implicitHeight
+            faSource: FontAwesome.fa_arrow_right_arrow_left
+            faColor: "white"
+            tooltip: qsTr("Change profile of the selected fixtures")
+            enabled: contextManager.selectedFixturesCount > 0
+            onClicked: dmxViewRoot.showFixtureBrowser(true)
+        }
     }
 }

--- a/qmlui/qmlui.qrc
+++ b/qmlui/qmlui.qrc
@@ -100,6 +100,7 @@
     <file alias="RGBPanelProperties.qml">qml/fixturesfunctions/RGBPanelProperties.qml</file>
     <file alias="FixtureDragItem.qml">qml/fixturesfunctions/FixtureDragItem.qml</file>
     <file alias="FixtureBrowserDelegate.qml">qml/fixturesfunctions/FixtureBrowserDelegate.qml</file>
+    <file alias="FixtureSubstitutionPanel.qml">qml/fixturesfunctions/FixtureSubstitutionPanel.qml</file>
     <file alias="FixtureGroupEditor.qml">qml/fixturesfunctions/FixtureGroupEditor.qml</file>
     <file alias="FixtureGroupManager.qml">qml/fixturesfunctions/FixtureGroupManager.qml</file>
     <file alias="FixtureNodeDelegate.qml">qml/fixturesfunctions/FixtureNodeDelegate.qml</file>

--- a/qmlui/virtualconsole/vcaudiotriggers.cpp
+++ b/qmlui/virtualconsole/vcaudiotriggers.cpp
@@ -141,6 +141,25 @@ VCWidget *VCAudioTriggers::createCopy(VCWidget *parent) const
     return audioTrigger;
 }
 
+void VCAudioTriggers::remapChannels(const QMap<SceneValue, SceneValue> &remapMap)
+{
+    for (AudioBar &bar : m_spectrumBars)
+    {
+        if (bar.m_type == DMXBar)
+        {
+            QList<SceneValue> newList;
+            for (const SceneValue &val : bar.m_dmxChannels)
+            {
+                SceneValue key(val.fxi, val.channel);
+                if (remapMap.contains(key))
+                    newList.append(remapMap.value(key));
+            }
+            bar.m_dmxChannels = newList;
+            rebuildBarAbsDmxChannels(bar);
+        }
+    }
+}
+
 bool VCAudioTriggers::captureEnabled() const
 {
     return m_captureEnabled;

--- a/qmlui/virtualconsole/vcaudiotriggers.h
+++ b/qmlui/virtualconsole/vcaudiotriggers.h
@@ -65,6 +65,9 @@ public:
     /** @reimp */
     VCWidget *createCopy(VCWidget *parent) const override;
 
+    /** @reimp */
+    void remapChannels(const QMap<SceneValue, SceneValue>& remapMap) override;
+
     /** Get/Set the capture enable status of this widget */
     bool captureEnabled() const;
     void setCaptureEnabled(bool enable);

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -181,6 +181,19 @@ VCWidget* VCSlider::createCopy(VCWidget* parent) const
     return slider;
 }
 
+void VCSlider::remapChannels(const QMap<SceneValue, SceneValue> &remapMap)
+{
+    QList<SceneValue> newChannels;
+    for (const SceneValue &val : m_levelChannels)
+    {
+        SceneValue key(val.fxi, val.channel);
+        if (remapMap.contains(key))
+            newChannels.append(remapMap.value(key));
+    }
+    m_levelChannels = newChannels;
+    emit channelsCountChanged();
+}
+
 bool VCSlider::copyFrom(const VCWidget *widget)
 {
     const VCSlider *slider = qobject_cast<const VCSlider*> (widget);

--- a/qmlui/virtualconsole/vcslider.h
+++ b/qmlui/virtualconsole/vcslider.h
@@ -92,6 +92,9 @@ public:
     /** @reimp */
     VCWidget *createCopy(VCWidget *parent) const override;
 
+    /** @reimp */
+    void remapChannels(const QMap<SceneValue, SceneValue>& remapMap) override;
+
 protected:
     /** @reimp */
     bool copyFrom(const VCWidget* widget) override;

--- a/qmlui/virtualconsole/vcwidget.cpp
+++ b/qmlui/virtualconsole/vcwidget.cpp
@@ -58,6 +58,11 @@ bool VCWidget::supportsPresets() const
     return false;
 }
 
+void VCWidget::remapChannels(const QMap<SceneValue, SceneValue> &remapMap)
+{
+    Q_UNUSED(remapMap);
+}
+
 QString VCWidget::presetsResource() const
 {
     return QString();

--- a/qmlui/virtualconsole/vcwidget.h
+++ b/qmlui/virtualconsole/vcwidget.h
@@ -125,6 +125,9 @@ public:
     /** Return true if this widget supports presets */
     virtual bool supportsPresets() const;
 
+    /** Remap this widget's channels using the provided $remapMap */
+    virtual void remapChannels(const QMap<SceneValue, SceneValue>& remapMap);
+
     /** Return a QML resource for preset properties */
     virtual QString presetsResource() const;
 

--- a/qmlui/virtualconsole/vcxypad.cpp
+++ b/qmlui/virtualconsole/vcxypad.cpp
@@ -188,6 +188,31 @@ VCWidget *VCXYPad::createCopy(VCWidget *parent) const
     return XYPad;
 }
 
+void VCXYPad::remapChannels(const QMap<SceneValue, SceneValue> &remapMap)
+{
+    for (int i = 0; i < m_fixtures.count(); i++)
+    {
+        XYPadFixture &fix = m_fixtures[i];
+        quint32 fxID = fix.m_head.fxi;
+
+        SceneValue xKey(fxID, fix.m_xMSB);
+        if (remapMap.contains(xKey))
+            fix.m_xMSB = remapMap.value(xKey).channel;
+
+        xKey.channel = fix.m_xLSB;
+        if (remapMap.contains(xKey))
+            fix.m_xLSB = remapMap.value(xKey).channel;
+
+        SceneValue yKey(fxID, fix.m_yMSB);
+        if (remapMap.contains(yKey))
+            fix.m_yMSB = remapMap.value(yKey).channel;
+
+        yKey.channel = fix.m_yLSB;
+        if (remapMap.contains(yKey))
+            fix.m_yLSB = remapMap.value(yKey).channel;
+    }
+}
+
 bool VCXYPad::copyFrom(const VCWidget *widget)
 {
     const VCXYPad *XYPad = qobject_cast<const VCXYPad*> (widget);

--- a/qmlui/virtualconsole/vcxypad.h
+++ b/qmlui/virtualconsole/vcxypad.h
@@ -71,6 +71,9 @@ public:
     /** @reimp */
     VCWidget *createCopy(VCWidget *parent) const override;
 
+    /** @reimp */
+    void remapChannels(const QMap<SceneValue, SceneValue>& remapMap) override;
+
 protected:
     /** @reimp */
     bool copyFrom(const VCWidget* widget) override;


### PR DESCRIPTION
This PR introduces the "Mass Profile Substitution" feature to QLC+ 5 (QML UI), achieving parity with a key functionality of QLC+ 4.

**Key changes:**
- **Engine:** Ported the intelligent fixture remapping logic from QLC+ 4. A new `FixtureRemap` class handles channel mapping by matching groups and colors.
- **Stability:** Implemented a "parking" strategy during re-patching to prevent DMX address collisions and application crashes when switching to profiles with more channels.
- **QML UI:** Added a new `FixtureSubstitutionPanel` accessible via the DMX View settings. It uses a clean, side-panel integrated browser.
- **Virtual Console:** Implemented `remapChannels()` across major widgets (`VCSlider`, `VCXYPad`, `VCAudioTriggers`) to ensure show programming is preserved after substitution.
- **UX Improvements:** Refined `FixtureProperties` to prevent automatic mode selection, reducing cognitive friction during the substitution process.
- **Tests:** Added comprehensive unit tests in `engine/test/fixture/fixtureremap_test.cpp`.

This feature significantly improves the workflow for users migrating shows between different fixture setups in the new QLC+ 5 interface.