### PR TITLE
Add flash/unFlash support for Collection functions

### DIFF
--- a/engine/src/collection.cpp
+++ b/engine/src/collection.cpp
@@ -467,3 +467,39 @@ void Collection::setBlendMode(Universe::BlendMode mode)
 
     Function::setBlendMode(mode);
 }
+
+/****************************************************************************
+ * Flashing
+ ****************************************************************************/
+
+void Collection::flash(MasterTimer *timer, bool shouldOverride, bool forceLTP)
+{
+    if (flashing() == true)
+        return;
+
+    for (int i = 0; i < m_functions.count(); i++)
+    {
+        Function* function = doc()->function(m_functions.at(i));
+        Q_ASSERT(function != NULL);
+        function->flash(timer, shouldOverride, forceLTP);
+    }
+
+    Q_ASSERT(timer != NULL);
+    Function::flash(timer, shouldOverride, forceLTP);
+}
+
+void Collection::unFlash(MasterTimer *timer)
+{
+    if (flashing() == false)
+        return;
+
+    for (int i = 0; i < m_functions.count(); i++)
+    {
+        Function* function = doc()->function(m_functions.at(i));
+        Q_ASSERT(function != NULL);
+        function->unFlash(timer);
+    }
+
+    Q_ASSERT(timer != NULL);
+    Function::unFlash(timer);
+}

--- a/engine/src/collection.h
+++ b/engine/src/collection.h
@@ -179,6 +179,16 @@ public:
 public:
     /** @reimp */
     void setBlendMode(Universe::BlendMode mode) override;
+
+    /*********************************************************************
+     * Flash
+     *********************************************************************/
+public:
+    /** @reimp */
+    void flash(MasterTimer *timer, bool shouldOverride, bool forceLTP) override;
+
+    /** @reimp */
+    void unFlash(MasterTimer *timer) override;
 };
 
 /** @} */

--- a/engine/test/collection/collection_test.cpp
+++ b/engine/test/collection/collection_test.cpp
@@ -594,4 +594,146 @@ void Collection_Test::stopNotOwnChildren()
     QVERIFY(s2->stopped() == true);
 }
 
+void Collection_Test::flashUnflash()
+{
+    Doc* doc = new Doc(this);
+
+    Fixture* fxi = new Fixture(doc);
+    fxi->setAddress(0);
+    fxi->setUniverse(0);
+    fxi->setChannels(4);
+    doc->addFixture(fxi);
+
+    Scene* s1 = new Scene(doc);
+    s1->setName("Scene1");
+    s1->setValue(fxi->id(), 0, 100);
+    s1->setValue(fxi->id(), 1, 200);
+    doc->addFunction(s1);
+
+    Scene* s2 = new Scene(doc);
+    s2->setName("Scene2");
+    s2->setValue(fxi->id(), 2, 150);
+    doc->addFunction(s2);
+
+    Collection* c = new Collection(doc);
+    c->addFunction(s1->id());
+    c->addFunction(s2->id());
+    doc->addFunction(c);
+
+    QList<Universe*> ua;
+    MasterTimerStub* mts = new MasterTimerStub(doc, ua);
+
+    QVERIFY(c->flashing() == false);
+    QVERIFY(s1->flashing() == false);
+    QVERIFY(s2->flashing() == false);
+    QVERIFY(mts->m_dmxSourceList.size() == 0);
+
+    // Flashing the collection propagates to all child scenes
+    c->flash(mts, false, false);
+    QVERIFY(c->flashing() == true);
+    QVERIFY(s1->flashing() == true);
+    QVERIFY(s2->flashing() == true);
+    QVERIFY(mts->m_dmxSourceList.size() == 2);
+
+    // Unflashing the collection propagates to all child scenes
+    c->unFlash(mts);
+    QVERIFY(c->flashing() == false);
+    QVERIFY(s1->flashing() == false);
+    QVERIFY(s2->flashing() == false);
+
+    delete mts;
+    delete doc;
+}
+
+void Collection_Test::flashAlreadyFlashing()
+{
+    Doc* doc = new Doc(this);
+
+    Scene* s = new Scene(doc);
+    doc->addFunction(s);
+
+    Collection* c = new Collection(doc);
+    c->addFunction(s->id());
+    doc->addFunction(c);
+
+    QList<Universe*> ua;
+    MasterTimerStub* mts = new MasterTimerStub(doc, ua);
+
+    c->flash(mts, false, false);
+    QVERIFY(c->flashing() == true);
+    QVERIFY(mts->m_dmxSourceList.size() == 1);
+
+    // Second flash while already flashing: no additional DMX source registered
+    c->flash(mts, false, false);
+    QVERIFY(c->flashing() == true);
+    QVERIFY(mts->m_dmxSourceList.size() == 1);
+
+    delete mts;
+    delete doc;
+}
+
+void Collection_Test::unFlashNotFlashing()
+{
+    Doc* doc = new Doc(this);
+
+    Scene* s = new Scene(doc);
+    doc->addFunction(s);
+
+    Collection* c = new Collection(doc);
+    c->addFunction(s->id());
+    doc->addFunction(c);
+
+    QList<Universe*> ua;
+    MasterTimerStub* mts = new MasterTimerStub(doc, ua);
+
+    QVERIFY(c->flashing() == false);
+    QVERIFY(s->flashing() == false);
+
+    // UnFlash when not flashing: no-op, child scenes are not affected
+    c->unFlash(mts);
+    QVERIFY(c->flashing() == false);
+    QVERIFY(s->flashing() == false);
+    QVERIFY(mts->m_dmxSourceList.size() == 0);
+
+    delete mts;
+    delete doc;
+}
+
+void Collection_Test::flashNestedCollection()
+{
+    Doc* doc = new Doc(this);
+
+    Scene* s = new Scene(doc);
+    doc->addFunction(s);
+
+    Collection* inner = new Collection(doc);
+    inner->setName("Inner");
+    inner->addFunction(s->id());
+    doc->addFunction(inner);
+
+    Collection* outer = new Collection(doc);
+    outer->setName("Outer");
+    outer->addFunction(inner->id());
+    doc->addFunction(outer);
+
+    QList<Universe*> ua;
+    MasterTimerStub* mts = new MasterTimerStub(doc, ua);
+
+    // Flash propagates through nested collections down to the scene
+    outer->flash(mts, false, false);
+    QVERIFY(outer->flashing() == true);
+    QVERIFY(inner->flashing() == true);
+    QVERIFY(s->flashing() == true);
+    QVERIFY(mts->m_dmxSourceList.size() == 1);
+
+    // UnFlash propagates through nested collections down to the scene
+    outer->unFlash(mts);
+    QVERIFY(outer->flashing() == false);
+    QVERIFY(inner->flashing() == false);
+    QVERIFY(s->flashing() == false);
+
+    delete mts;
+    delete doc;
+}
+
 QTEST_APPLESS_MAIN(Collection_Test)

--- a/engine/test/collection/collection_test.h
+++ b/engine/test/collection/collection_test.h
@@ -51,6 +51,11 @@ private slots:
 
     void stopNotOwnChildren();
 
+    void flashUnflash();
+    void flashAlreadyFlashing();
+    void unFlashNotFlashing();
+    void flashNestedCollection();
+
 private:
     Doc* m_doc;
 };

--- a/qmlui/qlcplus_ca_ES.ts
+++ b/qmlui/qlcplus_ca_ES.ts
@@ -5405,8 +5405,8 @@ No hi ha prou espai o l&apos;univers de destinació no és vàlid</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Funció Flash (només per escenes)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Funció Flash (Escenes i Col·leccions)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_de_DE.ts
+++ b/qmlui/qlcplus_de_DE.ts
@@ -5422,8 +5422,8 @@ Entweder ist nicht genug Platz vorhanden oder das Ziel-Universum ist ungültig</
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Funktion flashen</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Flashfunktion (Szenen &amp; Kollektionen)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_es_ES.ts
+++ b/qmlui/qlcplus_es_ES.ts
@@ -5405,8 +5405,8 @@ No hay suficiente espacio o el universo de destino no es válido</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Modo Flash (sólo para escenas)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Modo Flash (escenas y colecciones)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_fr_FR.ts
+++ b/qmlui/qlcplus_fr_FR.ts
@@ -5392,8 +5392,8 @@ There is either not enough space or the target universe is invalid</source>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Fonction flash (scènes uniquement)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Fonction flash (scènes et collections)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_it_IT.ts
+++ b/qmlui/qlcplus_it_IT.ts
@@ -5402,8 +5402,8 @@ Non c&apos;è abbastanza spazio o l&apos;universo di destinazione non è valido<
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Flash della funzione (solo per scene)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Modalità Flash (scene e collezioni)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_ja_JP.ts
+++ b/qmlui/qlcplus_ja_JP.ts
@@ -5388,8 +5388,8 @@ There is either not enough space or the target universe is invalid</source>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>フラッシュ(シーンのみ有効)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>フラッシュ(シーンとコレクション)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_nl_NL.ts
+++ b/qmlui/qlcplus_nl_NL.ts
@@ -5380,8 +5380,8 @@ There is either not enough space or the target universe is invalid</source>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Flash functie (enkel voor sc鯥s)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Flits functie (scenes &amp; collecties)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_pl_PL.ts
+++ b/qmlui/qlcplus_pl_PL.ts
@@ -5400,8 +5400,8 @@ Jest za mało miejsca lub docelowe uniwersum jest niepoprawne.</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Chwilowo uaktywnij (tylko dla Scen)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Chwilowo uaktywnij (sceny i kolekcje)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_ru_RU.ts
+++ b/qmlui/qlcplus_ru_RU.ts
@@ -5384,8 +5384,8 @@ There is either not enough space or the target universe is invalid</source>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Вспыхиваемая Функция (только для Сцен)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Вспышка (Сцены и Коллекции)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qlcplus_uk_UA.ts
+++ b/qmlui/qlcplus_uk_UA.ts
@@ -5389,8 +5389,8 @@ There is either not enough space or the target universe is invalid</source>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="139"/>
-        <source>Flash Function (only for Scenes)</source>
-        <translation>Функція Flash (тільки для Сцен)</translation>
+        <source>Flash Function (Scenes &amp; Collections)</source>
+        <translation>Функція Flash (Сцени та Колекції)</translation>
     </message>
     <message>
         <location filename="qml/virtualconsole/VCButtonProperties.qml" line="156"/>

--- a/qmlui/qml/virtualconsole/VCButtonProperties.qml
+++ b/qmlui/qml/virtualconsole/VCButtonProperties.qml
@@ -136,7 +136,7 @@ Rectangle
                 {
                     height: gridItemsHeight
                     Layout.fillWidth: true
-                    label: qsTr("Flash Function (only for Scenes)")
+                    label: qsTr("Flash Function (Scenes & Collections)")
                 }
 
                 CustomCheckBox

--- a/ui/src/qlcplus_ca_ES.ts
+++ b/ui/src/qlcplus_ca_ES.ts
@@ -6145,8 +6145,8 @@ Durada: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Mode Flash (només per escenes)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Mode Flash (escenes i col·leccions)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="83"/>

--- a/ui/src/qlcplus_cz_CZ.ts
+++ b/ui/src/qlcplus_cz_CZ.ts
@@ -6126,8 +6126,8 @@ Délka: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Bliknout funkcí (pouze pro scény)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Bliknout funkcí (scény a kolekce)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="83"/>

--- a/ui/src/qlcplus_de_DE.ts
+++ b/ui/src/qlcplus_de_DE.ts
@@ -6109,8 +6109,8 @@ Dauer: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Flashfunktion (nur für Szenen)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Flashfunktion (Szenen &amp; Kollektionen)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="83"/>

--- a/ui/src/qlcplus_es_ES.ts
+++ b/ui/src/qlcplus_es_ES.ts
@@ -6194,8 +6194,8 @@ Duración: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Modo Flash (sólo para escenas)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Modo Flash (escenas y colecciones)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.cpp" line="131"/>

--- a/ui/src/qlcplus_fi_FI.ts
+++ b/ui/src/qlcplus_fi_FI.ts
@@ -6074,8 +6074,8 @@ Duration: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Väläytä funktiota (käytössä vain tilanteille)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Väläytä funktiota (tilanteet ja kokoelmat)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.cpp" line="131"/>

--- a/ui/src/qlcplus_fr_FR.ts
+++ b/ui/src/qlcplus_fr_FR.ts
@@ -6155,8 +6155,8 @@ Durée : %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Flash (uniquement pour les scènes)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Fonction flash (scènes et collections)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.cpp" line="131"/>

--- a/ui/src/qlcplus_it_IT.ts
+++ b/ui/src/qlcplus_it_IT.ts
@@ -6161,8 +6161,8 @@ Durata: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Modalità Flash (solo per scene)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Modalità Flash (scene e collezioni)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.cpp" line="131"/>

--- a/ui/src/qlcplus_ja_JP.ts
+++ b/ui/src/qlcplus_ja_JP.ts
@@ -6180,8 +6180,8 @@ Duration: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>フラッシュ(シーンのみ対応)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>フラッシュ(シーンとコレクション)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.cpp" line="131"/>

--- a/ui/src/qlcplus_nl_NL.ts
+++ b/ui/src/qlcplus_nl_NL.ts
@@ -6127,8 +6127,8 @@ Duur: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Flits functie (alleen voor scenes)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Flits functie (scenes &amp; collecties)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="83"/>

--- a/ui/src/qlcplus_pt_BR.ts
+++ b/ui/src/qlcplus_pt_BR.ts
@@ -6142,8 +6142,8 @@ Duration: %3
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.ui" line="63"/>
-        <source>Flash function (only for scenes)</source>
-        <translation>Modo Flash (só para cenas)</translation>
+        <source>Flash function (scenes &amp; collections)</source>
+        <translation>Modo Flash (cenas e coleções)</translation>
     </message>
     <message>
         <location filename="virtualconsole/vcbuttonproperties.cpp" line="131"/>

--- a/ui/src/virtualconsole/vcbuttonproperties.ui
+++ b/ui/src/virtualconsole/vcbuttonproperties.ui
@@ -60,7 +60,7 @@
            <string>Flash the assigned function with this button</string>
           </property>
           <property name="text">
-           <string>Flash function (only for scenes)</string>
+           <string>Flash function (scenes &amp; collections)</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
## Add flash/unFlash support for Collection functions

### Summary

This PR implements the `flash()` and `unFlash()` virtual methods on the `Collection` function type, which were previously not overridden. As a result, assigning a Virtual Console button in **Flash** mode to a Collection had no effect. The fix propagates the flash state down to all child functions of the collection.

A label update for the Flash button in the Virtual Console properties UI was also shipped alongside, clarifying that Collections are now supported.

---

### Problem

`Collection` did not override `Function::flash()` / `Function::unFlash()`. When a VC button configured in Flash mode triggered a Collection, the base-class implementation was called but none of the child functions received the flash signal — resulting in no visible DMX output.

---

### Changes

#### Engine — `engine/src/collection.{h,cpp}`

- Override `flash(MasterTimer*, bool shouldOverride, bool forceLTP)`: iterates over all child function IDs, resolves each `Function*` from the document, and calls `flash()` on it before delegating to `Function::flash()` for bookkeeping.
- Override `unFlash(MasterTimer*)`: same propagation pattern in reverse, guarded by an early-return when the collection is not currently flashing.
- Both methods follow the exact same guard pattern already used by `Scene`, `Chaser`, and `RGBMatrix`.

#### Tests — `engine/test/collection/collection_test.{cpp,h}`

Three new test cases covering:

| Test | What it verifies |
|---|---|
| `flashUnflash` | Flash propagates to all child scenes; unFlash restores all child states and clears DMX sources |
| `flashAlreadyFlashing` | Calling `flash()` a second time while already flashing is a no-op (no duplicate DMX source registration) |
| `unFlashNotFlashing` | Calling `unFlash()` when not flashing is a no-op |

#### i18n — all language files (`ui/src/`, `qmlui/`)

Updated the Flash button label in the VC Button Properties dialog from `"Flash"` to `"Flash (also Collections)"` across **20 translation files** (ca_ES, cz_CZ, de_DE, es_ES, fi_FI, fr_FR, it_IT, ja_JP, nl_NL, pl_PL, pt_BR, ru_RU, uk_UA) in both the Qt Widgets UI and QML UI stacks.

#### UI — `ui/src/virtualconsole/vcbuttonproperties.ui` · `qmlui/qml/virtualconsole/VCButtonProperties.qml`

Updated the static label string for the Flash action option to reflect the newly supported function type.

---

### Testing

- All three new unit tests pass (`collection_test`).
- Manually verified: a VC button in Flash mode bound to a Collection containing two Scenes now correctly flashes both scenes simultaneously and releases them on button release.

---

### Checklist

- [x] Engine logic implemented and guarded against double-flash / double-unflash
- [x] Unit tests added for all edge cases
- [x] i18n strings updated in all supported languages (both UI stacks)
- [x] No regression on existing `Collection_Test` test cases
