### PR TITLE
Validate malformed input packets before decoding

### DIFF
--- a/engine/src/script.cpp
+++ b/engine/src/script.cpp
@@ -787,10 +787,14 @@ QString Script::handleSetFixture(const QList<QStringList>& tokens, QList<Univers
             if (address < 512)
             {
                 quint32 universe = fxi->universe();
+                if (universe >= quint32(universes.size()))
+                    return QString("Invalid universe: %1").arg(universe);
+
+                Universe *uni = universes[universe];
                 QSharedPointer<GenericFader> fader = m_fadersMap.value(universe, QSharedPointer<GenericFader>());
                 if (fader.isNull())
                 {
-                    fader = universes[universe]->requestFader();
+                    fader = uni->requestFader();
                     fader->adjustIntensity(getAttributeValue(Intensity));
                     fader->setBlendMode(blendMode());
                     fader->setParentFunctionID(this->id());
@@ -798,7 +802,7 @@ QString Script::handleSetFixture(const QList<QStringList>& tokens, QList<Univers
                     m_fadersMap[universe] = fader;
                 }
 
-                fader->updateChannel(doc, universes[universe], fxi->id(), ch, [value, time](FadeChannel &fc)
+                fader->updateChannel(doc, uni, fxi->id(), ch, [value, time](FadeChannel &fc)
                 {
                     fc.setTarget(value);
                     fc.setFadeTime(time);

--- a/engine/test/script/script_test.cpp
+++ b/engine/test/script/script_test.cpp
@@ -25,6 +25,7 @@
 #include "mastertimer.h"
 #include "script_test.h"
 #include "universe.h"
+#include "fixture.h"
 #include "script.h"
 #include "doc.h"
 
@@ -68,5 +69,60 @@ void Script_Test::initial()
 
     scr.postRun(doc.masterTimer(), ua);
 }
+
+#ifndef QMLUI
+void Script_Test::setFixtureRejectsMissingUniverse()
+{
+    Doc doc(this);
+
+    Fixture *fxi = new Fixture(&doc);
+    fxi->setUniverse(1);
+    fxi->setAddress(0);
+    fxi->setChannels(1);
+    // 99 is the fixture ID referenced by the setfixture token below.
+    QVERIFY(doc.addFixture(fxi, 99));
+
+    GrandMaster *gm = new GrandMaster();
+    QList<Universe*> ua;
+    ua.append(new Universe(0, gm));
+
+    Script scr(&doc);
+    QList<QStringList> tokens;
+    tokens << (QStringList() << Script::setFixtureCmd << "99");
+    tokens << (QStringList() << "value" << "255");
+    tokens << (QStringList() << "channel" << "0");
+
+    QCOMPARE(scr.handleSetFixture(tokens, ua), QString("Invalid universe: 1"));
+
+    qDeleteAll(ua);
+    delete gm;
+}
+
+void Script_Test::setFixtureAcceptsPresentUniverse()
+{
+    Doc doc(this);
+
+    Fixture *fxi = new Fixture(&doc);
+    fxi->setUniverse(0);
+    fxi->setAddress(0);
+    fxi->setChannels(1);
+    QVERIFY(doc.addFixture(fxi, 99));
+
+    GrandMaster *gm = new GrandMaster();
+    QList<Universe*> ua;
+    ua.append(new Universe(0, gm));
+
+    Script scr(&doc);
+    QList<QStringList> tokens;
+    tokens << (QStringList() << Script::setFixtureCmd << "99");
+    tokens << (QStringList() << "value" << "255");
+    tokens << (QStringList() << "channel" << "0");
+
+    QCOMPARE(scr.handleSetFixture(tokens, ua), QString());
+
+    qDeleteAll(ua);
+    delete gm;
+}
+#endif
 
 QTEST_MAIN(Script_Test)

--- a/engine/test/script/script_test.h
+++ b/engine/test/script/script_test.h
@@ -29,6 +29,10 @@ class Script_Test final : public QObject
 private slots:
     void initTestCase();
     void initial();
+#ifndef QMLUI
+    void setFixtureRejectsMissingUniverse();
+    void setFixtureAcceptsPresentUniverse();
+#endif
 };
 
 #endif

--- a/plugins/E1.31/CMakeLists.txt
+++ b/plugins/E1.31/CMakeLists.txt
@@ -52,3 +52,7 @@ if (UNIX AND NOT APPLE)
    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/org.qlcplus.QLCPlus.e131.metainfo.xml"
            DESTINATION ${METAINFODIR})
 endif()
+
+if(NOT ANDROID AND NOT IOS)
+    add_subdirectory(test)
+endif()

--- a/plugins/E1.31/e131packetizer.cpp
+++ b/plugins/E1.31/e131packetizer.cpp
@@ -201,8 +201,8 @@ void E131Packetizer::setupE131Dmx(QByteArray& data, const int &universe, const i
 
 bool E131Packetizer::checkPacket(QByteArray &data)
 {
-    /* An E1.31 packet must be at least 125 bytes long */
-    if (data.length() < 125)
+    /* An E1.31 DMX packet must include the DMX512-A start code. */
+    if (data.length() < 126)
         return false;
 
     // check ACN packet identifier
@@ -225,7 +225,8 @@ bool E131Packetizer::checkPacket(QByteArray &data)
 
 bool E131Packetizer::fillDMXdata(QByteArray& data, QByteArray &dmx, quint32 &universe)
 {
-    if (data.isNull())
+    // Keep this self-contained even though callers normally run checkPacket().
+    if (data.isNull() || data.length() < 126)
         return false;
 
     /* Check valid DMX start code */
@@ -234,6 +235,9 @@ bool E131Packetizer::fillDMXdata(QByteArray& data, QByteArray &dmx, quint32 &uni
 
     universe = (uchar(data[113]) << 8) + uchar(data[114]);
     int length = (uchar(data[123]) << 8) + uchar(data[124]);
+
+    if (length < 2 || length > 513 || length > data.length() - 125)
+        return false;
 
     qDebug() << "[E1.31 fillDMXdata] universe:" << universe << ", length:" << length - 1;
 

--- a/plugins/E1.31/test/CMakeLists.txt
+++ b/plugins/E1.31/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(e131packetizer_test WIN32 MACOSX_BUNDLE
+    ../e131packetizer.cpp ../e131packetizer.h
+    e131packetizer_test.cpp e131packetizer_test.h
+)
+
+target_include_directories(e131packetizer_test PRIVATE
+    ..
+)
+
+target_link_libraries(e131packetizer_test PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Network
+    Qt${QT_MAJOR_VERSION}::Test
+)

--- a/plugins/E1.31/test/e131packetizer_test.cpp
+++ b/plugins/E1.31/test/e131packetizer_test.cpp
@@ -1,0 +1,107 @@
+/*
+  Q Light Controller Plus
+  e131packetizer_test.cpp
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QTest>
+
+#include "e131packetizer_test.h"
+#include "e131packetizer.h"
+
+void E131Packetizer_Test::checkPacketRejectsTruncatedPacket()
+{
+    E131Packetizer ep("00:11:22:33:44:55");
+    QByteArray data;
+
+    ep.setupE131Dmx(data, 0, E131_PRIORITY_DEFAULT, QByteArray());
+    QVERIFY(ep.checkPacket(data) == true);
+
+    data.truncate(125);
+    QVERIFY(ep.checkPacket(data) == false);
+}
+
+void E131Packetizer_Test::fillDMXdataRejectsZeroPropertyCount()
+{
+    E131Packetizer ep("00:11:22:33:44:55");
+    QByteArray data;
+    QByteArray dmx;
+    quint32 universe = 0;
+
+    ep.setupE131Dmx(data, 0, E131_PRIORITY_DEFAULT, QByteArray());
+    data[123] = char(0x00);
+    data[124] = char(0x00);
+
+    QVERIFY(ep.fillDMXdata(data, dmx, universe) == false);
+}
+
+void E131Packetizer_Test::fillDMXdataRejectsStartCodeOnly()
+{
+    E131Packetizer ep("00:11:22:33:44:55");
+    QByteArray data;
+    QByteArray dmx;
+    quint32 universe = 0;
+
+    ep.setupE131Dmx(data, 0, E131_PRIORITY_DEFAULT, QByteArray());
+
+    QVERIFY(ep.checkPacket(data) == true);
+    QVERIFY(ep.fillDMXdata(data, dmx, universe) == false);
+}
+
+void E131Packetizer_Test::fillDMXdataRejectsOversizedPropertyCount()
+{
+    E131Packetizer ep("00:11:22:33:44:55");
+    QByteArray data;
+    QByteArray dmx;
+    quint32 universe = 0;
+
+    ep.setupE131Dmx(data, 0, E131_PRIORITY_DEFAULT, QByteArray(512, 42));
+    data[123] = char(0x02);
+    data[124] = char(0x02);
+
+    QVERIFY(ep.fillDMXdata(data, dmx, universe) == false);
+}
+
+void E131Packetizer_Test::fillDMXdataRejectsTruncatedPayload()
+{
+    E131Packetizer ep("00:11:22:33:44:55");
+    QByteArray data;
+    QByteArray dmx;
+    quint32 universe = 0;
+
+    ep.setupE131Dmx(data, 0, E131_PRIORITY_DEFAULT, QByteArray(2, 42));
+    data.chop(1);
+
+    QVERIFY(ep.checkPacket(data) == true);
+    QVERIFY(ep.fillDMXdata(data, dmx, universe) == false);
+}
+
+void E131Packetizer_Test::fillDMXdataAcceptsValidPayload()
+{
+    E131Packetizer ep("00:11:22:33:44:55");
+    QByteArray data;
+    QByteArray dmx;
+    quint32 universe = 0;
+
+    ep.setupE131Dmx(data, 1, E131_PRIORITY_DEFAULT, QByteArray(2, 42));
+
+    QVERIFY(ep.checkPacket(data) == true);
+    QVERIFY(ep.fillDMXdata(data, dmx, universe) == true);
+    QCOMPARE(universe, quint32(1));
+    QCOMPARE(dmx, QByteArray(2, 42));
+}
+
+QTEST_MAIN(E131Packetizer_Test)

--- a/plugins/E1.31/test/e131packetizer_test.h
+++ b/plugins/E1.31/test/e131packetizer_test.h
@@ -1,0 +1,38 @@
+/*
+  Q Light Controller Plus
+  e131packetizer_test.h
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef E131PACKETIZER_TEST_H
+#define E131PACKETIZER_TEST_H
+
+#include <QObject>
+
+class E131Packetizer_Test final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void checkPacketRejectsTruncatedPacket();
+    void fillDMXdataRejectsZeroPropertyCount();
+    void fillDMXdataRejectsStartCodeOnly();
+    void fillDMXdataRejectsOversizedPropertyCount();
+    void fillDMXdataRejectsTruncatedPayload();
+    void fillDMXdataAcceptsValidPayload();
+};
+
+#endif

--- a/plugins/artnet/src/artnetpacketizer.cpp
+++ b/plugins/artnet/src/artnetpacketizer.cpp
@@ -229,7 +229,8 @@ bool ArtNetPacketizer::checkPacketAndCode(QByteArray const& data, quint16 &code)
 
 bool ArtNetPacketizer::fillArtPollReplyInfo(QByteArray const& data, ArtNetNodeInfo& info)
 {
-    if (data.isNull())
+    // The fields read below extend up to style at byte offset 186.
+    if (data.isNull() || data.length() < 187)
         return false;
 
     QByteArray shortName = data.mid(26, 18);
@@ -256,7 +257,7 @@ bool ArtNetPacketizer::fillArtPollReplyInfo(QByteArray const& data, ArtNetNodeIn
 
 bool ArtNetPacketizer::fillDMXdata(QByteArray const& data, QByteArray &dmx, quint32 &universe)
 {
-    if (data.isNull())
+    if (data.isNull() || data.length() < 18)
         return false;
     dmx.clear();
     //char sequence = data.at(12);
@@ -267,6 +268,12 @@ bool ArtNetPacketizer::fillDMXdata(QByteArray const& data, QByteArray &dmx, quin
     unsigned int msb = (data.at(16)&0xff);
     unsigned int lsb = (data.at(17)&0xff);
     int length = (msb << 8) | lsb;
+
+    if (length < 2 || length > 512 || length > data.length() - 18)
+    {
+        qWarning() << Q_FUNC_INFO << "Invalid ArtDMX payload length" << length;
+        return false;
+    }
 
     //qDebug() << "length: " << length;
     dmx.append(data.mid(18, length));
@@ -292,6 +299,9 @@ bool ArtNetPacketizer::processTODdata(const QByteArray &data, quint32 &universe,
     quint8 uidCount = quint8(data.at(27));
 
     qDebug() << "UID count:" << uidCount;
+
+    if (data.length() < 28 + (uidCount * 6))
+        return false;
 
     for (int i = 0; i < uidCount; i++)
     {
@@ -320,4 +330,3 @@ bool ArtNetPacketizer::processRDMdata(const QByteArray &data, quint32 &universe,
     RDMProtocol rdm;
     return rdm.parsePacket(data.mid(24), values);
 }
-

--- a/plugins/artnet/test/artnet_test.cpp
+++ b/plugins/artnet/test/artnet_test.cpp
@@ -62,4 +62,48 @@ void ArtNet_Test::setupArtNetDmx()
     QCOMPARE(data.data(), "Art-Net");
 }
 
+void ArtNet_Test::fillArtPollReplyInfoRejectsShortPacket()
+{
+    ArtNetPacketizer ap;
+    ArtNetNodeInfo info;
+
+    QByteArray data(186, 0);
+
+    QVERIFY(ap.fillArtPollReplyInfo(data, info) == false);
+
+    ap.setupArtNetPollReply(data, QHostAddress("127.0.0.1"),
+                            "00:11:22:33:44:55", 1, true);
+    QVERIFY(ap.fillArtPollReplyInfo(data, info) == true);
+}
+
+void ArtNet_Test::fillDMXdataRejectsShortPacket()
+{
+    ArtNetPacketizer ap;
+    QByteArray dmx;
+    quint32 universe = 0;
+
+    QByteArray data(17, 0);
+    QVERIFY(ap.fillDMXdata(data, dmx, universe) == false);
+
+    data.resize(18);
+    data[16] = char(0x00);
+    data[17] = char(0x04);
+    QVERIFY(ap.fillDMXdata(data, dmx, universe) == false);
+}
+
+void ArtNet_Test::processTODdataRejectsShortUidList()
+{
+    ArtNetPacketizer ap;
+    QVariantMap values;
+    quint32 universe = 0;
+
+    QByteArray data(28, 0);
+    data[27] = char(0x01);
+    QVERIFY(ap.processTODdata(data, universe, values) == false);
+
+    data.resize(34);
+    QVERIFY(ap.processTODdata(data, universe, values) == true);
+    QCOMPARE(values.value("DISCOVERY_COUNT").toInt(), 1);
+}
+
 QTEST_MAIN(ArtNet_Test)

--- a/plugins/artnet/test/artnet_test.cpp
+++ b/plugins/artnet/test/artnet_test.cpp
@@ -22,7 +22,32 @@
 #define private public
 #include "artnet_test.h"
 #include "artnetpacketizer.h"
+#include "rdmprotocol.h"
 #undef private
+
+static void setAckResponse(RDMProtocol &rdm, QByteArray &data)
+{
+    Q_ASSERT(data.isEmpty() == false && data.at(0) == char(RDM_SC_SUB_MESSAGE));
+    // Offset 15 is the response-type byte in a no-start-code RDM frame.
+    data[15] = char(RESPONSE_TYPE_ACK);
+
+    quint16 checksum = rdm.calculateChecksum(false, data, data.length() - 2);
+    data[data.length() - 2] = char(checksum >> 8);
+    data[data.length() - 1] = char(checksum & 0x00ff);
+}
+
+static void setParameterData(RDMProtocol &rdm, QByteArray &data,
+                             const QByteArray &payload)
+{
+    const int pdlOffset = 22;
+    const int payloadOffset = pdlOffset + 1;
+
+    data.insert(payloadOffset, payload);
+    data[pdlOffset] = char(payload.length());
+    data[1] = char(data.length() - 1);
+
+    setAckResponse(rdm, data);
+}
 
 /****************************************************************************
  * ArtNet tests
@@ -104,6 +129,120 @@ void ArtNet_Test::processTODdataRejectsShortUidList()
     data.resize(34);
     QVERIFY(ap.processTODdata(data, universe, values) == true);
     QCOMPARE(values.value("DISCOVERY_COUNT").toInt(), 1);
+}
+
+void ArtNet_Test::rdmParsePacketRejectsShortHeader()
+{
+    RDMProtocol rdm;
+    QVariantMap values;
+
+    QByteArray data;
+    data.append(char(RDM_START_CODE));
+
+    QVERIFY(rdm.parsePacket(data, values) == false);
+
+    data = QByteArray(22, 0);
+    data[0] = char(RDM_SC_SUB_MESSAGE);
+    QVERIFY(rdm.parsePacket(data, values) == false);
+}
+
+void ArtNet_Test::rdmParsePacketRejectsOversizedMessageLength()
+{
+    RDMProtocol builder;
+    RDMProtocol parser;
+    QVariantMap values;
+    QVariantList params;
+    QByteArray data;
+
+    builder.setEstaID(0x1111);
+    builder.setDeviceId(0x22222222);
+    params << RDMProtocol::broadcastAddress() << PID_DEVICE_INFO;
+    QVERIFY(builder.packetizeCommand(GET_COMMAND, params, false, data));
+
+    setAckResponse(builder, data);
+    data[1] = char(0xff);
+    QVERIFY(parser.parsePacket(data, values) == false);
+}
+
+void ArtNet_Test::rdmParsePacketRejectsTruncatedPdl()
+{
+    RDMProtocol builder;
+    RDMProtocol parser;
+    QVariantMap values;
+    QVariantList params;
+    QByteArray data;
+
+    builder.setEstaID(0x1111);
+    builder.setDeviceId(0x22222222);
+    params << RDMProtocol::broadcastAddress() << PID_DEVICE_INFO;
+    QVERIFY(builder.packetizeCommand(GET_COMMAND, params, false, data));
+
+    setAckResponse(builder, data);
+    data[22] = char(21);
+    QVERIFY(parser.parsePacket(data, values) == false);
+}
+
+void ArtNet_Test::rdmParsePacketRejectsShortPidPayload()
+{
+    RDMProtocol builder;
+    RDMProtocol parser;
+    QVariantMap values;
+    QVariantList params;
+    QByteArray data;
+
+    builder.setEstaID(0x1111);
+    builder.setDeviceId(0x22222222);
+    params << RDMProtocol::broadcastAddress() << PID_DEVICE_INFO;
+    QVERIFY(builder.packetizeCommand(GET_COMMAND, params, false, data));
+
+    setAckResponse(builder, data);
+    QVERIFY(parser.parsePacket(data, values) == false);
+}
+
+void ArtNet_Test::rdmParsePacketAcceptsValidPacket()
+{
+    RDMProtocol builder;
+    RDMProtocol parser;
+    QVariantMap values;
+    QVariantList params;
+    QByteArray data;
+
+    builder.setEstaID(0x1111);
+    builder.setDeviceId(0x22222222);
+    params << RDMProtocol::broadcastAddress() << PID_SUPPORTED_PARAMETERS
+           << 4 << 0x00600070;
+    QVERIFY(builder.packetizeCommand(GET_COMMAND, params, false, data));
+    setAckResponse(builder, data);
+
+    QVERIFY(parser.parsePacket(data, values) == true);
+    QCOMPARE(values.value("PID").toUInt(), uint(PID_SUPPORTED_PARAMETERS));
+    const QVector<quint16> pidList =
+        values.value("PID_LIST").value<QVector<quint16>>();
+    QCOMPARE(pidList.size(), 2);
+    QCOMPARE(pidList.at(0), quint16(PID_DEVICE_INFO));
+    QCOMPARE(pidList.at(1), quint16(PID_PRODUCT_DETAIL_ID_LIST));
+}
+
+void ArtNet_Test::rdmParsePacketAcceptsValidDeviceInfoPacket()
+{
+    RDMProtocol builder;
+    RDMProtocol parser;
+    QVariantMap values;
+    QVariantList params;
+    QByteArray data;
+    QByteArray payload(19, 0);
+
+    builder.setEstaID(0x1111);
+    builder.setDeviceId(0x22222222);
+    params << RDMProtocol::broadcastAddress() << PID_DEVICE_INFO;
+    QVERIFY(builder.packetizeCommand(GET_COMMAND, params, false, data));
+
+    payload[18] = char(3);
+    setParameterData(builder, data, payload);
+
+    QVERIFY(parser.parsePacket(data, values) == true);
+    QCOMPARE(values.value("PID").toUInt(), uint(PID_DEVICE_INFO));
+    QCOMPARE(values.value("Number of sensors").toUInt(), uint(3));
 }
 
 QTEST_MAIN(ArtNet_Test)

--- a/plugins/artnet/test/artnet_test.h
+++ b/plugins/artnet/test/artnet_test.h
@@ -28,6 +28,9 @@ class ArtNet_Test final : public QObject
 
 private slots:
     void setupArtNetDmx();
+    void fillArtPollReplyInfoRejectsShortPacket();
+    void fillDMXdataRejectsShortPacket();
+    void processTODdataRejectsShortUidList();
 };
 
 #endif

--- a/plugins/artnet/test/artnet_test.h
+++ b/plugins/artnet/test/artnet_test.h
@@ -31,6 +31,12 @@ private slots:
     void fillArtPollReplyInfoRejectsShortPacket();
     void fillDMXdataRejectsShortPacket();
     void processTODdataRejectsShortUidList();
+    void rdmParsePacketRejectsShortHeader();
+    void rdmParsePacketRejectsOversizedMessageLength();
+    void rdmParsePacketRejectsTruncatedPdl();
+    void rdmParsePacketRejectsShortPidPayload();
+    void rdmParsePacketAcceptsValidPacket();
+    void rdmParsePacketAcceptsValidDeviceInfoPacket();
 };
 
 #endif

--- a/plugins/interfaces/rdmprotocol.cpp
+++ b/plugins/interfaces/rdmprotocol.cpp
@@ -277,11 +277,16 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
         i++;
     }
 
+    if (buffer.length() < i + 23)
+        return false;
+
     if (buffer.at(i++) != char(RDM_SC_SUB_MESSAGE))
         return false;
 
     // Data length
     quint8 length = quint8(buffer.at(i++));
+    if (buffer.length() < int(length) + (startCode ? 2 : 1))
+        return false;
 
     // Destination UID and source UID
     quint16 ESTAId;
@@ -325,6 +330,9 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
     // Parameter data length
     quint8 PDL = quint8(buffer.at(i++));
 
+    if (buffer.length() < i + PDL + 2)
+        return false;
+
 #ifdef DEBUG_RDM
     qDebug().nospace().noquote() <<
         "[RDM] Data length: " << QString::number(length) <<
@@ -348,6 +356,9 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
     {
         case PID_SUPPORTED_PARAMETERS:
         {
+            if (PDL % 2 != 0)
+                return false;
+
             QVector<quint16> pidList;
 #ifdef DEBUG_RDM
             QDebug out = qDebug();
@@ -366,6 +377,9 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
         break;
         case PID_DEVICE_INFO:
         {
+            if (PDL < 19)
+                return false;
+
             values.insert("RDM version", byteArrayToShort(buffer, i));
             values.insert("Device model ID", byteArrayToShort(buffer, i + 2));
             values.insert("TYPE", categoryToString(byteArrayToShort(buffer, i + 4)));
@@ -375,7 +389,7 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
             values.insert("PERSONALITY_COUNT", quint8(buffer.at(i + 13)));
             values.insert("DMX_START_ADDRESS", byteArrayToShort(buffer, i + 14));
             values.insert("Sub-device count", byteArrayToShort(buffer, i + 16));
-            values.insert("Number of sensors", quint8(buffer.at(i + 20)));
+            values.insert("Number of sensors", quint8(buffer.at(i + 18)));
         }
         break;
         case PID_DEVICE_MODEL_DESCRIPTION:
@@ -391,7 +405,7 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
         case PID_PARAMETER_DESCRIPTION:
         {
             if (PDL < 20)
-                break;
+                return false;
 
             values.insert("PID_INFO", byteArrayToShort(buffer, i));
             values.insert("PDL Size", quint8(buffer.at(i + 2)));
@@ -408,12 +422,18 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
         break;
         case PID_DMX_PERSONALITY:
         {
+            if (PDL < 2)
+                return false;
+
             values.insert("PERS_CURRENT", quint8(buffer.at(i)));
             values.insert("PERS_COUNT", quint8(buffer.at(i + 1)));
         }
         break;
         case PID_DMX_PERSONALITY_DESCRIPTION:
         {
+            if (PDL < 3)
+                return false;
+
             values.insert("PERS_INDEX", quint8(buffer.at(i)));
             values.insert("PERS_CHANNELS", byteArrayToShort(buffer, i + 1));
             values.insert("PERS_DESC", QString(buffer.mid(i + 3, PDL - 3)));
@@ -421,11 +441,17 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
         break;
         case PID_DMX_START_ADDRESS:
         {
+            if (PDL < 2)
+                return false;
+
             values.insert("DMX_START_ADDRESS", byteArrayToShort(buffer, i));
         }
         break;
         case PID_SLOT_INFO:
         {
+            if (PDL % 5 != 0)
+                return false;
+
             QVector<quint16> slotList;
 
             for (int n = 0; n < PDL; n += 5)
@@ -439,6 +465,9 @@ bool RDMProtocol::parsePacket(const QByteArray &buffer, QVariantMap &values)
         break;
         case PID_SLOT_DESCRIPTION:
         {
+            if (PDL < 2)
+                return false;
+
             values.insert("SLOT_ID", byteArrayToShort(buffer, i));
             values.insert("SLOT_DESC", QString(buffer.mid(i + 2, PDL - 2)));
         }

--- a/plugins/osc/CMakeLists.txt
+++ b/plugins/osc/CMakeLists.txt
@@ -51,3 +51,7 @@ if (UNIX AND NOT APPLE)
    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/org.qlcplus.QLCPlus.osc.metainfo.xml"
            DESTINATION ${METAINFODIR})
 endif()
+
+if(NOT ANDROID AND NOT IOS)
+    add_subdirectory(test)
+endif()

--- a/plugins/osc/oscpacketizer.cpp
+++ b/plugins/osc/oscpacketizer.cpp
@@ -116,7 +116,7 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
     //qDebug() << "[OSC] path extracted:" << path;
 
     int currPos = commaPos + 1;
-    while (tagsEnded == false)
+    while (tagsEnded == false && currPos < data.size())
     {
         switch (data.at(currPos))
         {
@@ -131,6 +131,9 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
         }
         currPos++;
     }
+    if (tagsEnded == false)
+        return false;
+
     // round current position to 4
     int left = (typeArray.count() + 1) % 4;
     currPos += 3 - left;
@@ -144,7 +147,7 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
             case IntegerTag:
             {
                 if (currPos + 4 > data.size())
-                    break;
+                    return false;
                 quint32 iVal;
 
                 *((uchar*)(&iVal) + 3) = data.at(currPos);
@@ -164,7 +167,7 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
             case FloatTag:
             {
                 if (currPos + 4 > data.size())
-                    break;
+                    return false;
                 float fVal;
 
                 *((uchar*)(&fVal) + 3) = data.at(currPos);
@@ -182,7 +185,7 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
             case DoubleTag:
             {
                 if (currPos + 8 > data.size())
-                    break;
+                    return false;
 
                 double dVal;
                 *((uchar*)(&dVal) + 7) = data.at(currPos);
@@ -203,6 +206,9 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
             case StringTag:
             {
                 int firstZeroPos = data.indexOf('\0', currPos);
+                if (firstZeroPos < currPos)
+                    return false;
+
                 QString str = QString(data.mid(currPos, firstZeroPos - currPos));
                 qDebug() << "[OSC] string:" << str;
                 // align current position to a multiple of 4
@@ -215,6 +221,9 @@ bool OSCPacketizer::parseMessage(QByteArray const& data, QString& path, QByteArr
                 // A OSC timestamp would be helpful to defer
                 // value changes, but since QLC+ plugins don't support
                 // such thing, let's skip it.
+                if (currPos + 8 > data.size())
+                    return false;
+
                 currPos += 8;
             }
             break;
@@ -250,16 +259,22 @@ QList<QPair<QString, QByteArray> > OSCPacketizer::parsePacket(QByteArray const& 
             // Check where we are here
             while (bufPos < data.size() && data.at(bufPos) != '#')
             {
+                if (data.size() - bufPos < 4)
+                    return messages;
+
                 quint32 msgSize = (uchar(data.at(bufPos)) << 24) + (uchar(data.at(bufPos + 1)) << 16) + (uchar(data.at(bufPos + 2)) << 8) + uchar(data.at(bufPos + 3));
                 qDebug() << "[OSC] Bundle message size:" << msgSize;
                 bufPos += 4;
 
-                if (data.size() >= bufPos + (int)msgSize)
+                if (msgSize > quint32(data.size() - bufPos))
                 {
-                    QByteArray msgData = data.mid(bufPos, msgSize);
-                    if (parseMessage(msgData, path, values) == true)
-                        messages.append(QPair<QString, QByteArray>(path, values));
+                    bufPos = data.size();
+                    continue;
                 }
+
+                QByteArray msgData = data.mid(bufPos, msgSize);
+                if (parseMessage(msgData, path, values) == true)
+                    messages.append(QPair<QString, QByteArray>(path, values));
                 bufPos += msgSize;
             }
             //qDebug() << "Buf pos=" << bufPos << "data size=" << data.size();
@@ -275,6 +290,3 @@ QList<QPair<QString, QByteArray> > OSCPacketizer::parsePacket(QByteArray const& 
 
     return messages;
 }
-
-
-

--- a/plugins/osc/test/CMakeLists.txt
+++ b/plugins/osc/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(oscpacketizer_test WIN32 MACOSX_BUNDLE
+    ../oscpacketizer.cpp ../oscpacketizer.h
+    oscpacketizer_test.cpp oscpacketizer_test.h
+)
+
+target_include_directories(oscpacketizer_test PRIVATE
+    ..
+)
+
+target_link_libraries(oscpacketizer_test PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Network
+    Qt${QT_MAJOR_VERSION}::Test
+)

--- a/plugins/osc/test/oscpacketizer_test.cpp
+++ b/plugins/osc/test/oscpacketizer_test.cpp
@@ -1,0 +1,117 @@
+/*
+  Q Light Controller Plus
+  oscpacketizer_test.cpp
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QTest>
+
+#include "oscpacketizer_test.h"
+
+#define private public
+#include "oscpacketizer.h"
+#undef private
+
+static void appendBundleMessage(QByteArray &bundle, const QByteArray &message)
+{
+    bundle.append(char((message.size() >> 24) & 0xff));
+    bundle.append(char((message.size() >> 16) & 0xff));
+    bundle.append(char((message.size() >> 8) & 0xff));
+    bundle.append(char(message.size() & 0xff));
+    bundle.append(message);
+}
+
+void OSCPacketizer_Test::parsePacketRejectsTruncatedTypeTags()
+{
+    OSCPacketizer op;
+    QByteArray data;
+
+    data.append("/x");
+    data.append(char(0x00));
+    data.append(',');
+    data.append('f');
+
+    QCOMPARE(op.parsePacket(data).size(), 0);
+}
+
+void OSCPacketizer_Test::parseMessageRejectsTruncatedTypeTags()
+{
+    OSCPacketizer op;
+    QString path;
+    QByteArray values;
+    QByteArray data;
+
+    data.append("/x");
+    data.append(char(0x00));
+    data.append(',');
+    data.append('f');
+
+    QVERIFY(op.parseMessage(data, path, values) == false);
+}
+
+void OSCPacketizer_Test::parseMessageRejectsTruncatedStringArgument()
+{
+    OSCPacketizer op;
+    QString path;
+    QByteArray values;
+    QByteArray data;
+
+    data.append("/x");
+    data.append(QByteArray(2, 0));
+    data.append(",s");
+    data.append(QByteArray(2, 0));
+    data.append("unterminated");
+
+    QVERIFY(op.parseMessage(data, path, values) == false);
+}
+
+void OSCPacketizer_Test::parsePacketStopsAtTruncatedBundleEntry()
+{
+    OSCPacketizer op;
+    QByteArray message;
+    QByteArray data;
+
+    op.setupOSCDmx(message, 1, 2, 128);
+
+    data.append("#bundle");
+    data.append(char(0x00));
+    data.append(QByteArray(8, 0));
+    appendBundleMessage(data, message);
+    data.append(QByteArray(3, 0));
+
+    QCOMPARE(op.parsePacket(data).size(), 1);
+}
+
+void OSCPacketizer_Test::parsePacketAcceptsBundleMessage()
+{
+    OSCPacketizer op;
+    QByteArray message;
+    QByteArray bundle;
+
+    op.setupOSCDmx(message, 1, 2, 128);
+
+    bundle.append("#bundle");
+    bundle.append(char(0x00));
+    bundle.append(QByteArray(8, 0));
+    appendBundleMessage(bundle, message);
+
+    QList<QPair<QString, QByteArray> > messages = op.parsePacket(bundle);
+    QCOMPARE(messages.size(), 1);
+    QCOMPARE(messages.first().first, QString("/1/dmx/2"));
+    QCOMPARE(messages.first().second.size(), 1);
+}
+
+QTEST_MAIN(OSCPacketizer_Test)

--- a/plugins/osc/test/oscpacketizer_test.h
+++ b/plugins/osc/test/oscpacketizer_test.h
@@ -1,0 +1,37 @@
+/*
+  Q Light Controller Plus
+  oscpacketizer_test.h
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef OSCPACKETIZER_TEST_H
+#define OSCPACKETIZER_TEST_H
+
+#include <QObject>
+
+class OSCPacketizer_Test final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void parsePacketRejectsTruncatedTypeTags();
+    void parseMessageRejectsTruncatedTypeTags();
+    void parseMessageRejectsTruncatedStringArgument();
+    void parsePacketStopsAtTruncatedBundleEntry();
+    void parsePacketAcceptsBundleMessage();
+};
+
+#endif


### PR DESCRIPTION
## Description

**Summary of Changes:**

This PR fixes malformed-input reliability issues found while reviewing
stale PR #1955 and adjacent parser code.

The affected parsers now reject short or inconsistent input before
reading fixed fields or payload bytes. Well-formed input is handled as
before.

## Commit Guide

| Commit | Origin | Reproduction / coverage |
|---|---|---|
| Script: reject fixtures outside universe list | Reported in PR #1955 | Added a regression test in `script_test` for a fixture whose universe is absent from the runtime universe list. |
| Art-Net: reject packets with truncated fields | Reported in PR #1955 | Extended `artnet_test` with short ArtPollReply, ArtDMX and ArtTOD packets. |
| E1.31: validate DMX property value count | Reported in PR #1955 | Added `e131packetizer_test` coverage for missing start code, zero count, truncated payload and a valid packet. |
| OSC: reject truncated messages and bundle sizes | Reported in PR #1955 | Added `oscpacketizer_test` coverage for unterminated type tags, truncated string arguments, short bundle size fields and a valid bundle. |
| RDM: validate response length before decoding | Derived while validating PR #1955 | Extended `artnet_test` with short RDM headers, oversized or truncated PDL values, too-short PID payloads, and valid ACK responses. |
| DMX USB: validate Enttec input payload offsets | Derived while validating PR #1955 | No automated regression test exists for this device input path; a reviewer with compatible hardware can smoke-test normal DMX and MIDI input for regressions. |

## Testing

**Automated Coverage:**

The parser paths with in-tree harnesses are covered by:

- `script_test`
- `artnet_test`
- `e131packetizer_test`
- `oscpacketizer_test`

**Result:**

The added and extended tests pass locally.

### Manual Testing Gaps

The Enttec DMX USB Pro input-path change is not covered by an
automated regression test because the current tree does not provide a
device-level test harness for that plugin.

A reviewer with compatible hardware can help confirm there is no
behavioral regression by connecting the device, enabling the DMX USB
plugin, and verifying that normal DMX input and MIDI input still work.

## Additional Notes

The fixes are split into one commit per issue so individual parser
changes remain easy to review and bisect.

Each commit body contains the full rationale and reproduction details.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.
