### PR TITLE
Updated Cue List to play cues on double-click (for some reason activa…

### DIFF
--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -170,6 +170,10 @@ VCCueList::VCCueList(QWidget *parent, Doc *doc) : VCWidget(parent, doc)
             this, SLOT(slotItemActivated(QTreeWidgetItem*)));
     connect(m_tree, SIGNAL(itemChanged(QTreeWidgetItem*,int)),
             this, SLOT(slotItemChanged(QTreeWidgetItem*,int)));
+#if defined(WIN32) || defined(Q_OS_WIN)
+    connect(m_tree, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)),
+            this, SLOT(slotItemDoubleClicked(QTreeWidgetItem *, int)));
+#endif
     vbox->addWidget(m_tree);
 
     m_progress = new QProgressBar(this);
@@ -894,6 +898,16 @@ void VCCueList::slotStepNoteChanged(int idx, QString note)
     step.note = note;
     ch->replaceStep(step, idx);
 }
+
+#if defined(WIN32) || defined(Q_OS_WIN)
+void VCCueList::slotItemDoubleClicked(QTreeWidgetItem *item, int column)
+{
+    if (mode() != Doc::Operate)
+        return;
+
+    playCueAtIndex(m_tree->indexOfTopLevelItem(item));
+}
+#endif
 
 void VCCueList::slotFunctionRunning(quint32 fid)
 {

--- a/ui/src/virtualconsole/vccuelist.cpp
+++ b/ui/src/virtualconsole/vccuelist.cpp
@@ -170,10 +170,8 @@ VCCueList::VCCueList(QWidget *parent, Doc *doc) : VCWidget(parent, doc)
             this, SLOT(slotItemActivated(QTreeWidgetItem*)));
     connect(m_tree, SIGNAL(itemChanged(QTreeWidgetItem*,int)),
             this, SLOT(slotItemChanged(QTreeWidgetItem*,int)));
-#if defined(WIN32) || defined(Q_OS_WIN)
     connect(m_tree, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)),
             this, SLOT(slotItemDoubleClicked(QTreeWidgetItem *, int)));
-#endif
     vbox->addWidget(m_tree);
 
     m_progress = new QProgressBar(this);
@@ -899,15 +897,15 @@ void VCCueList::slotStepNoteChanged(int idx, QString note)
     ch->replaceStep(step, idx);
 }
 
-#if defined(WIN32) || defined(Q_OS_WIN)
 void VCCueList::slotItemDoubleClicked(QTreeWidgetItem *item, int column)
 {
+    Q_UNUSED(column)
+
     if (mode() != Doc::Operate)
         return;
 
     playCueAtIndex(m_tree->indexOfTopLevelItem(item));
 }
-#endif
 
 void VCCueList::slotFunctionRunning(quint32 fid)
 {

--- a/ui/src/virtualconsole/vccuelist.h
+++ b/ui/src/virtualconsole/vccuelist.h
@@ -211,10 +211,8 @@ private slots:
         Note that only 'Notes" column is considered */
     void slotItemChanged(QTreeWidgetItem*item, int column);
 
-#if defined(WIN32) || defined(Q_OS_WIN)
     /** Slot that is called whenever an item field has been double-clicked */
     void slotItemDoubleClicked(QTreeWidgetItem *item, int column);
-#endif
 
     /** Slot called whenever a function is started */
     void slotFunctionRunning(quint32 fid);

--- a/ui/src/virtualconsole/vccuelist.h
+++ b/ui/src/virtualconsole/vccuelist.h
@@ -211,6 +211,11 @@ private slots:
         Note that only 'Notes" column is considered */
     void slotItemChanged(QTreeWidgetItem*item, int column);
 
+#if defined(WIN32) || defined(Q_OS_WIN)
+    /** Slot that is called whenever an item field has been double-clicked */
+    void slotItemDoubleClicked(QTreeWidgetItem *item, int column);
+#endif
+
     /** Slot called whenever a function is started */
     void slotFunctionRunning(quint32 fid);
 


### PR DESCRIPTION
## Description

**Summary of Changes:**
According to the documentation, cues are intended to run by double-clicking on the Cue List widget. On Windows, double-clicking a cue did nothing — `QTreeWidget::itemActivated` signal does not fire on mouse clicks on Windows (verified: Enter key still works correctly).

The fix connects `itemDoubleClicked` signal explicitly under `#ifdef Q_OS_WIN` to restore the documented behavior. The guard avoids double invocation on other platforms where `itemActivated` already fires on mouse interaction.

**Related Issues:** N/A

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
1. Open a workspace with a Cue List widget.
2. Switch to Operate mode.
3. Double-click a cue — verify it plays.

**Test Results:**

Before the fix — double-clicking a cue in Operate mode did nothing on Windows.

After the fix — double-clicking a cue plays it as expected.

## Additional Notes

The handler only acts in Operate mode, consistent with the rest of the Cue List interaction code.
