### PR TITLE
VCPage: Reset list of input sources correctly

### DIFF
--- a/qmlui/virtualconsole/vcwidget.cpp
+++ b/qmlui/virtualconsole/vcwidget.cpp
@@ -935,6 +935,13 @@ void VCWidget::deleteInputSurce(quint32 id, quint32 universe, quint32 channel)
     }
 }
 
+void VCWidget::deleteAllInputSources()
+{
+    m_inputSources.clear();
+
+    emit inputSourcesListChanged();
+}
+
 QList<QSharedPointer<QLCInputSource> > VCWidget::inputSources() const
 {
     return m_inputSources;
@@ -1085,6 +1092,14 @@ void VCWidget::addKeySequence(const QKeySequence &keySequence, const quint32 &id
 void VCWidget::deleteKeySequence(const QKeySequence &keySequence)
 {
     m_keySequenceMap.remove(keySequence);
+    setDocModified();
+
+    emit inputSourcesListChanged();
+}
+
+void VCWidget::deleteAllKeySequences()
+{
+    m_keySequenceMap.clear();
     setDocModified();
 
     emit inputSourcesListChanged();

--- a/qmlui/virtualconsole/vcwidget.h
+++ b/qmlui/virtualconsole/vcwidget.h
@@ -545,6 +545,9 @@ public:
                                                   int lower, int upper, int monitor);
     /** Delete an existing input source from this widget */
     void deleteInputSurce(quint32 id, quint32 universe, quint32 channel);
+    
+    /** Delete all existing input source from this widget */
+    void deleteAllInputSources();
 
     /** Return a list of references to the input sources currently
      *  added to this widget */
@@ -576,6 +579,9 @@ public:
 
     /** Delete an existing key sequence from this widget */
     void deleteKeySequence(const QKeySequence& keySequence);
+
+    /** Delete all existing key sequences from this widget */
+    void deleteAllKeySequences();
 
     /** Update an existing key sequence with the specified $id */
     void updateKeySequence(QKeySequence oldSequence, QKeySequence newSequence, const quint32 id = 0);

--- a/qmlui/virtualconsole/virtualconsole.cpp
+++ b/qmlui/virtualconsole/virtualconsole.cpp
@@ -140,6 +140,8 @@ void VirtualConsole::resetContents()
     foreach (VCPage *page, m_pages)
     {
         page->deleteChildren();
+        page->deleteAllInputSources();
+        page->deleteAllKeySequences();
         page->resetInputSourcesMap();
         page->resetProperties(pageIndex++);
     }


### PR DESCRIPTION
## Description

**Summary of Changes:**

The member VCPage::m_inputSources holds the external midi events which are associated with a page. This list is not cleared if a new project is loaded. 

This pull requests makes sure that this list is cleared if VirtualConsole::resetContents is beeing called. 

**Related Issues:**
This is a bugfix for https://github.com/mcallegari/qlcplus/issues/2014.

## Checklist

- [X ] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [ X] My code adheres to the project's coding style, including:
  - [X ] Placing opening braces `{` on a new line for functions and class definitions.
  - [ X] Consistent use of spaces and indentation.
- [X ] I have tested my changes on the following platforms:
  - [ X] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
I have manually tested the behavior by loading the project twice which is attached to issue https://github.com/mcallegari/qlcplus/issues/2014.

**Test Results:**

Even if the project has been loaded repeatedly, only one event appears in the list of external controls:

<img width="516" height="335" alt="Bildschirmfoto vom 2026-05-09 14-35-32" src="https://github.com/user-attachments/assets/45ca8d36-4116-41cd-bd2b-be9ad1e9f3a1" />
