### PR TITLE
miscellaneous small improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(qlcplus VERSION 4.14.2 LANGUAGES C CXX)
+project(qlcplus VERSION 4.14.4 LANGUAGES C CXX)
 
 option(qmlui "Build for QLC+ 5 QML UI" OFF)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@
 ### QLC+ on social media
 
 [![Instagram](https://img.shields.io/badge/Instagram-%23E4405F.svg?style=flat-square&logo=Instagram)](https://www.instagram.com/qlcplus/) 
-[![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=flat-square&logo=YouTube)](https://www.youtube.com/watch?v=I9bccwcYQpM&list=PLHT-wIriuitDiW4A9oKSDr__Z_jcmMVdi) 
+[![YouTube (v4)](https://img.shields.io/badge/YouTube%20(v4)-%23FF0000.svg?style=flat-square&logo=YouTube)](https://www.youtube.com/playlist?list=PLHT-wIriuitDiW4A9oKSDr__Z_jcmMVdi) 
+[![YouTube (v5)](https://img.shields.io/badge/YouTube%20(v5)-%23FF0000.svg?style=flat-square&logo=YouTube)](https://www.youtube.com/playlist?list=PLHT-wIriuitBQo0DKX9YgWVmS6LsEErE_) 
 [![Facebook](https://img.shields.io/badge/Facebook-%231877F2.svg?style=flat-square&logo=Facebook)](https://www.facebook.com/qlcplus)
 
 ## Support & bug reports

--- a/engine/src/scriptv4.h
+++ b/engine/src/scriptv4.h
@@ -169,7 +169,6 @@ private:
 
 private:
     ScriptRunner *m_runner;
-    QList <int> m_syntaxErrorLines;
 };
 
 /** @} */

--- a/webaccess/res/webaccess-v5.js
+++ b/webaccess/res/webaccess-v5.js
@@ -1469,7 +1469,7 @@ function renderMatrix(widget) {
       const input = document.createElement("input");
       input.type = "color";
       input.className = "animation-color";
-      input.value = widget[c.key] || "#ffffff";
+      input.value = widget[c.key] || "#000000";
       input.addEventListener("input", () => {
         sendWidgetCommand(widget.id, c.cmd, input.value);
       });


### PR DESCRIPTION
This PR contains some improvements and fixes for minor issues that I have noticed over the last few months:

- engine/scriptv4: remove unused variable
While working on the fixes for the v5 scripts, I noticed that this variable is declared but never used. According to `git blame`, it is probably a leftover from when the v5 scripts were first implemented (July 2018).

- README: add link to the new v5 tutorials on YouTube
The new video tutorials for QLC+ 5 are a very good resource for all sorts of questions, especially as the written documentation is still a work in progress and because there are some noticeable workflow changes/improvements compared to v4. Simply referring to the relevant video has saved a lot of typing time in the forums. So why not mention it here as well?

- CMakeLists: update project version to 4.14.4
Up to commit 512d72e0a58ac9bbf0b130a9772e93b0eabe8679, this line used to be updated whenever a QLC+ version was released. However, this has not happened since June 2025 (commit mentioned above).

- webaccess-qml: change default colour of colour picker to black (as local UI does)
When an Animation widget is added, the not yet specified values are shown as black locally. In the web interface, however, the same widget elements are white by default.