### PR TITLE
Fixture: Eurolite LED IP PIX Strobe RGB CW+WW

### DIFF
--- a/resources/fixtures/Eurolite/Eurolite-LED-IP-PIX-Strobe-RGB-CW-WW.qxf
+++ b/resources/fixtures/Eurolite/Eurolite-LED-IP-PIX-Strobe-RGB-CW-WW.qxf
@@ -1,0 +1,617 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>5.2.2</Version>
+  <Author>Adam Nuclear</Author>
+ </Creator>
+ <Manufacturer>Eurolite</Manufacturer>
+ <Model>LED IP PIX Strobe RGB CW+WW</Model>
+ <Type>Strobe</Type>
+ <Channel Name="Master Dimmer" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Red" Preset="IntensityRed"/>
+ <Channel Name="Green" Preset="IntensityGreen"/>
+ <Channel Name="Blue" Preset="IntensityBlue"/>
+ <Channel Name="Warm White">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Warm white, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Cold White">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Cold white, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="White Colour Temperature">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="0">Off</Capability>
+  <Capability Min="1" Max="30">3200K</Capability>
+  <Capability Min="31" Max="45">3300K</Capability>
+  <Capability Min="46" Max="56">3400K</Capability>
+  <Capability Min="57" Max="65">3500K</Capability>
+  <Capability Min="66" Max="74">3600K</Capability>
+  <Capability Min="75" Max="82">3700K</Capability>
+  <Capability Min="83" Max="89">3800K</Capability>
+  <Capability Min="90" Max="95">3900K</Capability>
+  <Capability Min="96" Max="102">4000K</Capability>
+  <Capability Min="103" Max="109">4100K</Capability>
+  <Capability Min="110" Max="116">4200K</Capability>
+  <Capability Min="117" Max="123">4300K</Capability>
+  <Capability Min="124" Max="130">4400K</Capability>
+  <Capability Min="131" Max="137">4500K</Capability>
+  <Capability Min="138" Max="143">4600K</Capability>
+  <Capability Min="144" Max="149">4700K</Capability>
+  <Capability Min="150" Max="154">4800K</Capability>
+  <Capability Min="155" Max="160">4900K</Capability>
+  <Capability Min="161" Max="165">5000K</Capability>
+  <Capability Min="166" Max="169">5100K</Capability>
+  <Capability Min="170" Max="173">5200K</Capability>
+  <Capability Min="174" Max="177">5300K</Capability>
+  <Capability Min="178" Max="182">5400K</Capability>
+  <Capability Min="183" Max="187">5500K</Capability>
+  <Capability Min="188" Max="191">5600K</Capability>
+  <Capability Min="192" Max="195">5700K</Capability>
+  <Capability Min="196" Max="199">5800K</Capability>
+  <Capability Min="200" Max="203">5900K</Capability>
+  <Capability Min="204" Max="207">6000K</Capability>
+  <Capability Min="208" Max="212">6100K</Capability>
+  <Capability Min="213" Max="216">6200K</Capability>
+  <Capability Min="217" Max="222">6300K</Capability>
+  <Capability Min="223" Max="227">6400K</Capability>
+  <Capability Min="228" Max="235">6500K</Capability>
+  <Capability Min="236" Max="255">6600K</Capability>
+ </Channel>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="8" Preset="ShutterOpen">No strobe function</Capability>
+  <Capability Min="9" Max="255" Preset="StrobeSlowToFast">Strobe effect with increasing speed</Capability>
+ </Channel>
+ <Channel Name="Strobe White">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="8" Preset="ShutterOpen">No strobe function</Capability>
+  <Capability Min="9" Max="255" Preset="StrobeSlowToFast">Strobe effect with increasing speed</Capability>
+ </Channel>
+ <Channel Name="Strobe RGB">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="8" Preset="ShutterOpen">No strobe function</Capability>
+  <Capability Min="9" Max="255" Preset="StrobeSlowToFast">Strobe effect with increasing speed</Capability>
+ </Channel>
+ <Channel Name="Strobe Effects White">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="127" Preset="ShutterOpen">No function</Capability>
+  <Capability Min="128" Max="169" Preset="RampUpSlowToFast">Opening pulse effect with increasing speed</Capability>
+  <Capability Min="170" Max="209" Preset="RampDownSlowToFast">Closing pulse effect with increasing speed</Capability>
+  <Capability Min="210" Max="255" Preset="StrobeRandom">Random strobe effect</Capability>
+ </Channel>
+ <Channel Name="Auto Programs White">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="7">No function</Capability>
+  <Capability Min="8" Max="47">Program 1</Capability>
+  <Capability Min="48" Max="67">Program 2</Capability>
+  <Capability Min="68" Max="87">Program 3</Capability>
+  <Capability Min="88" Max="107">Program 4</Capability>
+  <Capability Min="108" Max="127">Program 5</Capability>
+  <Capability Min="128" Max="147">Program 6</Capability>
+  <Capability Min="148" Max="167">Program 7</Capability>
+  <Capability Min="168" Max="187">Program 8</Capability>
+  <Capability Min="188" Max="207">Program 9</Capability>
+  <Capability Min="208" Max="227">Program 10</Capability>
+  <Capability Min="228" Max="247">Program 11</Capability>
+  <Capability Min="248" Max="255">Program 12</Capability>
+ </Channel>
+ <Channel Name="Auto Programs RGB">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="7">No function</Capability>
+  <Capability Min="8" Max="15">Program 1</Capability>
+  <Capability Min="16" Max="23">Program 2</Capability>
+  <Capability Min="24" Max="31">Program 3</Capability>
+  <Capability Min="32" Max="39">Program 4</Capability>
+  <Capability Min="40" Max="47">Program 5</Capability>
+  <Capability Min="48" Max="55">Program 6</Capability>
+  <Capability Min="56" Max="63">Program 7</Capability>
+  <Capability Min="64" Max="71">Program 8</Capability>
+  <Capability Min="72" Max="87">Program 9</Capability>
+  <Capability Min="88" Max="95">Program 10</Capability>
+  <Capability Min="96" Max="103">Program 11</Capability>
+  <Capability Min="104" Max="111">Program 12</Capability>
+  <Capability Min="112" Max="119">Program 13</Capability>
+  <Capability Min="120" Max="127">Program 14</Capability>
+  <Capability Min="128" Max="135">Program 15</Capability>
+  <Capability Min="136" Max="143">Program 16</Capability>
+  <Capability Min="144" Max="151">Program 17</Capability>
+  <Capability Min="152" Max="159">Program 18</Capability>
+  <Capability Min="160" Max="167">Program 19</Capability>
+  <Capability Min="168" Max="175">Program 20</Capability>
+  <Capability Min="176" Max="183">Program 21</Capability>
+  <Capability Min="184" Max="191">Program 22</Capability>
+  <Capability Min="192" Max="199">Program 23</Capability>
+  <Capability Min="200" Max="207">Program 24</Capability>
+  <Capability Min="208" Max="215">Program 25</Capability>
+  <Capability Min="216" Max="223">Program 26</Capability>
+  <Capability Min="224" Max="231">Program 27</Capability>
+  <Capability Min="232" Max="239">Program 28</Capability>
+  <Capability Min="240" Max="247">Program 29</Capability>
+  <Capability Min="248" Max="255">Program 30</Capability>
+ </Channel>
+ <Channel Name="Program Speed White">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Increasing speed of the auto programs 1 - 12 (white)</Capability>
+ </Channel>
+ <Channel Name="Program Speed RGB">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Increasing speed of the auto programs 1 - 30 (RGB)</Capability>
+ </Channel>
+ <Channel Name="Program Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Increasing speed of the auto programs (white / RGB)</Capability>
+ </Channel>
+ <Channel Name="Background Red">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">Red background colour, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Background Green">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">Green background colour, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Background Blue">
+  <Group Byte="0">Intensity</Group>
+  <Capability Min="0" Max="255">Blue background colour, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Direction">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="127">Forwards</Capability>
+  <Capability Min="128" Max="255">Backwards</Capability>
+ </Channel>
+ <Channel Name="Warm White 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Warm white segment 1, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Warm White 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Warm white segment 2, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Warm White 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Warm white segment 3, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Warm White 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Warm white segment 4, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Cold White 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Cold white segment 1, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Cold White 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Cold white segment 2, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Cold White 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Cold white segment 3, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Cold White 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>White</Colour>
+  <Capability Min="0" Max="255">Cold white segment 4, increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 1+2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 1+2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 1+2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 3+4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 3+4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 3+4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 5+6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 5+6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 5+6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 7+8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 7+8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 7+8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 1">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 2">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 3">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 4">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 5">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 5">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 5">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 6">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 7">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 7">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 7">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Red 8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Red</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Green 8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Green</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Channel Name="Blue 8">
+  <Group Byte="0">Intensity</Group>
+  <Colour>Blue</Colour>
+  <Capability Min="0" Max="255">Increasing brightness 0-100%</Capability>
+ </Channel>
+ <Mode Name="6 Channel">
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">Warm White</Channel>
+  <Channel Number="4">Cold White</Channel>
+  <Channel Number="5">Strobe</Channel>
+ </Mode>
+ <Mode Name="10 Channel">
+  <Channel Number="0">Red</Channel>
+  <Channel Number="1">Green</Channel>
+  <Channel Number="2">Blue</Channel>
+  <Channel Number="3">Warm White</Channel>
+  <Channel Number="4">Cold White</Channel>
+  <Channel Number="5">Strobe</Channel>
+  <Channel Number="6">Auto Programs White</Channel>
+  <Channel Number="7">Program Speed White</Channel>
+  <Channel Number="8">Auto Programs RGB</Channel>
+  <Channel Number="9">Program Speed RGB</Channel>
+ </Mode>
+ <Mode Name="18 Channel">
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">Red</Channel>
+  <Channel Number="2">Green</Channel>
+  <Channel Number="3">Blue</Channel>
+  <Channel Number="4">Cold White</Channel>
+  <Channel Number="5">Warm White</Channel>
+  <Channel Number="6">White Colour Temperature</Channel>
+  <Channel Number="7">Auto Programs White</Channel>
+  <Channel Number="8">Program Speed White</Channel>
+  <Channel Number="9">Strobe White</Channel>
+  <Channel Number="10">Strobe Effects White</Channel>
+  <Channel Number="11">Auto Programs RGB</Channel>
+  <Channel Number="12">Program Speed RGB</Channel>
+  <Channel Number="13">Strobe RGB</Channel>
+  <Channel Number="14">Background Red</Channel>
+  <Channel Number="15">Background Green</Channel>
+  <Channel Number="16">Background Blue</Channel>
+  <Channel Number="17">Direction</Channel>
+ </Mode>
+ <Mode Name="24 Channel">
+  <Channel Number="0">Red 1+2</Channel>
+  <Channel Number="1">Green 1+2</Channel>
+  <Channel Number="2">Blue 1+2</Channel>
+  <Channel Number="3">Warm White 1</Channel>
+  <Channel Number="4">Cold White 1</Channel>
+  <Channel Number="5">Red 3+4</Channel>
+  <Channel Number="6">Green 3+4</Channel>
+  <Channel Number="7">Blue 3+4</Channel>
+  <Channel Number="8">Warm White 2</Channel>
+  <Channel Number="9">Cold White 2</Channel>
+  <Channel Number="10">Red 5+6</Channel>
+  <Channel Number="11">Green 5+6</Channel>
+  <Channel Number="12">Blue 5+6</Channel>
+  <Channel Number="13">Warm White 3</Channel>
+  <Channel Number="14">Cold White 3</Channel>
+  <Channel Number="15">Red 7+8</Channel>
+  <Channel Number="16">Green 7+8</Channel>
+  <Channel Number="17">Blue 7+8</Channel>
+  <Channel Number="18">Warm White 4</Channel>
+  <Channel Number="19">Cold White 4</Channel>
+  <Channel Number="20">Strobe</Channel>
+  <Channel Number="21">Auto Programs White</Channel>
+  <Channel Number="22">Auto Programs RGB</Channel>
+  <Channel Number="23">Program Speed</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+   <Channel>3</Channel>
+   <Channel>4</Channel>
+  </Head>
+  <Head>
+   <Channel>5</Channel>
+   <Channel>6</Channel>
+   <Channel>7</Channel>
+   <Channel>8</Channel>
+   <Channel>9</Channel>
+  </Head>
+  <Head>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+  </Head>
+  <Head>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+   <Channel>17</Channel>
+   <Channel>18</Channel>
+   <Channel>19</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="25 Channel">
+  <Channel Number="0">Red 1+2</Channel>
+  <Channel Number="1">Green 1+2</Channel>
+  <Channel Number="2">Blue 1+2</Channel>
+  <Channel Number="3">Warm White 1</Channel>
+  <Channel Number="4">Cold White 1</Channel>
+  <Channel Number="5">Red 3+4</Channel>
+  <Channel Number="6">Green 3+4</Channel>
+  <Channel Number="7">Blue 3+4</Channel>
+  <Channel Number="8">Warm White 2</Channel>
+  <Channel Number="9">Cold White 2</Channel>
+  <Channel Number="10">Red 5+6</Channel>
+  <Channel Number="11">Green 5+6</Channel>
+  <Channel Number="12">Blue 5+6</Channel>
+  <Channel Number="13">Warm White 3</Channel>
+  <Channel Number="14">Cold White 3</Channel>
+  <Channel Number="15">Red 7+8</Channel>
+  <Channel Number="16">Green 7+8</Channel>
+  <Channel Number="17">Blue 7+8</Channel>
+  <Channel Number="18">Warm White 4</Channel>
+  <Channel Number="19">Cold White 4</Channel>
+  <Channel Number="20">Strobe</Channel>
+  <Channel Number="21">Auto Programs White</Channel>
+  <Channel Number="22">Program Speed White</Channel>
+  <Channel Number="23">Auto Programs RGB</Channel>
+  <Channel Number="24">Program Speed RGB</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+   <Channel>3</Channel>
+   <Channel>4</Channel>
+  </Head>
+  <Head>
+   <Channel>5</Channel>
+   <Channel>6</Channel>
+   <Channel>7</Channel>
+   <Channel>8</Channel>
+   <Channel>9</Channel>
+  </Head>
+  <Head>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+  </Head>
+  <Head>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+   <Channel>17</Channel>
+   <Channel>18</Channel>
+   <Channel>19</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="32 Channel">
+  <Channel Number="0">Warm White 1</Channel>
+  <Channel Number="1">Warm White 2</Channel>
+  <Channel Number="2">Warm White 3</Channel>
+  <Channel Number="3">Warm White 4</Channel>
+  <Channel Number="4">Cold White 1</Channel>
+  <Channel Number="5">Cold White 2</Channel>
+  <Channel Number="6">Cold White 3</Channel>
+  <Channel Number="7">Cold White 4</Channel>
+  <Channel Number="8">Red 1</Channel>
+  <Channel Number="9">Green 1</Channel>
+  <Channel Number="10">Blue 1</Channel>
+  <Channel Number="11">Red 2</Channel>
+  <Channel Number="12">Green 2</Channel>
+  <Channel Number="13">Blue 2</Channel>
+  <Channel Number="14">Red 3</Channel>
+  <Channel Number="15">Green 3</Channel>
+  <Channel Number="16">Blue 3</Channel>
+  <Channel Number="17">Red 4</Channel>
+  <Channel Number="18">Green 4</Channel>
+  <Channel Number="19">Blue 4</Channel>
+  <Channel Number="20">Red 5</Channel>
+  <Channel Number="21">Green 5</Channel>
+  <Channel Number="22">Blue 5</Channel>
+  <Channel Number="23">Red 6</Channel>
+  <Channel Number="24">Green 6</Channel>
+  <Channel Number="25">Blue 6</Channel>
+  <Channel Number="26">Red 7</Channel>
+  <Channel Number="27">Green 7</Channel>
+  <Channel Number="28">Blue 7</Channel>
+  <Channel Number="29">Red 8</Channel>
+  <Channel Number="30">Green 8</Channel>
+  <Channel Number="31">Blue 8</Channel>
+  <Head>
+   <Channel>8</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+  </Head>
+  <Head>
+   <Channel>11</Channel>
+   <Channel>12</Channel>
+   <Channel>13</Channel>
+  </Head>
+  <Head>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+  </Head>
+  <Head>
+   <Channel>17</Channel>
+   <Channel>18</Channel>
+   <Channel>19</Channel>
+  </Head>
+  <Head>
+   <Channel>20</Channel>
+   <Channel>21</Channel>
+   <Channel>22</Channel>
+  </Head>
+  <Head>
+   <Channel>23</Channel>
+   <Channel>24</Channel>
+   <Channel>25</Channel>
+  </Head>
+  <Head>
+   <Channel>26</Channel>
+   <Channel>27</Channel>
+   <Channel>28</Channel>
+  </Head>
+  <Head>
+   <Channel>29</Channel>
+   <Channel>30</Channel>
+   <Channel>31</Channel>
+  </Head>
+ </Mode>
+ <Physical>
+  <Bulb Type="MSR 1200W" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="3.3" Width="380" Height="145" Depth="110"/>
+  <Lens Name="Other" DegreesMin="120" DegreesMax="120"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Layout Width="4" Height="2"/>
+  <Technical PowerConsumption="135" DmxConnector="3-pin IP65"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION
<!--
Thank you for contributing a new fixture to QLC+!

Please make sure you've tested the fixture file thoroughly. This template will help reviewers validate and merge your contribution smoothly.
-->

## Fixture Information

**Manufacturer:**  
<!-- Example: Chauvet -->
Eurolite

**Model:**  
<!-- Example: Intimidator Spot 160 -->
LED IP PIX Strobe RGB CW+WW

https://www.thomann.de/de/eurolite_led_ip_pix_strobe_rgb_cwww.htm

**Mode(s) included:**  
<!-- List each DMX mode included, e.g. "16-channel", "8-channel basic", etc. -->

6-channel - basic
10 - channel
18 - channel
24 - channel
25 - channel
32 - channel

Included all variants based on manual: 

https://www.steinigke.de/download/52200940-Anleitung-158669-1.1000-eurolite-led-ip-pix-strobe-rgb-cw+ww-de_en.pdf

**Channels used:**  
<!-- Total number of DMX channels used, including any 16-bit pairs -->

6,10,18,24,25,32

## Testing

- [x] Physical data is included 
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly


## Source(s) of Information

<!-- Links to user manuals, DMX charts, official product pages, or any reference used -->

## Notes

<!-- Add any comments for the reviewer or explain any specific decisions made in the fixture file -->

---

Thank you for improving the QLC+ fixture library.
