### PR TITLE
Fix QML null dereferences and VC component memory leak

### DIFF
--- a/qmlui/qml/FixtureConsole.qml
+++ b/qmlui/qml/FixtureConsole.qml
@@ -63,24 +63,34 @@ Rectangle
         for (var i = 0; i < values.length; i++)
         {
             //console.log("Value " + i + " = " + values[i]);
-            channelsRpt.itemAt(i).dmxValue = values[i]
+            var valueItem = channelsRpt.itemAt(i)
+            if (valueItem)
+                valueItem.dmxValue = values[i]
         }
         externalChange = false
     }
 
     function setChannelValue(channel, value)
     {
+        var channelItem = channelsRpt.itemAt(channel)
+        if (!channelItem)
+            return
+
         if (showEnablers == true)
-            channelsRpt.itemAt(channel).isEnabled = true
+            channelItem.isEnabled = true
         externalChange = true
-        channelsRpt.itemAt(channel).dmxValue = value
+        channelItem.dmxValue = value
         externalChange = false
     }
 
     function updateChannels()
     {
         for (var i = 0; i < channelsRpt.count; i++)
-            channelsRpt.itemAt(i).updateChannel()
+        {
+            var channelItem = channelsRpt.itemAt(i)
+            if (channelItem)
+                channelItem.updateChannel()
+        }
     }
 
     Column
@@ -311,4 +321,3 @@ Rectangle
         }
     }
 }
-

--- a/qmlui/qml/TreeNodeDelegate.qml
+++ b/qmlui/qml/TreeNodeDelegate.qml
@@ -55,6 +55,8 @@ Column
     function getItemAtPos(x, y)
     {
         var child = nodeChildrenView.itemAt(x, y)
+        if (!child || !child.item)
+            return null
         if (child.item.hasOwnProperty("nodePath"))
             return child.item.getItemAtPos(x, y - child.item.y)
 

--- a/qmlui/qml/fixturesfunctions/Fixture2DItem.qml
+++ b/qmlui/qml/fixturesfunctions/Fixture2DItem.qml
@@ -108,12 +108,17 @@ Rectangle
     function setHeadIntensity(headIndex, intensity)
     {
         //console.log("headIdx: " + headIndex + ", int: " + intensity)
-        headsRepeater.itemAt(headIndex).dimmerValue = intensity
+        var headItem = headsRepeater.itemAt(headIndex)
+        if (!headItem)
+            return
+        headItem.dimmerValue = intensity
     }
 
     function setHeadRGBColor(headIndex, color)
     {
         var headItem = headsRepeater.itemAt(headIndex)
+        if (!headItem)
+            return
         headItem.isWheelColor = false
         headItem.headColor1 = color
     }
@@ -121,7 +126,11 @@ Rectangle
     function setShutter(type, low, high)
     {
         for (var i = 0; i < headsRepeater.count; i++)
-            headsRepeater.itemAt(i).setShutter(type, low, high);
+        {
+            var headItem = headsRepeater.itemAt(i)
+            if (headItem)
+                headItem.setShutter(type, low, high)
+        }
     }
 
     function setPosition(pan, tilt)
@@ -138,6 +147,8 @@ Rectangle
     function setWheelColor(headIndex, col1, col2)
     {
         var headItem = headsRepeater.itemAt(headIndex)
+        if (!headItem)
+            return
         headItem.headColor1 = col1
         if (col2 !== Qt.rgba(0,0,0,1))
         {
@@ -148,10 +159,14 @@ Rectangle
 
     function setGoboPicture(headIndex, resource)
     {
+        var headItem = headsRepeater.itemAt(headIndex)
+        if (!headItem)
+            return
+
         if (Qt.platform.os === "android")
-            headsRepeater.itemAt(headIndex).goboSource = resource
+            headItem.goboSource = resource
         else
-            headsRepeater.itemAt(headIndex).goboSource = "file:/" + resource
+            headItem.goboSource = "file:/" + resource
     }
 
     Grid

--- a/qmlui/qml/fixturesfunctions/FixtureDMXItem.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureDMXItem.qml
@@ -37,7 +37,11 @@ Rectangle
         {
             //console.log("Value " + i + " = " + values[i]);
             if (fxColumn.visible === true)
-                channelsRpt.itemAt(i).dmxValue = values[i]
+            {
+                var valueItem = channelsRpt.itemAt(i)
+                if (valueItem)
+                    valueItem.dmxValue = values[i]
+            }
             else
                 consoleLoader.setValues(values)
         }
@@ -49,7 +53,11 @@ Rectangle
             consoleLoader.item.updateChannels()
 
         for (var i = 0; i < channelsRpt.count; i++)
-            channelsRpt.itemAt(i).updateChannel()
+        {
+            var channelItem = channelsRpt.itemAt(i)
+            if (channelItem)
+                channelItem.updateChannel()
+        }
     }
 
     width: fxColumn.visible ? channelsRow.width : consoleLoader.width
@@ -216,7 +224,9 @@ Rectangle
             function onValueChanged(fixtureID, chIndex, value)
             {
                 //console.log("Channel " + chIndex + " value changed " + value)
-                channelsRpt.itemAt(chIndex).dmxValue = value
+                var channelItem = channelsRpt.itemAt(chIndex)
+                if (channelItem)
+                    channelItem.dmxValue = value
             }
 
             function onRequestTool(item, fixtureID, chIndex, value)

--- a/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
@@ -57,6 +57,8 @@ Column
     function getItemAtPos(x, y)
     {
         var child = nodeChildrenView.itemAt(x, y)
+        if (!child || !child.item)
+            return null
         if (child.item.hasOwnProperty("nodePath"))
             return child.item.getItemAtPos(x, y - child.item.y)
 

--- a/qmlui/virtualconsole/vcanimation.cpp
+++ b/qmlui/virtualconsole/vcanimation.cpp
@@ -90,6 +90,11 @@ void VCAnimation::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create animation component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("animationObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcaudiotriggers.cpp
+++ b/qmlui/virtualconsole/vcaudiotriggers.cpp
@@ -117,6 +117,11 @@ void VCAudioTriggers::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create audio triggers component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("audioTriggerObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcbutton.cpp
+++ b/qmlui/virtualconsole/vcbutton.cpp
@@ -99,6 +99,11 @@ void VCButton::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create button component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("buttonObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcclock.cpp
+++ b/qmlui/virtualconsole/vcclock.cpp
@@ -103,6 +103,11 @@ void VCClock::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create clock component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("clockObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vccuelist.cpp
+++ b/qmlui/virtualconsole/vccuelist.cpp
@@ -101,6 +101,11 @@ void VCCueList::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create cue list component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("cueListObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcframe.cpp
+++ b/qmlui/virtualconsole/vcframe.cpp
@@ -105,6 +105,11 @@ void VCFrame::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create frame component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("frameObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vclabel.cpp
+++ b/qmlui/virtualconsole/vclabel.cpp
@@ -60,6 +60,11 @@ void VCLabel::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create label component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("labelObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcslider.cpp
+++ b/qmlui/virtualconsole/vcslider.cpp
@@ -157,6 +157,11 @@ void VCSlider::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create slider component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("sliderObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcsoloframe.cpp
+++ b/qmlui/virtualconsole/vcsoloframe.cpp
@@ -50,16 +50,21 @@ void VCSoloFrame::render(QQuickView *view, QQuickItem *parent)
         return;
     }
 
-    QQuickItem *item = qobject_cast<QQuickItem*>(component->create());
+    m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create solo frame component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
-    item->setParentItem(parent);
-    item->setProperty("isSolo", true);
-    item->setProperty("frameObj", QVariant::fromValue(this));
+    m_item->setParentItem(parent);
+    m_item->setProperty("isSolo", true);
+    m_item->setProperty("frameObj", QVariant::fromValue(this));
 
     if (m_pagesMap.count() > 0)
     {
         QString chName = QString("frameDropArea%1").arg(id());
-        QQuickItem *childrenArea = qobject_cast<QQuickItem*>(item->findChild<QObject *>(chName));
+        QQuickItem *childrenArea = qobject_cast<QQuickItem*>(m_item->findChild<QObject *>(chName));
 
         foreach (VCWidget *child, m_pagesMap.keys())
             child->render(view, childrenArea);

--- a/qmlui/virtualconsole/vcspeeddial.cpp
+++ b/qmlui/virtualconsole/vcspeeddial.cpp
@@ -113,6 +113,11 @@ void VCSpeedDial::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create speed dial component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("speedObj", QVariant::fromValue(this));

--- a/qmlui/virtualconsole/vcxypad.cpp
+++ b/qmlui/virtualconsole/vcxypad.cpp
@@ -154,6 +154,11 @@ void VCXYPad::render(QQuickView *view, QQuickItem *parent)
     }
 
     m_item = qobject_cast<QQuickItem*>(component->create());
+    if (m_item == nullptr)
+        qWarning() << Q_FUNC_INFO << "Unable to create XY pad component" << component->errors();
+    delete component;
+    if (m_item == nullptr)
+        return;
 
     m_item->setParentItem(parent);
     m_item->setProperty("xyPadObj", QVariant::fromValue(this));

--- a/qmlui/waveformimageprovider.cpp
+++ b/qmlui/waveformimageprovider.cpp
@@ -113,7 +113,8 @@ QImage WaveformImageProvider::requestImage(const QString &id,
     if (!ok || m_doc == nullptr)
         return QImage();
 
-    if (m_doc->function(fid)->type() != Function::AudioType)
+    Function *f = m_doc->function(fid);
+    if (f == nullptr || f->type() != Function::AudioType)
         return QImage();
 
     // 1) Try cache first


### PR DESCRIPTION
## Description

**Summary of Changes:**

This PR fixes QML null dereferences and a Virtual Console component
memory leak found while reviewing stale PR #1955 and adjacent QML code.

The changes handle stale waveform image IDs, release temporary
`QQmlComponent` objects after successful Virtual Console item creation,
and guard `Repeater.itemAt()` results before dereferencing delegates.
Valid QML item creation and fixture delegate updates continue to behave
as before.

## Commit Guide

| Commit | Origin | Reproduction / coverage |
|---|---|---|
| QML: handle stale waveform image ids | Independent finding | Reproduce by requesting `image://waveform/<invalid-id>` or keeping a stale waveform source after deleting the Audio function. |
| QML VC: release temporary components after render | Reported in PR #1955 | Reproduce by repeatedly recreating QML Virtual Console widget trees and observing heap growth with a leak checker or profiler. |
| QML: guard fixture delegate lookups | Reported in PR #1955 and derived while validating it | Reproduce by triggering fixture updates during delegate creation or hit-testing tree views over empty space. |

## Testing

**Automated Coverage:**

There is no existing unit test target for these QML runtime paths.
Manual verification steps are listed below.

### Manual Testing Gaps

Reviewers can smoke-test by opening QML Show Manager waveform previews
after deleting an Audio function, repeatedly rebuilding QML Virtual
Console widget trees while watching for retained temporary components,
and loading or switching fixture views while delegates are still being
created.

## Additional Notes

The fixes are grouped because they all address QML-side runtime
robustness without overlapping the WebAccess or Show Manager changes.

Each commit body contains the full rationale and reproduction details.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.