### PR TITLE
Add beamZ Partybar 2 and 3 fixture definitions

### DIFF
--- a/resources/fixtures/beamZ/beamZ-Partybar-2.qxf
+++ b/resources/fixtures/beamZ/beamZ-Partybar-2.qxf
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Custom fixture definition for BeamZ PartyBar2</Name>
+  <Version>1.1</Version>
+  <Author>Joel Solomons</Author>
+ </Creator>
+
+ <Manufacturer>BeamZ</Manufacturer>
+ <Model>PartyBar2</Model>
+ <Type>Effect</Type>
+
+ <Channel Name="Derby 1 Red" Preset="IntensityRed"/>
+ <Channel Name="Derby 1 Green" Preset="IntensityGreen"/>
+ <Channel Name="Derby 1 Blue" Preset="IntensityBlue"/>
+ <Channel Name="Derby 1 White" Preset="IntensityWhite"/>
+
+ <Channel Name="Derby 1 Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Derby 1 speed</Capability>
+ </Channel>
+
+ <Channel Name="PARs Red" Preset="IntensityRed"/>
+ <Channel Name="PARs Green" Preset="IntensityGreen"/>
+ <Channel Name="PARs Blue" Preset="IntensityBlue"/>
+ <Channel Name="PARs White" Preset="IntensityWhite"/>
+
+ <Channel Name="Derby 2 Red" Preset="IntensityRed"/>
+ <Channel Name="Derby 2 Green" Preset="IntensityGreen"/>
+ <Channel Name="Derby 2 Blue" Preset="IntensityBlue"/>
+ <Channel Name="Derby 2 White" Preset="IntensityWhite"/>
+
+ <Channel Name="Derby 2 Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Derby 2 speed</Capability>
+ </Channel>
+
+ <Channel Name="Strobe Speed">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="9">No strobe</Capability>
+  <Capability Min="10" Max="255" Preset="StrobeSlowToFast">Strobe slow to fast</Capability>
+ </Channel>
+
+ <Mode Name="15-channel">
+  <Channel Number="0">Derby 1 Red</Channel>
+  <Channel Number="1">Derby 1 Green</Channel>
+  <Channel Number="2">Derby 1 Blue</Channel>
+  <Channel Number="3">Derby 1 White</Channel>
+  <Channel Number="4">Derby 1 Speed</Channel>
+  <Channel Number="5">PARs Red</Channel>
+  <Channel Number="6">PARs Green</Channel>
+  <Channel Number="7">PARs Blue</Channel>
+  <Channel Number="8">PARs White</Channel>
+  <Channel Number="9">Derby 2 Red</Channel>
+  <Channel Number="10">Derby 2 Green</Channel>
+  <Channel Number="11">Derby 2 Blue</Channel>
+  <Channel Number="12">Derby 2 White</Channel>
+  <Channel Number="13">Derby 2 Speed</Channel>
+  <Channel Number="14">Strobe Speed</Channel>
+ </Mode>
+
+ <Physical>
+  <Bulb Type="2 PAR cans with RGBW LEDs and 2 Derby effects with RGBW LEDs" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="7.15" Width="920" Height="390" Depth="190"/>
+  <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical DmxConnector="3-pin" PowerConsumption="100"/>
+ </Physical>
+</FixtureDefinition>

--- a/resources/fixtures/beamZ/beamZ-Partybar-2.qxf
+++ b/resources/fixtures/beamZ/beamZ-Partybar-2.qxf
@@ -36,8 +36,8 @@
   <Capability Min="0" Max="255">Derby 2 speed</Capability>
  </Channel>
 
- <Channel Name="Strobe Speed">
-  <Group Byte="0">Shutter</Group>
+<Channel Name="Strobe Speed">
+  <Group Byte="0">Speed</Group>
   <Capability Min="0" Max="9">No strobe</Capability>
   <Capability Min="10" Max="255" Preset="StrobeSlowToFast">Strobe slow to fast</Capability>
  </Channel>

--- a/resources/fixtures/beamZ/beamZ-Partybar-3.qxf
+++ b/resources/fixtures/beamZ/beamZ-Partybar-3.qxf
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Custom fixture definition for BeamZ PartyBar 3</Name>
+  <Version>1.1</Version>
+  <Author>Joel Solomons</Author>
+ </Creator>
+
+ <Manufacturer>BeamZ</Manufacturer>
+ <Model>PartyBar 3</Model>
+ <Type>Color Changer</Type>
+
+ <!--
+  BeamZ PartyBar 3 custom 8-channel definition.
+
+  Channel layout:
+   1: Macro Select
+   2: Colour Macro
+   3: Speed
+   4: Master Dimmer
+   5: Red Dimmer
+   6: Green Dimmer
+   7: Blue Dimmer
+   8: Magic Ball Dimmer
+
+  For manual RGB mixing, use:
+   Macro Select: 0
+   Colour Macro: 0
+   Speed: 0
+   Master Dimmer: 255
+   Red/Green/Blue: as required
+   Magic Ball Dimmer: 0 or 255 depending on whether you want the balls active
+ -->
+
+ <Channel Name="Macro Select">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="10">Manual RGB mode / no function</Capability>
+  <Capability Min="11" Max="50">Static colour macro mode</Capability>
+  <Capability Min="51" Max="100">Colour jump mode</Capability>
+  <Capability Min="101" Max="150">Colour fade mode</Capability>
+  <Capability Min="151" Max="200">Sound-activated mode</Capability>
+  <Capability Min="201" Max="255">Strobe all colours</Capability>
+ </Channel>
+
+ <Channel Name="Colour Macro">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="0">No colour macro / use RGB channels</Capability>
+  <Capability Min="1" Max="15">Red</Capability>
+  <Capability Min="16" Max="30">Green</Capability>
+  <Capability Min="31" Max="45">Blue</Capability>
+  <Capability Min="46" Max="60">Yellow</Capability>
+  <Capability Min="61" Max="75">Cyan</Capability>
+  <Capability Min="76" Max="90">Magenta</Capability>
+  <Capability Min="91" Max="105">White</Capability>
+  <Capability Min="106" Max="120">Amber</Capability>
+  <Capability Min="121" Max="135">Purple</Capability>
+  <Capability Min="136" Max="150">Hot pink</Capability>
+  <Capability Min="151" Max="165">Orange</Capability>
+  <Capability Min="166" Max="180">Lime</Capability>
+  <Capability Min="181" Max="195">Sky blue</Capability>
+  <Capability Min="196" Max="210">Warm white approximation</Capability>
+  <Capability Min="211" Max="225">Cool white approximation</Capability>
+  <Capability Min="226" Max="240">Pastel colour macro</Capability>
+  <Capability Min="241" Max="255">Full colour macro / rainbow</Capability>
+ </Channel>
+
+ <Channel Name="Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="0">Stopped / no speed</Capability>
+  <Capability Min="1" Max="63">Slow speed</Capability>
+  <Capability Min="64" Max="127">Medium speed</Capability>
+  <Capability Min="128" Max="191">Fast speed</Capability>
+  <Capability Min="192" Max="255">Very fast speed</Capability>
+ </Channel>
+
+ <Channel Name="Master Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="0">Blackout</Capability>
+  <Capability Min="1" Max="255">Master dimmer, dark to bright</Capability>
+ </Channel>
+
+ <Channel Name="Red Dimmer">
+  <Group Byte="0">Colour</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="0">Red off</Capability>
+  <Capability Min="1" Max="255">Red intensity, dark to bright</Capability>
+ </Channel>
+
+ <Channel Name="Green Dimmer">
+  <Group Byte="0">Colour</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="0">Green off</Capability>
+  <Capability Min="1" Max="255">Green intensity, dark to bright</Capability>
+ </Channel>
+
+ <Channel Name="Blue Dimmer">
+  <Group Byte="0">Colour</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="0">Blue off</Capability>
+  <Capability Min="1" Max="255">Blue intensity, dark to bright</Capability>
+ </Channel>
+
+ <Channel Name="Magic Ball Dimmer">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="0">Magic Balls off</Capability>
+  <Capability Min="1" Max="255">Magic Ball intensity, dark to bright</Capability>
+ </Channel>
+
+ <Mode Name="8-channel">
+  <Channel Number="0">Macro Select</Channel>
+  <Channel Number="1">Colour Macro</Channel>
+  <Channel Number="2">Speed</Channel>
+  <Channel Number="3">Master Dimmer</Channel>
+  <Channel Number="4">Red Dimmer</Channel>
+  <Channel Number="5">Green Dimmer</Channel>
+  <Channel Number="6">Blue Dimmer</Channel>
+  <Channel Number="7">Magic Ball Dimmer</Channel>
+ </Mode>
+
+ <Physical>
+  <Bulb Type="4 PAR cans with RGB LEDs and 4 Magic Balls with RGB LEDs" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="3.0" Width="735" Height="210" Depth="90"/>
+  <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical DmxConnector="3-pin" PowerConsumption="85"/>
+ </Physical>
+</FixtureDefinition>

--- a/resources/fixtures/beamZ/beamZ-Partybar-3.qxf
+++ b/resources/fixtures/beamZ/beamZ-Partybar-3.qxf
@@ -11,28 +11,6 @@
  <Model>PartyBar 3</Model>
  <Type>Color Changer</Type>
 
- <!--
-  BeamZ PartyBar 3 custom 8-channel definition.
-
-  Channel layout:
-   1: Macro Select
-   2: Colour Macro
-   3: Speed
-   4: Master Dimmer
-   5: Red Dimmer
-   6: Green Dimmer
-   7: Blue Dimmer
-   8: Magic Ball Dimmer
-
-  For manual RGB mixing, use:
-   Macro Select: 0
-   Colour Macro: 0
-   Speed: 0
-   Master Dimmer: 255
-   Red/Green/Blue: as required
-   Magic Ball Dimmer: 0 or 255 depending on whether you want the balls active
- -->
-
  <Channel Name="Macro Select">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="10">Manual RGB mode / no function</Capability>
@@ -81,21 +59,21 @@
  </Channel>
 
  <Channel Name="Red Dimmer">
-  <Group Byte="0">Colour</Group>
+  <Group Byte="0">Intensity</Group>
   <Colour>Red</Colour>
   <Capability Min="0" Max="0">Red off</Capability>
   <Capability Min="1" Max="255">Red intensity, dark to bright</Capability>
  </Channel>
 
  <Channel Name="Green Dimmer">
-  <Group Byte="0">Colour</Group>
+  <Group Byte="0">Intensity</Group>
   <Colour>Green</Colour>
   <Capability Min="0" Max="0">Green off</Capability>
   <Capability Min="1" Max="255">Green intensity, dark to bright</Capability>
  </Channel>
 
  <Channel Name="Blue Dimmer">
-  <Group Byte="0">Colour</Group>
+  <Group Byte="0">Intensity</Group>
   <Colour>Blue</Colour>
   <Capability Min="0" Max="0">Blue off</Capability>
   <Capability Min="1" Max="255">Blue intensity, dark to bright</Capability>


### PR DESCRIPTION
## Fixture Information

**Manufacturer:**  
BeamZ

**Model:**  
PartyBar2  
PartyBar 3

**Mode(s) included:**  
15-channel (PartyBar2)  
8-channel (PartyBar 3)

**Channels used:**  
15 (PartyBar2)  
8 (PartyBar 3)

## Testing

- [x] Physical data is included 
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly


## Source(s) of Information

User manual (partybar 3) and direct testing (partybar 2). 


## Notes

Includes two fixture definitions:

- **PartyBar2 (15-channel):** Separate control of Derby 1, Derby 2, 2x PARs, plus strobe channel. 
- **PartyBar 3 (8-channel):** Layout with macro control, RGB dimming, and magic ball intensity. 
