### PR TITLE
qmlui: restart universes after all workspace loads

### DIFF
--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -775,8 +775,6 @@ bool App::loadWorkspace(const QString &fileName)
             }
         }
 
-        m_doc->inputOutputMap()->startUniverses();
-
         return true;
     }
     return false;
@@ -967,6 +965,10 @@ bool App::loadXML(QXmlStreamReader &doc, bool goToConsole, bool fromMemory)
 
     // Perform post-load operations
     m_virtualConsole->postLoad();
+
+    // Workspace loading replaces Universe instances via InputOutputMap::loadXML(),
+    // so restart them only after the full document is in place.
+    m_doc->inputOutputMap()->startUniverses();
 
     if (m_doc->errorLog().isEmpty() == false &&
         fromMemory == false)


### PR DESCRIPTION
Projects loaded from memory recreate Universe instances in InputOutputMap::loadXML(), but startUniverses() was only called from the file-based load path.

That left web-loaded projects with patched outputs but no restarted universe threads. Move the restart into App::loadXML() so file-backed and in-memory loads share the same finalization path.

Fixes: #2001.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.
