### PR TITLE
engine: fix beat tracker integration and add comb-ACF tempo tracker (issue #1881)

### DIFF
--- a/engine/audio/src/CMakeLists.txt
+++ b/engine/audio/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(${module_name}
     audioplugincache.cpp audioplugincache.h
     audiorenderer.cpp audiorenderer.h
     beattracker.cpp beattracker.h
+    beattrackerauto.cpp beattrackerauto.h
     beattracking.cpp beattracking.h
 )
 set_property(TARGET ${module_name} PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/engine/audio/src/audiocapture.cpp
+++ b/engine/audio/src/audiocapture.cpp
@@ -24,7 +24,9 @@
 #include <qmath.h>
 
 #include "audiocapture.h"
-#ifdef NEW_TRACKER
+#if defined(AUTO_TRACKER)
+  #include "beattrackerauto.h"
+#elif defined(NEW_TRACKER)
   #include "beattracker.h"
 #else
   #include "beattracking.h"
@@ -78,13 +80,16 @@ AudioCapture::AudioCapture (QObject* parent)
     m_plan_forward = fftw_plan_dft_r2c_1d(m_bufferSize, m_fftInputBuffer,
                                           reinterpret_cast<fftw_complex*>(m_fftOutputBuffer), 0);
 #endif
- #ifdef NEW_TRACKER
+ #if defined(AUTO_TRACKER)
+    m_beatTracker = new BeatTrackerAuto(m_sampleRate, m_channels);
+    m_lastTrackerBpm = 0;
+ #elif defined(NEW_TRACKER)
     m_beatTracker = new BeatTracker(m_sampleRate, m_bufferSize, m_channels, 86, 1.3);
     m_beatTracker->setBand(40.0, 400.0);      // bit wider band for now
     m_beatTracker->setFluxSmoothing(0.6);     // less smoothing
     m_beatTracker->setMinBeatInterval(0.20);  // ~300 BPM max
  #else
-    m_beatTracker = new BeatTracking(2);
+    m_beatTracker = new BeatTracking(m_sampleRate, m_channels);
  #endif
 }
 
@@ -93,6 +98,7 @@ AudioCapture::~AudioCapture()
     // stop() has to be called from the implementation class
     Q_ASSERT(!this->isRunning());
 
+    delete m_beatTracker;
     delete[] m_audioBuffer;
     delete[] m_audioMixdown;
     delete[] m_fftInputBuffer;
@@ -360,6 +366,14 @@ void AudioCapture::run()
 
                 if (m_beatTracker->processAudio(m_audioBuffer, m_captureSize))
                     emit beatDetected();
+#ifdef AUTO_TRACKER
+                int bpm = qRound(m_beatTracker->bpm());
+                if (bpm != m_lastTrackerBpm)
+                {
+                    m_lastTrackerBpm = bpm;
+                    emit beatBpmChanged(bpm);
+                }
+#endif
             }
             else
             {

--- a/engine/audio/src/audiocapture.cpp
+++ b/engine/audio/src/audiocapture.cpp
@@ -82,7 +82,6 @@ AudioCapture::AudioCapture (QObject* parent)
 #endif
  #if defined(AUTO_TRACKER)
     m_beatTracker = new BeatTrackerAuto(m_sampleRate, m_channels);
-    m_lastTrackerBpm = 0;
  #elif defined(NEW_TRACKER)
     m_beatTracker = new BeatTracker(m_sampleRate, m_bufferSize, m_channels, 86, 1.3);
     m_beatTracker->setBand(40.0, 400.0);      // bit wider band for now
@@ -365,15 +364,15 @@ void AudioCapture::run()
                 processData();
 
                 if (m_beatTracker->processAudio(m_audioBuffer, m_captureSize))
-                    emit beatDetected();
-#ifdef AUTO_TRACKER
-                int bpm = qRound(m_beatTracker->bpm());
-                if (bpm != m_lastTrackerBpm)
                 {
-                    m_lastTrackerBpm = bpm;
-                    emit beatBpmChanged(bpm);
-                }
+#if defined(AUTO_TRACKER)
+                    emit beatDetected(qRound(m_beatTracker->bpm()));
+#elif defined(NEW_TRACKER)
+                    emit beatDetected(qRound(m_beatTracker->getCurrentBpm()));
+#else
+                    emit beatDetected(qRound(m_beatTracker->currentBpm()));
 #endif
+                }
             }
             else
             {

--- a/engine/audio/src/audiocapture.h
+++ b/engine/audio/src/audiocapture.h
@@ -44,9 +44,19 @@
 #define SPECTRUM_MIN_FREQUENCY          40
 #define SPECTRUM_MAX_FREQUENCY          5000
 
+/** Beat tracker implementation selection (issue #1881 work):
+ *  AUTO_TRACKER: multi-band onset front end + comb-scored ACF estimator,
+ *                ported from QLCplusShowCreator (benchmarked: 64/64 on the
+ *                synthetic audio suite vs 48/64 impl A and 54/64 impl B)
+ *  NEW_TRACKER:  reactive spectral-flux onset detector (beattracker.cpp)
+ *  neither:      ACF tempo-induction tracker by D. Suermann (beattracking.cpp)
+ */
+#define AUTO_TRACKER
 //#define NEW_TRACKER
 
-#ifdef NEW_TRACKER
+#if defined(AUTO_TRACKER)
+  class BeatTrackerAuto;
+#elif defined(NEW_TRACKER)
   class BeatTracker;
 #else
   class BeatTracking;
@@ -155,6 +165,12 @@ signals:
     void volumeChanged(int volume);
     void beatDetected();
 
+    /** Emitted when the beat tracker's own tempo estimate changes.
+     *  0 means "no confident estimate". Consumers should prefer this
+     *  over re-deriving BPM from the wall-clock spacing of
+     *  beatDetected() signals, which amplifies emission jitter. */
+    void beatBpmChanged(int bpm);
+
 protected:
     QMutex m_mutex;
 
@@ -178,7 +194,11 @@ protected:
     /** Map of the registered clients (key is the number of bands) */
     QMap <int, BandsData> m_fftMagnitudeMap;
 
-#ifdef NEW_TRACKER
+#if defined(AUTO_TRACKER)
+    BeatTrackerAuto *m_beatTracker;
+    /** Last BPM reported via beatBpmChanged() */
+    int m_lastTrackerBpm;
+#elif defined(NEW_TRACKER)
     BeatTracker *m_beatTracker;
 #else
     BeatTracking *m_beatTracker;

--- a/engine/audio/src/audiocapture.h
+++ b/engine/audio/src/audiocapture.h
@@ -45,9 +45,9 @@
 #define SPECTRUM_MAX_FREQUENCY          5000
 
 /** Beat tracker implementation selection (issue #1881 work):
- *  AUTO_TRACKER: multi-band onset front end + comb-scored ACF estimator,
- *                ported from QLCplusShowCreator (benchmarked: 64/64 on the
- *                synthetic audio suite vs 48/64 impl A and 54/64 impl B)
+ *  AUTO_TRACKER: multi-band onset front end + comb-scored ACF tempo
+ *                estimator by varghele (beattrackerauto.cpp, documented
+ *                in beattrackerauto.md)
  *  NEW_TRACKER:  reactive spectral-flux onset detector (beattracker.cpp)
  *  neither:      ACF tempo-induction tracker by D. Suermann (beattracking.cpp)
  */

--- a/engine/audio/src/audiocapture.h
+++ b/engine/audio/src/audiocapture.h
@@ -163,13 +163,12 @@ protected:
 signals:
     void dataProcessed(double *spectrumBands, int size, double maxMagnitude, quint32 power);
     void volumeChanged(int volume);
-    void beatDetected();
 
-    /** Emitted when the beat tracker's own tempo estimate changes.
-     *  0 means "no confident estimate". Consumers should prefer this
-     *  over re-deriving BPM from the wall-clock spacing of
-     *  beatDetected() signals, which amplifies emission jitter. */
-    void beatBpmChanged(int bpm);
+    /** Emitted on every beat detected by the beat tracker. @a bpm is
+     *  the tracker's own tempo estimate; 0 means "no estimate", in
+     *  which case the receiver has to derive the tempo from the
+     *  spacing of the beat signals. */
+    void beatDetected(int bpm);
 
 protected:
     QMutex m_mutex;
@@ -196,8 +195,6 @@ protected:
 
 #if defined(AUTO_TRACKER)
     BeatTrackerAuto *m_beatTracker;
-    /** Last BPM reported via beatBpmChanged() */
-    int m_lastTrackerBpm;
 #elif defined(NEW_TRACKER)
     BeatTracker *m_beatTracker;
 #else

--- a/engine/audio/src/beattracker.h
+++ b/engine/audio/src/beattracker.h
@@ -17,8 +17,8 @@
   limitations under the License.
 */
 
-#ifndef BEATTRACKING_H
-#define BEATTRACKING_H
+#ifndef BEATTRACKER_H
+#define BEATTRACKER_H
 
 #include <cstdint>
 #include <vector>

--- a/engine/audio/src/beattrackerauto.cpp
+++ b/engine/audio/src/beattrackerauto.cpp
@@ -2,11 +2,11 @@
   Q Light Controller Plus
   beattrackerauto.cpp
 
-  Port of the QLCplusShowCreator beat tracker (Python reference,
-  commit aa8ca6f). See beattrackerauto.h for the algorithm overview;
-  the reference implementation and its measured benchmarks live in
-  QLCplusShowCreator: audio/realtime_spectral.py (_push_beat_samples),
-  auto/bpm_detector.py (AutoBPMDetector), docs/beat-tracking.md.
+  Copyright (c) varghele
+
+  Beat tracker by varghele. See beattrackerauto.h for the class
+  overview and beattrackerauto.md for the full algorithm
+  documentation, tuning rationale and benchmark methodology.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/engine/audio/src/beattrackerauto.cpp
+++ b/engine/audio/src/beattrackerauto.cpp
@@ -1,0 +1,636 @@
+/*
+  Q Light Controller Plus
+  beattrackerauto.cpp
+
+  Port of the QLCplusShowCreator beat tracker (Python reference,
+  commit aa8ca6f). See beattrackerauto.h for the algorithm overview;
+  the reference implementation and its measured benchmarks live in
+  QLCplusShowCreator: audio/realtime_spectral.py (_push_beat_samples),
+  auto/bpm_detector.py (AutoBPMDetector), docs/beat-tracking.md.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#include "beattrackerauto.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/*****************************************************************************
+ * Small numeric helpers (match numpy semantics used by the reference)
+ *****************************************************************************/
+
+// np.hanning(M): 0.5 - 0.5*cos(2*pi*n/(M-1))
+static std::vector<double> hanning(int m)
+{
+    std::vector<double> w(m);
+    if (m == 1)
+    {
+        w[0] = 1.0;
+        return w;
+    }
+    for (int n = 0; n < m; n++)
+        w[n] = 0.5 - 0.5 * std::cos(2.0 * M_PI * n / (m - 1));
+    return w;
+}
+
+// np.convolve(x, k, mode="same")
+static std::vector<double> convolveSame(const std::vector<double> &x,
+                                        const std::vector<double> &k)
+{
+    const int n = int(x.size());
+    const int m = int(k.size());
+    const int off = (m - 1) / 2;
+    std::vector<double> out(n, 0.0);
+    for (int i = 0; i < n; i++)
+    {
+        double acc = 0.0;
+        for (int t = 0; t < m; t++)
+        {
+            int j = i + off - t;
+            if (j >= 0 && j < n)
+                acc += k[t] * x[j];
+        }
+        out[i] = acc;
+    }
+    return out;
+}
+
+// np.interp(pos, arange(n), y) for pos already clipped to [0, n-1]
+static double lerpAt(const std::vector<double> &y, double pos)
+{
+    if (pos <= 0.0)
+        return y.front();
+    const int n = int(y.size());
+    if (pos >= n - 1)
+        return y.back();
+    int i = int(pos);
+    double f = pos - i;
+    return y[i] + f * (y[i + 1] - y[i]);
+}
+
+// first-maximum argmax, numpy-style
+static int argmax(const std::vector<double> &v, int lo, int hi)
+{
+    int best = lo;
+    for (int i = lo + 1; i < hi; i++)
+        if (v[i] > v[best])
+            best = i;
+    return best;
+}
+
+// In-place iterative radix-2 complex FFT (size must be a power of two).
+static void fftRadix2(std::vector<double> &re, std::vector<double> &im)
+{
+    const int n = int(re.size());
+    for (int i = 1, j = 0; i < n; i++)
+    {
+        int bit = n >> 1;
+        for (; j & bit; bit >>= 1)
+            j ^= bit;
+        j ^= bit;
+        if (i < j)
+        {
+            std::swap(re[i], re[j]);
+            std::swap(im[i], im[j]);
+        }
+    }
+    for (int len = 2; len <= n; len <<= 1)
+    {
+        double ang = -2.0 * M_PI / len;
+        double wr = std::cos(ang), wi = std::sin(ang);
+        for (int i = 0; i < n; i += len)
+        {
+            double cr = 1.0, ci = 0.0;
+            for (int k = 0; k < len / 2; k++)
+            {
+                double ur = re[i + k], ui = im[i + k];
+                double vr = re[i + k + len / 2] * cr - im[i + k + len / 2] * ci;
+                double vi = re[i + k + len / 2] * ci + im[i + k + len / 2] * cr;
+                re[i + k] = ur + vr;
+                im[i + k] = ui + vi;
+                re[i + k + len / 2] = ur - vr;
+                im[i + k + len / 2] = ui - vi;
+                double ncr = cr * wr - ci * wi;
+                ci = cr * wi + ci * wr;
+                cr = ncr;
+            }
+        }
+    }
+}
+
+/*****************************************************************************
+ * BeatOnsetExtractor
+ *****************************************************************************/
+
+BeatOnsetExtractor::BeatOnsetExtractor(int sampleRate)
+    : m_sampleRate(sampleRate > 0 ? sampleRate : 44100)
+    , m_hop(512)
+    , m_fftSize(4096)
+{
+    std::vector<double> w = hanning(m_fftSize);
+    m_window.assign(w.begin(), w.end()); // float32 like the reference
+    m_re.resize(m_fftSize);
+    m_im.resize(m_fftSize);
+    reset();
+}
+
+void BeatOnsetExtractor::reset()
+{
+    m_buffer.assign(m_fftSize, 0.0f);
+    m_pending.clear();
+    m_prevMagLog.clear();
+    m_hasPrev = false;
+    for (int i = 0; i < 3; i++)
+    {
+        m_bandRefs[i] = 0.0;
+        m_bandPrev[i] = 0.0;
+    }
+    // Per-band peak follower with ~3 s decay at the onset frame rate
+    m_refDecay = std::exp(-1.0 / (3.0 * frameRateHz()));
+}
+
+void BeatOnsetExtractor::push(const float *samples, int count,
+                              std::vector<double> &onsetsOut)
+{
+    m_pending.insert(m_pending.end(), samples, samples + count);
+    size_t consumed = 0;
+    while (m_pending.size() - consumed >= size_t(m_hop))
+    {
+        processHop(m_pending.data() + consumed, onsetsOut);
+        consumed += m_hop;
+    }
+    if (consumed > 0)
+        m_pending.erase(m_pending.begin(), m_pending.begin() + consumed);
+}
+
+void BeatOnsetExtractor::processHop(const float *chunk,
+                                    std::vector<double> &onsetsOut)
+{
+    // Slide the analysis window by one hop
+    std::memmove(m_buffer.data(), m_buffer.data() + m_hop,
+                 (m_fftSize - m_hop) * sizeof(float));
+    std::memcpy(m_buffer.data() + (m_fftSize - m_hop), chunk,
+                m_hop * sizeof(float));
+
+    // Window (in float32, like the reference), FFT in double
+    for (int i = 0; i < m_fftSize; i++)
+    {
+        m_re[i] = double(m_buffer[i] * m_window[i]);
+        m_im[i] = 0.0;
+    }
+    fftRadix2(m_re, m_im);
+
+    const int bins = m_fftSize / 2 + 1;
+    std::vector<double> magLog(bins);
+    for (int k = 0; k < bins; k++)
+        magLog[k] = std::log1p(std::sqrt(m_re[k] * m_re[k] + m_im[k] * m_im[k]));
+
+    if (!m_hasPrev)
+    {
+        m_prevMagLog = magLog;
+        m_hasPrev = true;
+        onsetsOut.push_back(0.0);
+        return;
+    }
+
+    // Positive log-magnitude difference, summed per band:
+    // <200 Hz (kick), 200-4000 Hz (snare/vocals), >=4 kHz (hats/cymbals)
+    double bandSum[3] = { 0.0, 0.0, 0.0 };
+    for (int k = 0; k < bins; k++)
+    {
+        double diff = magLog[k] - m_prevMagLog[k];
+        m_prevMagLog[k] = magLog[k];
+        if (diff <= 0.0)
+            continue;
+        double freq = double(k) * m_sampleRate / m_fftSize;
+        int band = (freq < 200.0) ? 0 : (freq < 4000.0 ? 1 : 2);
+        bandSum[band] += diff;
+    }
+
+    // Per band: saturate against the band's recent peak (a kick and a
+    // snare onset then spike near-equally, so a backbeat's every-beat
+    // periodicity survives), keep only the rising edge (a snare's noise
+    // tail keeps producing "new energy" for several frames, a kick
+    // doesn't - shapes equalize), combine with hats down-weighted so
+    // subdivision does not read as double tempo.
+    static const double bandWeights[3] = { 1.0, 1.0, 0.4 };
+    double onset = 0.0;
+    for (int i = 0; i < 3; i++)
+    {
+        double v = bandSum[i];
+        double ref = std::max(v, m_bandRefs[i] * m_refDecay);
+        m_bandRefs[i] = ref;
+        double sat = (ref > 0.0) ? v / (v + 0.5 * ref) : 0.0;
+        onset += bandWeights[i] * std::max(0.0, sat - m_bandPrev[i]);
+        m_bandPrev[i] = sat;
+    }
+    onsetsOut.push_back(onset);
+}
+
+/*****************************************************************************
+ * AutoBpmDetector
+ *****************************************************************************/
+
+AutoBpmDetector::AutoBpmDetector(double analysisRateHz, double windowSeconds,
+                                 double octaveRaiseThreshold)
+    : m_rate(analysisRateHz)
+    , m_windowSize(int(windowSeconds * analysisRateHz))
+    , m_octaveRaiseThreshold(octaveRaiseThreshold)
+    , m_analysisInterval(2.0)
+    , m_beliefJumpProb(0.10)
+{
+    // Candidate tempo grid, 0.25 BPM steps over 50-240
+    for (double bpm = 50.0; bpm <= 240.0 + 1e-9; bpm += 0.25)
+        m_bpmGrid.push_back(bpm);
+
+    // Pre-ACF smoothing kernel, ~+/-23 ms absolute width: rate-scaled so
+    // human timing jitter is absorbed identically at any frame rate
+    int half = std::max(1, int(std::lround(0.023 * analysisRateHz)));
+    std::vector<double> k = hanning(2 * half + 3);
+    m_acfSmoothKernel.assign(k.begin() + 1, k.end() - 1);
+    double ksum = 0.0;
+    for (size_t i = 0; i < m_acfSmoothKernel.size(); i++)
+        ksum += m_acfSmoothKernel[i];
+    for (size_t i = 0; i < m_acfSmoothKernel.size(); i++)
+        m_acfSmoothKernel[i] /= ksum;
+
+    // Belief transition blur: 15-tap gaussian, sigma 4 grid steps
+    double bsum = 0.0;
+    for (int i = -7; i <= 7; i++)
+    {
+        double v = std::exp(-0.5 * (i / 4.0) * (i / 4.0));
+        m_beliefBlur.push_back(v);
+        bsum += v;
+    }
+    for (size_t i = 0; i < m_beliefBlur.size(); i++)
+        m_beliefBlur[i] /= bsum;
+
+    reset();
+}
+
+void AutoBpmDetector::reset()
+{
+    m_fluxBuffer.assign(m_windowSize, 0.0f);
+    m_writePos = 0;
+    m_count = 0;
+    m_lastAnalysisTime = 0.0;
+    m_hasBpm = false;
+    m_currentBpm = 0.0;
+    m_confidence = 0.0;
+    m_recentBpms.clear();
+    m_belief.clear();
+    m_hasBelief = false;
+    m_beatAnchorFrame = 0.0;
+    m_beatPeriodFrames = 0.0;
+    m_hasPhase = false;
+}
+
+void AutoBpmDetector::pushOnset(double value)
+{
+    m_fluxBuffer[m_writePos] = float(value);
+    m_writePos = (m_writePos + 1) % m_windowSize;
+    m_count++;
+
+    // Re-analyze every 2 s of AUDIO time (deterministic, unlike the
+    // wall-clock pacing of the Python reference; equivalent under the
+    // reference's own fake-clock test rig).
+    double now = double(m_count - 1) / m_rate;
+    if (now - m_lastAnalysisTime >= m_analysisInterval)
+    {
+        m_lastAnalysisTime = now;
+        analyze();
+    }
+}
+
+double AutoBpmDetector::bpm() const
+{
+    // Gate calibrated for this onset train: real music scores ~0.2-0.5,
+    // aperiodic noise stays well under 0.1
+    if (m_confidence < 0.15 || !m_hasBpm)
+        return 0.0;
+    if (m_recentBpms.empty())
+        return m_currentBpm;
+    std::vector<double> s(m_recentBpms);
+    std::sort(s.begin(), s.end());
+    size_t n = s.size();
+    return (n % 2 == 1) ? s[n / 2] : 0.5 * (s[n / 2 - 1] + s[n / 2]);
+}
+
+double AutoBpmDetector::nextBeatFrame() const
+{
+    if (m_confidence < 0.15 || !m_hasPhase || m_beatPeriodFrames <= 0.0)
+        return -1.0;
+    double framesNow = double(m_count - 1);
+    double k = std::ceil((framesNow - m_beatAnchorFrame) / m_beatPeriodFrames);
+    return m_beatAnchorFrame + k * m_beatPeriodFrames;
+}
+
+void AutoBpmDetector::analyze()
+{
+    if (m_count < m_windowSize / 2)
+        return; // not enough data
+
+    // Chronological onset signal (oldest first)
+    std::vector<double> signal;
+    if (m_count >= m_windowSize)
+    {
+        signal.resize(m_windowSize);
+        for (int i = 0; i < m_windowSize; i++)
+            signal[i] = m_fluxBuffer[(m_writePos + i) % m_windowSize];
+    }
+    else
+    {
+        signal.assign(m_fluxBuffer.begin(), m_fluxBuffer.begin() + int(m_count));
+    }
+    const int n = int(signal.size());
+    if (n < 100)
+        return;
+
+    // Remove DC, widen onset spikes (rate-scaled kernel) so a beat
+    // period between lag bins still forms one coherent ACF peak
+    double mean = 0.0;
+    for (int i = 0; i < n; i++)
+        mean += signal[i];
+    mean /= n;
+    for (int i = 0; i < n; i++)
+        signal[i] -= mean;
+    signal = convolveSame(signal, m_acfSmoothKernel);
+
+    // Unbiased autocorrelation (each lag averaged over its overlap count)
+    std::vector<double> acf(n);
+    for (int lag = 0; lag < n; lag++)
+    {
+        double acc = 0.0;
+        for (int i = lag; i < n; i++)
+            acc += signal[i] * signal[i - lag];
+        acf[lag] = acc / (n - lag);
+    }
+    if (acf[0] <= 0.0)
+        return;
+    for (int i = n - 1; i >= 0; i--)
+        acf[i] /= acf[0];
+
+    // Comb score per candidate tempo: ACF at 1x..4x the (fractional)
+    // period, each harmonic sampled as the local max within +/-1 lag
+    static const double harmonicWeights[4] = { 1.0, 0.7, 0.45, 0.3 };
+    static const double offsets[5] = { -1.0, -0.5, 0.0, 0.5, 1.0 };
+    const int gridSize = int(m_bpmGrid.size());
+    const double maxUsable = double(n - 1);
+    std::vector<double> scores(gridSize, 0.0);
+    std::vector<double> weightUsed(gridSize, 0.0);
+    for (int g = 0; g < gridSize; g++)
+    {
+        double period = m_rate * 60.0 / m_bpmGrid[g];
+        for (int k = 1; k <= 4; k++)
+        {
+            double h = k * period;
+            if (h > maxUsable)
+                continue;
+            double peak = -1e300;
+            for (int o = 0; o < 5; o++)
+            {
+                double pos = h + offsets[o];
+                if (pos < 0.0)
+                    pos = 0.0;
+                if (pos > maxUsable)
+                    pos = maxUsable;
+                peak = std::max(peak, lerpAt(acf, pos));
+            }
+            scores[g] += harmonicWeights[k - 1] * peak;
+            weightUsed[g] += harmonicWeights[k - 1];
+        }
+    }
+    bool anyUsable = false;
+    for (int g = 0; g < gridSize; g++)
+    {
+        if (weightUsed[g] > 0.0)
+        {
+            scores[g] /= weightUsed[g];
+            anyUsable = true;
+        }
+    }
+    if (!anyUsable)
+        return;
+
+    // Temporal belief filter: predict (blur + uniform jump), update with
+    // sharpened scores; the argmax is the stable base candidate
+    std::vector<double> obs(gridSize);
+    for (int g = 0; g < gridSize; g++)
+        obs[g] = scores[g] * scores[g] * scores[g] + 1e-9;
+    if (!m_hasBelief)
+    {
+        double s = 0.0;
+        for (int g = 0; g < gridSize; g++)
+            s += obs[g];
+        m_belief.resize(gridSize);
+        for (int g = 0; g < gridSize; g++)
+            m_belief[g] = obs[g] / s;
+        m_hasBelief = true;
+    }
+    else
+    {
+        std::vector<double> pred = convolveSame(m_belief, m_beliefBlur);
+        for (int g = 0; g < gridSize; g++)
+            pred[g] = (1.0 - m_beliefJumpProb) * pred[g]
+                      + m_beliefJumpProb / gridSize;
+        double s = 0.0;
+        for (int g = 0; g < gridSize; g++)
+        {
+            m_belief[g] = pred[g] * obs[g];
+            s += m_belief[g];
+        }
+        for (int g = 0; g < gridSize; g++)
+            m_belief[g] /= s;
+    }
+
+    int best = raiseOctave(argmax(m_belief, 0, gridSize), scores);
+
+    // Confidence is the harmonic score itself: ~1 for a cleanly periodic
+    // onset train, near 0 for aperiodic noise
+    m_confidence = std::min(1.0, std::max(0.0, scores[best]));
+    m_currentBpm = std::min(240.0, std::max(50.0, m_bpmGrid[best]));
+    m_hasBpm = true;
+    m_recentBpms.push_back(m_currentBpm);
+    if (m_recentBpms.size() > 3)
+        m_recentBpms.erase(m_recentBpms.begin());
+
+    estimatePhase(signal);
+}
+
+int AutoBpmDetector::raiseOctave(int idx, const std::vector<double> &scores) const
+{
+    // Walk up to 2x/3x-faster candidates while their comb evidence holds
+    // (>= threshold x current), searching +/-2 BPM around each multiple.
+    // Hysteresis: a candidate within ~0.06 octaves of the previously
+    // reported estimate needs 0.04 less evidence, so near-threshold
+    // octave decisions don't flap between analyses.
+    const double step = m_bpmGrid[1] - m_bpmGrid[0];
+    const int window = int(std::lround(2.0 / step));
+    const int gridSize = int(m_bpmGrid.size());
+
+    // m_currentBpm still holds the previous analysis' estimate here
+    const bool havePrev = m_hasBpm;
+    const double prevBpm = m_currentBpm;
+
+    while (true)
+    {
+        double bpm = m_bpmGrid[idx];
+        int bestCand = -1;
+        static const double mults[2] = { 2.0, 3.0 };
+        for (int mi = 0; mi < 2; mi++)
+        {
+            double target = bpm * mults[mi];
+            if (target > m_bpmGrid[gridSize - 1] + 1e-9)
+                continue;
+            int j = int(std::lround((target - m_bpmGrid[0]) / step));
+            int lo = std::max(0, j - window);
+            int hi = std::min(gridSize, j + window + 1);
+            int k = argmax(scores, lo, hi);
+            double threshold = m_octaveRaiseThreshold;
+            bool candNearPrev = havePrev
+                && std::fabs(std::log2(m_bpmGrid[k] / prevBpm)) < 0.06;
+            bool baseNearPrev = havePrev
+                && std::fabs(std::log2(bpm / prevBpm)) < 0.06;
+            if (candNearPrev)
+                threshold -= 0.04;
+            else if (baseNearPrev)
+                threshold += 0.04;
+            if (scores[k] >= threshold * scores[idx])
+            {
+                if (bestCand < 0 || scores[k] > scores[bestCand])
+                    bestCand = k;
+            }
+        }
+        if (bestCand < 0)
+            return idx;
+        idx = bestCand;
+    }
+}
+
+void AutoBpmDetector::estimatePhase(const std::vector<double> &signal)
+{
+    // Correlate the preprocessed onset window with an impulse train at
+    // the current period, weighted with a half-life of one beat so the
+    // most recent onsets dominate; the best fractional offset becomes
+    // the anchor for the predicted beat grid.
+    if (!m_hasBpm)
+        return;
+    double period = m_rate * 60.0 / m_currentBpm;
+    const int n = int(signal.size());
+    int nBeats = std::min(int(n / period), 16);
+    if (nBeats < 2)
+        return;
+
+    const int nOffsets = int(std::ceil(period / 0.25 - 1e-12));
+    std::vector<double> scores(nOffsets, 0.0);
+    double decay = 1.0;
+    for (int k = 0; k < nBeats; k++)
+    {
+        for (int o = 0; o < nOffsets; o++)
+        {
+            double pos = (n - 1) - o * 0.25 - k * period;
+            if (pos >= 0.0)
+                scores[o] += decay * lerpAt(signal, pos);
+        }
+        decay *= 0.5;
+    }
+    double best = 0.25 * argmax(scores, 0, nOffsets);
+    m_beatAnchorFrame = double(m_count - 1) - best;
+    m_beatPeriodFrames = period;
+    m_hasPhase = true;
+}
+
+/*****************************************************************************
+ * BeatTrackerAuto
+ *****************************************************************************/
+
+BeatTrackerAuto::BeatTrackerAuto(int sampleRate, int channels)
+    : m_sampleRate(sampleRate > 0 ? sampleRate : 44100)
+    , m_channels(std::max(1, channels))
+    , m_extractor(m_sampleRate)
+    , m_detector(m_extractor.frameRateHz())
+    , m_lastEmitFrame(-1.0)
+{
+}
+
+void BeatTrackerAuto::setFormat(int sampleRate, int channels)
+{
+    if (sampleRate <= 0)
+        return;
+    m_sampleRate = sampleRate;
+    m_channels = std::max(1, channels);
+    m_extractor = BeatOnsetExtractor(m_sampleRate);
+    m_detector = AutoBpmDetector(m_extractor.frameRateHz());
+    m_lastEmitFrame = -1.0;
+}
+
+void BeatTrackerAuto::reset()
+{
+    m_extractor.reset();
+    m_detector.reset();
+    m_lastEmitFrame = -1.0;
+}
+
+bool BeatTrackerAuto::processAudio(const int16_t *buffer, int bufferSize)
+{
+    if (!buffer || bufferSize <= 0)
+        return false;
+
+    // bufferSize is the TOTAL sample count (frames * channels)
+    const int frames = bufferSize / m_channels;
+    if (frames <= 0)
+        return false;
+
+    m_mono.resize(frames);
+    for (int i = 0; i < frames; i++)
+    {
+        int32_t acc = 0;
+        const int16_t *fp = buffer + i * m_channels;
+        for (int c = 0; c < m_channels; c++)
+            acc += fp[c];
+        m_mono[i] = float(double(acc) / (32768.0 * m_channels));
+    }
+
+    m_onsets.clear();
+    m_extractor.push(m_mono.data(), frames, m_onsets);
+
+    // Advance the detector hop by hop and emit on predicted-beat
+    // crossings at hop resolution (~11.6 ms at 44.1 kHz)
+    bool beat = false;
+    for (size_t i = 0; i < m_onsets.size(); i++)
+    {
+        m_detector.pushOnset(m_onsets[i]);
+        double next = m_detector.nextBeatFrame();
+        if (next < 0.0)
+            continue;
+        double framesNow = double(m_detector.frameCount() - 1);
+        double period = m_detector.beatPeriodFrames();
+        // The predicted beat lands before the next hop; the half-period
+        // refractory absorbs small grid shifts when a re-analysis moves
+        // the anchor
+        if (next - framesNow < 1.0
+            && (m_lastEmitFrame < 0.0
+                || framesNow - m_lastEmitFrame >= 0.5 * period))
+        {
+            beat = true;
+            m_lastEmitFrame = framesNow;
+        }
+    }
+    return beat;
+}

--- a/engine/audio/src/beattrackerauto.h
+++ b/engine/audio/src/beattrackerauto.h
@@ -1,0 +1,197 @@
+/*
+  Q Light Controller Plus
+  beattrackerauto.h
+
+  Port of the QLCplusShowCreator beat tracker (Python reference,
+  commit aa8ca6f): multi-band saturated rising-edge onset front end
+  (audio/realtime_spectral.py, _push_beat_samples) feeding a
+  comb-scored autocorrelation tempo estimator with a temporal belief
+  filter, octave-raise walk and beat-phase output
+  (auto/bpm_detector.py, AutoBPMDetector).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef BEATTRACKERAUTO_H
+#define BEATTRACKERAUTO_H
+
+#include <cstdint>
+#include <vector>
+
+/** @addtogroup engine_audio Audio
+ * @{
+ */
+
+/**
+ * Onset front end: one band-combined onset value per 512 input samples
+ * (86.13 Hz at 44100). 4096-sample Hann-windowed FFT (~93 ms - the window
+ * span in SECONDS is load-bearing: a ~46 ms window resolves every
+ * micro-transient of sustained instruments and buries the beat in onset
+ * noise on real music), log1p magnitude, positive spectral difference,
+ * three bands (<200 Hz kick / 200-4000 Hz snare-vocals / >=4 kHz hats).
+ * Each band is saturated against its own recent peak (~3 s decay
+ * follower) and reduced to its rising edge, then combined with weights
+ * 1 / 1 / 0.4. Self-contained radix-2 FFT; no external dependencies.
+ */
+class BeatOnsetExtractor
+{
+public:
+    explicit BeatOnsetExtractor(int sampleRate);
+
+    void reset();
+
+    /** Onset values produced per second of audio (sampleRate / 512). */
+    double frameRateHz() const { return double(m_sampleRate) / double(m_hop); }
+
+    /** Feed mono samples in [-1, 1]; appends one onset value per
+     *  elapsed 512-sample hop to @a onsetsOut (possibly none). */
+    void push(const float *samples, int count, std::vector<double> &onsetsOut);
+
+private:
+    void processHop(const float *chunk, std::vector<double> &onsetsOut);
+
+private:
+    int m_sampleRate;
+    int m_hop;      // 512
+    int m_fftSize;  // 4096
+
+    std::vector<float> m_window;    // Hann, float32 to match the reference
+    std::vector<float> m_buffer;    // sliding fftSize window
+    std::vector<float> m_pending;   // not-yet-hop-aligned input
+
+    std::vector<double> m_prevMagLog;
+    bool m_hasPrev;
+
+    double m_refDecay;              // exp(-1 / (3 s * frame rate))
+    double m_bandRefs[3];
+    double m_bandPrev[3];
+
+    // FFT workspace (radix-2, complex in-place)
+    std::vector<double> m_re, m_im;
+};
+
+/**
+ * Tempo + phase estimator over the onset train. Every 2 s of audio it
+ * runs, on an 8 s window: unbiased autocorrelation pre-smoothed with a
+ * rate-scaled (~+/-23 ms) Hann kernel; a harmonic comb score for every
+ * candidate on a fractional 50-240 BPM grid (0.25 steps, ACF sampled at
+ * 1x..4x the period as the local max within +/-1 lag, weights
+ * 1/0.7/0.45/0.3); a forward-filtered belief over the grid (observation
+ * = scores^3, transition = gaussian blur + 10% uniform jump) picks the
+ * base candidate; an octave-raise walk prefers the fastest 2x/3x
+ * candidate holding >= 0.90 of the current score, with +/-0.04
+ * hysteresis toward the previous estimate. Reported BPM is the median
+ * of the last 3 analyses, gated on comb confidence >= 0.15.
+ */
+class AutoBpmDetector
+{
+public:
+    explicit AutoBpmDetector(double analysisRateHz,
+                             double windowSeconds = 8.0,
+                             double octaveRaiseThreshold = 0.90);
+
+    void reset();
+
+    /** Feed one onset value (one hop of audio). */
+    void pushOnset(double value);
+
+    /** Median of the last 3 analyses, or 0.0 while confidence < 0.15. */
+    double bpm() const;
+
+    /** Comb score of the current estimate, ~0..1. */
+    double confidence() const { return m_confidence; }
+
+    /** Total onset frames received so far. */
+    long long frameCount() const { return m_count; }
+
+    /** Absolute (fractional) frame index of the next predicted beat,
+     *  >= frameCount()-1, or a negative value when there is no
+     *  confident estimate. */
+    double nextBeatFrame() const;
+
+    /** Current beat period in frames, or 0 when unknown. */
+    double beatPeriodFrames() const { return m_beatPeriodFrames; }
+
+private:
+    void analyze();
+    int raiseOctave(int idx, const std::vector<double> &scores) const;
+    void estimatePhase(const std::vector<double> &signal);
+
+private:
+    double m_rate;
+    int m_windowSize;
+    double m_octaveRaiseThreshold;
+
+    std::vector<float> m_fluxBuffer;   // ring buffer, float32 like the reference
+    int m_writePos;
+    long long m_count;
+    double m_lastAnalysisTime;         // audio seconds
+    double m_analysisInterval;
+
+    bool m_hasBpm;
+    double m_currentBpm;
+    double m_confidence;
+    std::vector<double> m_recentBpms;  // last <= 3 analyses
+
+    std::vector<double> m_bpmGrid;     // 50..240 step 0.25
+    std::vector<double> m_acfSmoothKernel;
+    std::vector<double> m_beliefBlur;  // 15-tap gaussian, sigma 4 grid steps
+    double m_beliefJumpProb;
+    std::vector<double> m_belief;
+    bool m_hasBelief;
+
+    double m_beatAnchorFrame;          // absolute frame of last located beat
+    double m_beatPeriodFrames;
+    bool m_hasPhase;
+};
+
+/**
+ * QLC+ facade: implements the AudioCapture beat interface (interleaved
+ * int16 blocks, bufferSize = TOTAL samples = frames * channels).
+ * processAudio() returns true when a predicted beat falls inside the
+ * block; bpm() exposes the estimator's tempo so the UI can display it
+ * instead of re-deriving BPM from wall-clock signal spacing.
+ */
+class BeatTrackerAuto
+{
+public:
+    BeatTrackerAuto(int sampleRate, int channels);
+
+    /** Reconfigure for a new capture format; resets all state. */
+    void setFormat(int sampleRate, int channels);
+
+    void reset();
+
+    /** Process an interleaved int16 block; bufferSize is the total
+     *  number of samples (frames * channels). Returns true if a beat
+     *  occurred within this block. */
+    bool processAudio(const int16_t *buffer, int bufferSize);
+
+    /** Current tempo estimate, 0.0 while unavailable/low-confidence. */
+    double bpm() const { return m_detector.bpm(); }
+
+    double confidence() const { return m_detector.confidence(); }
+
+private:
+    int m_sampleRate;
+    int m_channels;
+    BeatOnsetExtractor m_extractor;
+    AutoBpmDetector m_detector;
+    std::vector<float> m_mono;
+    std::vector<double> m_onsets;
+    double m_lastEmitFrame;
+};
+
+/** @} */
+
+#endif // BEATTRACKERAUTO_H

--- a/engine/audio/src/beattrackerauto.h
+++ b/engine/audio/src/beattrackerauto.h
@@ -2,12 +2,12 @@
   Q Light Controller Plus
   beattrackerauto.h
 
-  Port of the QLCplusShowCreator beat tracker (Python reference,
-  commit aa8ca6f): multi-band saturated rising-edge onset front end
-  (audio/realtime_spectral.py, _push_beat_samples) feeding a
-  comb-scored autocorrelation tempo estimator with a temporal belief
-  filter, octave-raise walk and beat-phase output
-  (auto/bpm_detector.py, AutoBPMDetector).
+  Copyright (c) varghele
+
+  Beat tracker by varghele: a multi-band saturated rising-edge onset
+  front end feeding a comb-scored autocorrelation tempo estimator with
+  a temporal belief filter, octave-raise walk and beat-phase output.
+  Algorithm documentation: beattrackerauto.md (same directory).
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/engine/audio/src/beattrackerauto.md
+++ b/engine/audio/src/beattrackerauto.md
@@ -1,0 +1,149 @@
+# BeatTrackerAuto — algorithm documentation
+
+Beat tracker by varghele, developed and benchmarked in Python across several
+measured iterations, then ported to self-contained C++ for QLC+
+(`beattrackerauto.{h,cpp}`). This document is the standalone description of
+how it works, why each stage exists, and how it was validated. Related
+upstream discussion: issue #1881.
+
+## Overview
+
+Two components, connected by an onset-strength stream:
+
+```
+int16 PCM blocks -> BeatOnsetExtractor -> onset value per 512-sample hop
+                        (~86 Hz)              |
+                                              v
+                                       AutoBpmDetector -> BPM estimate,
+                                        (analysis every    confidence,
+                                         2 s of audio)     predicted beat grid
+```
+
+`BeatTrackerAuto` is the facade that adapts both to QLC+'s `AudioCapture`
+contract: interleaved int16 input where `bufferSize` is the **total** sample
+count (frames × channels), a boolean per-block "beat occurred" return that
+drives `beatDetected()`, and a `bpm()` getter for the UI.
+
+Everything is plain C++ with an internal radix-2 FFT — no Qt, no fftw3.
+This is deliberate: fftw3 is an optional engine dependency (`HAS_FFTW3`),
+so a tracker relying on it silently disappears from builds without it.
+CPU cost is ~1.3% of one core at 44.1 kHz.
+
+## Onset front end (`BeatOnsetExtractor`)
+
+Per 512-sample hop (86.13 Hz at 44.1 kHz):
+
+1. **FFT** over a sliding 4096-sample Hann window (~93 ms). The window
+   length in *seconds* is load-bearing: a ~46 ms window resolves every
+   micro-transient of sustained instruments and buries the beat in onset
+   noise on real music (measured, cost a full benchmark round).
+2. **log1p magnitude, positive spectral difference** vs. the previous hop
+   (only energy increases count as onset evidence).
+3. **Three bands**: < 200 Hz (kick), 200–4000 Hz (snare/vocals),
+   ≥ 4 kHz (hats/cymbals).
+4. **Per-band saturation** against the band's own recent peak (peak
+   follower with ~3 s decay): `v / (v + 0.5·ref)`. A kick and a snare
+   onset then spike near-equally, so a backbeat's every-beat periodicity
+   survives instead of half-locking at the kick rate.
+5. **Rising edge only**: `max(0, sat − previous sat)`. A snare's noise
+   tail keeps producing "new energy" for several frames, a kick doesn't —
+   this equalizes the spike *shapes* between instruments.
+6. **Weighted sum** with weights 1 / 1 / 0.4: hats stay visibly weaker
+   than beats so subdivision does not read as double tempo.
+
+The backbeat fix (stages 4–5) was found by measurement: neither scalar nor
+per-bin log compression solved kick/snare alternation — the problem is
+spectral extent and envelope shape, not loudness.
+
+## Tempo estimator (`AutoBpmDetector`)
+
+Runs every 2 s of **audio time** (not wall clock — deterministic and
+testable) over an 8 s window of the onset stream:
+
+1. **Pre-smoothing**: the DC-removed onset signal is convolved with a
+   Hann kernel of ~±23 ms absolute width, *scaled with the frame rate* —
+   it absorbs human timing jitter, which otherwise smears the ACF peak
+   across more lags the finer the hop grid gets.
+2. **Unbiased autocorrelation** (each lag normalized by its overlap
+   count), computed directly (n ≈ 690, negligible cost).
+3. **Harmonic comb score** for every candidate on a fractional BPM grid
+   (50–240, 0.25 steps): the ACF sampled at 1×..4× the candidate period
+   with weights 1 / 0.7 / 0.45 / 0.3, each harmonic taken as the local
+   maximum within ±1 lag (offsets −1, −0.5, 0, +0.5, +1). The fractional
+   grid removes lag quantization (at 86 Hz a 190 BPM beat is only ~27
+   hops); the local-max sampling lets a slightly detuned harmonic count
+   at full height while a genuinely weak off-beat stays weak — that is
+   what keeps the octave decision discriminative.
+4. **Temporal belief filter** over the grid: prediction = 15-tap gaussian
+   blur (sigma 4 grid steps) plus a 10% uniform jump probability;
+   observation = comb scores cubed. The belief argmax is the stable base
+   candidate — one noisy analysis cannot flip the estimate, while a real
+   tempo change wins within a few analyses via the jump mass.
+5. **Octave-raise walk**: from the base candidate, move to a 2×/3× faster
+   candidate (searched within ±2 BPM of the multiple) while its comb
+   score holds ≥ 0.90 of the current one, with ±0.04 hysteresis toward
+   the previously reported estimate so near-threshold decisions don't
+   flap between analyses. This disambiguates octaves in both directions
+   without a tempo prior. (A log-normal tempo prior and a continuity
+   score bonus were both tried and rejected on measurements: the prior
+   systematically halves everything ≥ 190 BPM, the bonus locks in early
+   wrong estimates.)
+6. **Reporting**: `bpm()` returns the median of the last 3 analyses,
+   gated on comb confidence ≥ 0.15 (real music scores ~0.2–0.5,
+   aperiodic noise stays well under 0.1 — silence and noise never
+   report).
+
+## Beat phase and emission
+
+Each analysis correlates the preprocessed onset window with an impulse
+train at the found period, weighted with a half-life of one beat so the
+most recent onsets dominate, over a 0.25-hop offset grid. The best offset
+becomes the beat anchor; anchor + period define a predicted beat grid.
+The facade emits a beat when the next predicted beat falls within the
+current hop (~11.6 ms resolution), with a half-period refractory that
+absorbs small grid shifts when a re-analysis moves the anchor.
+
+Emitting from the predicted grid — rather than reacting to individual
+onsets — is what makes the beat output steady on syncopated material.
+
+## Behavior characteristics
+
+- **First estimate** after ~4 s of music (half the analysis window);
+  typically correct by 4–8 s.
+- **Re-lock after a live tempo change**: ~12–16 s. This is the deliberate
+  price of the belief filter + median-of-3 stability (without them,
+  single-analysis errors flap the reported BPM).
+- **Known limit**: material genuinely dominated by 8th-note energy can
+  read an octave up — this is evidence-driven (the subdivision really
+  does carry the energy), not a systematic bias.
+- **Silence**: onset stream goes to zero, confidence collapses below the
+  gate, no beats are emitted and no BPM is reported.
+- **Format**: any sample rate (all time constants derive from it) and
+  any channel count (interleaved frames are averaged to mono).
+
+## Validation
+
+- The C++ port was verified hop-for-hop against the Python reference:
+  identical gated BPM decisions on every hop, onset values matching to
+  ~1e-7 (float32 rounding).
+- Synthetic audio suite (8 scenarios × 8 tempi, 50–240 BPM: four-on-floor,
+  8th hats, kick/snare backbeat, 8th-note bassline, swung hats, ±3% drift,
+  2.5 s dropout, +30% tempo step; rendered percussion as int16 PCM):
+  **64/64 correct** (4% tolerance). Faithful ports of QLC+'s two existing
+  trackers on the same suite: 48/64 (beattracking.cpp) and 54/64
+  (beattracker.cpp).
+- Onset-level suite (7 scenarios × 20 tempi incl. noise at SNR 2:1):
+  139/140.
+- Real songs: 9-song album benchmark with per-section ground truth,
+  scored as % of post-warmup time within 4%: 65% vs. 63% and 4% for the
+  two existing trackers.
+- Issue #1881's reference video (a 100 BPM metronome): reads 100.00 BPM
+  with 0.600 s beat intervals; a 140 BPM rock drum-track video reads
+  139.75. Both confirmed in a live microphone test.
+- Unit test: `engine/test/beattrackerauto` (tempo accuracy at
+  90/120/140/174 BPM, beat spacing regularity, silence gating,
+  stereo/mono equivalence).
+
+The benchmark harness (including the Python ports of the existing QLC+
+trackers used for the head-to-head numbers) is part of varghele's
+reference implementation and is available on request.

--- a/engine/audio/src/beattrackerauto.md
+++ b/engine/audio/src/beattrackerauto.md
@@ -131,7 +131,11 @@ onsets — is what makes the beat output steady on syncopated material.
   2.5 s dropout, +30% tempo step; rendered percussion as int16 PCM):
   **64/64 correct** (4% tolerance). Faithful ports of QLC+'s two existing
   trackers on the same suite: 48/64 (beattracking.cpp) and 54/64
-  (beattracker.cpp).
+  (beattracker.cpp). An in-repo C++ port of this suite lives in
+  `engine/test/beattrackerbench` (run with `--full` for the whole table);
+  with its RNG it reproduces 63/64 vs. 54/64 vs. 48/64 — the single flip
+  is a 90 BPM 8th-hats clip reading an octave up, i.e. the known limit
+  described above.
 - Onset-level suite (7 scenarios × 20 tempi incl. noise at SNR 2:1):
   139/140.
 - Real songs: 9-song album benchmark with per-section ground truth,

--- a/engine/audio/src/beattracking.cpp
+++ b/engine/audio/src/beattracking.cpp
@@ -31,10 +31,10 @@
 const double filterCoeffA[] = { 1, 0.23484048, 0};
 const double filterCoeffB[] = { 0.15998789, 0.31997577, 0.15998789 };
 
-BeatTracking::BeatTracking(int channels, QObject *parent)
+BeatTracking::BeatTracking(int sampleRate, int channels, QObject *parent)
     : QObject(parent)
-    , m_channels(channels)
-    , m_sampleRate(BEAT_DEFAULT_SAMPLE_RATE)
+    , m_channels(channels > 0 ? channels : 1)
+    , m_sampleRate(sampleRate > 0 ? sampleRate : BEAT_DEFAULT_SAMPLE_RATE)
     , m_windowSize(BEAT_DEFAULT_WINDOW_SIZE)
     , m_hopSize(BEAT_DEFAULT_HOP_SIZE)
     , m_onsetWindowSize(ONSET_WINDOW_SIZE)
@@ -121,7 +121,9 @@ bool BeatTracking::processAudio(int16_t * buffer, int bufferSize)
     //timer1.start(); // Monitor computation time
     bool isBeat = false;
 
-    for (int i = 0; i < bufferSize; ++i)
+    // bufferSize is the total sample count; mix interleaved frames to mono
+    int frames = bufferSize / static_cast<int>(m_channels);
+    for (int i = 0; i < frames; ++i)
     {
         m_windowBuffer.append(0.0);
         int idx = m_windowBuffer.size() - 1;

--- a/engine/audio/src/beattracking.h
+++ b/engine/audio/src/beattracking.h
@@ -40,8 +40,12 @@ class BeatTracking : public QObject
     Q_OBJECT
 
 public:
-    BeatTracking(int channels, QObject *parent = nullptr);
+    BeatTracking(int sampleRate, int channels, QObject *parent = nullptr);
     ~BeatTracking();
+
+    /** Process an interleaved int16 block. @a bufferSize is the TOTAL
+     *  number of samples (frames * channels), matching what
+     *  AudioCapture::run() passes. */
     bool processAudio(int16_t *buffer, int bufferSize);
 
 private:

--- a/engine/audio/src/beattracking.h
+++ b/engine/audio/src/beattracking.h
@@ -48,6 +48,9 @@ public:
      *  AudioCapture::run() passes. */
     bool processAudio(int16_t *buffer, int bufferSize);
 
+    /** Current tempo estimate in BPM */
+    double currentBpm() const { return m_currentBPM; }
+
 private:
     enum PredictionState{ACF, CONTINUITY};
 

--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -49,7 +49,6 @@ InputOutputMap::InputOutputMap(const Doc *doc, quint32 universes)
     , m_universeChanged(false)
     , m_localProfilesLoaded(false)
     , m_currentBPM(0)
-    , m_audioTrackerBpm(0)
     , m_beatTime(new QElapsedTimer())
     , m_networkServerType(NativeServer)
     , m_networkServerAutoStart(false)
@@ -1031,9 +1030,7 @@ void InputOutputMap::setBeatGeneratorType(InputOutputMap::BeatGeneratorType type
     if (m_beatGeneratorType == Audio)
     {
         m_inputCapture->unregisterBandsNumber(4);
-        disconnect(m_inputCapture, SIGNAL(beatDetected()), this, SLOT(slotProcessBeat()));
-        disconnect(m_inputCapture, SIGNAL(beatBpmChanged(int)), this, SLOT(slotAudioBpmChanged(int)));
-        m_audioTrackerBpm = 0;
+        disconnect(m_inputCapture, SIGNAL(beatDetected(int)), this, SLOT(slotProcessBeat(int)));
     }
 
     m_beatGeneratorType = type;
@@ -1063,9 +1060,7 @@ void InputOutputMap::setBeatGeneratorType(InputOutputMap::BeatGeneratorType type
             m_beatTime->restart();
             QSharedPointer<AudioCapture> capture(m_doc->audioInputCapture());
             m_inputCapture = capture.data();
-            m_audioTrackerBpm = 0;
-            connect(m_inputCapture, SIGNAL(beatDetected()), this, SLOT(slotProcessBeat()));
-            connect(m_inputCapture, SIGNAL(beatBpmChanged(int)), this, SLOT(slotAudioBpmChanged(int)));
+            connect(m_inputCapture, SIGNAL(beatDetected(int)), this, SLOT(slotProcessBeat(int)));
             m_inputCapture->registerBandsNumber(4);
         }
         break;
@@ -1129,39 +1124,38 @@ int InputOutputMap::bpmNumber() const
     return m_currentBPM;
 }
 
-void InputOutputMap::slotProcessBeat()
+void InputOutputMap::slotProcessBeat(int bpm)
 {
     // process the timer as first thing, to avoid wasting time
     // with the operations below
     qint64 elapsed = m_beatTime->elapsed();
     m_beatTime->restart();
 
-    // When the audio tracker reports its own tempo estimate (see
-    // slotAudioBpmChanged), that value drives the BPM number; deriving
-    // it from the wall-clock spacing of beat signals amplifies every
-    // hop of emission jitter into a BPM change
-    if (m_beatGeneratorType != Audio || m_audioTrackerBpm <= 0)
+    if (bpm > 0)
     {
-        int bpm = qRound(60000.0 / (float)elapsed);
+        // the beat source provides its own tempo estimate
+        if (bpm != m_currentBPM)
+        {
+            qDebug() << "[InputOutputMap] beat source BPM:" << bpm;
+            setBpmNumber(bpm);
+        }
+    }
+    else
+    {
+        // no tempo estimate available: derive the BPM number from the
+        // wall-clock spacing of the beat signals
+        int elapsedBpm = qRound(60000.0 / (float)elapsed);
         float currBpmTime = 60000.0 / (float)m_currentBPM;
         // here we check if the difference between the current BPM duration
         // and the current time elapsed is within a range of +/-1ms.
         // If it isn't, then the BPM number has really changed, otherwise
         // it's just a tiny time drift
         if (qAbs((float)elapsed - currBpmTime) > 1)
-            setBpmNumber(bpm);
+            setBpmNumber(elapsedBpm);
     }
 
     m_doc->masterTimer()->requestBeat();
     emit beat();
-}
-
-void InputOutputMap::slotAudioBpmChanged(int bpm)
-{
-    qDebug() << "[InputOutputMap] audio tracker BPM:" << bpm;
-    m_audioTrackerBpm = bpm;
-    if (m_beatGeneratorType == Audio && bpm > 0)
-        setBpmNumber(bpm);
 }
 
 void InputOutputMap::slotMasterTimerBeat()

--- a/engine/src/inputoutputmap.cpp
+++ b/engine/src/inputoutputmap.cpp
@@ -49,6 +49,7 @@ InputOutputMap::InputOutputMap(const Doc *doc, quint32 universes)
     , m_universeChanged(false)
     , m_localProfilesLoaded(false)
     , m_currentBPM(0)
+    , m_audioTrackerBpm(0)
     , m_beatTime(new QElapsedTimer())
     , m_networkServerType(NativeServer)
     , m_networkServerAutoStart(false)
@@ -1031,6 +1032,8 @@ void InputOutputMap::setBeatGeneratorType(InputOutputMap::BeatGeneratorType type
     {
         m_inputCapture->unregisterBandsNumber(4);
         disconnect(m_inputCapture, SIGNAL(beatDetected()), this, SLOT(slotProcessBeat()));
+        disconnect(m_inputCapture, SIGNAL(beatBpmChanged(int)), this, SLOT(slotAudioBpmChanged(int)));
+        m_audioTrackerBpm = 0;
     }
 
     m_beatGeneratorType = type;
@@ -1060,7 +1063,9 @@ void InputOutputMap::setBeatGeneratorType(InputOutputMap::BeatGeneratorType type
             m_beatTime->restart();
             QSharedPointer<AudioCapture> capture(m_doc->audioInputCapture());
             m_inputCapture = capture.data();
+            m_audioTrackerBpm = 0;
             connect(m_inputCapture, SIGNAL(beatDetected()), this, SLOT(slotProcessBeat()));
+            connect(m_inputCapture, SIGNAL(beatBpmChanged(int)), this, SLOT(slotAudioBpmChanged(int)));
             m_inputCapture->registerBandsNumber(4);
         }
         break;
@@ -1131,17 +1136,32 @@ void InputOutputMap::slotProcessBeat()
     qint64 elapsed = m_beatTime->elapsed();
     m_beatTime->restart();
 
-    int bpm = qRound(60000.0 / (float)elapsed);
-    float currBpmTime = 60000.0 / (float)m_currentBPM;
-    // here we check if the difference between the current BPM duration
-    // and the current time elapsed is within a range of +/-1ms.
-    // If it isn't, then the BPM number has really changed, otherwise
-    // it's just a tiny time drift
-    if (qAbs((float)elapsed - currBpmTime) > 1)
-        setBpmNumber(bpm);
+    // When the audio tracker reports its own tempo estimate (see
+    // slotAudioBpmChanged), that value drives the BPM number; deriving
+    // it from the wall-clock spacing of beat signals amplifies every
+    // hop of emission jitter into a BPM change
+    if (m_beatGeneratorType != Audio || m_audioTrackerBpm <= 0)
+    {
+        int bpm = qRound(60000.0 / (float)elapsed);
+        float currBpmTime = 60000.0 / (float)m_currentBPM;
+        // here we check if the difference between the current BPM duration
+        // and the current time elapsed is within a range of +/-1ms.
+        // If it isn't, then the BPM number has really changed, otherwise
+        // it's just a tiny time drift
+        if (qAbs((float)elapsed - currBpmTime) > 1)
+            setBpmNumber(bpm);
+    }
 
     m_doc->masterTimer()->requestBeat();
     emit beat();
+}
+
+void InputOutputMap::slotAudioBpmChanged(int bpm)
+{
+    qDebug() << "[InputOutputMap] audio tracker BPM:" << bpm;
+    m_audioTrackerBpm = bpm;
+    if (m_beatGeneratorType == Audio && bpm > 0)
+        setBpmNumber(bpm);
 }
 
 void InputOutputMap::slotMasterTimerBeat()

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -606,12 +606,12 @@ public:
 protected slots:
     void slotMasterTimerBeat();
     void slotPluginBeat(quint32 universe, quint32 channel, uchar value, const QString &key);
-    void slotProcessBeat();
 
-    /** Receives the audio beat tracker's own tempo estimate (0 = no
-     *  confident estimate). Preferred over the wall-clock BPM derived
-     *  in slotProcessBeat(), which jitters with emission timing. */
-    void slotAudioBpmChanged(int bpm);
+    /** Process a beat from the current beat source. @a bpm is the
+     *  source's own tempo estimate; 0 means "unknown", in which case
+     *  the BPM number is derived from the wall-clock spacing of the
+     *  beat signals. */
+    void slotProcessBeat(int bpm = 0);
 
 signals:
     void beatGeneratorTypeChanged();
@@ -621,10 +621,6 @@ signals:
 private:
     BeatGeneratorType m_beatGeneratorType;
     int m_currentBPM;
-    /** Tracker-reported BPM while the Audio generator is active
-     *  (0 = none); when set, slotProcessBeat() skips its wall-clock
-     *  BPM derivation. */
-    int m_audioTrackerBpm;
     QElapsedTimer *m_beatTime;
     AudioCapture *m_inputCapture;
 

--- a/engine/src/inputoutputmap.h
+++ b/engine/src/inputoutputmap.h
@@ -608,6 +608,11 @@ protected slots:
     void slotPluginBeat(quint32 universe, quint32 channel, uchar value, const QString &key);
     void slotProcessBeat();
 
+    /** Receives the audio beat tracker's own tempo estimate (0 = no
+     *  confident estimate). Preferred over the wall-clock BPM derived
+     *  in slotProcessBeat(), which jitters with emission timing. */
+    void slotAudioBpmChanged(int bpm);
+
 signals:
     void beatGeneratorTypeChanged();
     void bpmNumberChanged(int bpmNumber);
@@ -616,6 +621,10 @@ signals:
 private:
     BeatGeneratorType m_beatGeneratorType;
     int m_currentBPM;
+    /** Tracker-reported BPM while the Audio generator is active
+     *  (0 = none); when set, slotProcessBeat() skips its wall-clock
+     *  BPM derivation. */
+    int m_audioTrackerBpm;
     QElapsedTimer *m_beatTime;
     AudioCapture *m_inputCapture;
 

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(test)
 
+add_subdirectory(beattrackerauto)
 add_subdirectory(bus)
 add_subdirectory(channelsgroup)
 add_subdirectory(channelmodifier)

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(test)
 
 add_subdirectory(beattrackerauto)
+add_subdirectory(beattrackerbench)
 add_subdirectory(bus)
 add_subdirectory(channelsgroup)
 add_subdirectory(channelmodifier)

--- a/engine/test/beattrackerauto/CMakeLists.txt
+++ b/engine/test/beattrackerauto/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(beattrackerauto_test WIN32
+    beattrackerauto_test.cpp beattrackerauto_test.h
+)
+target_include_directories(beattrackerauto_test PRIVATE
+    ../../../plugins/interfaces
+    ../../audio/src
+    ../../src
+)
+
+target_link_libraries(beattrackerauto_test PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Gui
+    Qt${QT_MAJOR_VERSION}::Test
+    qlcplusengine
+)

--- a/engine/test/beattrackerauto/beattrackerauto_test.cpp
+++ b/engine/test/beattrackerauto/beattrackerauto_test.cpp
@@ -2,7 +2,7 @@
   Q Light Controller Plus - Unit test
   beattrackerauto_test.cpp
 
-  Copyright (c) Massimo Callegari
+  Copyright (c) varghele
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/engine/test/beattrackerauto/beattrackerauto_test.cpp
+++ b/engine/test/beattrackerauto/beattrackerauto_test.cpp
@@ -1,0 +1,180 @@
+/*
+  Q Light Controller Plus - Unit test
+  beattrackerauto_test.cpp
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <QtTest>
+#include <cmath>
+#include <vector>
+
+#include "beattrackerauto.h"
+#include "beattrackerauto_test.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define SAMPLE_RATE 44100
+#define BLOCK_FRAMES 2048   // frames per AudioCapture block
+
+/** Mix a synthetic kick drum (150->45 Hz sweep, exponential decay)
+ *  into the buffer at the given start frame */
+static void addKick(std::vector<int16_t> &buffer, int startFrame)
+{
+    const int length = int(0.09 * SAMPLE_RATE);
+    double phase = 0.0;
+    for (int i = 0; i < length; i++)
+    {
+        int pos = startFrame + i;
+        if (pos >= int(buffer.size()))
+            break;
+        double t = double(i) / SAMPLE_RATE;
+        double freq = 150.0 * std::exp(-t * 25.0) + 45.0;
+        phase += 2.0 * M_PI * freq / SAMPLE_RATE;
+        double v = std::sin(phase) * std::exp(-t * 30.0) * 0.9;
+        int sample = int(buffer[pos]) + int(v * 20000.0);
+        if (sample > 32767) sample = 32767;
+        if (sample < -32768) sample = -32768;
+        buffer[pos] = int16_t(sample);
+    }
+}
+
+/** Render a mono kick track at the given tempo */
+static std::vector<int16_t> makeKickTrack(double bpm, double seconds)
+{
+    std::vector<int16_t> buffer(size_t(seconds * SAMPLE_RATE), 0);
+    double beat = 0.0;
+    while (beat < seconds)
+    {
+        addKick(buffer, int(beat * SAMPLE_RATE));
+        beat += 60.0 / bpm;
+    }
+    return buffer;
+}
+
+/** Feed a mono track through the tracker in AudioCapture-sized blocks;
+ *  returns the block index of every emitted beat */
+static std::vector<int> runTracker(BeatTrackerAuto &tracker,
+                                   const std::vector<int16_t> &audio,
+                                   int channels = 1)
+{
+    std::vector<int> beatBlocks;
+    const int blockSamples = BLOCK_FRAMES * channels;
+    std::vector<int16_t> block(blockSamples);
+    int blockIndex = 0;
+    for (size_t start = 0; start + BLOCK_FRAMES <= audio.size();
+         start += BLOCK_FRAMES, blockIndex++)
+    {
+        for (int i = 0; i < BLOCK_FRAMES; i++)
+            for (int c = 0; c < channels; c++)
+                block[i * channels + c] = audio[start + i];
+
+        if (tracker.processAudio(block.data(), blockSamples))
+            beatBlocks.push_back(blockIndex);
+    }
+    return beatBlocks;
+}
+
+void BeatTrackerAuto_Test::detectsSteadyTempo_data()
+{
+    QTest::addColumn<double>("bpm");
+    QTest::newRow("90 BPM") << 90.0;
+    QTest::newRow("120 BPM") << 120.0;
+    QTest::newRow("140 BPM") << 140.0;
+    QTest::newRow("174 BPM") << 174.0;
+}
+
+void BeatTrackerAuto_Test::detectsSteadyTempo()
+{
+    QFETCH(double, bpm);
+
+    BeatTrackerAuto tracker(SAMPLE_RATE, 1);
+    std::vector<int16_t> audio = makeKickTrack(bpm, 20.0);
+    runTracker(tracker, audio);
+
+    QVERIFY(tracker.bpm() > 0.0);
+    QVERIFY2(std::fabs(tracker.bpm() - bpm) / bpm < 0.02,
+             qPrintable(QString("detected %1, expected %2")
+                        .arg(tracker.bpm()).arg(bpm)));
+}
+
+void BeatTrackerAuto_Test::beatSpacingIsRegular()
+{
+    const double bpm = 120.0;
+    BeatTrackerAuto tracker(SAMPLE_RATE, 1);
+    std::vector<int16_t> audio = makeKickTrack(bpm, 30.0);
+    std::vector<int> beats = runTracker(tracker, audio);
+
+    // Skip the warmup (first estimate needs ~4s = ~86 blocks + lock time)
+    const double blockSeconds = double(BLOCK_FRAMES) / SAMPLE_RATE;
+    const int warmupBlocks = int(8.0 / blockSeconds);
+    std::vector<double> intervals;
+    int previous = -1;
+    for (size_t i = 0; i < beats.size(); i++)
+    {
+        if (beats[i] < warmupBlocks)
+            continue;
+        if (previous >= 0)
+            intervals.push_back((beats[i] - previous) * blockSeconds);
+        previous = beats[i];
+    }
+    QVERIFY2(intervals.size() >= 30,
+             qPrintable(QString("only %1 post-warmup beat intervals")
+                        .arg(intervals.size())));
+
+    // Each interval within one block of the true beat period, mean within 2%
+    const double period = 60.0 / bpm;
+    double sum = 0.0;
+    for (size_t i = 0; i < intervals.size(); i++)
+    {
+        sum += intervals[i];
+        QVERIFY2(std::fabs(intervals[i] - period) < 2.0 * blockSeconds,
+                 qPrintable(QString("interval %1 s, expected %2 s")
+                            .arg(intervals[i]).arg(period)));
+    }
+    double mean = sum / intervals.size();
+    QVERIFY2(std::fabs(mean - period) / period < 0.02,
+             qPrintable(QString("mean interval %1 s, expected %2 s")
+                        .arg(mean).arg(period)));
+}
+
+void BeatTrackerAuto_Test::silenceGivesNoEstimate()
+{
+    BeatTrackerAuto tracker(SAMPLE_RATE, 1);
+    std::vector<int16_t> silence(size_t(15.0 * SAMPLE_RATE), 0);
+    std::vector<int> beats = runTracker(tracker, silence);
+
+    QCOMPARE(tracker.bpm(), 0.0);
+    QVERIFY(beats.empty());
+}
+
+void BeatTrackerAuto_Test::stereoMatchesMono()
+{
+    const double bpm = 120.0;
+    std::vector<int16_t> audio = makeKickTrack(bpm, 20.0);
+
+    BeatTrackerAuto mono(SAMPLE_RATE, 1);
+    runTracker(mono, audio, 1);
+
+    BeatTrackerAuto stereo(SAMPLE_RATE, 2);
+    runTracker(stereo, audio, 2);
+
+    QVERIFY(mono.bpm() > 0.0);
+    QCOMPARE(stereo.bpm(), mono.bpm());
+}
+
+QTEST_GUILESS_MAIN(BeatTrackerAuto_Test)

--- a/engine/test/beattrackerauto/beattrackerauto_test.h
+++ b/engine/test/beattrackerauto/beattrackerauto_test.h
@@ -2,7 +2,7 @@
   Q Light Controller Plus - Unit test
   beattrackerauto_test.h
 
-  Copyright (c) Massimo Callegari
+  Copyright (c) varghele
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/engine/test/beattrackerauto/beattrackerauto_test.h
+++ b/engine/test/beattrackerauto/beattrackerauto_test.h
@@ -1,0 +1,37 @@
+/*
+  Q Light Controller Plus - Unit test
+  beattrackerauto_test.h
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef BEATTRACKERAUTO_TEST_H
+#define BEATTRACKERAUTO_TEST_H
+
+#include <QObject>
+
+class BeatTrackerAuto_Test : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void detectsSteadyTempo_data();
+    void detectsSteadyTempo();
+    void beatSpacingIsRegular();
+    void silenceGivesNoEstimate();
+    void stereoMatchesMono();
+};
+
+#endif

--- a/engine/test/beattrackerauto/test.sh
+++ b/engine/test/beattrackerauto/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export LD_LIBRARY_PATH=../../src
+export DYLD_FALLBACK_LIBRARY_PATH=../../src
+./beattrackerauto_test

--- a/engine/test/beattrackerbench/CMakeLists.txt
+++ b/engine/test/beattrackerbench/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Console application (no WIN32 flag): the comparison table goes to stdout
+add_executable(beattrackerbench
+    beattrackerbench.cpp
+)
+target_include_directories(beattrackerbench PRIVATE
+    ../../../plugins/interfaces
+    ../../audio/src
+    ../../src
+)
+
+# Link the audio static library directly: the benchmark drives all three
+# tracker implementations, including ones not referenced by (and therefore
+# not exported from) the engine shared library
+target_link_libraries(beattrackerbench PRIVATE
+    Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Gui
+    qlcplusaudio
+    qlcplusengine
+)

--- a/engine/test/beattrackerbench/beattrackerbench.cpp
+++ b/engine/test/beattrackerbench/beattrackerbench.cpp
@@ -1,0 +1,401 @@
+/*
+  Q Light Controller Plus
+  beattrackerbench.cpp
+
+  Copyright (c) varghele
+
+  Head-to-head benchmark of the beat tracker implementations on
+  synthesized percussion audio with known ground-truth tempo.
+  C++ port of varghele's Python benchmark harness (the source of the
+  numbers quoted in issue #1881).
+
+  Usage:
+    beattrackerbench            quick mode: 4 scenarios x 4 tempi,
+                                asserts the default tracker is correct
+                                on every clip (used by test.sh)
+    beattrackerbench --full     8 scenarios x 8 tempi comparison table
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "beattrackerauto.h"
+#include "beattracker.h"
+#include "beattracking.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define SAMPLE_RATE 44100
+#define BLOCK_FRAMES 2048          // AudioCapture block size in frames
+#define CLIP_SECONDS 24.0
+#define TOLERANCE 0.04             // 4% relative: "correct"
+
+typedef std::vector<double> Wave;
+typedef std::mt19937 Rng;
+
+/*****************************************************************************
+ * Percussion synthesis (kick, snare, hats, bass over a sustained pad)
+ *****************************************************************************/
+
+static Wave makeKick()
+{
+    const int n = int(0.09 * SAMPLE_RATE);
+    Wave w(n);
+    double phase = 0.0;
+    for (int i = 0; i < n; i++)
+    {
+        double t = double(i) / SAMPLE_RATE;
+        double freq = 150.0 * std::exp(-t * 25.0) + 45.0;
+        phase += 2.0 * M_PI * freq / SAMPLE_RATE;
+        w[i] = std::sin(phase) * std::exp(-t * 30.0) * 0.9;
+    }
+    return w;
+}
+
+static Wave makeSnare(Rng &rng)
+{
+    const int n = int(0.12 * SAMPLE_RATE);
+    std::normal_distribution<double> gauss(0.0, 1.0);
+    Wave w(n);
+    for (int i = 0; i < n; i++)
+    {
+        double t = double(i) / SAMPLE_RATE;
+        double body = std::sin(2.0 * M_PI * 190.0 * t) * std::exp(-t * 40.0) * 0.4;
+        double rattle = gauss(rng) * std::exp(-t * 35.0) * 0.25;
+        w[i] = body + rattle;
+    }
+    return w;
+}
+
+static Wave makeHat(Rng &rng)
+{
+    const int n = int(0.03 * SAMPLE_RATE);
+    std::normal_distribution<double> gauss(0.0, 1.0);
+    Wave x(n);
+    for (int i = 0; i < n; i++)
+        x[i] = gauss(rng) * std::exp(-double(i) / (0.005 * SAMPLE_RATE));
+    Wave w(n);
+    double prev = 0.0;
+    for (int i = 0; i < n; i++)
+    {
+        w[i] = (x[i] - prev) * 0.20; // crude high-pass
+        prev = x[i];
+    }
+    return w;
+}
+
+static Wave makeBassNote()
+{
+    const int n = int(0.18 * SAMPLE_RATE);
+    Wave w(n);
+    for (int i = 0; i < n; i++)
+    {
+        double t = double(i) / SAMPLE_RATE;
+        double env = std::fmin(t / 0.005, 1.0) * std::exp(-t * 12.0);
+        w[i] = std::sin(2.0 * M_PI * 85.0 * t) * env * 0.45;
+    }
+    return w;
+}
+
+struct Event
+{
+    double time;
+    const Wave *sample;
+};
+
+/** Beat times for a (possibly time-varying) tempo function */
+template <typename TempoFn>
+static std::vector<double> beatTimes(TempoFn bpmAt, double seconds)
+{
+    std::vector<double> times;
+    double t = 0.0;
+    while (t < seconds)
+    {
+        times.push_back(t);
+        t += 60.0 / bpmAt(t);
+    }
+    return times;
+}
+
+/** Render events over a sustained pad + noise floor, int16 round trip */
+static std::vector<int16_t> render(const std::vector<Event> &events,
+                                   double seconds, Rng &rng,
+                                   double gapStart = -1.0, double gapEnd = -1.0)
+{
+    const int n = int(seconds * SAMPLE_RATE);
+    std::normal_distribution<double> gauss(0.0, 1.0);
+    Wave audio(n);
+    for (int i = 0; i < n; i++)
+    {
+        double t = double(i) / SAMPLE_RATE;
+        audio[i] = 0.05 * std::sin(2.0 * M_PI * 110.0 * t)
+                 + 0.02 * std::sin(2.0 * M_PI * 220.0 * t)
+                 + 0.015 * std::sin(2.0 * M_PI * 330.5 * t)
+                 + gauss(rng) * 0.002;
+    }
+    for (size_t e = 0; e < events.size(); e++)
+    {
+        int start = int(events[e].time * SAMPLE_RATE);
+        const Wave &s = *events[e].sample;
+        for (size_t i = 0; i < s.size() && start + int(i) < n; i++)
+            if (start + int(i) >= 0)
+                audio[start + i] += s[i];
+    }
+    if (gapStart >= 0.0)
+        for (int i = int(gapStart * SAMPLE_RATE);
+             i < int(gapEnd * SAMPLE_RATE) && i < n; i++)
+            audio[i] = 0.0;
+
+    std::vector<int16_t> pcm(n);
+    for (int i = 0; i < n; i++)
+    {
+        double v = audio[i];
+        if (v > 1.0) v = 1.0;
+        if (v < -1.0) v = -1.0;
+        pcm[i] = int16_t(v * 32767.0);
+    }
+    return pcm;
+}
+
+/*****************************************************************************
+ * Scenarios (mirror varghele's Python benchmark suite)
+ *****************************************************************************/
+
+struct Clip
+{
+    std::vector<int16_t> pcm;
+    double truth;
+};
+
+static Clip scenarioClip(const std::string &name, double bpm, Rng &rng)
+{
+    static const Wave kick = makeKick();
+    static const Wave bass = makeBassNote();
+    Wave snare = makeSnare(rng);
+    Wave hat = makeHat(rng);
+    double seconds = CLIP_SECONDS;
+    std::vector<Event> ev;
+
+    if (name == "kick four-on-floor")
+    {
+        std::vector<double> beats = beatTimes([&](double){ return bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+            ev.push_back(Event{ beats[i], &kick });
+    }
+    else if (name == "kick + 8th hats")
+    {
+        std::vector<double> beats = beatTimes([&](double){ return bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+        {
+            ev.push_back(Event{ beats[i], &kick });
+            ev.push_back(Event{ beats[i] + 30.0 / bpm, &hat });
+        }
+    }
+    else if (name == "kick/snare backbeat")
+    {
+        std::vector<double> beats = beatTimes([&](double){ return bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+            ev.push_back(Event{ beats[i], (i % 2 == 0) ? &kick : &snare });
+    }
+    else if (name == "8th-note bassline")
+    {
+        std::vector<double> beats = beatTimes([&](double){ return bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+        {
+            ev.push_back(Event{ beats[i], &kick });
+            ev.push_back(Event{ beats[i] + 30.0 / bpm, &bass });
+        }
+    }
+    else if (name == "swung hats")
+    {
+        std::vector<double> beats = beatTimes([&](double){ return bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+        {
+            ev.push_back(Event{ beats[i], &kick });
+            ev.push_back(Event{ beats[i] + 40.0 / bpm, &hat });
+        }
+    }
+    else if (name == "tempo drift +/-3%")
+    {
+        std::vector<double> beats = beatTimes(
+            [&](double t){ return bpm * (0.97 + 0.06 * t / CLIP_SECONDS); }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+            ev.push_back(Event{ beats[i], &kick });
+    }
+    else if (name == "2.5 s dropout")
+    {
+        std::vector<double> beats = beatTimes([&](double){ return bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+            ev.push_back(Event{ beats[i], &kick });
+        Clip clip;
+        clip.pcm = render(ev, seconds, rng, 10.0, 12.5);
+        clip.truth = bpm;
+        return clip;
+    }
+    else if (name == "tempo step +30%")
+    {
+        seconds = 28.0;
+        std::vector<double> beats = beatTimes(
+            [&](double t){ return (t < 12.0) ? bpm / 1.3 : bpm; }, seconds);
+        for (size_t i = 0; i < beats.size(); i++)
+            ev.push_back(Event{ beats[i], &kick });
+    }
+
+    Clip clip;
+    clip.pcm = render(ev, seconds, rng);
+    clip.truth = bpm;
+    return clip;
+}
+
+/*****************************************************************************
+ * Tracker adapters and scoring
+ *****************************************************************************/
+
+/** Feed a mono clip in AudioCapture-sized blocks; return the final BPM */
+template <typename ProcessFn, typename BpmFn>
+static double runClip(const Clip &clip, ProcessFn process, BpmFn bpm)
+{
+    for (size_t s = 0; s + BLOCK_FRAMES <= clip.pcm.size(); s += BLOCK_FRAMES)
+        process(const_cast<int16_t *>(clip.pcm.data() + s), BLOCK_FRAMES);
+    return bpm();
+}
+
+enum Verdict { Correct, Octave, Wrong, None };
+
+static Verdict classify(double est, double truth)
+{
+    if (est <= 0.0)
+        return None;
+    if (std::fabs(est - truth) / truth <= TOLERANCE)
+        return Correct;
+    static const double octaves[] = { 2.0, 0.5, 3.0, 1.0 / 3.0, 1.5, 2.0 / 3.0 };
+    for (size_t i = 0; i < sizeof(octaves) / sizeof(octaves[0]); i++)
+        if (std::fabs(est - truth * octaves[i]) / (truth * octaves[i]) <= TOLERANCE)
+            return Octave;
+    return Wrong;
+}
+
+static const char *verdictName(Verdict v)
+{
+    switch (v)
+    {
+        case Correct: return "correct";
+        case Octave: return "octave";
+        case Wrong: return "wrong";
+        default: return "none";
+    }
+}
+
+int main(int argc, char **argv)
+{
+    const bool full = (argc > 1 && std::strcmp(argv[1], "--full") == 0);
+
+    static const char *allScenarios[] = {
+        "kick four-on-floor", "kick + 8th hats", "kick/snare backbeat",
+        "8th-note bassline", "swung hats", "tempo drift +/-3%",
+        "2.5 s dropout", "tempo step +30%"
+    };
+    static const double allTempi[] = { 60, 75, 90, 105, 120, 140, 160, 180 };
+    const int nScenarios = full ? 8 : 4;
+    const int nTempi = full ? 8 : 4;
+    static const double quickTempi[] = { 75, 105, 140, 174 };
+    const double *tempi = full ? allTempi : quickTempi;
+
+    static const char *trackerNames[] = {
+        "BeatTrackerAuto (default)", "BeatTracker (spectral flux)",
+        "BeatTracking (ACF)"
+    };
+    int correct[3] = { 0, 0, 0 };
+    int perScenario[3][8];
+    std::memset(perScenario, 0, sizeof(perScenario));
+    int defaultTrackerFailures = 0;
+
+    std::printf("Beat tracker comparison: %d scenarios x %d tempi, "
+                "%.0f+ s clips, tolerance %.0f%%\n\n",
+                nScenarios, nTempi, CLIP_SECONDS, TOLERANCE * 100.0);
+
+    Rng rng(1234);
+    for (int s = 0; s < nScenarios; s++)
+    {
+        for (int t = 0; t < nTempi; t++)
+        {
+            Clip clip = scenarioClip(allScenarios[s], tempi[t], rng);
+            double est[3];
+            Verdict verdict[3];
+
+            BeatTrackerAuto autoTracker(SAMPLE_RATE, 1);
+            est[0] = runClip(clip,
+                [&](int16_t *b, int n){ autoTracker.processAudio(b, n); },
+                [&](){ return autoTracker.bpm(); });
+
+            BeatTracker flux(SAMPLE_RATE, BLOCK_FRAMES, 1, 86, 1.3);
+            flux.setBand(40.0, 400.0);
+            flux.setFluxSmoothing(0.6);
+            flux.setMinBeatInterval(0.20);
+            est[1] = runClip(clip,
+                [&](int16_t *b, int n){ flux.processAudio(b, n); },
+                [&](){ return flux.getCurrentBpm(); });
+
+            BeatTracking acf(SAMPLE_RATE, 1);
+            est[2] = runClip(clip,
+                [&](int16_t *b, int n){ acf.processAudio(b, n); },
+                [&](){ return acf.currentBpm(); });
+
+            for (int i = 0; i < 3; i++)
+            {
+                verdict[i] = classify(est[i], clip.truth);
+                if (verdict[i] == Correct)
+                {
+                    correct[i]++;
+                    perScenario[i][s]++;
+                }
+            }
+            if (verdict[0] != Correct)
+                defaultTrackerFailures++;
+
+            std::printf("%-20s %3.0f BPM:  auto %7.2f (%s)  flux %7.2f (%s)"
+                        "  acf %7.2f (%s)\n",
+                        allScenarios[s], clip.truth,
+                        est[0], verdictName(verdict[0]),
+                        est[1], verdictName(verdict[1]),
+                        est[2], verdictName(verdict[2]));
+        }
+    }
+
+    const int total = nScenarios * nTempi;
+    std::printf("\n%-30s %s\n", "tracker", "correct");
+    for (int i = 0; i < 3; i++)
+    {
+        std::printf("%-30s %d/%d   per scenario:", trackerNames[i],
+                    correct[i], total);
+        for (int s = 0; s < nScenarios; s++)
+            std::printf(" %d", perScenario[i][s]);
+        std::printf("\n");
+    }
+
+    if (!full && defaultTrackerFailures > 0)
+    {
+        std::printf("\nFAIL: default tracker missed %d/%d quick clips\n",
+                    defaultTrackerFailures, total);
+        return 1;
+    }
+    return 0;
+}

--- a/engine/test/beattrackerbench/test.sh
+++ b/engine/test/beattrackerbench/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+export LD_LIBRARY_PATH=../../src
+export DYLD_FALLBACK_LIBRARY_PATH=../../src
+# Quick mode: asserts the default tracker on 16 clips and prints the
+# three-way comparison. Run ./beattrackerbench --full for the complete
+# 8 scenarios x 8 tempi table.
+./beattrackerbench


### PR DESCRIPTION
<!-- Thank you for contributing to QLC+! -->

## Description

**Summary of Changes:**

As discussed in #1881, this fixes the beat tracker integration defects behind the reported symptoms and adds a tempo-induction beat tracker (`beattrackerauto.cpp`) as the active implementation.

*Integration fixes:*
- `BeatTracking` now takes `(sampleRate, channels)` and converts total samples to frames in its mixdown — this removes an out-of-bounds read and a 2x time-base distortion (the previous hard-coded stereo mixdown on mono capture is what doubled the BPM and produced erratic beats; the issue's test video is a 100 BPM metronome and read ~198 with the bug reproduced, 99.6 correctly wired).
- New `AudioCapture::beatBpmChanged(int)` signal: the UI now shows the tracker's own tempo estimate instead of re-deriving BPM from the wall-clock spacing of `beatDetected()` signals, which amplified every hop of emission jitter into a BPM change.
- Bugfix found along the way: `beattracker.h` reused `BEATTRACKING_H` as its include guard, colliding with `beattracking.h` — a translation unit including both silently dropped one of them.

*New tracker (in one paragraph):* an onset front end computes, per 512-sample hop (~86/s), the positive log-magnitude spectral difference over a ~93 ms window, split into three bands (<200 Hz / 200-4000 Hz / >=4 kHz) with per-band peak saturation and rising-edge detection, so kicks and snares contribute near-equally (no backbeat half-lock) while hats stay weaker (no subdivision double-tempo). Every 2 s an 8 s onset window is autocorrelated and every candidate on a fractional 50-240 BPM grid is scored by a harmonic comb (ACF at 1-4x the period); a temporal belief filter picks a stable base, an octave-raise step resolves the half-tempo trap, and the reported BPM is the median of the last 3 analyses, gated on confidence. Beats are emitted from the predicted tempo+phase grid ("steady beats"), not per audible onset. Full documentation, tuning rationale and validation record: `engine/audio/src/beattrackerauto.md`.

It is self-contained plain C++ (own radix-2 FFT): no Qt or fftw3 dependency, so beat tracking also works in builds without fftw3. CPU: ~1.3% of one core.

*Behavior notes (documented):* first estimate after ~4 s of music; re-lock after a live tempo change takes ~12-16 s (deliberate stability trade-off); material fully dominated by 8th-note energy can read an octave up.

*Kept for the consolidation:* the previous spectral-flux tracker stays selectable behind the `NEW_TRACKER` define for A/B comparison (see the benchmark below) — happy to remove it in a follow-up commit if a hard replacement is preferred.

**Related Issues:**
Related to #1881.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux (Ubuntu 24.04, GCC 13.3, Qt 6.4)
  - [x] Windows (MinGW 13.1, Qt 6.8)
  - [ ] macOS (untested — the tracker is plain C++ with no platform-specific code; CI should confirm)
- [x] Documentation: no new user-facing options; the algorithm is documented in-repo (`engine/audio/src/beattrackerauto.md`).

## Testing

**Test Cases:**

- **Unit test** (`engine/test/beattrackerauto`, runs in `make check`): synthetic kick tracks through `processAudio()` in capture-sized blocks — tempo within 2% at 90/120/140/174 BPM, regular post-warmup beat spacing, no estimate/beats on silence, interleaved stereo matches mono. 9/9 pass on both platforms.
- **Three-way benchmark tool** (`engine/test/beattrackerbench`): synthesizes 8 percussion scenarios (four-on-floor, 8th hats, backbeat, 8th-note bassline, swung hats, ±3% drift, 2.5 s dropout, +30% tempo step) x 8 tempi with known ground truth and runs all three implementations head-to-head. Quick mode runs inside `make check`; `--full` prints the complete table. The benchmark is deterministic (fixed seed) — it reproduces this exact table on Windows and Linux:

  | tracker | correct (4% tolerance) |
  |---|---|
  | BeatTrackerAuto (default) | **63/64** |
  | BeatTracker (spectral flux) | 54/64 |
  | BeatTracking (ACF) | 48/64 |

  The new tracker's single miss is a 90 BPM 8th-hats clip reading an octave up — the documented known limit (the ACF tracker flips on the same clip).
- **The issue's own test material**: the #1881 video (a 100 BPM metronome) reads 100.00 BPM with 0.600 s beat intervals; a 140 BPM rock drum-track video reads 139.75. Confirmed at file level and in live microphone tests on Windows (phone speaker -> laptop mic: locks at 100 within seconds, holds steady) and Linux (virtual source).
- **Full engine test suite**: complete run on Linux (95 suites, 3416 assertions, 0 failures, fixture validation OK); on Windows all suites pass except pre-existing path-normalization/name-casing cases that fail identically on the untouched branch.

**Testing note:** while verifying on Linux we also noticed that a test suite aborting (e.g. a non-executable `test.sh`) is silently swallowed by `unittest.sh` — `make check` still reports success while skipping the remaining suites. Pre-existing and unrelated to this PR; happy to file it separately.
