### PR TITLE
Add qtbase translations

### DIFF
--- a/create-exe.sh
+++ b/create-exe.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # remove uneeded stuff
-rm -rf generic networkinformation qmltooling renderplugins tls translations
+rm -rf generic networkinformation qmltooling renderplugins tls
 
 
 # Create Installer

--- a/platforms/windows/qlcplus4Qt5.nsi
+++ b/platforms/windows/qlcplus4Qt5.nsi
@@ -98,6 +98,7 @@ Section
 	File /r ModifiersTemplates
 	File /r Plugins
 	File /r RGBScripts
+	File /r translations
 	File /r Web
 
 	WriteRegStr HKCR ".qxw" "" "QLightControllerPlus.Document"
@@ -139,6 +140,7 @@ Section "Uninstall"
 	RMDir /r $INSTDIR\ModifiersTemplates
 	RMDir /r $INSTDIR\Plugins
 	RMDir /r $INSTDIR\RGBScripts
+	RMDir /r $INSTDIR\translations
 	RMDir /r $INSTDIR\Web
 
 	RMDir $INSTDIR

--- a/platforms/windows/qlcplus4Qt6.nsi
+++ b/platforms/windows/qlcplus4Qt6.nsi
@@ -97,6 +97,7 @@ Section
 	File /r ModifiersTemplates
 	File /r Plugins
 	File /r RGBScripts
+	File /r translations
 	File /r Web
 
 	WriteRegStr HKCR ".qxw" "" "QLightControllerPlus.Document"
@@ -137,6 +138,7 @@ Section "Uninstall"
 	RMDir /r $INSTDIR\ModifiersTemplates
 	RMDir /r $INSTDIR\Plugins
 	RMDir /r $INSTDIR\RGBScripts
+	RMDir /r $INSTDIR\translations
 	RMDir /r $INSTDIR\Web
 
 	RMDir $INSTDIR

--- a/platforms/windows/qlcplus5Qt6.nsi
+++ b/platforms/windows/qlcplus5Qt6.nsi
@@ -124,6 +124,7 @@ Section
 	File /r ModifiersTemplates
 	File /r Plugins
 	File /r RGBScripts
+	File /r translations
 	File /r Web
 
 	WriteRegStr HKCU "SOFTWARE\qlcplus" "Install_Dir" "$INSTDIR"
@@ -159,6 +160,7 @@ Section "Uninstall"
 	RMDir /r $INSTDIR\ModifiersTemplates
 	RMDir /r $INSTDIR\Plugins
 	RMDir /r $INSTDIR\RGBScripts
+	RMDir /r $INSTDIR\translations
 	RMDir /r $INSTDIR\Web
 
 	RMDir $INSTDIR

--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -289,7 +289,7 @@ void App::setLanguage(QString locale)
     if (m_translator->load(file, translationPath) == true)
         QCoreApplication::installTranslator(m_translator);
 
-    QString file_base(QString("%1_%2").arg("qtbase").arg(locale));
+    QString file_base(QString("%1_%2").arg("qt").arg(locale));
     m_translator_base = new QTranslator(QCoreApplication::instance());
     if (m_translator_base->load(file_base, QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
         QCoreApplication::installTranslator(m_translator_base);

--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -79,6 +79,7 @@ App::App()
     , m_accessMask(defaultMask())
     , m_is3dSupported(true)
     , m_translator(nullptr)
+    , m_translator_base(nullptr)
     , m_fixtureBrowser(nullptr)
     , m_fixtureManager(nullptr)
     , m_contextManager(nullptr)
@@ -272,6 +273,11 @@ void App::setLanguage(QString locale)
         QCoreApplication::removeTranslator(m_translator);
         delete m_translator;
     }
+    if (m_translator_base != nullptr)
+    {
+        QCoreApplication::removeTranslator(m_translator_base);
+        delete m_translator_base;
+    }
 
     QString translationPath = QLCFile::systemDirectory(TRANSLATIONDIR).absolutePath();
 
@@ -283,8 +289,10 @@ void App::setLanguage(QString locale)
     if (m_translator->load(file, translationPath) == true)
         QCoreApplication::installTranslator(m_translator);
 
-    if (m_translator->load(QString("%1_%2").arg("qtbase").arg(locale), QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
-        QCoreApplication::installTranslator(m_translator);
+    QString file_base(QString("%1_%2").arg("qtbase").arg(locale));
+    m_translator_base = new QTranslator(QCoreApplication::instance());
+    if (m_translator_base->load(file_base, QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
+        QCoreApplication::installTranslator(m_translator_base);
     }
 
     QSettings settings;

--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -26,6 +26,7 @@
 #include <QOpenGLContext>
 #include <QPrintDialog>
 #include <QApplication>
+#include <QLibraryInfo>
 #include <QTranslator>
 #include <QQmlContext>
 #include <QQuickItem>
@@ -281,6 +282,10 @@ void App::setLanguage(QString locale)
     m_translator = new QTranslator(QCoreApplication::instance());
     if (m_translator->load(file, translationPath) == true)
         QCoreApplication::installTranslator(m_translator);
+
+    if (m_translator->load(QString("%1_%2").arg("qtbase").arg(locale), QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
+        QCoreApplication::installTranslator(m_translator);
+    }
 
     QSettings settings;
     settings.setValue(SETTINGS_LANGUAGE, locale);

--- a/qmlui/app.h
+++ b/qmlui/app.h
@@ -220,6 +220,7 @@ private:
     bool m_is3dSupported;
 
     QTranslator *m_translator;
+    QTranslator *m_translator_base;
 
     FixtureBrowser *m_fixtureBrowser;
     FixtureManager *m_fixtureManager;


### PR DESCRIPTION
<!--
Thank you for contributing to QLC+!

Please ensure your code changes adhere to the project's standards and guidelines to facilitate a smooth review process.
-->

## Description

**Summary of Changes:**
Added loading of qtbase translation files in order to translate e.g. dialog standard buttons like Yes, No and Cancel, which are only displayed in English otherwise:
<img width="1515" height="974" alt="Bildschirmfoto vom 2026-05-25 20-13-36" src="https://github.com/user-attachments/assets/66d1ee76-17b3-4cb4-961b-f66982ac1884" />


## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [x] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
<!-- Describe the test cases you have implemented or run to verify your changes. -->

**Test Results:**
<!-- Provide the results of your testing, including any screenshots or logs if applicable. -->

## Additional Notes