### PR TITLE
fixtureeditor: reject definitions without modes

### DIFF
--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -256,7 +256,7 @@ bool QLCFixtureEditor::checkFixtureDefinition()
                              tr("Missing important information"),
                              tr("Missing fixture mode.\n"
                                 "Unable to save fixture."));
-        m_tab->setCurrentIndex(3);
+        m_tab->setCurrentWidget(Modes);
         m_addModeButton->setFocus();
         return false;
     }

--- a/fixtureeditor/fixtureeditor.cpp
+++ b/fixtureeditor/fixtureeditor.cpp
@@ -226,10 +226,10 @@ void QLCFixtureEditor::closeEvent(QCloseEvent *e)
     }
 }
 
-bool QLCFixtureEditor::checkManufacturerModel()
+bool QLCFixtureEditor::checkFixtureDefinition()
 {
-    /* Check that the fixture has a manufacturer and a model for
-       unique identification */
+    /* Check that the fixture has a manufacturer, a model and at least one
+       mode for unique identification and loading */
     if (m_fixtureDef->manufacturer().length() == 0)
     {
         QMessageBox::warning(this,
@@ -250,13 +250,23 @@ bool QLCFixtureEditor::checkManufacturerModel()
         m_modelEdit->setFocus();
         return false;
     }
+    else if (m_fixtureDef->modes().isEmpty() == true)
+    {
+        QMessageBox::warning(this,
+                             tr("Missing important information"),
+                             tr("Missing fixture mode.\n"
+                                "Unable to save fixture."));
+        m_tab->setCurrentIndex(3);
+        m_addModeButton->setFocus();
+        return false;
+    }
 
     return true;
 }
 
 bool QLCFixtureEditor::save()
 {
-    if (checkManufacturerModel() == false)
+    if (checkFixtureDefinition() == false)
         return false;
 
     if (m_fileName.simplified().isEmpty() == true)
@@ -284,8 +294,8 @@ bool QLCFixtureEditor::save()
 
 bool QLCFixtureEditor::saveAs()
 {
-    /* Bail out if there is no manufacturer or model */
-    if (checkManufacturerModel() == false)
+    /* Bail out if the fixture definition is incomplete */
+    if (checkFixtureDefinition() == false)
         return false;
 
     /* Create a file save dialog */

--- a/fixtureeditor/fixtureeditor.h
+++ b/fixtureeditor/fixtureeditor.h
@@ -78,7 +78,7 @@ protected slots:
     void slotTypeActivated(int index);
 
 protected:
-    bool checkManufacturerModel();
+    bool checkFixtureDefinition();
     void setCaption();
     void ensureNewExtension();
     bool newExtensionReminder();


### PR DESCRIPTION
## Summary

Prevent the Fixture Editor from saving a fixture definition that has no modes.

## Root cause

Since v4.14.4, `QLCFixtureDef::loadXML()` correctly rejects definitions without modes to prevent the crash fixed by #1775. The Fixture Editor could still create and save exactly that invalid definition, leaving it impossible to reopen.

## Changes

- validate that a definition contains at least one mode before Save or Save As
- show the existing missing-information warning, select the Modes tab by widget reference, and focus the add-mode control
- rename the validation helper to reflect its broader responsibility

This preserves the engine-side load guard while preventing the editor from producing files it cannot reload.

Fixes #2095.

## Validation

- `git diff --check`
- inspected against the v4.14.4 source and the reported no-mode QXF reproduction
- the upstream CI build is awaiting maintainer approval because this PR originates from a fork

The local workspace does not include CMake or Qt development dependencies, so the project's `make check` suite could not be run there.