### PR TITLE
chaserrunner: apply submaster updates to all crossfade steps

### DIFF
--- a/engine/src/chaserrunner.cpp
+++ b/engine/src/chaserrunner.cpp
@@ -423,24 +423,38 @@ void ChaserRunner::adjustStepIntensity(qreal fraction, int requestedStepIndex, i
     int stepIndex = requestedStepIndex;
     if (stepIndex == -1)
     {
-        stepIndex = m_lastRunStepIdx;
         // store the intensity to be applied at the next step startup
         m_pendingAction.m_masterIntensity = fraction;
-    }
 
-    foreach (ChaserRunnerStep *step, m_runnerSteps)
-    {
-        if (stepIndex == step->m_index && step->m_function != NULL)
+        foreach (ChaserRunnerStep *step, m_runnerSteps)
         {
-            if (requestedStepIndex == -1 && step->m_function->type() == Function::SceneType)
+            if (step == NULL || step->m_function == NULL)
+                continue;
+
+            step->m_masterIntensity = fraction;
+            if (step->m_function->type() == Function::SceneType)
             {
                 Scene *scene = qobject_cast<Scene *>(step->m_function);
                 scene->adjustAttribute(fraction, step->m_pIntensityOverrideId);
             }
             else
             {
-                step->m_function->adjustAttribute(fraction, step->m_intensityOverrideId);
+                step->m_function->adjustAttribute(fraction * step->m_stepIntensity, step->m_intensityOverrideId);
             }
+        }
+
+        return;
+    }
+
+    foreach (ChaserRunnerStep *step, m_runnerSteps)
+    {
+        if (stepIndex == step->m_index && step->m_function != NULL)
+        {
+            step->m_stepIntensity = fraction;
+            if (step->m_function->type() == Function::SceneType)
+                step->m_function->adjustAttribute(fraction, step->m_intensityOverrideId);
+            else
+                step->m_function->adjustAttribute(step->m_masterIntensity * fraction, step->m_intensityOverrideId);
             return;
         }
     }
@@ -494,6 +508,11 @@ void ChaserRunner::startNewStep(int index, MasterTimer *timer, qreal mIntensity,
 
     ChaserRunnerStep *newStep = new ChaserRunnerStep();
     newStep->m_index = index;
+    newStep->m_function = func;
+    newStep->m_masterIntensity = mIntensity;
+    newStep->m_stepIntensity = sIntensity;
+    newStep->m_intensityOverrideId = Function::invalidAttributeId();
+    newStep->m_pIntensityOverrideId = Function::invalidAttributeId();
 
     // check if blending between Scenes is needed
     if (m_lastFunctionID != Function::invalidId() &&
@@ -547,8 +566,6 @@ void ChaserRunner::startNewStep(int index, MasterTimer *timer, qreal mIntensity,
     newStep->m_elapsedBeats = 0; //(newStep->m_elapsed / timer->beatTimeDuration()) * 1000;
 
     m_startOffset = 0;
-
-    newStep->m_function = func;
 
     if (m_chaser->type() == Function::SequenceType)
     {

--- a/engine/src/chaserrunner.h
+++ b/engine/src/chaserrunner.h
@@ -44,6 +44,8 @@ typedef struct
 {
     int m_index;                        //! Index of the step from the original Chaser
     Function *m_function;               //! Currently active function
+    qreal m_masterIntensity;            //! Current master intensity applied to this step
+    qreal m_stepIntensity;              //! Current step intensity applied to this step
     quint32 m_elapsed;                  //! Elapsed milliseconds
     quint32 m_elapsedBeats;             //! Elapsed beats
     uint m_fadeIn;                      //! Step fade in in ms

--- a/engine/test/chaserrunner/chaserrunner_test.cpp
+++ b/engine/test/chaserrunner/chaserrunner_test.cpp
@@ -1377,4 +1377,45 @@ void ChaserRunner_Test::adjustIntensity()
     QCOMPARE(m_scene3->getAttributeValue(Function::Intensity), qreal(1.0));
 }
 
+void ChaserRunner_Test::adjustMasterIntensityAcrossRunningCrossfadeSteps()
+{
+    m_chaser->setDirection(Function::Forward);
+    m_chaser->setRunOrder(Function::Loop);
+    m_chaser->setDuration(Function::infiniteSpeed());
+
+    ChaserRunner cr(m_doc, m_chaser);
+    MasterTimer *timer = m_doc->masterTimer();
+
+    cr.adjustStepIntensity(0.75, 0, Chaser::BlendedCrossfade);
+    timer->timerTick();
+    cr.adjustStepIntensity(0.25, 1, Chaser::BlendedCrossfade);
+    timer->timerTick();
+
+    QCOMPARE(cr.runningStepsNumber(), 2);
+    QCOMPARE(cr.m_runnerSteps.size(), 2);
+    QCOMPARE(cr.m_runnerSteps.at(0)->m_index, 0);
+    QCOMPARE(cr.m_runnerSteps.at(1)->m_index, 1);
+    QCOMPARE(cr.m_runnerSteps.at(0)->m_masterIntensity, qreal(1.0));
+    QCOMPARE(cr.m_runnerSteps.at(1)->m_masterIntensity, qreal(1.0));
+    QCOMPARE(m_scene1->getAttributeValue(Function::Intensity), qreal(0.75));
+    QCOMPARE(m_scene2->getAttributeValue(Function::Intensity), qreal(0.25));
+    QCOMPARE(m_scene1->getAttributeValue(Scene::ParentIntensity), qreal(1.0));
+    QCOMPARE(m_scene2->getAttributeValue(Scene::ParentIntensity), qreal(1.0));
+
+    cr.adjustStepIntensity(0.0);
+
+    QCOMPARE(cr.m_runnerSteps.at(0)->m_masterIntensity, qreal(0.0));
+    QCOMPARE(cr.m_runnerSteps.at(1)->m_masterIntensity, qreal(0.0));
+    QCOMPARE(m_scene1->getAttributeValue(Scene::ParentIntensity), qreal(0.0));
+    QCOMPARE(m_scene2->getAttributeValue(Scene::ParentIntensity), qreal(0.0));
+
+    timer->timerTick();
+
+    QList<Universe *> universes = m_doc->inputOutputMap()->claimUniverses();
+    universes[0]->processFaders(MasterTimer::tick());
+    QCOMPARE(universes[0]->postGMValue(0), uchar(0));
+    QCOMPARE(universes[0]->postGMValue(1), uchar(0));
+    m_doc->inputOutputMap()->releaseUniverses(false);
+}
+
 QTEST_APPLESS_MAIN(ChaserRunner_Test)

--- a/engine/test/chaserrunner/chaserrunner_test.h
+++ b/engine/test/chaserrunner/chaserrunner_test.h
@@ -67,6 +67,7 @@ private slots:
     void writeNoAutoStep();
 
     void adjustIntensity();
+    void adjustMasterIntensityAcrossRunningCrossfadeSteps();
 
 private:
     Doc* m_doc;


### PR DESCRIPTION
Track the master and step intensities of each running step and reapply master-intensity changes to every active crossfade step.

Add an engine regression in chaserrunner_test so this bug can be proposed independently from #1595.

Fixes: #2004.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

New testcase in engine/test/chaserrunner/chaserrunner_test.cpp.