### PR TITLE
Fixed plugin parameters not saved when device is disconnected

### DIFF
--- a/engine/src/inputpatch.cpp
+++ b/engine/src/inputpatch.cpp
@@ -206,9 +206,12 @@ void InputPatch::setPluginParameter(QString prop, QVariant value)
 QMap<QString, QVariant> InputPatch::getPluginParameters()
 {
     if (m_plugin != NULL)
-        return m_plugin->getParameters(m_universe, m_pluginLine, QLCIOPlugin::Input);
-
-    return QMap<QString, QVariant>();
+    {
+        const auto params = m_plugin->getParameters(m_universe, m_pluginLine, QLCIOPlugin::Input);
+        if (!params.isEmpty())
+            return params;
+    }
+    return m_parametersCache;
 }
 
 void InputPatch::slotValueChanged(quint32 universe, quint32 input, quint32 channel,

--- a/engine/src/outputpatch.cpp
+++ b/engine/src/outputpatch.cpp
@@ -152,9 +152,12 @@ void OutputPatch::setPluginParameter(QString prop, QVariant value)
 QMap<QString, QVariant> OutputPatch::getPluginParameters()
 {
     if (m_plugin != NULL)
-        return m_plugin->getParameters(m_universe, m_pluginLine, QLCIOPlugin::Output);
-
-    return QMap<QString, QVariant>();
+    {
+        const auto params = m_plugin->getParameters(m_universe, m_pluginLine, QLCIOPlugin::Output);
+        if (!params.isEmpty())
+            return params;
+    }
+    return m_parametersCache;
 }
 
 /*****************************************************************************


### PR DESCRIPTION
## Description

**Summary of Changes:**
`InputPatch::getPluginParameters()` and `OutputPatch::getPluginParameters()` returned an empty map when the plugin device was disconnected (`m_plugin == NULL`), causing all custom plugin parameters to be silently dropped when saving a workspace while the device is not connected.

`m_parametersCache` already existed and was used in `reconnect()`, but `getPluginParameters()` ignored it. This fix adds the missing fallback.

**Related Issues:** N/A

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
1. Open a workspace with MIDI plugin parameters configured (init message, send note off, mode).
2. Disconnect the device and save the workspace.
3. Check the saved XML — verify parameters are present.

**Test Results:**

Before the fix — workspace opened with MIDI parameters configured, saved with device disconnected, parameters lost.

Was:
```xml
    <Input Plugin="MIDI" UID="None" Line="0" Profile="Akai APC Mini">
     <PluginParameters MIDISendNoteOff="false" initmessage="APC mini Ableton mode 2"/>
    </Input>
    <Output Plugin="DMX USB" UID="None" Line="0">
     <PluginParameters UniverseChannels="279"/>
    </Output>
    <Feedback Plugin="MIDI" UID="None" Line="1">
     <PluginParameters initmessage="APC mini Ableton mode 2" mode="Note Velocity"/>
    </Feedback>
```
Became:
```xml
    <Input Plugin="MIDI" UID="None" Line="0" Profile="Akai APC Mini"/>
    <Output Plugin="DMX USB" UID="None" Line="0"/>
    <Feedback Plugin="MIDI" UID="None" Line="1"/>
```

After the fix — same scenario, parameters preserved:

Was:
```xml
    <Input Plugin="MIDI" UID="None" Line="0" Profile="Akai APC Mini">
     <PluginParameters MIDISendNoteOff="false" initmessage="APC mini Ableton mode 2"/>
    </Input>
    <Output Plugin="DMX USB" UID="None" Line="0">
     <PluginParameters UniverseChannels="279"/>
    </Output>
    <Feedback Plugin="MIDI" UID="None" Line="1">
     <PluginParameters initmessage="APC mini Ableton mode 2" mode="Note Velocity"/>
    </Feedback>
```
Became:
```xml
    <Input Plugin="MIDI" UID="None" Line="0" Profile="Akai APC Mini">
     <PluginParameters MIDISendNoteOff="false" initmessage="APC mini Ableton mode 2"/>
    </Input>
    <Output Plugin="DMX USB" UID="None" Line="0">
     <PluginParameters UniverseChannels="279"/>
    </Output>
    <Feedback Plugin="MIDI" UID="None" Line="1">
     <PluginParameters initmessage="APC mini Ableton mode 2" mode="Note Velocity"/>
    </Feedback>
```

