### PR TITLE
plugins: restore Qt5 compatibility

### DIFF
--- a/plugins/interfaces/qlcioplugin.cpp
+++ b/plugins/interfaces/qlcioplugin.cpp
@@ -45,7 +45,14 @@ QStringList QLCIOPlugin::outputs()
 
 QStringList QLCIOPlugin::outputsUID()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     return QStringList(outputs().count(), QString());
+#else
+    QStringList result;
+    for (int i = 0; i < outputs().count(); i++)
+        result << QString();
+    return result;
+#endif
 }
 
 QString QLCIOPlugin::outputInfo(quint32 output)
@@ -86,7 +93,14 @@ QStringList QLCIOPlugin::inputs()
 
 QStringList QLCIOPlugin::inputsUID()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     return QStringList(inputs().count(), QString());
+#else
+    QStringList result;
+    for (int i = 0; i < inputs().count(); i++)
+        result << QString();
+    return result;
+#endif
 }
 
 QString QLCIOPlugin::inputInfo(quint32 input)


### PR DESCRIPTION
From time to time, I run QLC+ 4 builds on a Qt5 Ubuntu machine to ensure backwards compatibility with this legacy version of Qt.

In doing so, I noticed that `plugins/interfaces/qlcioplugin.cpp` fails to compile due to the recently added `QStringList QLCIOPlugin::outputsUID()` and `QStringList QLCIOPlugin::inputsUID()` functions (695413170a2d1658db1ff7127edfd725e2038c77).

These methods use the [`QList::QList(qsizetype size, QList<T>::parameter_type value)`](https://doc.qt.io/qt-6/qlist.html#QList-6) constructor to initialise the return value, which is apparently not present in Qt5.

```
error: no matching function for call to ‘QStringList::QStringList(int, QString)’
```

This PR fixes the issue described by manually implementing the functionality if QLC+ is compiled with a Qt version < 6.0.