### PR TITLE
engine/scene,ui/sceneditor: implement fixture reordering

### DIFF
--- a/engine/src/scene.cpp
+++ b/engine/src/scene.cpp
@@ -364,12 +364,28 @@ void Scene::slotFixtureRemoved(quint32 fxi_id)
 void Scene::addFixture(quint32 fixtureId)
 {
     if (m_fixtures.contains(fixtureId) == false)
+    {
         m_fixtures.append(fixtureId);
+        emit changed(this->id());
+    }
 }
 
 bool Scene::removeFixture(quint32 fixtureId)
 {
-    return m_fixtures.removeOne(fixtureId);
+    bool result = m_fixtures.removeOne(fixtureId);
+    emit changed(this->id());
+    return result;
+}
+
+bool Scene::moveFixture(int from, int to)
+{
+    const int length = m_fixtures.count();
+    if ((from < 0) || (to < 0) || (from >= length) || (to >= length))
+        return false;
+
+    m_fixtures.move(from, to);
+    emit changed(this->id());
+    return true;
 }
 
 QList<quint32> Scene::fixtures() const

--- a/engine/src/scene.h
+++ b/engine/src/scene.h
@@ -197,6 +197,7 @@ public slots:
 public:
     void addFixture(quint32 fixtureId);
     bool removeFixture(quint32 fixtureId);
+    bool moveFixture(int from, int to);
     QList<quint32> fixtures() const;
 
 private:

--- a/ui/src/sceneeditor.cpp
+++ b/ui/src/sceneeditor.cpp
@@ -309,6 +309,10 @@ void SceneEditor::init(bool applyValues)
             this, SLOT(slotAddFixtureClicked()));
     connect(m_removeFixtureButton, SIGNAL(clicked()),
             this, SLOT(slotRemoveFixtureClicked()));
+    connect(m_moveFixtureUpButton, SIGNAL(clicked()),
+            this, SLOT(slotMoveFixtureUpClicked()));
+    connect(m_moveFixtureDownButton, SIGNAL(clicked()),
+            this, SLOT(slotMoveFixtureDownClicked()));
 
     m_nameEdit->setText(m_scene->name());
     m_nameEdit->setSelection(0, m_nameEdit->text().length());
@@ -1326,6 +1330,73 @@ void SceneEditor::slotRemoveFixtureClicked()
             m_scene->removeFixture(fixture->id());
         }
     }
+}
+
+void SceneEditor::moveFixture(int offset)
+{
+    if ((m_tree == NULL) || (m_scene == NULL) || (offset == 0))
+        return;
+
+    QListIterator<QTreeWidgetItem*> it(m_tree->selectedItems());
+    if (!it.hasNext())
+        return;
+
+    QTreeWidgetItem* item = it.next();
+    if (item == NULL)
+        return;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QModelIndex modelIndex = m_tree->indexFromItem(item);
+#else
+    m_tree->setCurrentItem(item);
+    const QModelIndex modelIndex = m_tree->currentIndex();
+#endif
+    int row = modelIndex.row();
+    if (!m_scene->moveFixture(row, row+offset))
+        return;
+
+    m_tree->takeTopLevelItem(row);
+    m_tree->insertTopLevelItem(row+offset, item);
+    m_tree->setCurrentItem(item);
+
+    const QVariant tabMode = m_scene->uiStateValue(UI_STATE_TAB_MODE);
+    if (m_tab == NULL)
+        return;
+
+    if (tabMode.isNull() || (tabMode.toInt() == UI_STATE_TABBED_FIXTURES))
+    {
+        QTabBar* tabBar = m_tab->tabBar();
+        if (tabBar == NULL)
+            return;
+
+        const int from = m_fixtureFirstTabIndex + row;
+        tabBar->moveTab(from, from+offset);
+    } else {
+        QScrollArea* area = qobject_cast<QScrollArea*>(m_tab->widget(m_fixtureFirstTabIndex));
+        if (area == NULL)
+            return;
+
+        QGroupBox* grpBox = qobject_cast<QGroupBox*>(area->widget());
+        if (grpBox == NULL)
+            return;
+
+        QHBoxLayout* fixturesLayout = qobject_cast<QHBoxLayout*>(grpBox->layout());
+        if (fixturesLayout == NULL)
+            return;
+
+        QLayoutItem* console = fixturesLayout->takeAt(row);
+        fixturesLayout->insertItem(row+offset, console);
+    }
+}
+
+void SceneEditor::slotMoveFixtureUpClicked()
+{
+    moveFixture(-1);
+}
+
+void SceneEditor::slotMoveFixtureDownClicked()
+{
+    moveFixture(1);
 }
 
 void SceneEditor::slotEnableAll()

--- a/ui/src/sceneeditor.h
+++ b/ui/src/sceneeditor.h
@@ -141,11 +141,14 @@ private:
 
     bool addFixtureItem(Fixture* fixture);
     void removeFixtureItem(quint32 fixtureID);
+    void moveFixture(int offset);
 
 private slots:
     void slotNameEdited(const QString& name);
     void slotAddFixtureClicked();
     void slotRemoveFixtureClicked();
+    void slotMoveFixtureUpClicked();
+    void slotMoveFixtureDownClicked();
 
     void slotEnableAll();
     void slotDisableAll();

--- a/ui/src/sceneeditor.ui
+++ b/ui/src/sceneeditor.ui
@@ -57,7 +57,7 @@
       <number>0</number>
      </property>
      <property name="elideMode">
-      <enum>Qt::ElideMiddle</enum>
+      <enum>Qt::TextElideMode::ElideMiddle</enum>
      </property>
      <widget class="QWidget" name="General">
       <attribute name="title">
@@ -67,10 +67,10 @@
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="9" column="3" rowspan="5">
+       <item row="9" column="3" rowspan="6">
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -131,7 +131,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="1" rowspan="7">
+       <item row="7" column="1" rowspan="8">
         <widget class="QTreeWidget" name="m_tree">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -143,7 +143,7 @@
           <bool>true</bool>
          </property>
          <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
          </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
@@ -181,7 +181,41 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="2" rowspan="7">
+       <item row="9" column="0">
+        <widget class="QToolButton" name="m_moveFixtureUpButton">
+         <property name="toolTip">
+          <string>Move the selected fixture up in the list</string>
+         </property>
+         <property name="icon">
+          <iconset resource="qlcui.qrc">
+           <normaloff>:/up.png</normaloff>:/up.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>22</width>
+           <height>22</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QToolButton" name="m_moveFixtureDownButton">
+         <property name="toolTip">
+          <string>Move the selected fixture down in the list</string>
+         </property>
+         <property name="icon">
+          <iconset resource="qlcui.qrc">
+           <normaloff>:/down.png</normaloff>:/down.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>22</width>
+           <height>22</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="2" rowspan="8">
         <widget class="QTreeWidget" name="m_channelGroupsTree">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -193,7 +227,7 @@
           <bool>true</bool>
          </property>
          <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
          </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
@@ -211,14 +245,14 @@
          </column>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="11" column="0">
         <widget class="Line" name="line">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="13" column="0">
         <widget class="QToolButton" name="m_disableChannelsButton">
          <property name="toolTip">
           <string>Disable all fixtures' channels</string>
@@ -235,7 +269,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="12" column="0">
         <widget class="QToolButton" name="m_enableChannelsButton">
          <property name="toolTip">
           <string>Enable all fixtures' channels</string>
@@ -252,10 +286,10 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0" rowspan="2">
+       <item row="14" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>


### PR DESCRIPTION
_I’ve often wished I had this feature myself, and recently https://www.qlcplus.org/forum/viewtopic.php?t=19647 motivated me to give implementing it a go._

**To Reproduce**
1. Open QLC+ v4 with an empty workspace.
2. Add two fixture (for example, two `Generic Dimmer`s).
3. Create a scene with both fixtures.
4. There is no way to change the order of the fixtures, which is helpful for maintaining an overview, especially when fixtures are added after the scene has been created.

**Proposed Solutions**
The fixtures added to a scene are stored in `QList<quint32> m_fixtures` within the `Scene` class (more specifically, in objects of this class). Generally, newly added fixtures are appended to the end of the list. Therefore, the list (which also determines the order of the fixtures in the UI) is usually sorted in the order in which the fixtures were added.

However, this list can be easily reordered using the ` void QList::move(qsizetype from, qsizetype to)` function. This has no effect on internal data structures, as these all map fixture values to the fixture ID rather than their index in the `m_fixtures` list.

Finally, the user interface must be updated, namely the list on the `General` page as well as the tabs for the individual fixtures or the fixture consoles on the `All fixtures` page, respectively.

Furthermore, buttons to trigger those movements have been added to the sceneeditor.
The `Scene` class now also emits `changed` when fixtures are added or removed, in addition to when they are moved.

**Note:** To keep it simple and reliable, only one fixture can be moved at a time. Even if multiple fixtures are selected, only the first one is moved.