### PR TITLE
ci: update remaining GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           echo "NPROC: ${NPROC}"
 
       - name: Download, cache and install packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: ${{env.PACKAGES_ALL}}
           version: ${{runner.os}}-apt
@@ -198,7 +198,7 @@ jobs:
       - name: Store original install artifacts before stripping and AppImage
         # Activate for debugging
         if: ${{ false && ! startsWith( matrix.task, 'coverage') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.task }}-files
           path: ${{ env.INSTALL_ROOT }}
@@ -242,7 +242,7 @@ jobs:
 
       - name: Store AppImage artifacts
         if: ${{ ! startsWith( matrix.task, 'coverage') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.task }}-AppImage
           path: qlcplus-${{env.TASK}}-${{env.APPVERSION}}-${{env.BUILD_DATE}}-${{env.GIT_REV}}.AppImage
@@ -438,7 +438,7 @@ jobs:
           mv /c/qlcplus/${{env.OUTFILE}} /d/a/qlcplus/qlcplus/${{matrix.task}}-${{env.OUTFILE}}
 
       - name: Store executable artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: QLC+-${{matrix.task}}-${{env.APPVERSION}}-${{env.BUILD_DATE}}-${{env.GIT_REV}}.exe
           path: ${{matrix.task}}-${{env.OUTFILE}}
@@ -584,7 +584,7 @@ jobs:
         # Use retry loop to work around a race condition on macOS causing
         # 'Resource busy' errors with 'hdiutil'. See
         # https://github.com/actions/runner-images/issues/7522
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 30
           max_attempts: 12
@@ -618,7 +618,7 @@ jobs:
           rm -f /tmp/AuthKey.p8
 
       - name: Store DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: QLC+-${{env.APPVERSION}}-${{env.BUILD_DATE}}-${{env.GIT_REV}}.dmg
           path: QLC+_${{ matrix.task }}.dmg


### PR DESCRIPTION
  This follows up #2010, which updated some GitHub Actions but missed a few remaining refs.

  This PR updates the remaining direct calls in `build.yml`:
  - `actions/upload-artifact`: `v4` -> `v7`
  - `nick-fields/retry`: `v3` -> `v4`
  - `awalsh128/cache-apt-pkgs-action`: `v1.4.3` -> `v1.6.0`

  Current upstream state of `awalsh128/cache-apt-pkgs-action`, as of May 8, 2026:
  - the latest release is `v1.6.0`, published on October 15, 2025
  - the released `v1.6.0` tag still pins `actions/cache/restore` and `actions/cache/save` to `v4.3.0`
  - the released `v1.6.0` tag also still pins `actions/upload-artifact` to `v4.6.2`
  - current `master` still shows the same pins
  - upstream tracking is still open in `awalsh128/cache-apt-pkgs-action#191`, `awalsh128/cache-apt-pkgs-action#193`, and `awalsh128/cache-apt-pkgs-action#198`

That means this PR updates QLC+'s direct action refs, but a remaining Node 20 deprecation warning may still come transitively from `awalsh128/cache-apt-pkgs-action`.

  Verified against:

  - Latest release: https://github.com/awalsh128/cache-apt-pkgs-action/releases/tag/v1.6.0
  - Current master action.yml: https://raw.githubusercontent.com/awalsh128/cache-apt-pkgs-action/master/action.yml
  - Released v1.6.0 action.yml: https://raw.githubusercontent.com/awalsh128/cache-apt-pkgs-action/v1.6.0/action.yml
  - Tracking issue: https://github.com/awalsh128/cache-apt-pkgs-action/issues/191
  - Tracking PRs: https://github.com/awalsh128/cache-apt-pkgs-action/pull/193 and https://github.com/awalsh128/cache-apt-pkgs-action/pull/198

