### PR TITLE
Harden WebAccess request handling and rendered output

### DIFF
--- a/webaccess/CMakeLists.txt
+++ b/webaccess/CMakeLists.txt
@@ -2,3 +2,6 @@ project(webaccess)
 
 add_subdirectory(src)
 add_subdirectory(res)
+if(NOT ANDROID AND NOT IOS)
+    add_subdirectory(test)
+endif()

--- a/webaccess/src/CMakeLists.txt
+++ b/webaccess/src/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
 endif()
 
 set(WEBACCESS_SOURCES
+    commonjscss.cpp
     commonjscss.h
     qhttpserver/http_parser.c qhttpserver/http_parser.h
     qhttpserver/qhttpconnection.cpp qhttpserver/qhttpconnection.h

--- a/webaccess/src/CMakeLists.txt
+++ b/webaccess/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(WEBACCESS_SOURCES
     webaccessauth.cpp webaccessauth.h
     webaccessconfiguration.cpp webaccessconfiguration.h
     webaccesssimpledesk.cpp webaccesssimpledesk.h
+    webaccessupload.cpp webaccessupload.h
     ${QM_FILES}
 )
 

--- a/webaccess/src/commonjscss.cpp
+++ b/webaccess/src/commonjscss.cpp
@@ -1,0 +1,75 @@
+/*
+  Q Light Controller Plus
+  commonjscss.cpp
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "commonjscss.h"
+
+QString webAccessJsStringEscaped(const QString &text)
+{
+    QString escaped;
+    escaped.reserve(text.length() * 2);
+
+    for (const QChar &ch : text)
+    {
+        const char16_t code = ch.unicode();
+
+        switch (code)
+        {
+            case '\\':
+                escaped += "\\\\";
+            break;
+            case '\'':
+                escaped += "\\'";
+            break;
+            case '"':
+                escaped += "\\\"";
+            break;
+            case '\b':
+                escaped += "\\b";
+            break;
+            case '\f':
+                escaped += "\\f";
+            break;
+            case '\n':
+                escaped += "\\n";
+            break;
+            case '\r':
+                escaped += "\\r";
+            break;
+            case '\t':
+                escaped += "\\t";
+            break;
+            case '<':
+                escaped += "\\x3C";
+            break;
+            default:
+                if (code < 0x20 || code == 0x2028 || code == 0x2029)
+                {
+                    escaped += "\\u";
+                    escaped += QString::number(code, 16).rightJustified(4, '0');
+                }
+                else
+                {
+                    escaped += ch;
+                }
+            break;
+        }
+    }
+
+    return escaped;
+}

--- a/webaccess/src/commonjscss.h
+++ b/webaccess/src/commonjscss.h
@@ -20,6 +20,10 @@
 #ifndef COMMONJSCSS_H
 #define COMMONJSCSS_H
 
+#include <QString>
+
+QString webAccessJsStringEscaped(const QString &text);
+
 #define HTML_HEADER \
     "<!DOCTYPE html>\n" \
     "<head>\n" \

--- a/webaccess/src/webaccess-qml.cpp
+++ b/webaccess/src/webaccess-qml.cpp
@@ -774,12 +774,6 @@ void WebAccessQml::slotHandleWebSocketRequest(QHttpConnection *conn, QString dat
         m_sd->setAbsoluteChannelValue(absAddress, uchar(value));
         return;
     }
-    else if (cmdList[0] == "GM_VALUE")
-    {
-        uchar value = cmdList[1].toInt();
-        m_doc->inputOutputMap()->setGrandMasterValue(value);
-        return;
-    }
     else if (cmdList[0] == "POLL")
         return;
 

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -352,6 +352,9 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
 
             quint32 wID = cmdList[2].toUInt();
             VCWidget *widget = m_vc->widget(wID);
+            if (widget == nullptr)
+                return;
+
             switch(widget->type())
             {
                 case VCWidget::AnimationWidget:

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -452,12 +452,6 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
 
         return;
     }
-    else if (cmdList[0] == "GM_VALUE")
-    {
-        uchar value = cmdList[1].toInt();
-        m_doc->inputOutputMap()->setGrandMasterValue(value);
-        return;
-    }
     else if (cmdList[0] == "POLL")
         return;
 
@@ -517,30 +511,36 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
                     cue->slotPreviousCue();
                 else if (cmdList[1] == "NEXT")
                     cue->slotNextCue();
-                else if (cmdList[1] == "STEP")
+                else if (cmdList[1] == "STEP" && cmdList.count() > 2)
                     cue->slotCurrentStepChanged(cmdList[2].toInt());
-                else if (cmdList[1] == "CUE_STEP_NOTE")
+                else if (cmdList[1] == "CUE_STEP_NOTE" && cmdList.count() > 3)
                     cue->slotStepNoteChanged(cmdList[2].toInt(), cmdList[3]);
-                else if (cmdList[1] == "CUE_SHOWPANEL")
+                else if (cmdList[1] == "CUE_SHOWPANEL" && cmdList.count() > 2)
                     cue->slotSideFaderButtonChecked(cmdList[2] == "1" ? false : true);
-                else if (cmdList[1] == "CUE_SIDECHANGE")
+                else if (cmdList[1] == "CUE_SIDECHANGE" && cmdList.count() > 2)
                     cue->slotSetSideFaderValue((cmdList[2]).toInt());
             }
             break;
             case VCWidget::FrameWidget:
             case VCWidget::SoloFrameWidget:
             {
+                if (cmdList.count() < 2)
+                    return;
+
                 VCFrame *frame = qobject_cast<VCFrame*>(widget);
                 if (cmdList[1] == "NEXT_PG")
                     frame->slotNextPage();
                 else if (cmdList[1] == "PREV_PG")
                     frame->slotPreviousPage();
-                else if (cmdList[1] == "FRAME_DISABLE")
+                else if (cmdList[1] == "FRAME_DISABLE" && cmdList.count() > 2)
                     frame->setDisableState(cmdList[2] == "1" ? false : true);
             }
             break;
             case VCWidget::ClockWidget:
             {
+                if (cmdList.count() < 2)
+                    return;
+
                 VCClock *clock = qobject_cast<VCClock*>(widget);
                 if (cmdList[1] == "S")
                     clock->playPauseTimer();
@@ -550,24 +550,27 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             break;
             case VCWidget::AnimationWidget:
             {
+                if (cmdList.count() < 2)
+                    return;
+
                 VCMatrix *matrix = qobject_cast<VCMatrix*>(widget);
-                if (cmdList[1] == "MATRIX_SLIDER_CHANGE")
+                if (cmdList[1] == "MATRIX_SLIDER_CHANGE" && cmdList.count() > 2)
                     matrix->slotSetSliderValue(cmdList[2].toInt());
-                if (cmdList[1] == "MATRIX_COMBO_CHANGE")
+                if (cmdList[1] == "MATRIX_COMBO_CHANGE" && cmdList.count() > 2)
                     matrix->slotSetAnimationValue(cmdList[2]);
-                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList[2] == "COLOR_1")
+                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList.count() > 3 && cmdList[2] == "COLOR_1")
                     matrix->slotColor1Changed(cmdList[3].toInt());
-                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList[2] == "COLOR_2")
+                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList.count() > 3 && cmdList[2] == "COLOR_2")
                     matrix->slotColor2Changed(cmdList[3].toInt());
-                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList[2] == "COLOR_3")
+                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList.count() > 3 && cmdList[2] == "COLOR_3")
                     matrix->slotColor3Changed(cmdList[3].toInt());
-                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList[2] == "COLOR_4")
+                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList.count() > 3 && cmdList[2] == "COLOR_4")
                     matrix->slotColor4Changed(cmdList[3].toInt());
-                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList[2] == "COLOR_5")
+                if (cmdList[1] == "MATRIX_COLOR_CHANGE" && cmdList.count() > 3 && cmdList[2] == "COLOR_5")
                     matrix->slotColor5Changed(cmdList[3].toInt());
-                if (cmdList[1] == "MATRIX_KNOB")
+                if (cmdList[1] == "MATRIX_KNOB" && cmdList.count() > 3)
                     matrix->slotMatrixControlKnobValueChanged(cmdList[2].toInt(), cmdList[3].toInt());
-                if (cmdList[1] == "MATRIX_PUSHBUTTON")
+                if (cmdList[1] == "MATRIX_PUSHBUTTON" && cmdList.count() > 2)
                     matrix->slotMatrixControlPushButtonClicked(cmdList[2].toInt());
             }
             break;

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -710,7 +710,7 @@ QString WebAccess::getFrameHTML(const VCFrame *frame)
             for (const VCFramePageShortcut* shortcut : shortcuts)
             {
                 m_JScode += "framesPageNames[" + QString::number(frame->id()) + "][" + QString::number(index) + "] = \"" +
-                            QString(shortcut->name()).replace("\\", "\\\\").replace("\"", "\\\"") + "\";\n";
+                            webAccessJsStringEscaped(shortcut->name()) + "\";\n";
                 index++;
             }
             currentPageName = QString(shortcuts[frame->currentPage()]->name());
@@ -734,7 +734,7 @@ QString WebAccess::getFrameHTML(const VCFrame *frame)
         str += "</div>\n";
 
         m_JScode += "frameCaption[" + QString::number(frame->id()) + "] = \"" +
-                    QString(frame->caption()).replace("\\", "\\\\").replace("\"", "\\\"") + "\";\n";
+                    webAccessJsStringEscaped(frame->caption()) + "\";\n";
 
         if (frame->isEnableButtonVisible()) {
             str += "<a class=\"vcframeButton\" id=\"frEnBtn" + QString::number(frame->id()) + "\" " +
@@ -758,7 +758,8 @@ QString WebAccess::getFrameHTML(const VCFrame *frame)
                    "<img src=\"back.png\" title=\"" + tr("Back") + "\" width=\"27\"></a>";
 
             str += "<div class=\"vcframePageLabel\" id=\"frPglbl" + QString::number(frame->id()) + "\" style=\"width: " + QString::number(frame->isCollapsed() ? 60 : 100)+"px;\">" +
-                   "<div class=\"vcFrameText\" id=\"fr" + QString::number(frame->id()) + "Page\">" + currentPageName + "</div></div>\n";
+                   "<div class=\"vcFrameText\" id=\"fr" + QString::number(frame->id()) + "Page\">" +
+                   currentPageName.toHtmlEscaped() + "</div></div>\n";
 
             str += "<a class=\"vcframeButton\" id=\"frMpHdrNext" + QString::number(frame->id()) + "\" href=\"javascript:frameNextPage(" +
                    QString::number(frame->id()) + ");\" style=\"display: " + QString(!frame->isCollapsed() ? "block" : "none") + ";\">" +
@@ -819,7 +820,7 @@ QString WebAccess::getSoloFrameHTML(const VCSoloFrame *frame)
             for (const VCFramePageShortcut* shortcut : shortcuts)
             {
                 m_JScode += "framesPageNames[" + QString::number(frame->id()) + "][" + QString::number(index) + "] = \"" +
-                            QString(shortcut->name()).replace("\\", "\\\\").replace("\"", "\\\"") + "\";\n";
+                            webAccessJsStringEscaped(shortcut->name()) + "\";\n";
                 index++;
             }
             currentPageName = QString(shortcuts[frame->currentPage()]->name());
@@ -843,7 +844,7 @@ QString WebAccess::getSoloFrameHTML(const VCSoloFrame *frame)
         str += "</div>\n";
 
         m_JScode += "frameCaption[" + QString::number(frame->id()) + "] = \"" +
-                    QString(frame->caption()).replace("\\", "\\\\").replace("\"", "\\\"") + "\";\n";
+                    webAccessJsStringEscaped(frame->caption()) + "\";\n";
 
         if (frame->isEnableButtonVisible()) {
             str += "<a class=\"vcframeButton\" id=\"frEnBtn" + QString::number(frame->id()) + "\" " +
@@ -867,7 +868,8 @@ QString WebAccess::getSoloFrameHTML(const VCSoloFrame *frame)
                    "<img src=\"back.png\" title=\"" + tr("Back") + "\" width=\"27\"></a>";
 
             str += "<div class=\"vcframePageLabel\" id=\"frPglbl" + QString::number(frame->id()) + "\" style=\"width: " + QString::number(frame->isCollapsed() ? 60 : 100) + "px;\">" +
-                   "<div class=\"vcFrameText\" id=\"fr" + QString::number(frame->id()) + "Page\">" + currentPageName + "</div></div>\n";
+                   "<div class=\"vcFrameText\" id=\"fr" + QString::number(frame->id()) + "Page\">" +
+                   currentPageName.toHtmlEscaped() + "</div></div>\n";
 
             str += "<a class=\"vcframeButton\" id=\"frMpHdrNext" + QString::number(frame->id()) + "\" href=\"javascript:frameNextPage(" +
                    QString::number(frame->id()) + ");\" style=\"display: " + QString(!frame->isCollapsed() ? "block" : "none") + ";\">" +

--- a/webaccess/src/webaccessbase.cpp
+++ b/webaccess/src/webaccessbase.cpp
@@ -20,7 +20,6 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QFileInfo>
 #include <QHostAddress>
 #include <QProcess>
 #include <QRegularExpression>
@@ -31,6 +30,7 @@
 #include "webaccessconfiguration.h"
 #include "webaccesssimpledesk.h"
 #include "webaccessnetwork.h"
+#include "webaccessupload.h"
 #include "commonjscss.h"
 #include "qlcconfig.h"
 #include "qlcfile.h"
@@ -49,13 +49,6 @@
 
 namespace
 {
-QString sanitizeUploadedFileName(const QString &rawName)
-{
-    QString normalizedName = rawName;
-    normalizedName.replace('\\', '/');
-    return QFileInfo(normalizedName).fileName();
-}
-
 bool extractMultipartFilePayload(const QHttpRequest *req, QByteArray &payload, QString *fileName = nullptr)
 {
     payload.clear();
@@ -117,7 +110,16 @@ bool extractMultipartFilePayload(const QHttpRequest *req, QByteArray &payload, Q
         QRegularExpression re("filename=\"([^\"]*)\"");
         QRegularExpressionMatch match = re.match(QString::fromUtf8(partHeaders));
         if (match.hasMatch())
-            *fileName = sanitizeUploadedFileName(match.captured(1));
+        {
+            const QString rawName = match.captured(1);
+            if (!isPlainUploadedFileName(rawName))
+            {
+                qWarning() << Q_FUNC_INFO << "Rejected fixture upload filename" << rawName;
+                return false;
+            }
+
+            *fileName = rawName;
+        }
     }
 
     const int payloadStart = headersEnd + payloadSeparatorSize;

--- a/webaccess/src/webaccessbase.cpp
+++ b/webaccess/src/webaccessbase.cpp
@@ -629,6 +629,18 @@ bool WebAccessBase::handleCommonWebSocketCommand(QHttpConnection *conn, const We
 
         return true;
     }
+    else if (cmdList[0] == "GM_VALUE")
+    {
+        if (m_auth && user && user->level < SIMPLE_DESK_AND_VC_LEVEL)
+            return true;
+
+        if (cmdList.count() < 2)
+            return true;
+
+        uchar value = cmdList[1].toInt();
+        m_doc->inputOutputMap()->setGrandMasterValue(value);
+        return true;
+    }
     else if (cmdList[0] == "QLC+AUTH")
     {
         if (!m_auth)
@@ -642,6 +654,9 @@ bool WebAccessBase::handleCommonWebSocketCommand(QHttpConnection *conn, const We
 
         if (cmdList.at(1) == "ADD_USER")
         {
+            if (cmdList.count() < 5)
+                return true;
+
             QString username = cmdList.at(2);
             QString password = cmdList.at(3);
             int level = cmdList.at(4).toInt();
@@ -664,12 +679,18 @@ bool WebAccessBase::handleCommonWebSocketCommand(QHttpConnection *conn, const We
         }
         else if (cmdList.at(1) == "DEL_USER")
         {
+            if (cmdList.count() < 3)
+                return true;
+
             QString username = cmdList.at(2);
             if (!username.isEmpty())
                 m_auth->deleteUser(username);
         }
         else if (cmdList.at(1) == "SET_USER_LEVEL")
         {
+            if (cmdList.count() < 4)
+                return true;
+
             QString username = cmdList.at(2);
             int level = cmdList.at(3).toInt();
             if (username.isEmpty())
@@ -716,7 +737,15 @@ bool WebAccessBase::handleCommonWebSocketCommand(QHttpConnection *conn, const We
         if (cmdList.at(1) == "NETWORK" && m_netConfig != nullptr)
         {
             QString wsMessage;
-            if (m_netConfig->updateNetworkSettings(cmdList))
+            // QLC+SYS|NETWORK|dev|mode|ip|netmask|gateway|ssid|wpapsk
+            if (cmdList.count() < 9)
+            {
+                wsMessage = QString("ALERT|" + tr("Invalid network configuration request."));
+                if (conn)
+                    conn->webSocketWrite(wsMessage);
+                return true;
+            }
+            else if (m_netConfig->updateNetworkSettings(cmdList))
                 wsMessage = QString("ALERT|" + tr("Network configuration changed. Reboot to apply the changes."));
             else
                 wsMessage = QString("ALERT|" + tr("An error occurred while updating the network configuration."));

--- a/webaccess/src/webaccessconfiguration.cpp
+++ b/webaccess/src/webaccessconfiguration.cpp
@@ -86,7 +86,8 @@ QString WebAccessConfiguration::getIOConfigHTML(const Doc *doc)
         quint32 currentFeedback = (fp == NULL)?QLCChannel::invalid():fp->output();
         QString currentProfileName = (ip == NULL)?KInputNone:ip->profileName();
 
-        html += "<tr style=\"text-align: center;\"><td>" + uniName + "</td>\n";
+        html += "<tr style=\"text-align: center;\"><td>" +
+                uniName.toHtmlEscaped() + "</td>\n";
         html += "<td><select onchange=\"ioChanged('INPUT', " + QString::number(i) + ", this.value);\">\n";
         for (int in = 0; in < inputLines.count(); in++)
         {
@@ -94,8 +95,10 @@ QString WebAccessConfiguration::getIOConfigHTML(const Doc *doc)
             QString selected = "";
             if (currentInputPluginName == strList.at(0) && currentInput == strList.at(2).toUInt())
                 selected = "selected";
-            html += "<option value=\"" + QString("%1|%2").arg(strList.at(0)).arg(strList.at(2)) + "\" " + selected + ">" +
-                    QString("[%1] %2").arg(strList.at(0)).arg(strList.at(1)) + "</option>\n";
+            const QString value = QString("%1|%2").arg(strList.at(0)).arg(strList.at(2));
+            const QString text = QString("[%1] %2").arg(strList.at(0)).arg(strList.at(1));
+            html += "<option value=\"" + value.toHtmlEscaped() + "\" " + selected + ">" +
+                    text.toHtmlEscaped() + "</option>\n";
         }
         html += "</select></td>\n";
         html += "<td><select onchange=\"ioChanged('OUTPUT', " + QString::number(i) + ", this.value);\">\n";
@@ -105,8 +108,10 @@ QString WebAccessConfiguration::getIOConfigHTML(const Doc *doc)
             QString selected = "";
             if (currentOutputPluginName == strList.at(0) && currentOutput == strList.at(2).toUInt())
                 selected = "selected";
-            html += "<option value=\"" + QString("%1|%2").arg(strList.at(0)).arg(strList.at(2)) + "\" " + selected + ">" +
-                    QString("[%1] %2").arg(strList.at(0)).arg(strList.at(1)) + "</option>\n";
+            const QString value = QString("%1|%2").arg(strList.at(0)).arg(strList.at(2));
+            const QString text = QString("[%1] %2").arg(strList.at(0)).arg(strList.at(1));
+            html += "<option value=\"" + value.toHtmlEscaped() + "\" " + selected + ">" +
+                    text.toHtmlEscaped() + "</option>\n";
         }
         html += "</select></td>\n";
         html += "<td><select onchange=\"ioChanged('FB', " + QString::number(i) + ", this.value);\">\n";
@@ -116,8 +121,10 @@ QString WebAccessConfiguration::getIOConfigHTML(const Doc *doc)
             QString selected = "";
             if (currentFeedbackPluginName == strList.at(0) && currentFeedback == strList.at(2).toUInt())
                 selected = "selected";
-            html += "<option value=\"" + QString("%1|%2").arg(strList.at(0)).arg(strList.at(2)) + "\" " + selected + ">" +
-                    QString("[%1] %2").arg(strList.at(0)).arg(strList.at(1)) + "</option>\n";
+            const QString value = QString("%1|%2").arg(strList.at(0)).arg(strList.at(2));
+            const QString text = QString("[%1] %2").arg(strList.at(0)).arg(strList.at(1));
+            html += "<option value=\"" + value.toHtmlEscaped() + "\" " + selected + ">" +
+                    text.toHtmlEscaped() + "</option>\n";
         }
         html += "</select></td>\n";
         html += "<td><select onchange=\"ioChanged('PROFILE', " + QString::number(i) + ", this.value);\">\n";
@@ -126,7 +133,8 @@ QString WebAccessConfiguration::getIOConfigHTML(const Doc *doc)
             QString selected = "";
             if (currentProfileName == profiles.at(p))
                 selected = "selected";
-            html += "<option value=\"" + profiles.at(p) + "\" " + selected + ">" + profiles.at(p) + "</option>\n";
+            html += "<option value=\"" + profiles.at(p).toHtmlEscaped() + "\" " +
+                    selected + ">" + profiles.at(p).toHtmlEscaped() + "</option>\n";
         }
         html += "</select></td>\n";
         html += "<td><label><input type=\"checkbox\" ";
@@ -169,13 +177,13 @@ QString WebAccessConfiguration::getAudioConfigHTML(const Doc *doc)
     foreach (AudioDeviceInfo info, devList)
     {
         if (info.capabilities & AUDIO_CAP_INPUT)
-            audioInSelect += "<option value=\"" + info.privateName + "\" " +
+            audioInSelect += "<option value=\"" + info.privateName.toHtmlEscaped() + "\" " +
                              ((info.privateName == inputName)?"selected":"") + ">" +
-                             info.deviceName + "</option>\n";
+                             info.deviceName.toHtmlEscaped() + "</option>\n";
         if (info.capabilities & AUDIO_CAP_OUTPUT)
-            audioOutSelect += "<option value=\"" + info.privateName + "\" " +
+            audioOutSelect += "<option value=\"" + info.privateName.toHtmlEscaped() + "\" " +
                     ((info.privateName == outputName)?"selected":"") + ">" +
-                    info.deviceName + "</option>\n";
+                    info.deviceName.toHtmlEscaped() + "</option>\n";
     }
     audioInSelect += "</select></td>\n";
     audioOutSelect += "</select></td>\n";
@@ -202,7 +210,7 @@ QString WebAccessConfiguration::getUserFixturesConfigHTML()
         QString path(it.next());
 
         if (path.toLower().endsWith(".qxf") || path.toLower().endsWith(".d4"))
-                html += "<tr><td>" + path + "</td></tr>\n";
+                html += "<tr><td>" + path.toHtmlEscaped() + "</td></tr>\n";
     }
     html += "</table>\n";
     html += "<br><a class=\"button button-blue\" href=\"javascript:document.getElementById('loadTrigger').click();\">\n"
@@ -226,14 +234,16 @@ QString WebAccessConfiguration::getPasswordsConfigHTML(const WebAccessAuth *auth
     foreach (WebAccessUser user, auth->getUsers())
     {
         QString username = user.username;
+        QString usernameAttr = username.toHtmlEscaped();
+        QString usernameJsAttr = webAccessJsStringEscaped(username).toHtmlEscaped();
         int level = user.level;
 
-        html += "<tr id=\"auth-row-" + username + "\">";
-        html += "<td>" + username + "</td>";
-        html += "<td><input type=\"password\" id=\"auth-password-" + username + "\""
-                " placeholder=\"" + tr("Leave blank to not change") + "\"></td>";
+        html += "<tr id=\"auth-row-" + usernameAttr + "\">";
+        html += "<td>" + usernameAttr + "</td>";
+        html += "<td><input type=\"password\" id=\"auth-password-" + usernameAttr + "\""
+                " placeholder=\"" + tr("Leave blank to not change").toHtmlEscaped() + "\"></td>";
         html += "<td>";
-            html += "<select id=\"auth-level-" + username + "\">";
+            html += "<select id=\"auth-level-" + usernameAttr + "\">";
 
             html += "<option value=\"" + QString::number(VC_ONLY_LEVEL) + "\"";
             if (level >= VC_ONLY_LEVEL && level < SIMPLE_DESK_AND_VC_LEVEL)
@@ -253,17 +263,17 @@ QString WebAccessConfiguration::getPasswordsConfigHTML(const WebAccessAuth *auth
             html += "</select>";
         html += "</td>";
         html += "<td>";
-            html += "<button onclick=\"authChangeUser('" + username + "')\">"
+            html += "<button onclick=\"authChangeUser('" + usernameJsAttr + "')\">"
                  + tr("Change") + "</button>";
-            html += "<button onclick=\"authDeleteUser('" + username + "')\">"
+            html += "<button onclick=\"authDeleteUser('" + usernameJsAttr + "')\">"
                  + tr("Delete user") + "</button>";
         html += "</td>";
         html += "</tr>";
     }
 
     html += "<tr>";
-    html += "<td><input type=\"text\" id=\"auth-new-username\" placeholder=\"" + tr("New username...") + "\"></td>";
-    html += "<td><input type=\"password\" id=\"auth-new-password\" placeholder=\"" + tr("New password...") + "\"></td>";
+    html += "<td><input type=\"text\" id=\"auth-new-username\" placeholder=\"" + tr("New username...").toHtmlEscaped() + "\"></td>";
+    html += "<td><input type=\"password\" id=\"auth-new-password\" placeholder=\"" + tr("New password...").toHtmlEscaped() + "\"></td>";
     html += "<td>";
         html += "<select id=\"auth-new-level\">";
 
@@ -279,9 +289,10 @@ QString WebAccessConfiguration::getPasswordsConfigHTML(const WebAccessAuth *auth
     html += "<td>";
         // Script will dynamically add rows with users so it needs to know translations
         html += "<button onclick=\"authAddUser("
-                "'" + tr("Change") + "','" + tr("Delete user") + "'"
-                ",'" + tr("Username and password are required fields.") + "'"
-                ",'" + tr("New password...") + "'"
+                "'" + webAccessJsStringEscaped(tr("Change")).toHtmlEscaped() + "',"
+                "'" + webAccessJsStringEscaped(tr("Delete user")).toHtmlEscaped() + "',"
+                "'" + webAccessJsStringEscaped(tr("Username and password are required fields.")).toHtmlEscaped() + "',"
+                "'" + webAccessJsStringEscaped(tr("New password...")).toHtmlEscaped() + "'"
                 ")\" class=\"authAddUser\">"
                 + tr("Add user") + "</button>";
     html += "</td>";

--- a/webaccess/src/webaccessnetwork.cpp
+++ b/webaccess/src/webaccessnetwork.cpp
@@ -367,7 +367,10 @@ bool WebAccessNetwork::updateNetworkSettings(QStringList cmdList)
 
             m_interfaces[i].enabled = true;
             bool staticRequest = cmdList.at(3) == "static" ? true : false;
-            QString args = "con add con-name qlcplus" + m_interfaces[i].devName + " ifname " + m_interfaces[i].devName;
+            QString conName = "qlcplus" + m_interfaces[i].devName;
+            QStringList args;
+            args << "con" << "add" << "con-name" << conName
+                 << "ifname" << m_interfaces[i].devName;
 
             if (staticRequest)
             {
@@ -388,11 +391,12 @@ bool WebAccessNetwork::updateNetworkSettings(QStringList cmdList)
                 }
 
                 if (m_interfaces[i].isWireless)
-                    args = args + " type wifi ssid " + cmdList.at(7);
+                    args << "type" << "wifi" << "ssid" << cmdList.at(7);
                 else
-                    args = args + " type ethernet";
+                    args << "type" << "ethernet";
 
-                args = args + " ip4 " + cmdList.at(4) + "/" + QString::number(bitCount) + " gw4 " + cmdList.at(6);
+                args << "ip4" << cmdList.at(4) + "/" + QString::number(bitCount)
+                     << "gw4" << cmdList.at(6);
             }
             else // DHCP
             {
@@ -400,27 +404,27 @@ bool WebAccessNetwork::updateNetworkSettings(QStringList cmdList)
                 {
                     //m_interfaces[i].ssid = cmdList.at(7);
                     //m_interfaces[i].wpaPass = cmdList.at(8);
-                    args = args + " type wifi ssid " + cmdList.at(7);
+                    args << "type" << "wifi" << "ssid" << cmdList.at(7);
                 }
                 else
                 {
-                    args += " type ethernet";
+                    args << "type" << "ethernet";
                 }
             }
 
             // add the new/updated connection profile
-            getNmcliOutput(args.split(" "));
+            getNmcliOutput(args);
 
             // if a password is set, modify the just created connection
             if (m_interfaces[i].isWireless && !cmdList.at(8).isEmpty())
             {
-                args = "con mod qlcplus" + m_interfaces[i].devName + " wifi-sec.key-mgmt wpa-psk wifi-sec.psk " + cmdList.at(8);
-                getNmcliOutput(args.split(" "));
+                getNmcliOutput(QStringList() << "con" << "mod" << conName
+                                             << "wifi-sec.key-mgmt" << "wpa-psk"
+                                             << "wifi-sec.psk" << cmdList.at(8));
             }
 
             // finally, activate the connection
-            args = "con up qlcplus" + m_interfaces[i].devName;
-            getNmcliOutput(args.split(" "));
+            getNmcliOutput(QStringList() << "con" << "up" << conName);
 
             refreshConnectionsList();
 

--- a/webaccess/src/webaccessnetwork.cpp
+++ b/webaccess/src/webaccessnetwork.cpp
@@ -99,6 +99,8 @@ void WebAccessNetwork::appendInterface(InterfaceInfo iface)
 
 QString WebAccessNetwork::getInterfaceHTML(const InterfaceInfo *iface) const
 {
+    const QString devNameAttr = iface->devName.toHtmlEscaped();
+    const QString devNameJsAttr = webAccessJsStringEscaped(iface->devName).toHtmlEscaped();
     QString dhcpChk = iface->isStatic ? QString() : QString("checked");
     QString staticChk = iface->isStatic ? QString("checked") : QString();
     QString editable = iface->isStatic ? QString("") : QString("disabled");
@@ -116,7 +118,7 @@ QString WebAccessNetwork::getInterfaceHTML(const InterfaceInfo *iface) const
         html += "<td><form style=\"margin: 5px 15px; color:#FFF;\">\n";
         html += "<table><tr>";
         html += "<td>" + tr("Access point name (SSID): ") + "</td><td><input type=\"text\" id=\"" +
-                "hotspotSSID\" size=\"15\" value=\"" + iface->ssid + "\"></td></tr>\n";
+                "hotspotSSID\" size=\"15\" value=\"" + iface->ssid.toHtmlEscaped() + "\"></td></tr>\n";
         html += "<td>" + tr("WPA-PSK Password: ") + "</td><td><input type=\"text\" id=\"" +
                 "hotspotWPAPSK\" size=\"15\" value=\"\"></td></tr>\n";
         html += "</tr></table>";
@@ -127,35 +129,35 @@ QString WebAccessNetwork::getInterfaceHTML(const InterfaceInfo *iface) const
     else
     {
         html += "<td style=\"padding: 0 20px; text-align: center; background: #333;\">";
-        html += tr("Network interface") + "<br>" + iface->devName + "</td>\n";
+        html += tr("Network interface") + "<br>" + iface->devName.toHtmlEscaped() + "</td>\n";
 
         html += "<td><form style=\"margin: 5px 15px; color:#FFF;\">\n";
         if (iface->isWireless)
         {
             html += "<table><tr>";
             html += "<td>" + tr("Access point name (SSID): ") + "</td><td><input type=\"text\" id=\"" +
-                    iface->devName + "SSID\" size=\"15\" value=\"" + iface->ssid + "\"></td></tr>\n";
+                    devNameAttr + "SSID\" size=\"15\" value=\"" + iface->ssid.toHtmlEscaped() + "\"></td></tr>\n";
             html += "<td>" + tr("WPA-PSK Password: ") + "</td><td><input type=\"text\" id=\"" +
-                    iface->devName + "WPAPSK\" size=\"15\" value=\"" + iface->wpaPass + "\"></td></tr>\n";
+                    devNameAttr + "WPAPSK\" size=\"15\" value=\"" + iface->wpaPass.toHtmlEscaped() + "\"></td></tr>\n";
             html += "</tr></table>";
         }
         /** IP mode radio buttons */
-        html += "<input type=\"radio\" name=" + iface->devName + "NetGroup onclick=\"showStatic('" +
-                iface->devName + "', false);\" value=\"dhcp\" " + dhcpChk + ">" + tr("Dynamic (DHCP)") + "<br>\n";
-        html += "<input type=\"radio\" name=" + iface->devName + "NetGroup onclick=\"showStatic('" +
-                iface->devName + "', true);\" value=\"static\" " + staticChk + ">" + tr("Static") + "<br>\n";
+        html += "<input type=\"radio\" name=\"" + devNameAttr + "NetGroup\" onclick=\"showStatic('" +
+                devNameJsAttr + "', false);\" value=\"dhcp\" " + dhcpChk + ">" + tr("Dynamic (DHCP)") + "<br>\n";
+        html += "<input type=\"radio\" name=\"" + devNameAttr + "NetGroup\" onclick=\"showStatic('" +
+                devNameJsAttr + "', true);\" value=\"static\" " + staticChk + ">" + tr("Static") + "<br>\n";
 
         /** Static IP fields */
-        html += "<div id=\"" + iface->devName + "StaticFields\" style=\"padding: 5px 30px;\">\n";
+        html += "<div id=\"" + devNameAttr + "StaticFields\" style=\"padding: 5px 30px;\">\n";
         html += "<table><tr>";
         html += "<td>" + tr("IP Address: ") + "</td><td><input type=\"text\" id=\"" +
-                iface->devName + "IPaddr\" size=\"15\" value=\"" + iface->address + "\" " + editable + "></td></tr>\n";
+                devNameAttr + "IPaddr\" size=\"15\" value=\"" + iface->address.toHtmlEscaped() + "\" " + editable + "></td></tr>\n";
         html += "<td>" + tr("Netmask: ") + "</td><td><input type=\"text\" id=\"" +
-                iface->devName + "Netmask\" size=\"15\" value=\"" + iface->netmask + "\" " + editable + "></td></tr>\n";
+                devNameAttr + "Netmask\" size=\"15\" value=\"" + iface->netmask.toHtmlEscaped() + "\" " + editable + "></td></tr>\n";
         html += "<td>" + tr("Gateway: ") + "</td><td><input type=\"text\" size=\"15\" id=\"" +
-                iface->devName + "Gateway\" value=\"" + iface->gateway + "\" " + editable + "></td></tr>\n";
+                devNameAttr + "Gateway\" value=\"" + iface->gateway.toHtmlEscaped() + "\" " + editable + "></td></tr>\n";
         html += "</table></div>\n";
-        html += "<input type=\"button\" value=\"" + tr("Apply changes") + "\" onclick=\"applyParams('" + iface->devName + "');\" >\n";
+        html += "<input type=\"button\" value=\"" + tr("Apply changes") + "\" onclick=\"applyParams('" + devNameJsAttr + "');\" >\n";
     }
 
     html += "</form></td></tr></table></div></div>";

--- a/webaccess/src/webaccesssimpledesk.cpp
+++ b/webaccess/src/webaccesssimpledesk.cpp
@@ -77,7 +77,8 @@ QString WebAccessSimpleDesk::getHTML(const Doc *doc, const SimpleDesk *sd)
     QStringList uniList = doc->inputOutputMap()->universeNames();
     for (int i = 0; i < uniList.count(); i++)
     {
-        bodyHTML += "<option value=\"" + QString::number(i) + "\">" + uniList.at(i) + "</option>\n";
+        bodyHTML += "<option value=\"" + QString::number(i) + "\">" +
+                    uniList.at(i).toHtmlEscaped() + "</option>\n";
     }
     bodyHTML += "</select></div>\n";
     bodyHTML += "</div>\n";

--- a/webaccess/src/webaccessupload.cpp
+++ b/webaccess/src/webaccessupload.cpp
@@ -1,0 +1,39 @@
+/*
+  Q Light Controller Plus
+  webaccessupload.cpp
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QFileInfo>
+
+#include "webaccessupload.h"
+
+bool isPlainUploadedFileName(const QString &rawName)
+{
+    if (rawName.isEmpty() || rawName.length() > 255 ||
+        rawName == "." || rawName == "..")
+        return false;
+
+    if (rawName.contains('/') || rawName.contains('\\'))
+        return false;
+
+    if (!rawName.endsWith(".qxf", Qt::CaseInsensitive) &&
+        !rawName.endsWith(".d4", Qt::CaseInsensitive))
+        return false;
+
+    // Backstop for any path component Qt normalizes internally.
+    return QFileInfo(rawName).fileName() == rawName;
+}

--- a/webaccess/src/webaccessupload.h
+++ b/webaccess/src/webaccessupload.h
@@ -1,0 +1,27 @@
+/*
+  Q Light Controller Plus
+  webaccessupload.h
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef WEBACCESSUPLOAD_H
+#define WEBACCESSUPLOAD_H
+
+#include <QString>
+
+bool isPlainUploadedFileName(const QString &rawName);
+
+#endif // WEBACCESSUPLOAD_H

--- a/webaccess/test/CMakeLists.txt
+++ b/webaccess/test/CMakeLists.txt
@@ -9,3 +9,15 @@ target_link_libraries(webaccessescaping_test PRIVATE
     Qt${QT_MAJOR_VERSION}::Core
     Qt${QT_MAJOR_VERSION}::Test
 )
+
+add_executable(webaccessupload_test WIN32 MACOSX_BUNDLE
+    ../src/webaccessupload.cpp
+    webaccessupload_test.cpp webaccessupload_test.h
+)
+target_include_directories(webaccessupload_test PRIVATE
+    ../src
+)
+target_link_libraries(webaccessupload_test PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Test
+)

--- a/webaccess/test/CMakeLists.txt
+++ b/webaccess/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(webaccessescaping_test WIN32 MACOSX_BUNDLE
+    ../src/commonjscss.cpp
+    webaccessescaping_test.cpp webaccessescaping_test.h
+)
+target_include_directories(webaccessescaping_test PRIVATE
+    ../src
+)
+target_link_libraries(webaccessescaping_test PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Test
+)

--- a/webaccess/test/webaccessescaping_test.cpp
+++ b/webaccess/test/webaccessescaping_test.cpp
@@ -1,0 +1,64 @@
+/*
+  Q Light Controller Plus
+  webaccessescaping_test.cpp
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QTest>
+
+#include "commonjscss.h"
+#include "webaccessescaping_test.h"
+
+void WebAccessEscaping_Test::leavesPlainAsciiUnchanged()
+{
+    QCOMPARE(webAccessJsStringEscaped("QLC+ fixture 123"),
+             QString("QLC+ fixture 123"));
+}
+
+void WebAccessEscaping_Test::escapesJavaScriptStringDelimiters()
+{
+    QCOMPARE(webAccessJsStringEscaped("'\"\\"),
+             QString("\\'\\\"\\\\"));
+}
+
+void WebAccessEscaping_Test::escapesScriptBreakingCharacters()
+{
+    QString text;
+    text.append('<');
+    text.append('>');
+    text.append('&');
+    text.append(QChar(0x2028));
+    text.append(QChar(0x2029));
+
+    QCOMPARE(webAccessJsStringEscaped(text),
+             QString("\\x3C>&\\u2028\\u2029"));
+}
+
+void WebAccessEscaping_Test::escapesControlCharacters()
+{
+    QString text;
+    text.append(QChar(0x0000));
+    text.append('\b');
+    text.append('\f');
+    text.append('\n');
+    text.append('\r');
+    text.append('\t');
+
+    QCOMPARE(webAccessJsStringEscaped(text),
+             QString("\\u0000\\b\\f\\n\\r\\t"));
+}
+
+QTEST_MAIN(WebAccessEscaping_Test)

--- a/webaccess/test/webaccessescaping_test.h
+++ b/webaccess/test/webaccessescaping_test.h
@@ -1,0 +1,36 @@
+/*
+  Q Light Controller Plus
+  webaccessescaping_test.h
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef WEBACCESSESCAPING_TEST_H
+#define WEBACCESSESCAPING_TEST_H
+
+#include <QObject>
+
+class WebAccessEscaping_Test final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void leavesPlainAsciiUnchanged();
+    void escapesJavaScriptStringDelimiters();
+    void escapesScriptBreakingCharacters();
+    void escapesControlCharacters();
+};
+
+#endif // WEBACCESSESCAPING_TEST_H

--- a/webaccess/test/webaccessupload_test.cpp
+++ b/webaccess/test/webaccessupload_test.cpp
@@ -1,0 +1,59 @@
+/*
+  Q Light Controller Plus
+  webaccessupload_test.cpp
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QTest>
+
+#include "webaccessupload.h"
+#include "webaccessupload_test.h"
+
+void WebAccessUpload_Test::acceptsFixtureFileNames()
+{
+    QVERIFY(isPlainUploadedFileName("fixture.qxf"));
+    QVERIFY(isPlainUploadedFileName("fixture.D4"));
+}
+
+void WebAccessUpload_Test::rejectsPathComponents()
+{
+    QVERIFY(isPlainUploadedFileName("../fixture.qxf") == false);
+    QVERIFY(isPlainUploadedFileName("..\\fixture.qxf") == false);
+    QVERIFY(isPlainUploadedFileName("/tmp/fixture.qxf") == false);
+    QVERIFY(isPlainUploadedFileName("dir/fixture.qxf") == false);
+}
+
+void WebAccessUpload_Test::rejectsReservedAndEmptyNames()
+{
+    QVERIFY(isPlainUploadedFileName("") == false);
+    QVERIFY(isPlainUploadedFileName(".") == false);
+    QVERIFY(isPlainUploadedFileName("..") == false);
+}
+
+void WebAccessUpload_Test::rejectsUnexpectedExtensions()
+{
+    QVERIFY(isPlainUploadedFileName("fixture.php") == false);
+    QVERIFY(isPlainUploadedFileName("fixture.qxf.php") == false);
+    QVERIFY(isPlainUploadedFileName("fixture") == false);
+}
+
+void WebAccessUpload_Test::rejectsOverlongNames()
+{
+    QVERIFY(isPlainUploadedFileName(QString(251, 'a') + ".qxf"));
+    QVERIFY(isPlainUploadedFileName(QString(252, 'a') + ".qxf") == false);
+}
+
+QTEST_MAIN(WebAccessUpload_Test)

--- a/webaccess/test/webaccessupload_test.h
+++ b/webaccess/test/webaccessupload_test.h
@@ -1,0 +1,37 @@
+/*
+  Q Light Controller Plus
+  webaccessupload_test.h
+
+  Copyright (c) Q Light Controller Plus
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef WEBACCESSUPLOAD_TEST_H
+#define WEBACCESSUPLOAD_TEST_H
+
+#include <QObject>
+
+class WebAccessUpload_Test final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void acceptsFixtureFileNames();
+    void rejectsPathComponents();
+    void rejectsReservedAndEmptyNames();
+    void rejectsUnexpectedExtensions();
+    void rejectsOverlongNames();
+};
+
+#endif // WEBACCESSUPLOAD_TEST_H


### PR DESCRIPTION
## Description

**Summary of Changes:**

This PR fixes WebAccess reliability issues found while reviewing stale
PR #1955 and adjacent WebAccess request handling.

The changes handle missing widgets, validate malformed WebSocket
commands, apply the expected permission gate to Grand Master updates,
escape rendered project/device strings by context, and reject fixture
upload filenames that contain path syntax. Well-formed WebAccess
requests and fixture upload filenames are handled as before.

## Commit Guide

| Commit | Origin | Reproduction / coverage |
|---|---|---|
| WebAccess: handle missing widget sub-id queries | Reported in PR #1955 | Reproduce with an authenticated WebSocket request for `QLC+API|getWidgetSubIdList|<missing-id>`. |
| WebAccess: validate websocket command arguments | Independent finding | Reproduce with authenticated messages such as `QLC+AUTH|ADD_USER`, `QLC+SYS|NETWORK|wlan0|dhcp`, or `GM_VALUE|0` as a low-level user; also verify that SSIDs and WPA passwords containing spaces survive nmcli argument construction. |
| WebAccess: escape rendered project and device strings | Reported in PR #1955 and derived while validating it | Reproduce with a multipage frame page name like `</script><script>alert(1)</script>` or a universe name like `<img src=x onerror=alert(1)>`. |
| WebAccess: reject fixture upload path names | Independent finding | Reproduce by posting to `/loadFixture` with a multipart filename such as `../../tmp/outside.qxf`, `fixture.php`, or an overlong fixture name. |

## Testing

**Test Cases:**

This PR adds focused WebAccess unit tests for the pure escaping and
upload filename validation helpers. The commit guide lists the remaining
manual/protocol reproductions.

**Test Results:**

- `webaccessescaping_test`
- `webaccessupload_test`

### Manual Testing Gaps

The escaping and upload filename changes have focused automated tests.
The WebSocket command-validation changes do not have an automated
regression test; reviewers can verify them by opening an
authenticated WebAccess session and sending the malformed commands
listed in the commit guide, then confirming QLC+ rejects them without
crashing or applying unauthorized Grand Master changes.

The NetworkManager argument change needs a suitable Wi-Fi setup for full
manual verification. A reviewer with that setup can configure an SSID
and WPA passphrase containing spaces and confirm they are passed to
NetworkManager unchanged.

## Additional Notes

The fixes are grouped because they all affect WebAccess. The commits are
kept separate so pointer validation, command validation, rendering
escaping and upload filename validation can be reviewed independently.

Each commit body contains the full rationale and reproduction details.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.