### PR TITLE
audioeditor: save fade edits on focus loss

### DIFF
--- a/ui/src/audioeditor.cpp
+++ b/ui/src/audioeditor.cpp
@@ -60,9 +60,9 @@ AudioEditor::AudioEditor(QWidget* parent, Audio *audio, Doc* doc)
     connect(m_speedDialButton, SIGNAL(toggled(bool)),
             this, SLOT(slotSpeedDialToggle(bool)));
 
-    connect(m_fadeInEdit, SIGNAL(returnPressed()),
+    connect(m_fadeInEdit, SIGNAL(editingFinished()),
             this, SLOT(slotFadeInEdited()));
-    connect(m_fadeOutEdit, SIGNAL(returnPressed()),
+    connect(m_fadeOutEdit, SIGNAL(editingFinished()),
             this, SLOT(slotFadeOutEdited()));
 
     connect(m_previewButton, SIGNAL(toggled(bool)),
@@ -204,6 +204,9 @@ void AudioEditor::slotFadeInEdited()
     newValue = Function::stringToSpeed(text);
     m_fadeInEdit->setText(Function::speedToString(newValue));
 
+    if (m_audio->fadeInSpeed() == newValue)
+        return;
+
     m_audio->setFadeInSpeed(newValue);
     m_doc->setModified();
 }
@@ -215,6 +218,9 @@ void AudioEditor::slotFadeOutEdited()
 
     newValue = Function::stringToSpeed(text);
     m_fadeOutEdit->setText(Function::speedToString(newValue));
+
+    if (m_audio->fadeOutSpeed() == newValue)
+        return;
 
     m_audio->setFadeOutSpeed(newValue);
     m_doc->setModified();


### PR DESCRIPTION
The audio editor only saved fade-in and fade-out fields when Enter was pressed.
Clicking another audio function or TAB discarded the typed value.

Steps to reproduce:
1. Open the QtWidgets Function Manager.
2. Select an Audio function.
3. Change Fade out to 1s without pressing Enter.
4. Click another function, then reopen the Audio function.
5. Observe Fade out reset to the previous value.

Use editingFinished() for both fields so the editor commits values when focus leaves the line edit.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
None.

**Test Results:**
N/A

## Additional Notes
-
