### PR TITLE
qmlui: persist 3D View "Show FPS" setting across view switches

### DIFF
--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -84,6 +84,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_createItemCount(0)
     , m_sceneGeneration(0)
     , m_frameAction(nullptr)
+    , m_frameCountEnabled(false)
     , m_frameCount(0)
     , m_minFrameCount(0)
     , m_maxFrameCount(0)
@@ -272,7 +273,11 @@ void MainView3D::resetItems()
     m_minFrameCount = 0;
     m_maxFrameCount = 0;
     m_avgFrameCount = 1.0;
-    setFrameCountEnabled(false);
+    // Tear down the QFrameAction, since the scene root entity it is attached
+    // to is about to be destroyed, but keep the user's "Show FPS" preference
+    // (m_frameCountEnabled) so it is restored when the 3D scene is rebuilt,
+    // e.g. after switching to another view and back.
+    detachFrameAction();
 }
 
 void MainView3D::resetCameraPosition()
@@ -382,33 +387,51 @@ void MainView3D::setUniverseFilter(quint32 universeFilter)
 
 bool MainView3D::frameCountEnabled() const
 {
-    return m_frameAction != nullptr ? true : false;
+    return m_frameCountEnabled;
 }
 
 void MainView3D::setFrameCountEnabled(bool enable)
 {
+    if (m_frameCountEnabled == enable)
+        return;
+
+    m_frameCountEnabled = enable;
+
     if (enable)
     {
-        m_frameAction = new QFrameAction();
-        connect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
-        if (m_sceneRootEntity)
-            m_sceneRootEntity->addComponent(m_frameAction);
-        m_fpsElapsed.start();
+        attachFrameAction();
     }
     else
     {
-        if (m_frameAction)
-        {
-            disconnect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
-            delete m_frameAction;
-            m_frameAction = nullptr;
-        }
+        detachFrameAction();
         m_frameCount = 0;
         m_minFrameCount = 0;
         m_maxFrameCount = 0;
         m_avgFrameCount = 0;
     }
     emit frameCountEnabledChanged();
+}
+
+void MainView3D::attachFrameAction()
+{
+    if (m_frameAction == nullptr)
+    {
+        m_frameAction = new QFrameAction();
+        connect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
+    }
+    if (m_sceneRootEntity)
+        m_sceneRootEntity->addComponent(m_frameAction);
+    m_fpsElapsed.start();
+}
+
+void MainView3D::detachFrameAction()
+{
+    if (m_frameAction)
+    {
+        disconnect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
+        delete m_frameAction;
+        m_frameAction = nullptr;
+    }
 }
 
 void MainView3D::slotFrameProcessed()
@@ -542,8 +565,10 @@ bool MainView3D::initialize3DProperties()
 
     m_initRetryCount = 0;
 
-    if (m_frameAction)
-        m_sceneRootEntity->addComponent(m_frameAction);
+    // re-attach the FPS counter if the user had it enabled: the previous
+    // QFrameAction (if any) was destroyed together with the old scene root
+    if (m_frameCountEnabled)
+        attachFrameAction();
 
     qDebug() << m_sceneRootEntity << m_quadEntity << m_gBuffer;
 

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -206,6 +206,18 @@ public:
 protected slots:
     void slotFrameProcessed();
 
+private:
+    /** Create the QFrameAction (if needed) and attach it to the current
+     *  scene root entity. Called both when the user enables the FPS counter
+     *  and whenever the 3D scene is (re)initialized, so the setting survives
+     *  switching to another view and back. */
+    void attachFrameAction();
+
+    /** Detach and destroy the QFrameAction. Must be called before the scene
+     *  root entity is torn down, otherwise Qt3D would delete the action
+     *  (it gets reparented on addComponent) and leave a dangling pointer. */
+    void detachFrameAction();
+
 signals:
     void frameCountEnabledChanged();
     void FPSChanged(int fps);
@@ -216,6 +228,9 @@ signals:
 private:
     QElapsedTimer m_fpsElapsed;
     QFrameAction *m_frameAction;
+    /** User-requested state of the FPS counter, kept independently from
+     *  m_frameAction so it persists across 3D scene teardown/rebuild */
+    bool m_frameCountEnabled;
     int m_frameCount;
     int m_minFrameCount;
     int m_maxFrameCount;

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -280,6 +280,7 @@ Rectangle
                         {
                             implicitHeight: UISettings.listItemHeight
                             implicitWidth: implicitHeight
+                            checked: View3D ? View3D.frameCountEnabled : false
                             onToggled: View3D.frameCountEnabled = checked
                         }
 


### PR DESCRIPTION
## Description

### What this fixes

The 3D view's **Rendering -> Show FPS** option is switched off again every time the user leaves the 3D view. Turn it on, go to Virtual Console and come back, and it is off. The other Rendering settings — Quality, Ambient light, Smoke amount — are plain members that nothing resets, so only this one is affected.

### Why it happens

`MainView3D::resetItems()` unconditionally calls `setFrameCountEnabled(false)`, and `resetItems()` runs from `enableContext(false)`, i.e. on every view switch.

On top of that, the enabled state was derived from `m_frameAction != nullptr`. The `QFrameAction` is reparented onto the scene root when it is added as a component, so it is destroyed with the 3D scene — meaning the object being used to remember the user's choice does not outlive the scene the choice applies to.

### The change

The preference is tracked in a dedicated `m_frameCountEnabled` bool, independent of the transient `QFrameAction`. `resetItems()` now only detaches the action, and `initialize3DProperties()` recreates and re-attaches it whenever the scene is rebuilt, if the option is enabled.

`SettingsView3D.qml` also gains the `checked` binding the "Show FPS" checkbox was missing, so it reflects the current state like the other controls in that panel.

Three files, all in `qmlui`. **No engine changes.**

**Related Issues:**

There are a series of 5 related PRs + 1 doc PR to improve the 3D View and fix a couple of other issues. This is the first PR.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
1. Enter the 3D View. Check "Show FPS". Switch to Virtual Console. Switch back to 3D view. Verify that the "Show FPS" setting is still on.

### Testing

Builds clean and `make check` passes, with the same single pre-existing
`RGBText_Test::load()` font failure seen before the change.

Smoke tested.

Linux (Ubuntu and Debian) / Qt 6.11 only. **Not tested on Windows or macOS.**

**Test Results:**
Pass

## Additional Notes

The setting is still runtime-only here — it is not written to the project. Persisting it, along with the rest of the Rendering group, is the follow-up PR, which builds on this one because it touches the same code.

