### PR TITLE
resources: Add Stairville HZ-1500 Pro Touring Hazer

### DIFF
--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -1805,6 +1805,7 @@
     <F n="Stairville-HF-900-Haze-Fogger" m="HF-900 Haze Fogger"/>
     <F n="Stairville-HL-x9-18-DCL-CW-WWFlood-9-18x6W" m="HL-x9-18 DCL CW-WWFlood 9-18x6W"/>
     <F n="Stairville-HL-x9-Quad-Color-Flood-9x8W" m="HL-x9 Quad Color Flood 9x8W"/>
+    <F n="Stairville-HZ-1500-Pro-Touring-Hazer-DMX" m="HZ-1500 Pro Touring Hazer DMX"/>
     <F n="Stairville-Hz-200-DMX" m="Hz-200 DMX"/>
     <F n="Stairville-Infinite-Pixel-250" m="Infinite Pixel 250"/>
     <F n="Stairville-JunoScan-MKII" m="JunoScan MKII"/>

--- a/resources/fixtures/Stairville/Stairville-HZ-1500-Pro-Touring-Hazer-DMX.qxf
+++ b/resources/fixtures/Stairville/Stairville-HZ-1500-Pro-Touring-Hazer-DMX.qxf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.14.4</Version>
+  <Author>Christoph Müllner</Author>
+ </Creator>
+ <Manufacturer>Stairville</Manufacturer>
+ <Model>HZ-1500 Pro Touring Hazer DMX</Model>
+ <Type>Hazer</Type>
+ <Channel Name="Haze Amount">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">No haze output (1%) to maximum haze output (100%)</Capability>
+ </Channel>
+ <Channel Name="Fan Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Minimum fan speed (0%) to maximum fan speed (100%)</Capability>
+ </Channel>
+ <Mode Name="2 Channel">
+  <Channel Number="0">Haze Amount</Channel>
+  <Channel Number="1">Fan Speed</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="16.45" Width="490" Height="345" Depth="170"/>
+  <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical PowerConsumption="1420" DmxConnector="3-pin and 5-pin"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION
Add a QXF definition for the Stairville HZ-1500 Pro Touring Hazer DMX and register it in FixturesMap.xml.

Links:
- Product www.thomann.de/de/stairville_hz_1500_pro_touring_hazer_dmx.htm
- Manual https://images.static-thomann.de/pics/atg/atgdata/document/ \ manual/450663_c_450663_v3_en_online.pdf

<!--
Thank you for contributing a new fixture to QLC+!

Please make sure you've tested the fixture file thoroughly. This template will help reviewers validate and merge your contribution smoothly.
-->

## Fixture Information

**Manufacturer:**  
Stairville

**Model:**  
HZ-1500 Pro Touring Hazer DMX

**Mode(s) included:**  
"2 Channel"

**Channels used:**  
"Haze Amount", "Fan Speed"

## Testing

- [x] Physical data is included 
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly

## Source(s) of Information

https://www.thomann.de/de/stairville_hz_1500_pro_touring_hazer_dmx.htm
https://images.static-thomann.de/pics/atg/atgdata/document/manual/450663_c_450663_v3_en_online.pdf