### PR TITLE
Fix Show Manager edge cases around timing and previews

### DIFF
--- a/qmlui/showmanager.cpp
+++ b/qmlui/showmanager.cpp
@@ -1517,9 +1517,10 @@ bool ShowManager::checkOverlapping(Track *track, ShowFunction *sourceFunc,
         Function *func = m_doc->function(sf->functionID());
         if (func != nullptr)
         {
-            quint32 fst = sf->startTime();
-            if ((startTime >= fst && startTime <= fst + sf->duration()) ||
-                (fst >= startTime && fst <= startTime + duration))
+            quint64 fst = sf->startTime();
+            quint64 endTime = quint64(startTime) + duration;
+            quint64 fend = fst + sf->duration();
+            if (startTime < fend && fst < endTime)
             {
                 return true;
             }

--- a/qmlui/showmanager.cpp
+++ b/qmlui/showmanager.cpp
@@ -1581,10 +1581,16 @@ QVariantList ShowManager::previewData(Function *f) const
         {
             data.append(RepeatingDuration);
             data.append(f->totalDuration());
-            data.append(FadeIn);
-            data.append(f->fadeInSpeed());
-            data.append(FadeOut);
-            data.append(f->fadeOutSpeed());
+            if (f->fadeInSpeed() > 0)
+            {
+                data.append(FadeIn);
+                data.append(f->fadeInSpeed());
+            }
+            if (f->fadeOutSpeed() > 0)
+            {
+                data.append(FadeOut);
+                data.append(f->fadeOutSpeed());
+            }
         }
         break;
         default:

--- a/ui/src/showmanager/audioitem.cpp
+++ b/ui/src/showmanager/audioitem.cpp
@@ -65,6 +65,15 @@ AudioItem::AudioItem(Audio *aud, ShowFunction *func)
             this, SLOT(slotAudioPreviewStereo()));
 }
 
+AudioItem::~AudioItem()
+{
+    stopWaveformPreviewThreads();
+
+    QMutexLocker locker(&m_previewMutex);
+    delete m_preview;
+    m_preview = NULL;
+}
+
 void AudioItem::calculateWidth()
 {
     int newWidth = 0;
@@ -146,10 +155,34 @@ Audio *AudioItem::getAudio() const
 
 void AudioItem::updateWaveformPreview()
 {
+    for (PreviewThread *thread : m_previewThreads)
+        thread->requestInterruption();
+
     PreviewThread *waveformThread = new PreviewThread;
     waveformThread->setAudioItem(this);
-    connect(waveformThread, SIGNAL(finished()), waveformThread, SLOT(deleteLater()));
+    m_previewThreads.append(waveformThread);
+    connect(waveformThread, &PreviewThread::finished, this,
+            [this, waveformThread]()
+            {
+                m_previewThreads.removeOne(waveformThread);
+                waveformThread->deleteLater();
+            });
     waveformThread->start();
+}
+
+void AudioItem::stopWaveformPreviewThreads()
+{
+    for (PreviewThread *thread : m_previewThreads)
+        thread->requestInterruption();
+
+    for (PreviewThread *thread : m_previewThreads)
+    {
+        disconnect(thread, &PreviewThread::finished, this, nullptr);
+        thread->wait();
+        delete thread;
+    }
+
+    m_previewThreads.clear();
 }
 
 void AudioItem::slotAudioChanged(quint32)
@@ -212,6 +245,12 @@ void AudioItem::contextMenuEvent(QGraphicsSceneContextMenuEvent *)
     menu.exec(QCursor::pos());
 }
 
+PreviewThread::PreviewThread(QObject *parent)
+    : QThread(parent)
+    , m_item(NULL)
+{
+}
+
 void PreviewThread::setAudioItem(AudioItem *item)
 {
     m_item = item;
@@ -240,6 +279,9 @@ qint32 PreviewThread::getSample(const unsigned char *data, quint32 idx, int samp
 
 void PreviewThread::run()
 {
+    if (m_item == NULL || isInterruptionRequested())
+        return;
+
     bool left = m_item->m_previewLeftAction->isChecked() || m_item->m_previewStereoAction->isChecked();
     bool right = m_item->m_previewRightAction->isChecked() || m_item->m_previewStereoAction->isChecked();
 
@@ -289,7 +331,7 @@ void PreviewThread::run()
         }
         m_item->update();
 
-        while (dataRead)
+        while (dataRead && !isInterruptionRequested())
         {
             quint32 tmpExceedData = 0;
             if (audioDataOffset < onePixelReadLen)
@@ -399,6 +441,12 @@ void PreviewThread::run()
         }
         //qDebug() << "Iterations done: " << xpos;
         delete ad;
+        if (isInterruptionRequested())
+        {
+            delete preview;
+            return;
+        }
+
         {
             QMutexLocker locker(&m_item->m_previewMutex);
             m_item->m_preview = preview;
@@ -411,5 +459,6 @@ void PreviewThread::run()
         m_item->m_preview = NULL;
     }
 
-    m_item->update();
+    if (!isInterruptionRequested())
+        m_item->update();
 }

--- a/ui/src/showmanager/audioitem.cpp
+++ b/ui/src/showmanager/audioitem.cpp
@@ -89,10 +89,17 @@ void AudioItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 
     ShowItem::paint(painter, option, widget);
 
-    if (m_preview != NULL)
+    QPixmap preview;
+    {
+        QMutexLocker locker(&m_previewMutex);
+        if (m_preview != NULL)
+            preview = *m_preview;
+    }
+
+    if (preview.isNull() == false)
     {
         // show preview here
-        painter->drawPixmap(0, 0, m_preview->scaled(m_width, TRACK_HEIGHT - 4));
+        painter->drawPixmap(0, 0, preview.scaled(m_width, TRACK_HEIGHT - 4));
     }
 
     if (m_audio->fadeInSpeed() != 0)
@@ -275,8 +282,11 @@ void PreviewThread::run()
         qDebug() << "Samples per second:" << oneSecondSamples << ", for one pixel:" << onePixelSamples <<
                     ", onePixelReadLen:" << onePixelReadLen;
 
-        delete m_item->m_preview;
-        m_item->m_preview = NULL;
+        {
+            QMutexLocker locker(&m_item->m_previewMutex);
+            delete m_item->m_preview;
+            m_item->m_preview = NULL;
+        }
         m_item->update();
 
         while (dataRead)
@@ -389,10 +399,14 @@ void PreviewThread::run()
         }
         //qDebug() << "Iterations done: " << xpos;
         delete ad;
-        m_item->m_preview = preview;
+        {
+            QMutexLocker locker(&m_item->m_previewMutex);
+            m_item->m_preview = preview;
+        }
     }
     else // no preview selected. Delete pixmap
     {
+        QMutexLocker locker(&m_item->m_previewMutex);
         delete m_item->m_preview;
         m_item->m_preview = NULL;
     }

--- a/ui/src/showmanager/audioitem.h
+++ b/ui/src/showmanager/audioitem.h
@@ -24,10 +24,14 @@
 #include <QObject>
 #include <QAction>
 #include <QFont>
+#include <QList>
 #include <QMutex>
+#include <QThread>
 
 #include "showitem.h"
 #include "audio.h"
+
+class PreviewThread;
 
 /** @addtogroup ui_functions
  * @{
@@ -45,6 +49,7 @@ class AudioItem final : public ShowItem
 
 public:
     AudioItem(Audio *aud, ShowFunction *func);
+    ~AudioItem() override;
 
     /** @reimp */
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
@@ -81,8 +86,14 @@ private:
     /** Start a thread to elapse a waveform preview over the item */
     void updateWaveformPreview();
 
+    /** Stop and release any running waveform preview threads */
+    void stopWaveformPreviewThreads();
+
     /** Protects waveform preview replacement and paint access */
     QMutex m_previewMutex;
+
+    /** Running waveform preview workers */
+    QList<PreviewThread *> m_previewThreads;
 
 public:
     /** Reference to the actual Audio Function */
@@ -100,6 +111,8 @@ public:
 class PreviewThread final : public QThread
 {
 public:
+    explicit PreviewThread(QObject *parent = nullptr);
+
     void setAudioItem(AudioItem *item);
 
 private:

--- a/ui/src/showmanager/audioitem.h
+++ b/ui/src/showmanager/audioitem.h
@@ -24,6 +24,7 @@
 #include <QObject>
 #include <QAction>
 #include <QFont>
+#include <QMutex>
 
 #include "showitem.h"
 #include "audio.h"
@@ -72,11 +73,16 @@ protected slots:
     void slotAudioPreviewStereo();
 
 private:
+    friend class PreviewThread;
+
     /** Calculate sequence width for paint() and boundingRect() */
     void calculateWidth();
 
     /** Start a thread to elapse a waveform preview over the item */
     void updateWaveformPreview();
+
+    /** Protects waveform preview replacement and paint access */
+    QMutex m_previewMutex;
 
 public:
     /** Reference to the actual Audio Function */

--- a/ui/src/showmanager/efxitem.cpp
+++ b/ui/src/showmanager/efxitem.cpp
@@ -78,14 +78,18 @@ void EFXItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
     ShowItem::paint(painter, option, widget);
 
     int loopCount = 0;
-    if (getDuration() == Function::infiniteSpeed())
-        loopCount = 10000 / m_efx->duration();
-    else if (getDuration() > 0)
-        loopCount = qFloor(getDuration() / m_efx->duration());
+    quint32 loopDuration = m_efx->totalDuration();
+    if (loopDuration > 0)
+    {
+        if (getDuration() == Function::infiniteSpeed())
+            loopCount = 10000 / loopDuration;
+        else if (getDuration() > 0)
+            loopCount = qFloor(getDuration() / loopDuration);
+    }
 
     for (int i = 0; i < loopCount; i++)
     {
-        xpos += ((timeUnit * float(m_efx->duration())) / 1000);
+        xpos += ((timeUnit * float(loopDuration)) / 1000);
         // draw loop vertical delimiter
         painter->setPen(QPen(Qt::white, 1));
         painter->drawLine(int(xpos), 1, int(xpos), TRACK_HEIGHT - 5);

--- a/ui/src/showmanager/multitrackview.cpp
+++ b/ui/src/showmanager/multitrackview.cpp
@@ -532,7 +532,7 @@ void MultiTrackView::slotTimeScaleChanged(int val)
     }
 
     int newCursorPos = getPositionFromTime(m_cursor->getTime());
-    m_cursor->setPos(newCursorPos + 2, m_cursor->y());
+    m_cursor->setPos(newCursorPos, m_cursor->y());
     updateViewSize();
 }
 
@@ -623,4 +623,3 @@ void MultiTrackView::slotAlignToCursor(ShowItem *item)
     item->setStartTime(getTimeFromPosition(item->x()));
     m_scene->update();
 }
-

--- a/ui/src/showmanager/rgbmatrixitem.cpp
+++ b/ui/src/showmanager/rgbmatrixitem.cpp
@@ -67,14 +67,18 @@ void RGBMatrixItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
     ShowItem::paint(painter, option, widget);
 
     int loopCount = 0;
-    if (getDuration() == Function::infiniteSpeed())
-        loopCount = 10000 / m_matrix->duration();
-    else if (getDuration() > 0)
-        loopCount = qFloor(getDuration() / m_matrix->duration());
+    quint32 loopDuration = m_matrix->totalDuration();
+    if (loopDuration > 0)
+    {
+        if (getDuration() == Function::infiniteSpeed())
+            loopCount = 10000 / loopDuration;
+        else if (getDuration() > 0)
+            loopCount = qFloor(getDuration() / loopDuration);
+    }
 
     for (int i = 0; i < loopCount; i++)
     {
-        xpos += ((timeUnit * float(m_matrix->totalDuration())) / 1000);
+        xpos += ((timeUnit * float(loopDuration)) / 1000);
         // draw loop vertical delimiter
         painter->setPen(QPen(Qt::white, 1));
         painter->drawLine(int(xpos), 1, int(xpos), TRACK_HEIGHT - 5);

--- a/ui/src/showmanager/sequenceitem.cpp
+++ b/ui/src/showmanager/sequenceitem.cpp
@@ -99,6 +99,7 @@ void SequenceItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
         if (stepFadeIn > 0)
         {
             int fadeXpos = xpos + ((timeUnit * (float)stepFadeIn) / 1000);
+            fadeXpos = qMin(fadeXpos, getWidth());
             // doesn't even draw it if too small
             if (fadeXpos - xpos > 5)
             {
@@ -128,6 +129,7 @@ void SequenceItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
         if (stepFadeOut > 0)
         {
             int fadeXpos = xpos + ((timeUnit * (float)stepFadeOut) / 1000);
+            fadeXpos = qMin(fadeXpos, getWidth());
             // doesn't even draw it if too small
             if (fadeXpos - xpos > 5)
             {

--- a/ui/src/showmanager/showmanager.cpp
+++ b/ui/src/showmanager/showmanager.cpp
@@ -1746,9 +1746,10 @@ bool ShowManager::checkOverlapping(quint32 startTime, quint32 duration)
         Function *func = m_doc->function(sf->functionID());
         if (func != NULL)
         {
-            quint32 fst = sf->startTime();
-            if ((startTime >= fst && startTime <= fst + sf->duration()) ||
-                (fst >= startTime && fst <= startTime + duration))
+            quint64 fst = sf->startTime();
+            quint64 endTime = quint64(startTime) + duration;
+            quint64 fend = fst + sf->duration();
+            if (startTime < fend && fst < endTime)
             {
                 return true;
             }


### PR DESCRIPTION
## Description

**Summary of Changes:**

This PR fixes Show Manager reliability issues found while reviewing stale
PR #1955.

The changes allow adjacent timeline items, keep the cursor stable after
time-scale changes, avoid invalid preview marker calculations, and
synchronize audio waveform preview access between painting and preview
generation, and stop preview threads before Audio items are destroyed.
Normal timeline editing and preview rendering behavior is unchanged for
valid items.

## Commit Guide

| Commit | Origin | Reproduction / coverage |
|---|---|---|
| Show Manager: allow adjacent track items | Reported in PR #1955 | Reproduce by placing one item exactly at another item's end time; the v4 and QML overlap checks now use half-open intervals. |
| Show Manager: keep cursor stable when scaling | Reported in PR #1955 | Reproduce by moving the v4 play cursor, changing the time scale, and observing the previous two-pixel shift. |
| Show Manager: clamp preview duration markers | Reported in PR #1955 | Reproduce with zero-duration EFX/RGB Matrix functions, long Sequence fade-out markers, or zero-speed QML audio/video fades. |
| Show Manager: synchronize audio preview pixmap | Independent finding | Reproduce by repainting the v4 Show Manager while waveform preview generation replaces the preview pixmap; ThreadSanitizer is the best verification tool. |
| Show Manager: stop audio preview threads on teardown | Independent finding | Reproduce by deleting an Audio item or reloading the show while waveform preview generation is still active. |

## Testing

**Automated Coverage:**

There is no dedicated Show Manager unit test target in the current tree.

### Manual Testing Gaps

Reviewers can smoke-test the affected paths by placing adjacent items on
the same track, changing the v4 timeline scale with a visible cursor,
opening items with zero-duration or long fade markers, and deleting or
reloading an Audio item while waveform preview generation is active.

## Additional Notes

The fixes are grouped because they all affect Show Manager timeline or
preview behavior. They are still kept as separate commits for review.

Each commit body contains the full rationale and reproduction details.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.