### PR TITLE
webaccess-v5: fix topbar layout on narrow viewports (mobile)

### DIFF
--- a/webaccess/res/webaccess-v5.css
+++ b/webaccess/res/webaccess-v5.css
@@ -93,9 +93,38 @@ body {
   left: -200vw;
 }
 
+/* ============================================================
+ * Touch ergonomics: prevent text selection / long-press callout
+ * on interactive controls. Without this, long-pressing a button
+ * on iOS/Android selects nearby text or opens a context menu,
+ * which is disruptive when operating a live show.
+ * Defined early in the file so later, more specific selectors
+ * can still override individual properties if needed.
+ * ============================================================ */
+button,
+a,
+.nav-btn,
+.page-tab {
+  touch-action: manipulation;
+}
+
+.topbar,
+.nav-btn,
+.page-tab,
+.vc-stage button,
+.vc-button,
+.vc-frame-header,
+.vc-label {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
 .topbar {
-  height: var(--toolbar-height);
+  min-height: var(--toolbar-height);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   padding: 0 6px;
@@ -122,7 +151,6 @@ body {
 }
 
 .topbar-right {
-  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -143,6 +171,7 @@ body {
   font-family: var(--font-main);
   text-decoration: none;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .nav-btn:hover {
@@ -157,13 +186,17 @@ body {
 }
 
 .status {
-  width: calc(var(--toolbar-height) - 10px);
-  height: calc(var(--toolbar-height) - 10px);
+  position: fixed;
+  top: 6px;
+  right: 6px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: #ff3b30;
   border: 1px solid #7a1210;
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.4), 0 0 6px rgba(0, 0, 0, 0.4);
-  flex-shrink: 0;
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.4), 0 0 4px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  pointer-events: none;
 }
 
 .status.connected {
@@ -173,10 +206,10 @@ body {
 
 .pages-wrap {
   flex: 1;
-  min-width: 0;
+  min-width: 220px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 6px;
   position: relative;
 }
@@ -1872,17 +1905,23 @@ body {
   font-weight: 700;
 }
 
-@media (max-width: 900px) {
+/* On narrow viewports, scale topbar UP for finger-friendly tap targets.
+   Variables are scoped to .topbar so the rest of the app is unaffected. */
+@media (max-width: 650px) {
   .topbar {
-    flex-wrap: wrap;
-    height: auto;
-    padding: 4px 6px;
+    --text-size-default: 20px;
+    --toolbar-height: 40px;
   }
-  .actions {
-    margin-left: 0;
+
+  .brand-sub {
+    display: none;
   }
-  .pages {
-    height: auto;
-    padding: 4px 6px;
+
+  /* Truncate the (server-provided) app name to avoid eating the whole row */
+  .brand-title {
+    max-width: 4.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/webaccess/res/webaccess-v5.html
+++ b/webaccess/res/webaccess-v5.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="webaccess-v5.css">
 </head>
 <body>
+  <div class="status disconnected" id="wsStatus" aria-label="Disconnected" title="Disconnected"></div>
   <div id="app">
     <form id="loadForm" action="/loadProject" method="POST" enctype="multipart/form-data">
       <input id="loadTrigger" type="file" accept=".qxw" name="qlcprj">
@@ -28,7 +29,6 @@
           <a class="nav-btn" href="/simpleDesk">Simple Desk</a>
           <a class="nav-btn" href="/config">Configuration</a>
         </div>
-        <div class="status disconnected" id="wsStatus" aria-label="Disconnected" title="Disconnected"></div>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary

The v5 web UI topbar has several layout issues on phones and tablets that make it awkward to use as a live remote. This PR addresses them with CSS-only changes (one trivial HTML move for the connection-status dot).

## Problems fixed

- The existing `@media (max-width: 900px)` block sets `.actions { margin-left: 0 }`, but the auto-margin that pushes content to the right actually lives on `.topbar-right`. The override is therefore a no-op and right-side buttons stay pushed off-screen on narrow viewports.
- The connection status dot is a flex item inside `.topbar-right` and jumps around once the bar starts wrapping, ending up in different positions per page.
- `--text-size-default` (12px) and `--toolbar-height` do not scale with viewport, so tap targets are uncomfortably small on touch devices.
- `.nav-btn` labels could break across two lines mid-bar.
- Long-pressing a button on iOS/Android selects nearby text or opens the context menu, which is disruptive when operating a live show.

## Changes

**`webaccess-v5.css`**
- `.topbar`: `min-height` instead of `height`, `flex-wrap: wrap` unconditionally; the buggy 900px media query is removed.
- `.topbar-right`: drop `margin-left: auto`; horizontal distribution is handled by `.pages-wrap { flex: 1 }`.
- `.status`: moved out of the flex layout to `position: fixed` top-right (8x8 dot, `pointer-events: none`) so it stays put across pages and wrap states.
- `.pages-wrap`: `min-width: 220px`, `justify-content: flex-start`.
- New `@media (max-width: 650px)` block scopes larger `--text-size-default` (20px) and `--toolbar-height` (40px) to `.topbar` for finger-friendly targets, hides `.brand-sub`, and truncates `.brand-title` with ellipsis.
- `.nav-btn { white-space: nowrap }`.
- Touch ergonomics: `user-select: none`, `-webkit-touch-callout: none`, `-webkit-tap-highlight-color: transparent` on topbar/nav/VC controls; `touch-action: manipulation` on interactive elements.

**`webaccess-v5.html`**
- The `#wsStatus` div is moved from inside `.topbar-right` to the top of `<body>` so it can be positioned globally and remain consistent across pages.

## Scope

- Touches only `webaccess/res/webaccess-v5.css` and `webaccess/res/webaccess-v5.html`.
- No JS changes.
- No behavior changes on desktop above 650px width except: the connection dot is smaller and pinned top-right instead of inline in the topbar.

## Testing

Tested on macOS Safari (desktop), iOS Safari on iPhone, and iPad Safari against QLC+ 5.2.1 with several `.qxw` projects (Virtual Console with multiple pages and frames, Simple Desk, Configuration). The topbar now wraps cleanly, all buttons remain reachable, and touch targets are comfortable.