### PR TITLE
main: add qtbase translations

### DIFF
--- a/engine/src/qlci18n.cpp
+++ b/engine/src/qlci18n.cpp
@@ -23,6 +23,7 @@
 #include <QString>
 #include <QDebug>
 #include <QDir>
+#include <QLibraryInfo>
 
 #include "qlcconfig.h"
 #include "qlcfile.h"
@@ -59,14 +60,8 @@ QString QLCi18n::translationFilePath()
 
 bool QLCi18n::loadTranslation(const QString& component)
 {
-    QString lc;
-
-    if (defaultLocale().isEmpty() == true)
-        lc = QLocale::system().name();
-    else
-        lc = defaultLocale();
-
-    QString file(QString("%1_%2").arg(component).arg(lc));
+    const QString lc = defaultLocale().isEmpty() ? QLocale::system().name() : defaultLocale();
+    const QString file(QString("%1_%2").arg(component).arg(lc));
     QTranslator* translator = new QTranslator(QCoreApplication::instance());
     if (translator->load(file, translationFilePath()) == true)
     {
@@ -77,4 +72,21 @@ bool QLCi18n::loadTranslation(const QString& component)
     {
         return false;
     }
+}
+
+bool QLCi18n::loadQtTranslation(const QString& component)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const QString qtTranslationsPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#else
+    const QString qtTranslationsPath = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+#endif
+
+    const QString lc = defaultLocale().isEmpty() ? QLocale::system().name() : defaultLocale();
+    const QString file(QString("%1_%2").arg(component).arg(lc));
+    QTranslator* qtTranslator = new QTranslator(QCoreApplication::instance());
+    if (qtTranslator->load(file, qtTranslationsPath))
+        return QCoreApplication::installTranslator(qtTranslator);
+    else
+        return false;
 }

--- a/engine/src/qlci18n.h
+++ b/engine/src/qlci18n.h
@@ -55,6 +55,7 @@ public:
      * @return true if translation was loaded successfully, otherwise false
      */
     static bool loadTranslation(const QString& component);
+    static bool loadQtTranslation(const QString& component);
 
 private:
     static QString s_defaultLocale;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -328,6 +328,11 @@ int main(int argc, char** argv)
 
     /* Load translation for main application */
     QLCi18n::loadTranslation("qlcplus");
+#if defined(Q_OS_MACOS)
+    QLCi18n::loadTranslation("qtbase");
+#else
+    QLCi18n::loadQtTranslation("qt");
+#endif
 
     /* Handle debug messages */
     qInstallMessageHandler(qlcMessageHandler);


### PR DESCRIPTION
_follow-up to #2035_

As mentioned in #2035, I had already implemented the changes of that PR for QLC+ 4.

Since that PR already changed the v4 installer accordingly, this PR only needs to add the code to load the Qt translation files.

I also added the case distinction between operating systems (macOS vs. non-macOS) from 87a7cdedc00b01cf9f882176d1194d38229bcc43, but I am unable to test this due to the lack of such hardware.