### PR TITLE
ci: update GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -112,7 +112,7 @@ jobs:
         run: pip install lxml
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.task }}
 
@@ -262,12 +262,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.task }}
 
@@ -466,7 +466,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -528,7 +528,7 @@ jobs:
           rm -f /tmp/macos_cert.p12
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.task }}
 


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 and hendrikmuhs/ccache-action from v1.2 to v1.2.23.

Both releases support the Node 24 runtime natively, removing the Node 20 deprecation warning from these steps.

  GitHub will switch Actions runners to Node 24 by default on June 2, 2026:
  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

  actions/checkout moved to the Node 24 runtime in v5:
  https://github.com/actions/checkout#checkout-v5
  https://github.com/actions/checkout/releases/tag/v5.0.0

  hendrikmuhs/ccache-action moved from Node 20 to Node 24 in v1.2.21:
  https://github.com/hendrikmuhs/ccache-action/releases/tag/v1.2.21
