### PR TITLE
fixtures: restore ROOT PAR 6 non-delay modes

### DIFF
--- a/resources/fixtures/Cameo/Cameo-ROOT-Par-6.qxf
+++ b/resources/fixtures/Cameo/Cameo-ROOT-Par-6.qxf
@@ -157,28 +157,51 @@
   <Capability Min="208" Max="213">User Color_2</Capability>
   <Capability Min="214" Max="219">User Color_3</Capability>
   <Capability Min="220" Max="225">User Color_4</Capability>
-  <Capability Min="226" Max="255">no function</Capability>
+  <Capability Min="226" Max="255">UV</Capability>
  </Channel>
- <Mode Name="3-Channel">
+ <Mode Name="2 Channel">
+  <Channel Number="0" ActsOn="1">Master Dimmer</Channel>
+  <Channel Number="1">Color Presets &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
+ </Mode>
+ <Mode Name="3 Channel with DMX delay">
   <Channel Number="0" ActsOn="2">Master Dimmer</Channel>
   <Channel Number="1">Color Presets &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
   <Channel Number="2">DMX Delay</Channel>
  </Mode>
- <Mode Name="5-Channel 1">
+ <Mode Name="4 Channel 1">
+  <Channel Number="0" ActsOn="3">Master Dimmer</Channel>
+  <Channel Number="1">Strobe functions</Channel>
+  <Channel Number="2">Color Presets &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
+  <Channel Number="3">Sound (triggers Strobe, Color Jumping &amp; Fading)</Channel>
+ </Mode>
+ <Mode Name="5 Channel 1 with DMX delay">
   <Channel Number="0" ActsOn="4">Master Dimmer</Channel>
   <Channel Number="1">Strobe functions</Channel>
   <Channel Number="2">Color Presets &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
   <Channel Number="3">Sound (triggers Strobe, Color Jumping &amp; Fading)</Channel>
   <Channel Number="4">DMX Delay</Channel>
  </Mode>
- <Mode Name="5-Channel 2 (compatibility for ROOT PAR 4)">
+ <Mode Name="4 Channel">
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+ </Mode>
+ <Mode Name="5 Channel 2 (compatibility for ROOT PAR 4) with DMX delay">
   <Channel Number="0" ActsOn="4">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
   <Channel Number="3">White</Channel>
   <Channel Number="4">DMX Delay</Channel>
  </Mode>
- <Mode Name="6-Channel">
+ <Mode Name="5 Channel">
+  <Channel Number="0" ActsOn="4">Master Dimmer</Channel>
+  <Channel Number="1">Strobe</Channel>
+  <Channel Number="2">Chase of Ch 4 and Ch 5</Channel>
+  <Channel Number="3">Color Presets 1 &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
+  <Channel Number="4">Color Presets 2 &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
+ </Mode>
+ <Mode Name="6 Channel with DMX delay">
   <Channel Number="0" ActsOn="5">Master Dimmer</Channel>
   <Channel Number="1">Strobe</Channel>
   <Channel Number="2">Chase of Ch 4 and Ch 5</Channel>
@@ -186,7 +209,15 @@
   <Channel Number="4">Color Presets 2 &amp; Color Jumping &amp; Color Fading &amp; User Colors</Channel>
   <Channel Number="5">DMX Delay</Channel>
  </Mode>
- <Mode Name="7-Channel">
+ <Mode Name="6 Channel">
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">White</Channel>
+  <Channel Number="4">Amber</Channel>
+  <Channel Number="5">UV</Channel>
+ </Mode>
+ <Mode Name="7 Channel with DMX delay">
   <Channel Number="0" ActsOn="6">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
@@ -195,7 +226,17 @@
   <Channel Number="5">UV</Channel>
   <Channel Number="6">DMX Delay</Channel>
  </Mode>
- <Mode Name="9-Channel">
+ <Mode Name="8 Channel">
+  <Channel Number="0" ActsOn="7">Master Dimmer</Channel>
+  <Channel Number="1">Strobe</Channel>
+  <Channel Number="2">Red</Channel>
+  <Channel Number="3">Green</Channel>
+  <Channel Number="4">Blue</Channel>
+  <Channel Number="5">White</Channel>
+  <Channel Number="6">Amber</Channel>
+  <Channel Number="7">UV</Channel>
+ </Mode>
+ <Mode Name="9 Channel with DMX delay">
   <Channel Number="0" ActsOn="8">Master Dimmer</Channel>
   <Channel Number="1">Strobe</Channel>
   <Channel Number="2">Red</Channel>
@@ -206,7 +247,20 @@
   <Channel Number="7">UV</Channel>
   <Channel Number="8">DMX Delay</Channel>
  </Mode>
- <Mode Name="12-Channel">
+ <Mode Name="11 Channel">
+  <Channel Number="0" ActsOn="10">Master Dimmer</Channel>
+  <Channel Number="1">Master dimmer fine</Channel>
+  <Channel Number="2">Strobe functions</Channel>
+  <Channel Number="3">Red</Channel>
+  <Channel Number="4">Green</Channel>
+  <Channel Number="5">Blue</Channel>
+  <Channel Number="6">White</Channel>
+  <Channel Number="7">Amber</Channel>
+  <Channel Number="8">UV</Channel>
+  <Channel Number="9">Color Presets &amp; Color Jumping &amp; Color Fading &amp; User Colors (override RGBWA+UV)</Channel>
+  <Channel Number="10">Sound (triggers Strobe, Color Jumping &amp; Fading)</Channel>
+ </Mode>
+ <Mode Name="12 Channel with DMX delay">
   <Channel Number="0" ActsOn="11">Master Dimmer</Channel>
   <Channel Number="1">Master dimmer fine</Channel>
   <Channel Number="2">Strobe functions</Channel>


### PR DESCRIPTION
Restore the 2/4/5/6/8/11 channel modes from the ROOT PAR 6 DMX table and rename the delay variants to make the extra DMX delay channel explicit.

These names are closer to the specification and therefore less ambiguous and less misleading than plain channel counts for the D* modes. This also restores the historic "4 Channel", "6 Channel" and "8 Channel" names for existing projects.

Fix the 12 Channel override macro so 226-255 maps to UV.

Topic was raised here:
  https://www.qlcplus.org/forum/viewtopic.php?t=19599

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Notes

This is my preferred solution of this issue.
I reached out for feedback a week before creating the PR, but did not get any feedback.
I'm also fine with another solution, but I wanted to avoid this not moving forward.