### PR TITLE
webaccess: fix None patch handling

### DIFF
--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -413,7 +413,8 @@ bool InputOutputMap::setInputPatch(quint32 universe, const QString &pluginName,
         currProfile = currInPatch->profile();
         disconnect(currInPatch, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)),
                 this, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)));
-        if (currInPatch->plugin()->capabilities() & QLCIOPlugin::Beats)
+        QLCIOPlugin *currPlugin = currInPatch->plugin();
+        if (currPlugin != NULL && currPlugin->capabilities() & QLCIOPlugin::Beats)
         {
             disconnect(currInPatch, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)),
                        this, SLOT(slotPluginBeat(quint32,quint32,uchar,const QString&)));
@@ -446,7 +447,8 @@ bool InputOutputMap::setInputPatch(quint32 universe, const QString &pluginName,
         {
             connect(ip, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)),
                     this, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)));
-            if (ip->plugin()->capabilities() & QLCIOPlugin::Beats)
+            QLCIOPlugin *inputPlugin = ip->plugin();
+            if (inputPlugin != NULL && inputPlugin->capabilities() & QLCIOPlugin::Beats)
             {
                 connect(ip, SIGNAL(inputValueChanged(quint32,quint32,uchar,const QString&)),
                         this, SLOT(slotPluginBeat(quint32,quint32,uchar,const QString&)));

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -594,7 +594,7 @@ bool Universe::setInputPatch(QLCIOPlugin *plugin,
     }
     else
     {
-        if (input == QLCIOPlugin::invalidLine())
+        if (plugin == NULL || input == QLCIOPlugin::invalidLine())
         {
             disconnectInputPatch();
             delete m_inputPatch;

--- a/engine/test/inputoutputmap/inputoutputmap_test.cpp
+++ b/engine/test/inputoutputmap/inputoutputmap_test.cpp
@@ -358,6 +358,29 @@ void InputOutputMap_Test::setInputPatch()
     QVERIFY(im.inputPatch(3) == NULL);
     QVERIFY(im.inputMapping(stub->name(), 3) == 2);
 
+    // Clearing through a null plugin must fully remove the patch.
+    QVERIFY(im.setInputPatch(0, KInputNone, "", 0) == true);
+    QVERIFY(im.inputPatch(0) == NULL);
+    QVERIFY(im.inputMapping(stub->name(), 0) == InputOutputMap::invalidUniverse());
+    QVERIFY(im.isUniversePatched(0) == false);
+
+    QVERIFY(im.setInputPatch(0, stub->name(), stub->inputs().at(1), 1) == true);
+    QVERIFY(im.inputPatch(0) != NULL);
+    QVERIFY(im.inputPatch(0)->plugin() == stub);
+    QVERIFY(im.inputPatch(0)->input() == 1);
+    QVERIFY(im.inputMapping(stub->name(), 1) == 0);
+    QVERIFY(im.isUniversePatched(0) == true);
+
+    QVERIFY(im.setInputPatch(0, KInputNone, "", QLCIOPlugin::invalidLine()) == true);
+    QVERIFY(im.inputPatch(0) == NULL);
+    QVERIFY(im.inputMapping(stub->name(), 1) == InputOutputMap::invalidUniverse());
+    QVERIFY(im.isUniversePatched(0) == false);
+
+    QVERIFY(im.setInputPatch(0, stub->name(), stub->inputs().at(2), 2) == true);
+    QVERIFY(im.inputPatch(0) != NULL);
+    QVERIFY(im.inputPatch(0)->plugin() == stub);
+    QVERIFY(im.inputPatch(0)->input() == 2);
+
     // Universe out of bounds
     QVERIFY(im.setInputPatch(im.universesCount(), stub->name(), stub->inputs().at(0), 0) == false);
 }

--- a/webaccess/src/webaccessbase.cpp
+++ b/webaccess/src/webaccessbase.cpp
@@ -32,6 +32,7 @@
 #include "webaccesssimpledesk.h"
 #include "webaccessnetwork.h"
 #include "commonjscss.h"
+#include "qlcioplugin.h"
 #include "qlcconfig.h"
 #include "qlcfile.h"
 #include "doc.h"
@@ -53,6 +54,18 @@ QString sanitizeUploadedFileName(const QString &rawName)
     QString normalizedName = rawName;
     normalizedName.replace('\\', '/');
     return QFileInfo(normalizedName).fileName();
+}
+
+quint32 parsePatchLineValue(const QString &rawValue)
+{
+    bool ok = false;
+    int parsedLine = rawValue.toInt(&ok);
+
+    // Negative line values are interpreted as "None".
+    if (ok == false || parsedLine < 0)
+        return QLCIOPlugin::invalidLine();
+
+    return quint32(parsedLine);
 }
 
 bool extractMultipartFilePayload(const QHttpRequest *req, QByteArray &payload, QString *fileName = nullptr)
@@ -546,17 +559,29 @@ bool WebAccessBase::handleCommonWebSocketCommand(QHttpConnection *conn, const We
 
         if (cmdList[1] == "INPUT")
         {
-            m_doc->inputOutputMap()->setInputPatch(universe, cmdList[3], "", cmdList[4].toUInt());
+            if (cmdList.count() < 5)
+                return true;
+
+            m_doc->inputOutputMap()->setInputPatch(universe, cmdList[3], "",
+                                                   parsePatchLineValue(cmdList[4]));
             m_doc->inputOutputMap()->saveDefaults();
         }
         else if (cmdList[1] == "OUTPUT")
         {
-            m_doc->inputOutputMap()->setOutputPatch(universe, cmdList[3], "", cmdList[4].toUInt(), false);
+            if (cmdList.count() < 5)
+                return true;
+
+            m_doc->inputOutputMap()->setOutputPatch(universe, cmdList[3], "",
+                                                    parsePatchLineValue(cmdList[4]), false);
             m_doc->inputOutputMap()->saveDefaults();
         }
         else if (cmdList[1] == "FB")
         {
-            m_doc->inputOutputMap()->setOutputPatch(universe, cmdList[3], "", cmdList[4].toUInt(), true);
+            if (cmdList.count() < 5)
+                return true;
+
+            m_doc->inputOutputMap()->setOutputPatch(universe, cmdList[3], "",
+                                                    parsePatchLineValue(cmdList[4]), true);
             m_doc->inputOutputMap()->saveDefaults();
         }
         else if (cmdList[1] == "PROFILE")


### PR DESCRIPTION
WebAccess encodes "[None]" as a negative line value. Parse negative line numbers as invalidLine(), and let input patch removal work with a null plugin too.

Extend inputoutputmap coverage for clearing and reattaching an input patch.

Fixes: #2002.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

Added a new test in `engine/test/inputoutputmap/inputoutputmap_test.cpp`.