### PR TITLE
webaccess(-qml): improve localisation possibilities

### DIFF
--- a/engine/src/qlci18n.cpp
+++ b/engine/src/qlci18n.cpp
@@ -31,6 +31,7 @@
 
 QString QLCi18n::s_defaultLocale = QString();
 QString QLCi18n::s_translationFilePath = QString();
+QString QLCi18n::s_loadedLanguage = QString();
 
 void QLCi18n::init()
 {
@@ -58,6 +59,16 @@ QString QLCi18n::translationFilePath()
     return s_translationFilePath;
 }
 
+void QLCi18n::setLoadedLanguage(const QString& language)
+{
+    s_loadedLanguage = language;
+}
+
+QString QLCi18n::loadedLanguage()
+{
+    return s_loadedLanguage;
+}
+
 bool QLCi18n::loadTranslation(const QString& component)
 {
     const QString lc = defaultLocale().isEmpty() ? QLocale::system().name() : defaultLocale();
@@ -66,10 +77,12 @@ bool QLCi18n::loadTranslation(const QString& component)
     if (translator->load(file, translationFilePath()) == true)
     {
         QCoreApplication::installTranslator(translator);
+        setLoadedLanguage(lc);
         return true;
     }
     else
     {
+        setLoadedLanguage("en");
         return false;
     }
 }

--- a/engine/src/qlci18n.cpp
+++ b/engine/src/qlci18n.cpp
@@ -32,6 +32,7 @@
 QString QLCi18n::s_defaultLocale = QString();
 QString QLCi18n::s_translationFilePath = QString();
 QString QLCi18n::s_loadedLanguage = QString();
+QString QLCi18n::s_loadedLanguageHTML = QString();
 
 void QLCi18n::init()
 {
@@ -62,11 +63,17 @@ QString QLCi18n::translationFilePath()
 void QLCi18n::setLoadedLanguage(const QString& language)
 {
     s_loadedLanguage = language;
+    s_loadedLanguageHTML = language.toLower().replace('_', '-');
 }
 
 QString QLCi18n::loadedLanguage()
 {
     return s_loadedLanguage;
+}
+
+QString QLCi18n::loadedLanguageHTML()
+{
+    return s_loadedLanguageHTML;
 }
 
 bool QLCi18n::loadTranslation(const QString& component)

--- a/engine/src/qlci18n.h
+++ b/engine/src/qlci18n.h
@@ -50,6 +50,7 @@ public:
 
     /** Get the currently used locale */
     static QString loadedLanguage();
+    static QString loadedLanguageHTML();
 
     /**
      * Load translation for a component. The translation file that this method
@@ -67,6 +68,7 @@ private:
     static QString s_defaultLocale;
     static QString s_translationFilePath;
     static QString s_loadedLanguage;
+    static QString s_loadedLanguageHTML;
 };
 
 /** @} */

--- a/engine/src/qlci18n.h
+++ b/engine/src/qlci18n.h
@@ -45,6 +45,12 @@ public:
     /** Get the folder path where translation are loaded from */
     static QString translationFilePath();
 
+    /** Set the currently used locale */
+    static void setLoadedLanguage(const QString& language);
+
+    /** Get the currently used locale */
+    static QString loadedLanguage();
+
     /**
      * Load translation for a component. The translation file that this method
      * attempts to load takes the following form: "<component>_<locale>.qm". For
@@ -60,6 +66,7 @@ public:
 private:
     static QString s_defaultLocale;
     static QString s_translationFilePath;
+    static QString s_loadedLanguage;
 };
 
 /** @} */

--- a/qmlui/app.cpp
+++ b/qmlui/app.cpp
@@ -335,6 +335,19 @@ void App::setLanguage(QString locale)
     engine()->retranslate();
 }
 
+QString App::language()
+{
+    const QSettings settings;
+    const QVariant language = settings.value(SETTINGS_LANGUAGE);
+
+    return language.isValid() ? language.toString() : "";
+}
+
+QString App::languageHTML()
+{
+    return language().toLower().replace('_', '-');
+}
+
 QString App::goboSystemPath() const
 {
     return QLCFile::systemDirectory(GOBODIR).absolutePath();

--- a/qmlui/app.h
+++ b/qmlui/app.h
@@ -165,6 +165,8 @@ public:
     Q_INVOKABLE void toggleFullscreen();
 
     Q_INVOKABLE void setLanguage(QString locale);
+    static QString language();
+    static QString languageHTML();
 
     Q_INVOKABLE QString goboSystemPath() const;
 

--- a/translate.sh
+++ b/translate.sh
@@ -81,16 +81,6 @@ is_cmake_build_dir() {
   [[ -e "$1/CMakeCache.txt" || -d "$1/CMakeFiles" ]]
 }
 
-find_ts_for_lang() {
-  # args: lang, flavor
-  local lang="$1"; local flavor="$2"
-  if [[ "$flavor" == "qmlui" ]]; then
-    find . -type f -path "./qmlui/*" -name "*_${lang}.ts"
-  else
-    find . -type f -not -path "./qmlui/*" -name "*_${lang}.ts"
-  fi
-}
-
 case "$ACTION" in
   update)
     echo "Scanning for translation folders and updating .ts files..."
@@ -128,7 +118,7 @@ case "$ACTION" in
       # Gather files
       files_tmp="$(mktemp)"
       if [[ "$FLAVOR" == "qmlui" ]]; then
-        find . -type f -path "./qmlui/*" -name "*_${lang}.ts" > "$files_tmp"
+        find . -type f \( -path "./qmlui/*" -o -path "./plugins/*" -o -path "./webaccess/*" \) -name "*_${lang}.ts" > "$files_tmp"
       else
         find . -type f -not -path "./qmlui/*" -name "*_${lang}.ts" > "$files_tmp"
       fi
@@ -156,7 +146,7 @@ case "$ACTION" in
     # Collect reference TS files for the flavor
     refs_tmp="$(mktemp)"
     if [[ "$FLAVOR" == "qmlui" ]]; then
-      find . -type f -path "./qmlui/*" -name "*_[a-z][a-z]_[A-Z][A-Z].ts" > "$refs_tmp"
+      find . -type f \( -path "./qmlui/*" -o -path "./plugins/*" -o -path "./webaccess/*" \) -name "*_[a-z][a-z]_[A-Z][A-Z].ts" > "$refs_tmp"
     else
       find . -type f -not -path "./qmlui/*" -name "*_[a-z][a-z]_[A-Z][A-Z].ts" > "$refs_tmp"
     fi

--- a/webaccess/res/keypad.html
+++ b/webaccess/res/keypad.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">

--- a/webaccess/res/webaccess-v5.html
+++ b/webaccess/res/webaccess-v5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/webaccess/res/webaccess-v5.js
+++ b/webaccess/res/webaccess-v5.js
@@ -113,6 +113,11 @@ const wsStatus = document.getElementById("wsStatus");
 const brandTitle = document.querySelector(".brand-title");
 const appMeta = document.getElementById("appMeta");
 
+const connectedTranslationEnglishFallback = "Connected";
+const disconnectedTranslationEnglishFallback = "Disconnected";
+let connectedTranslation = connectedTranslationEnglishFallback;
+let disconnectedTranslation = disconnectedTranslationEnglishFallback;
+
 function updateWebPixelDensity() {
   const dpr = window.devicePixelRatio || 1;
   const dpi = 96 * dpr;
@@ -174,8 +179,8 @@ function setStatus(connected) {
   wsStatus.textContent = "";
   wsStatus.classList.toggle("connected", connected);
   wsStatus.classList.toggle("disconnected", !connected);
-  wsStatus.setAttribute("aria-label", connected ? "Connected" : "Disconnected");
-  wsStatus.title = connected ? "Connected" : "Disconnected";
+  wsStatus.setAttribute("aria-label", connected ? connectedTranslation : disconnectedTranslation);
+  wsStatus.title = connected ? connectedTranslation : disconnectedTranslation;
 }
 
 function updatePagesCompact() {
@@ -2690,6 +2695,12 @@ function renderVC(vcData) {
   const appVersion = vcData.app?.version || "";
   if (brandTitle) brandTitle.textContent = appName;
   appMeta.textContent = appVersion;
+  if (vcData.translations?.loadProject) document.getElementById("loadProjectBtn").innerText = vcData.translations?.loadProject;
+  if (vcData.translations?.simpleDesk) document.getElementById("loadProjectBtn").nextElementSibling.innerText = vcData.translations?.simpleDesk;
+  if (vcData.translations?.configuration) document.getElementById("loadProjectBtn").nextElementSibling.nextElementSibling.innerText = vcData.translations?.configuration;
+  connectedTranslation = vcData.translations?.connected || connectedTranslationEnglishFallback;
+  disconnectedTranslation = vcData.translations?.disconnected || disconnectedTranslationEnglishFallback;
+  setStatus(wsStatus.classList.contains('connected'));
   renderPages(vcData);
 }
 

--- a/webaccess/res/webaccess-v5.js
+++ b/webaccess/res/webaccess-v5.js
@@ -1152,15 +1152,6 @@ function renderXYPad(widget) {
     return (rel / rect.height) * 255;
   };
 
-  const handleRangePointer = (axis, ev, container) => {
-    const value = rangeValueFromPointer(axis, ev, container);
-    const which = pickRangeTarget(axis, value);
-    setActiveRangeHandle(axis, which);
-    updateRangeValue(axis, which, value);
-    syncRangeInputs();
-    sendRangeUpdate(axis);
-  };
-
   const rangeDrag = { active: false, axis: null, which: null, container: null };
   const startRangeDrag = (axis, ev, container) => {
     rangeDrag.active = true;
@@ -2380,7 +2371,6 @@ function renderFrame(widget, isSolo) {
   const root = applyWidgetBase(document.createElement("div"), widget);
   root.classList.add(isSolo ? "vc-soloframe" : "vc-frame");
 
-  let headerHeight = 0;
   let pageSelect = null;
   let enableBtn = null;
   let collapseBtn = null;
@@ -2388,7 +2378,6 @@ function renderFrame(widget, isSolo) {
   if (widget.showHeader) {
     const header = document.createElement("div");
     header.className = "vc-frame-header";
-    headerHeight = 28;
 
     collapseBtn = document.createElement("button");
     collapseBtn.className = "frame-btn";

--- a/webaccess/src/commonjscss.h
+++ b/webaccess/src/commonjscss.h
@@ -24,8 +24,9 @@
 
 QString webAccessJsStringEscaped(const QString &text);
 
-#define HTML_HEADER \
+#define HTML_HEADER(LANG) \
     "<!DOCTYPE html>\n" \
+    "<html" LANG ">\n" \
     "<head>\n" \
     "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n" \
     "<link rel=\"shortcut icon\" href=\"/favicon.ico\">\n" \
@@ -50,5 +51,13 @@ QString webAccessJsStringEscaped(const QString &text);
     "function checkProjectLoaded() {\n" \
     " websocket.send(\"QLC+API|isProjectLoaded\");\n" \
     "};\n"
+
+#ifdef QMLUI
+#include "app.h"
+#define LANGUAGE_HTML App::languageHTML()
+#else
+#include "qlci18n.h"
+#define LANGUAGE_HTML QLCi18n::loadedLanguageHTML()
+#endif
 
 #endif // COMMONJSCSS_H

--- a/webaccess/src/webaccess-qml.cpp
+++ b/webaccess/src/webaccess-qml.cpp
@@ -50,6 +50,7 @@
 
 #include "function.h"
 #include "chaser.h"
+#include "app.h"
 #include "doc.h"
 #include "fixture.h"
 #include "qlcchannel.h"
@@ -412,7 +413,7 @@ static QString getSimpleDeskQmlHtml(const Doc *doc, const SimpleDesk *sd)
                 "</main>\n"
                 "</div>\n";
 
-    return QString(HTML_HEADER) + JScode + CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
+    return QString(HTML_HEADER(" lang=\"" + App::languageHTML() + "\"")) + JScode + CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
 }
 
 WebAccessQml::WebAccessQml(Doc *doc, VirtualConsole *vcInstance, SimpleDesk *sdInstance,
@@ -481,7 +482,7 @@ void WebAccessQml::slotHandleHTTPRequest(QHttpRequest *req, QHttpResponse *resp)
 
     if (serveWebFile(resp, "/webaccess-v5.html", "text/html"))
         return;
-    content = QString(HTML_HEADER) + "</head><body>Missing webaccess-v5.html</body></html>";
+    content = QString(HTML_HEADER(" lang=\"" + App::languageHTML() + "\"")) + "</head><body>Missing webaccess-v5.html</body></html>";
     sendHtmlResponse(resp, content);
 }
 

--- a/webaccess/src/webaccess-qml.cpp
+++ b/webaccess/src/webaccess-qml.cpp
@@ -1361,6 +1361,13 @@ QByteArray WebAccessQml::getVCJson()
     appObj["name"] = QString(APPNAME);
     appObj["version"] = QString(APPVERSION);
     root["app"] = appObj;
+    QJsonObject translationObj;
+    translationObj["loadProject"] = QObject::tr("Load project");
+    translationObj["simpleDesk"] = QObject::tr("Simple Desk");
+    translationObj["configuration"] = QObject::tr("Configuration");
+    translationObj["connected"] = QObject::tr("Connected");
+    translationObj["disconnected"] = QObject::tr("Disconnected");
+    root["translations"] = translationObj;
     root["pixelDensity"] = m_vc->pixelDensity();
     root["selectedPage"] = m_vc->selectedPage();
     QJsonObject uiStyle = loadUiStyleJson();

--- a/webaccess/src/webaccess-qml.cpp
+++ b/webaccess/src/webaccess-qml.cpp
@@ -372,7 +372,7 @@ static QString getSimpleDeskQmlHtml(const Doc *doc, const SimpleDesk *sd)
     {
         QString selected = (i + 1 == uni) ? " selected" : "";
         bodyHTML += "<option value=\"" + QString::number(i) + "\"" + selected + ">"
-                + uniList.at(i) + "</option>\n";
+                + uniList.at(i).toHtmlEscaped() + "</option>\n";
     }
 
     bodyHTML += "</select>\n"

--- a/webaccess/src/webaccess.cpp
+++ b/webaccess/src/webaccess.cpp
@@ -24,6 +24,7 @@
 #include "webaccesssimpledesk.h"
 #include "webaccessnetwork.h"
 #include "commonjscss.h"
+#include "qlci18n.h"
 #include "vcaudiotriggers.h"
 #include "virtualconsole.h"
 #include "rgbalgorithm.h"
@@ -2009,13 +2010,13 @@ QString WebAccess::getVCHTML()
     widgetsHTML += "</div>\n";
     m_JScode += "\n</script>\n";
 
-    QString str = HTML_HEADER + m_CSScode + "</head>\n<body>\n" + widgetsHTML + "</div>\n" + m_JScode + "</body>\n</html>";
+    QString str = HTML_HEADER(" lang=\"" + QLCi18n::loadedLanguageHTML() + "\"") + m_CSScode + "</head>\n<body>\n" + widgetsHTML + "</div>\n" + m_JScode + "</body>\n</html>";
     return str;
 }
 
 QString WebAccess::getSimpleDeskHTML() const
 {
-    QString str = HTML_HEADER;
+    QString str = HTML_HEADER(" lang=\"" + QLCi18n::loadedLanguageHTML() + "\"");
     return str;
 }
 

--- a/webaccess/src/webaccessauth.cpp
+++ b/webaccess/src/webaccessauth.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "webaccessauth.h"
+#include "commonjscss.h"
 #include "qlcconfig.h"
 
 #include "qhttprequest.h"
@@ -195,7 +196,7 @@ void WebAccessAuth::sendUnauthorizedResponse(QHttpResponse* res) const
 
     const static QByteArray text = QString(
         "<!DOCTYPE html>\n"
-        "<html>\n"
+        "<html lang=\"" + LANGUAGE_HTML + "\">\n"
         "    <head>\n"
         "        <meta charset=\"utf-8\">\n"
         "        <title>" + QObject::tr("Unauthorized") + "</title>\n"

--- a/webaccess/src/webaccessbase.cpp
+++ b/webaccess/src/webaccessbase.cpp
@@ -315,13 +315,16 @@ void WebAccessBase::sendProjectLoadingResponse(QHttpResponse *resp) const
         return;
 
     QByteArray postReply =
-            QString("<html><head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
+            QString("<!DOCTYPE html>\n<html>\n<head>\n"
+            "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
             "<script>\n" PROJECT_LOADED_JS
-            "</script></head><body style=\"background-color: #45484d;\">"
-            "<div style=\"position: absolute; width: 100%; height: 30px; top: 50%; background-color: #888888;"
-            "text-align: center; font: bold 24px/1.2em sans-serif;\">"
+            "</script>\n"
+            "<title>QLC+ Webaccess: " + tr("Loading project...") + "</title>\n"
+            "</head>\n<body style=\"background-color: #45484d;\">\n"
+            "<div style=\"position: absolute; width: 100%; height: 30px; top: 50%; background-color: #888888; "
+            "text-align: center; font: bold 24px/1.2em sans-serif;\">\n"
             + tr("Loading project...") +
-            "</div></body></html>").toUtf8();
+            "\n</div>\n</body>\n</html>").toUtf8();
 
     resp->setHeader("Content-Type", "text/html");
     resp->setHeader("Content-Length", QString::number(postReply.size()));
@@ -400,17 +403,18 @@ WebAccessBase::CommonRequestResult WebAccessBase::handleCommonHTTPRequest(const 
         if (req == nullptr)
             return CommonRequestResult::NotHandled;
 
+        const QString reply("<!DOCTYPE html>\n<html>\n<head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
+                            "<title>QLC+ Webaccess%1</title>\n"
+                            "<script>\n"
+                            " alert(\"%2\");\n"
+                            " window.location = \"/config\";\n"
+                            "</script>\n</head>\n</html>");
         QByteArray fixtureXML;
         QString fxName;
         if (!extractMultipartFilePayload(req, fixtureXML, &fxName) || fxName.isEmpty())
         {
             qWarning() << Q_FUNC_INFO << "Invalid fixture upload payload";
-            QByteArray postReply =
-                    QString("<html><head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
-                            "<script>\n"
-                            " alert(\"" + tr("Invalid fixture upload payload") + "\");"
-                            " window.location = \"/config\"\n"
-                            "</script></head></html>").toUtf8();
+            const QByteArray postReply = reply.arg(": " + tr("Error")).arg(tr("Invalid fixture upload payload")).toUtf8();
 
             resp->setHeader("Content-Type", "text/html");
             resp->setHeader("Content-Length", QString::number(postReply.size()));
@@ -421,12 +425,7 @@ WebAccessBase::CommonRequestResult WebAccessBase::handleCommonHTTPRequest(const 
 
         if (!storeFixtureDefinition(fxName, fixtureXML))
         {
-            QByteArray postReply =
-                    QString("<html><head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
-                            "<script>\n"
-                            " alert(\"" + tr("Unable to store fixture definition") + "\");"
-                            " window.location = \"/config\"\n"
-                            "</script></head></html>").toUtf8();
+            const QByteArray postReply = reply.arg(": " + tr("Error")).arg(tr("Unable to store fixture definition")).toUtf8();
 
             resp->setHeader("Content-Type", "text/html");
             resp->setHeader("Content-Length", QString::number(postReply.size()));
@@ -435,12 +434,7 @@ WebAccessBase::CommonRequestResult WebAccessBase::handleCommonHTTPRequest(const 
             return CommonRequestResult::Handled;
         }
 
-        QByteArray postReply =
-                QString("<html><head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
-                        "<script>\n"
-                        " alert(\"" + tr("Fixture stored and loaded") + "\");"
-                        " window.location = \"/config\"\n"
-                        "</script></head></html>").toUtf8();
+        const QByteArray postReply = reply.arg("").arg(tr("Fixture stored and loaded")).toUtf8();
 
         resp->setHeader("Content-Type", "text/html");
         resp->setHeader("Content-Length", QString::number(postReply.size()));

--- a/webaccess/src/webaccessbase.cpp
+++ b/webaccess/src/webaccessbase.cpp
@@ -315,7 +315,7 @@ void WebAccessBase::sendProjectLoadingResponse(QHttpResponse *resp) const
         return;
 
     QByteArray postReply =
-            QString("<!DOCTYPE html>\n<html>\n<head>\n"
+            QString("<!DOCTYPE html>\n<html lang=\"" + LANGUAGE_HTML + "\">\n<head>\n"
             "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
             "<script>\n" PROJECT_LOADED_JS
             "</script>\n"
@@ -403,7 +403,8 @@ WebAccessBase::CommonRequestResult WebAccessBase::handleCommonHTTPRequest(const 
         if (req == nullptr)
             return CommonRequestResult::NotHandled;
 
-        const QString reply("<!DOCTYPE html>\n<html>\n<head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
+        const QString reply("<!DOCTYPE html>\n<html lang=\"" + LANGUAGE_HTML + "\">\n"
+                            "<head>\n<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n"
                             "<title>QLC+ Webaccess%1</title>\n"
                             "<script>\n"
                             " alert(\"%2\");\n"

--- a/webaccess/src/webaccessconfiguration.cpp
+++ b/webaccess/src/webaccessconfiguration.cpp
@@ -378,7 +378,7 @@ QString WebAccessConfiguration::getHTML(const Doc *doc, const WebAccessAuth *aut
         bodyHTML += "</div>";
     }
 
-    QString str = HTML_HEADER + m_JScode + m_CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
+    QString str = HTML_HEADER(" lang=\"" + LANGUAGE_HTML + "\"") + m_JScode + m_CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
 
     return str;
 }

--- a/webaccess/src/webaccessnetwork.cpp
+++ b/webaccess/src/webaccessnetwork.cpp
@@ -350,7 +350,7 @@ QString WebAccessNetwork::getHTML()
     bodyHTML += "<input type=\"button\" value=\"" + tr("Shutdown") + "\" onclick=\"javascript:websocket.send('QLC+SYS|HALT');\">";
     bodyHTML += "</div>\n";
 
-    QString str = HTML_HEADER + m_JScode + m_CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
+    QString str = HTML_HEADER(" lang=\"" + LANGUAGE_HTML + "\"") + m_JScode + m_CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
 
     return str;
 }

--- a/webaccess/src/webaccesssimpledesk.cpp
+++ b/webaccess/src/webaccesssimpledesk.cpp
@@ -85,7 +85,7 @@ QString WebAccessSimpleDesk::getHTML(const Doc *doc, const SimpleDesk *sd)
 
     bodyHTML += "<div id=\"slidersContainer\"></div>\n\n";
 
-    QString str = HTML_HEADER + JScode + CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
+    QString str = HTML_HEADER(" lang=\"" + LANGUAGE_HTML + "\"") + JScode + CSScode + "</head>\n<body>\n" + bodyHTML + "</body>\n</html>";
 
     return str;
 }

--- a/webaccess/test/CMakeLists.txt
+++ b/webaccess/test/CMakeLists.txt
@@ -4,11 +4,19 @@ add_executable(webaccessescaping_test WIN32 MACOSX_BUNDLE
 )
 target_include_directories(webaccessescaping_test PRIVATE
     ../src
+    ../../engine/src
 )
 target_link_libraries(webaccessescaping_test PRIVATE
     Qt${QT_MAJOR_VERSION}::Core
+    Qt${QT_MAJOR_VERSION}::Quick
     Qt${QT_MAJOR_VERSION}::Test
 )
+if(qmlui)
+    target_include_directories(webaccessescaping_test PRIVATE
+        ../../qmlui
+        ../../plugins/interfaces
+    )
+endif()
 
 add_executable(webaccessupload_test WIN32 MACOSX_BUNDLE
     ../src/webaccessupload.cpp


### PR DESCRIPTION
- webaccess-qml: HTML-escape universe name on "Simple Desk" page
- webaccess: remove unused code

Those changes build on previous work and should therefore be self-explanatory.

- webaccess/webaccessbase: fix HTML validation errors and refactor code
The HTML validation errors involved missing `<!DOCTYPE html>` tags at the beginning of documents as well as missing `<title>` tags within the HTML `head`. Additionally, some newlines were added to improve readability.
Finally, in the `WebAccessBase::handleCommonHTTPRequest` function, there are some repeated HTML templates used for different error pages. This commit refactors this by keeping only one centralised copy, which contains format string placeholders for parametrisation.

- translations: add plugin and webaccess translations to qmlui builds, remove unused function
The `.qm` files created in `qmlui` builds only contain strings from the `qmlui` directory, but none from `plugins` and `webaccess` directories, whose source code is also compiled.
This commit modifies the `translate.sh` script so that these translation files are also included.

- webaccess-qml: make more strings translatable
The main page (Virtual Console) of the `v5` webaccess is a client-side web “application” consisting of a static HTML page and JavaScript code for rendering the page.
In this architecture, the most strings in the page header (button labels, etc.) are hard-coded in English. Only the QLC+ version number is sent via the Virtual Console data (JSON via `/vc.json`) and inserted dynamically.
This commit adds code to send some translated strings with Virtual Console data and to update the corresponding UI elements.
Another approach to achieving this functionality would be to build this static HTML page (only the base page, not the actual Virtual Console widgets) dynamically on the server side, so that translated strings could be inserted there.

- engine/qlci18n: store language code of currently used locale
This commit serves as preparatory work for the next commit and adds a variable and some getter/setter functions to the `QLCi18n` class to store the language code of the currently loaded/used locale (QLC+ 4).

- webaccess: add "lang" tags to all web pages
Firstly, this commit adds the functionality of the previous commit for QLC+ 5. It also includes a function to convert this QLC+ locale string to a [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) used in HTML `lang` attributes.
This commit then adds those HTML `lang` attribute to all static and dynamically generated web/HTML pages. This is a best practice for accessibility and enables web browsers (such as Firefox) to automatically offer (local) translation options for web pages.
To implement this for the dynamically generated pages, whose code is also shared between `v4` and `v5`, a pre-processor variable (to retrieve the language code) has been added to the `commonjscss.h` file. In addition, a parameter has been added to the `HTML_HEADER` macro to insert the `lang` attribute when needed.