### PR TITLE
gitignore: ignore CMake and Qt generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,10 @@
 
 .qmake.stash
 .qtc_clangd
+.qt/
 *.pro.user
 *.pro.user.*
+*.qrc.depends
 moc_*.cpp
 qrc_*.cpp
 Makefile
@@ -26,6 +28,7 @@ Makefile.*
 *-build-*
 ui_*
 object_*
+*_autogen/
 engine/src/qlcconfig.h
 *.swp
 *.qmlc
@@ -53,3 +56,13 @@ coverage/
 # CMake build
 CMakeLists.txt.user
 build*
+.ninja_deps
+.ninja_log
+CMakeCache.txt
+CMakeFiles/
+CPackConfig.cmake
+CPackSourceConfig.cmake
+cmake_install.cmake
+cmake_uninstall.cmake
+install_manifest.txt
+/install/


### PR DESCRIPTION
An in-tree CMake build leaves generated metadata, Qt autogen directories, and install staging files as untracked changes.

Ignore those generated paths so build output does not obscure real source changes in git status. Narrow build* to build*/ so tracked files such as .github/workflows/build.yml are not hidden by ignore rules.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.


