### PR TITLE
fix yaml syntax in obs workflow file

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -2,7 +2,8 @@ workflow:
   steps:
     - trigger_services:
         project: home:mcallegari79
-        package: qlcplus-git
-        package: qlcplus5-git
+        packages:
+          - qlcplus-git
+          - qlcplus5-git
   filters:
     event: push


### PR DESCRIPTION
duplicate keys aren't possible in yaml, thus qlcplus-git trigger got overwritten by the later entry...