### PR TITLE
various small improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,7 @@ jobs:
           cmake --build build --target install
           cp -v resources/icons/svg/qlcplus.svg ${INSTALL_ROOT}
           cp -v platforms/linux/qlcplus.desktop ${INSTALL_ROOT}
+          cp -v $QTDIR/translations/qtbase_* ${INSTALL_ROOT}/share/qlcplus/translations/
 
       - name: Set APPVERSION
         if: ${{ ! startsWith( matrix.task, 'coverage') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
 
@@ -95,7 +95,7 @@ jobs:
           echo "NPROC: ${NPROC}"
 
       - name: Download, cache and install packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
           packages: ${{env.PACKAGES_ALL}}
           version: ${{runner.os}}-apt
@@ -263,7 +263,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
 
@@ -467,7 +467,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
 

--- a/engine/audio/src/beattracker.h
+++ b/engine/audio/src/beattracker.h
@@ -43,7 +43,7 @@
  * follower) and reduced to its rising edge, then combined with weights
  * 1 / 1 / 0.4. Self-contained radix-2 FFT; no external dependencies.
  */
-class BeatOnsetExtractor
+class BeatOnsetExtractor final
 {
 public:
     explicit BeatOnsetExtractor(int sampleRate);
@@ -93,7 +93,7 @@ private:
  * hysteresis toward the previous estimate. Reported BPM is the median
  * of the last 3 analyses, gated on comb confidence >= 0.15.
  */
-class AutoBpmDetector
+class AutoBpmDetector final
 {
 public:
     explicit AutoBpmDetector(double analysisRateHz,
@@ -162,7 +162,7 @@ private:
  * block; bpm() exposes the estimator's tempo so the UI can display it
  * instead of re-deriving BPM from wall-clock signal spacing.
  */
-class BeatTracker
+class BeatTracker final
 {
 public:
     BeatTracker(int sampleRate, int channels);

--- a/engine/src/fixtureremapper.h
+++ b/engine/src/fixtureremapper.h
@@ -49,7 +49,7 @@ class Fixture;
  *     the sourceList() / targetList() accessors together with
  *     remapSceneValues().
  */
-class FixtureRemapper
+class FixtureRemapper final
 {
 public:
     FixtureRemapper();

--- a/engine/test/beattracker/beattracker_test.h
+++ b/engine/test/beattracker/beattracker_test.h
@@ -22,7 +22,7 @@
 
 #include <QObject>
 
-class BeatTracker_Test : public QObject
+class BeatTracker_Test final : public QObject
 {
     Q_OBJECT
 

--- a/engine/test/fixtureremapper/fixtureremapper_test.h
+++ b/engine/test/fixtureremapper/fixtureremapper_test.h
@@ -27,7 +27,7 @@ class Fixture;
 class QLCFixtureDef;
 class QLCFixtureMode;
 
-class FixtureRemapper_Test : public QObject
+class FixtureRemapper_Test final : public QObject
 {
     Q_OBJECT
 

--- a/engine/test/universeperf/universeperf_test.cpp
+++ b/engine/test/universeperf/universeperf_test.cpp
@@ -47,7 +47,7 @@ namespace
 #define PERF_BENCHMARK_TICKS 150
 #define PERF_FADE_MS        2000
 
-class TestUniverse : public Universe
+class TestUniverse final : public Universe
 {
 public:
     using Universe::Universe;

--- a/qmlui/fixtureeditor/aliasedit.cpp
+++ b/qmlui/fixtureeditor/aliasedit.cpp
@@ -205,7 +205,7 @@ int AliasEdit::applyToAllModes(QString targetChannel)
     return added;
 }
 
-QString AliasEdit::aliasWarning(int index)
+QString AliasEdit::aliasWarning(int index) const
 {
     if (m_capability == nullptr || m_fixtureDef == nullptr)
         return QString();

--- a/qmlui/fixtureeditor/aliasedit.h
+++ b/qmlui/fixtureeditor/aliasedit.h
@@ -95,7 +95,7 @@ public:
 
     /** Return a validation warning string for the alias at $index, or an
      *  empty string when the alias is valid */
-    Q_INVOKABLE QString aliasWarning(int index);
+    Q_INVOKABLE QString aliasWarning(int index) const;
 
 private:
     /** Rebuild the QML list model from the capability alias list */

--- a/qmlui/fixtureremapmanager.h
+++ b/qmlui/fixtureremapmanager.h
@@ -43,7 +43,7 @@ class Fixture;
  *
  * Registered as QML context property "FixtureRemapManager".
  */
-class FixtureRemapManager : public QObject
+class FixtureRemapManager final : public QObject
 {
     Q_OBJECT
 

--- a/ui/src/dmxdumpfactory.cpp
+++ b/ui/src/dmxdumpfactory.cpp
@@ -215,7 +215,7 @@ void DmxDumpFactory::accept()
     QByteArray dumpMask = m_properties->channelsMask();
     QList<Universe*> ua = m_doc->inputOutputMap()->claimUniverses();
 
-    QByteArray preGMValues(ua.size() * UNIVERSE_SIZE, 0); //= ua->preGMValues();
+    QByteArray preGMValues(ua.size() * UNIVERSE_SIZE, 0); // = ua->preGMValues();
 
     for (int i = 0; i < ua.count(); ++i)
     {

--- a/ui/src/efxeditor.h
+++ b/ui/src/efxeditor.h
@@ -164,7 +164,7 @@ private slots:
 
 private:
     /* Dimmer envelope widgets, created at runtime and added to the
-       parameters group, gated by the dimmer control checkbox) */
+       parameters group, gated by the dimmer control checkbox */
     QCheckBox *m_dimmerControlCheck = nullptr;
 
 private:

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -198,8 +198,13 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
         else if (apiCmd == "getWidgetsNumber")
         {
             VCFrame *mainFrame = m_vc->contents();
-            QList<VCWidget *> chList = mainFrame->findChildren<VCWidget*>();
-            wsAPIMessage.append(QString::number(chList.count()));
+            if (mainFrame != NULL)
+            {
+                QList<VCWidget *> chList = mainFrame->findChildren<VCWidget*>();
+                wsAPIMessage.append(QString::number(chList.count()));
+            } else {
+                wsAPIMessage.append("-1");
+            }
         }
         else if (apiCmd == "getWidgetsList")
         {

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -202,7 +202,9 @@ void WebAccess::slotHandleWebSocketRequest(QHttpConnection *conn, QString data)
             {
                 QList<VCWidget *> chList = mainFrame->findChildren<VCWidget*>();
                 wsAPIMessage.append(QString::number(chList.count()));
-            } else {
+            } 
+            else 
+            {
                 wsAPIMessage.append("-1");
             }
         }
@@ -1197,25 +1199,33 @@ void WebAccess::slotCuePlaybackStateChanged()
     QString stopButtonImage = "player_stop.png";
     bool stopButtonPaused = false;
 
-    if (chaser->isRunning()) {
-        if (cue->playbackLayout() == VCCueList::PlayPauseStop) {
-            if (chaser->isPaused()) {
+    if (chaser->isRunning()) 
+    {
+        if (cue->playbackLayout() == VCCueList::PlayPauseStop) 
+        {
+            if (chaser->isPaused()) 
+            {
                 playbackButtonImage = "player_play.png";
                 playbackButtonPaused = true;
-            } else {
+            } 
+            else 
+            {
                 playbackButtonImage  = "player_pause.png";
             }
-        } else if (cue->playbackLayout() == VCCueList::PlayStopPause) {
+        } 
+        else if (cue->playbackLayout() == VCCueList::PlayStopPause) 
+        {
             playbackButtonImage = "player_stop.png";
             stopButtonImage = "player_pause.png";
-            if (chaser->isPaused()) {
+
+            if (chaser->isPaused()) 
                 stopButtonPaused = true;
-            }
         }
-    } else {
-        if (cue->playbackLayout() == VCCueList::PlayStopPause) {
+    } 
+    else 
+    {
+        if (cue->playbackLayout() == VCCueList::PlayStopPause)
             stopButtonImage = "player_pause.png";
-        }
     }
 
     QString wsMessage = QString("%1|CUE_CHANGE|%2|%3|%4|%5")

--- a/webaccess/src/webaccessnetwork.cpp
+++ b/webaccess/src/webaccessnetwork.cpp
@@ -129,7 +129,7 @@ QString WebAccessNetwork::getInterfaceHTML(const InterfaceInfo *iface) const
     else
     {
         html += "<td style=\"padding: 0 20px; text-align: center; background: #333;\">";
-        html += tr("Network interface") + "<br>" + iface->devName.toHtmlEscaped() + "</td>\n";
+        html += tr("Network interface") + "<br>" + devNameAttr + "</td>\n";
 
         html += "<td><form style=\"margin: 5px 15px; color:#FFF;\">\n";
         if (iface->isWireless)


### PR DESCRIPTION
This PR contains small improvements and fixes for minor issues that I have noticed over the last few months:

- qmlui/aliasedit: make function const

- engine,qmlui: add missing final keywords

- ui/efxeditor: fix typo in comment

Those changes continue previous efforts and should therefore be self-explanatory.

- webaccess/webaccessnetwork: replace redundant calculation
#2026 hardened various parts of the `WebAccess` by adding input validation and escaping as well as some `nullptr` checks. However, in this case, the expression has already been calculated and stored in a variable, so use that instead.

- webaccess/webaccess: add additional check
This change (which was somewhat inspired by #1955) continues the aforementioned hardening effort of #2026 by adding a missing `nullptr` check.

- actions: add Qt translation files to AppImage builds
Although 30ee0e145761229b840e7375cf9e2c38091236f8 (which fixed #2056) added the Qt translation files to AppImage builds (via the AppImage creation script `create-appimage.sh`), this script is not used to build the GitHub Action AppImages. Hence, those development/test builds do not contain those translation files, contrary to the release versions. This commit tries to close this gap. See also #2035 and #2046.

- ui/dmxdumpfactory: fix lupdate warning
When running `lupdate` via the `translate.sh update` command, using Qt 6.10.2, the following warning is generated:
```
[...]/ui/src/dmxdumpfactory.cpp:218: Setting translation IDs using //= or #= is deprecated and will be removed in the upcoming versions.
[...]/ui/src/dmxdumpfactory.cpp:220: Discarding unconsumed meta data
```

- ci: update GitHub Actions versions
This follows up #2010 and #2013 and updates `build.yml`:
  - `actions/checkout`: `v6` -> `v7`
  - `awalsh128/cache-apt-pkgs-action`: `v1.6.0` -> `v1.6.3`

Current upstream state of `awalsh128/cache-apt-pkgs-action` (as of July 23, 2026):
  - the latest release is `v1.6.3`, published on June 30, 2026
  - the released `v1.6.3` tag now pins `actions/cache/restore` and `actions/cache/save` to `v6.1.0` as well as `actions/upload-artifact` to `v7.0.0`

All those versions support the Node 24 runtime natively, finally removing all Node 20 deprecation warnings* (also the transitive ones from `awalsh128/cache-apt-pkgs-action`) from QLC+’s builds.

\* GitHub switched Actions runners to Node 24 [by default on June 16, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).