### PR TITLE
qmlui: render light beams for LED Bar (Beams) fixtures in the 3D view

### DIFF
--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -1241,17 +1241,17 @@ void MainView3D::initializeFixture(quint32 itemID, QEntity *fxEntity, const QSce
 
         Qt3DCore::QTransform *transform = getTransform(meshRef->m_headItem);
 
-        if (baseItem != nullptr)
+        // A mesh based fixture only tilts if the loaded scene has a base item
+        // under the head, i.e. it is a moving head or a scanner. An item drawn
+        // without a mesh has no base to look for: its head entity IS the movable
+        // part, so a Tilt channel is enough. Without the second case, a motorized
+        // beam bar would animate a tilt angle that nothing ever applies.
+        if ((baseItem != nullptr || loader == nullptr) && transform != nullptr &&
+            fixture->channelNumber(QLCChannel::Tilt, QLCChannel::MSB) != QLCChannel::invalid())
         {
-            if (fixture->channelNumber(QLCChannel::Tilt, QLCChannel::MSB) != QLCChannel::invalid())
-            {
-                // If there is a base item and a tilt channel,
-                // this is either a moving head or a scanner
-                if (transform != nullptr)
-                    QMetaObject::invokeMethod(meshRef->m_rootItem, "bindTiltTransform",
-                            Q_ARG(QVariant, QVariant::fromValue(transform)),
-                            Q_ARG(QVariant, tiltDeg));
-            }
+            QMetaObject::invokeMethod(meshRef->m_rootItem, "bindTiltTransform",
+                    Q_ARG(QVariant, QVariant::fromValue(transform)),
+                    Q_ARG(QVariant, tiltDeg));
         }
 
         meshRef->m_rootItem->setProperty("focusMinDegrees", focusMin);

--- a/qmlui/qml/fixturesfunctions/3DView/3DView.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/3DView.qml
@@ -115,6 +115,8 @@ Rectangle
                     for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                     {
                         headEntity = fixtureItem.getHead(iHead)
+                        if (!headEntity)
+                            continue
 
                         component.createObject(frameGraph.myShadowFrameGraphNode,
                         {
@@ -236,11 +238,14 @@ Rectangle
                 for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                 {
                     headEntity = fixtureItem.getHead(iHead)
+                    if (!headEntity)
+                        continue
 
                     component.createObject(frameGraph.myCameraSelector,
                     {
                         "gBuffer": gBufferTarget,
-                        "shadowTex": headEntity.depthTex,
+                        // heads that don't cast shadows have no shadow map at all
+                        "shadowTex": fixtureItem.useShadows ? headEntity.depthTex : null,
                         "useShadows": fixtureItem.useShadows,
                         "spotlightShadingLayer": headEntity.spotlightShadingLayer,
                         "frameTarget": frameTarget
@@ -269,6 +274,8 @@ Rectangle
                 for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                 {
                     headEntity = fixtureItem.getHead(iHead)
+                    if (!headEntity)
+                        continue
 
                     component.createObject(frameGraph.myCameraSelector,
                     {
@@ -282,7 +289,7 @@ Rectangle
                         "frontDepth": depthTarget,
                         "gBuffer": gBufferTarget,
                         "spotlightScatteringLayer": headEntity.spotlightScatteringLayer,
-                        "shadowTex": headEntity.depthTex,
+                        "shadowTex": fixtureItem.useShadows ? headEntity.depthTex : null,
                         "frameTarget": frameTarget,
                         "useShadows": fixtureItem.useShadows
                     });

--- a/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
@@ -26,64 +26,91 @@ import Qt3D.Extras
 import "Math3DView.js" as Math3D
 import "."
 
+/*
+  A single light emitter of a multi-beam fixture (see MultiBeams3DItem).
+  It plays the role Fixture3DItem plays for a one-head fixture: it owns the
+  three spotlight cones and exposes the uniforms the spotlight shaders read.
+  It has no geometry of its own - the bar mesh is drawn by the parent item.
+*/
 Entity
 {
     id: beamEntity
 
     property int headIndex
     property real dimmerValue: 0
-    property real shutterValue: 0
+    property real shutterValue: 1.0
     property real lightIntensity: dimmerValue * shutterValue
 
     property color lightColor: Qt.rgba(0, 0, 0, 1)
     property vector3d lightPos: Qt.vector3d(0, 0, 0)
     property vector3d lightDir: Qt.vector3d(0, 0, 0)
 
-    property real raymarchSteps
+    /* Orientation of the emitter. SpotlightConeEntity and the shading/scattering
+       shaders need a pan/tilt angle to place and aim the cone; when they are
+       missing the cone model matrix collapses and nothing is drawn. LED bars
+       never pan, and tilt (motorized bars) is pushed down from the parent item. */
+    property real panRotation: 0
+    property real tiltRotation: 0
+
+    /* This MUST stay an int. It ends up in the "raymarchSteps" uniform of
+       spotlight_scattering.frag, which is declared as an int, and Qt3D does not
+       convert: a QML real is stored as a float and its raw bytes are handed to
+       glUniform1iv, so the shader would read the *bit pattern* of the float
+       (40.0 becomes 1109393408) and ray march for over a billion iterations.
+       That hangs the GPU, which is why the scattering cone below used to be
+       commented out with a "this hangs your PC" note. Fixture3DItem declares
+       the same property as an int. */
+    property int raymarchSteps: 0
+
     property real cutoffAngle
     property real distCutoff
     property real headLength
-    property real coneBottomRadius
     property real coneTopRadius
+    /* Derived exactly like Fixture3DItem so that changing the beam aperture
+       (zoom) keeps the cone geometry consistent. */
+    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
     property Texture2D goboTexture
     property real goboRotation: 0
+
+    /* Spotlight matrices - same math as Fixture3DItem.qml. These are read as
+       uniforms by SpotlightConeEntity; the per-head lightPos and lightMatrix
+       are provided by the parent through setHeadLightProps(). */
+    property matrix4x4 lightMatrix
+    property matrix4x4 lightViewMatrix:
+        Math3D.getLightViewMatrix(lightMatrix, panRotation, tiltRotation, lightPos)
+    // getLightProjectionMatrix() divides by (coneBottomRadius / coneTopRadius - 1),
+    // so a not-yet-known aperture would produce a degenerate matrix
+    property matrix4x4 lightProjectionMatrix:
+        coneTopRadius > 0 && coneBottomRadius > coneTopRadius ?
+            Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle) :
+            Qt.matrix4x4()
+    property matrix4x4 lightViewProjectionMatrix: lightProjectionMatrix.times(lightViewMatrix)
+    property matrix4x4 lightViewProjectionScaleAndOffsetMatrix:
+        Math3D.getLightViewProjectionScaleOffsetMatrix(lightViewProjectionMatrix)
 
     readonly property Layer spotlightShadingLayer: Layer { }
     readonly property Layer outputDepthLayer: Layer { }
     readonly property Layer spotlightScatteringLayer: Layer { }
 
-    property Transform headTransform: Transform { translation: Qt.vector3d(0.1 * headIndex, 0, 0) }
+    /* Shadow map of this emitter. It is what makes the beam stop at the first
+       surface it hits: spotlight_shading.frag has no distance bound of its own,
+       so without a shadow map the cone lights every G-buffer texel inside its
+       projection - through walls and everything behind them.
 
-    function setupScattering(sceneEntity)
-    {
-        shadingCone.coneEffect = sceneEntity.spotlightShadingEffect
-        shadingCone.parent = sceneEntity
-        shadingCone.spotlightConeMesh = sceneEntity.coneMesh
-
-        //scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect // this hangs your PC
-        scatteringCone.parent = sceneEntity
-        scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
-
-        outDepthCone.coneEffect = sceneEntity.outputFrontDepthEffect
-        outDepthCone.parent = sceneEntity
-        outDepthCone.spotlightConeMesh = sceneEntity.coneMesh
-    }
-
-    function cleanupScattering()
-    {
-        if (shadingCone)
-            shadingCone.destroy()
-        if (scatteringCone)
-            scatteringCone.destroy()
-        if (outDepthCone)
-            outDepthCone.destroy()
-    }
+       Same size as Fixture3DItem, deliberately. The frustum covers exactly the
+       cone, so what matters is resolution per degree of aperture, and a bar is
+       not the narrow emitter it might seem: real definitions of this type carry
+       lenses of 40 and even 120 degrees, against the 30 of a typical PAR. A
+       smaller map is therefore coarser here than for a single head fixture, not
+       finer, and a coarse map is what makes a wide beam fail its own shadow
+       test and emit nothing at all. */
+    property int shadowMapSize: 1024
 
     property Texture2D depthTex:
         Texture2D
         {
-            width: 1024
-            height: 1024
+            width: shadowMapSize
+            height: shadowMapSize
             format: Texture.D32F
             generateMipMaps: false
             magnificationFilter: Texture.Nearest
@@ -107,6 +134,36 @@ Entity
             ] // attachments
         }
 
+    function setupScattering(sceneEntity)
+    {
+        shadingCone.coneEffect = sceneEntity.spotlightShadingEffect
+        shadingCone.parent = sceneEntity
+        shadingCone.spotlightConeMesh = sceneEntity.coneMesh
+
+        // Volumetric beam in the air. As in Fixture3DItem, its cost is governed
+        // by raymarchSteps, which is 0 on Low render quality.
+        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
+        scatteringCone.parent = sceneEntity
+        scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
+
+        outDepthCone.coneEffect = sceneEntity.outputFrontDepthEffect
+        outDepthCone.parent = sceneEntity
+        outDepthCone.spotlightConeMesh = sceneEntity.coneMesh
+    }
+
+    /* Must be called before this entity is destroyed: setupScattering() moves the
+       three cones under the scene root, so they do not go away with their
+       declaring entity and would be left in the scene bound to a dead object. */
+    function cleanupScattering()
+    {
+        if (shadingCone)
+            shadingCone.destroy()
+        if (scatteringCone)
+            scatteringCone.destroy()
+        if (outDepthCone)
+            outDepthCone.destroy()
+    }
+
     /* Cone meshes used for scattering. These get re-parented to
        the main Scene entity via setupScattering */
     SpotlightConeEntity
@@ -127,8 +184,4 @@ Entity
         coneLayer: outputDepthLayer
         fxEntity: beamEntity
     }
-
-    components: [
-        headTransform
-    ]
 } // Entity

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -45,6 +45,22 @@ Entity
         updateHeads()
     }
 
+    /* Number of emitters across the bar width and along its depth.
+
+       The physical layout describes the cell grid of the fixture body, which is
+       NOT required to agree with the number of heads the selected mode declares.
+       The Pulse LED BAR 320 is an 8x1 bar whose 4 channel mode declares no head
+       at all, so the engine synthesises a single one covering every channel:
+       laying that one emitter out on an 8 wide grid puts it in cell 0, i.e. at
+       one end of the bar instead of across it. Only trust the layout when it
+       accounts for exactly the emitters we have; otherwise put them in one row. */
+    readonly property bool layoutMatchesHeads:
+        headsLayout.width * headsLayout.height === headsNumber
+    readonly property int cellColumns:
+        layoutMatchesHeads ? headsLayout.width : Math.max(1, headsNumber)
+    readonly property int cellRows:
+        layoutMatchesHeads ? headsLayout.height : 1
+
     /* **************** Tilt properties (motorized bars) **************** */
     property real tiltMaxDegrees: 270
     property real tiltSpeed: 4000 // in milliseconds
@@ -60,7 +76,15 @@ Entity
 
     /* **************** Rendering quality properties **************** */
     property bool useScattering: View3D.renderQuality === MainView3D.LowQuality ? false : true
+
+    /* Shadows are not optional for this renderer: spotlight_shading.frag bounds
+       the beam with the emitter's shadow map and nothing else, so an emitter
+       without one lights everything inside its cone projection, straight through
+       the walls of the stage environment. The per emitter cost is bounded from
+       two sides: RenderShadowMapFilter matches no render pass while a cell is
+       dark, and LightEntity uses a smaller map than a single head fixture. */
     property bool useShadows: View3D.renderQuality === MainView3D.LowQuality ? false : true
+
     property int raymarchSteps:
     {
         switch(View3D.renderQuality)
@@ -70,19 +94,37 @@ Entity
             case MainView3D.HighQuality: return 40
             case MainView3D.UltraQuality: return 80
         }
+        return 0
     }
 
-    /* **************** Spotlight cone properties **************** */
-    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
-    property real coneTopRadius: transform ? (0.24023 / 2) * transform.scale3D.x * 0.7 : 0.0 // (diameter / 2) * scale * magic number
+    /* Ray march steps of a single beam. The volumetric scattering pass runs once
+       per emitter, so a bar would otherwise cost as much as headsNumber separate
+       spotlights. Spend the budget of about four spotlights on the whole bar
+       instead, with a floor that still reads as a beam: the cones of a bar are
+       thin, so they need far fewer samples than a wide spotlight cone. */
+    readonly property int beamRaymarchSteps:
+        raymarchSteps <= 0 ? 0
+                           : Math.max(6, Math.min(raymarchSteps,
+                                                  Math.round((raymarchSteps * 4) / Math.max(1, headsNumber))))
 
-    property real headLength: 0.5 * transform.scale3D.x
+    /* **************** Spotlight cone properties **************** */
+    /* Radius of a single cell, rather than the lens radius of a PAR mesh that
+       this item does not have. The 0.7 factor matches Fixture3DItem, where it
+       compensates the mesh lens being slightly larger than the emitting surface. */
+    property real coneTopRadius:
+        Math.max(0.005, 0.5 * 0.7 * Math.min(phySize.x / cellColumns, phySize.z / cellRows))
+    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
+
+    /* Depth of the emitter inside the fixture body. Fixture3DItem takes this from
+       the loaded mesh; a bar is drawn as a plain cuboid, so its own height is the
+       closest equivalent. */
+    property real headLength: Math.max(0.01, phySize.y)
 
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
-    property real shutterValue: 1.0
-    property vector3d lightDir: Math3D.getLightDirection(transform, 0, tiltTransform)
+    property real shutterValue: sAnimator.shutterValue
+    property vector3d lightDir: Math3D.getLightDirection(transform, null, tiltTransform)
 
     property var headsList: []
 
@@ -99,39 +141,78 @@ Entity
     {
         var i
 
-        // delete existing heads first
+        // Delete the existing heads first. setupScattering() re-parents the three
+        // cones of a head to the scene root, so they do not die with it: without
+        // cleanupScattering() they would be left in the scene, still bound to a
+        // destroyed emitter, and every rebuild would add three more.
         for (i = headsList.length - 1; i >= 0; i--)
+        {
+            headsList[i].cleanupScattering()
             headsList[i].destroy()
+        }
 
         headsList = []
 
+        // itemID is invalid while the item is being built - MainView3D sets the
+        // real one right after creation - and MainView3D::resetItems() sets it
+        // back to -1 when the 3D view is torn down. Building a set of heads in
+        // either case is pure waste, and in the teardown case it allocates
+        // emitters into a scene that is being destroyed.
+        if (itemID < 0 || headsNumber <= 0)
+            return
+
+        var component = Qt.createComponent("LightEntity.qml")
+        if (component.status !== Component.Ready)
+        {
+            console.warn("MultiBeams3DItem: cannot load LightEntity.qml:", component.errorString())
+            return
+        }
+
         for (i = 0; i < headsNumber; i++)
         {
-            console.log("Item " + itemID + " creating head - " + i)
-
-            var component = Qt.createComponent("LightEntity.qml");
-            if (component.status === Component.Error)
-                console.log("Error loading component:", component.errorString())
-
+            // Everything shared with the parent is bound rather than copied: most
+            // of these are only known once MainView3D::initializeFixture() has run,
+            // which happens below, and render quality, zoom, shutter and tilt keep
+            // changing afterwards.
             var headNode = component.createObject(fixtureEntity,
             {
                 "headIndex": i,
-                "lightDir": lightDir,
-                "shutterValue": shutterValue,
-                "raymarchSteps": raymarchSteps,
-                "cutoffAngle": cutoffAngle,
-                "distCutoff": distCutoff,
-                "headLength": headLength,
-                "coneBottomRadius": coneBottomRadius,
-                "coneTopRadius": coneTopRadius,
-                "tiltRotation": tiltRotation,
-                "goboTexture": goboTexture
+                "enabled": Qt.binding(function() { return fixtureEntity.enabled }),
+                "lightDir": Qt.binding(function() { return fixtureEntity.lightDir }),
+                "shutterValue": Qt.binding(function() { return fixtureEntity.shutterValue }),
+                "raymarchSteps": Qt.binding(function() { return fixtureEntity.beamRaymarchSteps }),
+                "cutoffAngle": Qt.binding(function() { return fixtureEntity.cutoffAngle }),
+                "tiltRotation": Qt.binding(function() { return fixtureEntity.tiltRotation }),
+                "distCutoff": Qt.binding(function() { return fixtureEntity.distCutoff }),
+                "headLength": Qt.binding(function() { return fixtureEntity.headLength }),
+                "coneTopRadius": Qt.binding(function() { return fixtureEntity.coneTopRadius }),
+                "goboTexture": Qt.binding(function() { return fixtureEntity.goboTexture })
             });
+
+            if (headNode === null)
+            {
+                console.warn("MultiBeams3DItem: cannot create head", i, "of item", itemID)
+                break
+            }
 
             headsList.push(headNode)
         }
 
+        // 3DView.qml walks headsNumber heads when it builds the frame graph, so
+        // this must never promise more emitters than actually exist
+        if (headsList.length !== headsNumber)
+            headsNumber = headsList.length
+
+        // initializeFixture() is what hands us phySize and the lens angles, so the
+        // beam geometry logged below is only meaningful once it has returned
         View3D.initializeFixture(itemID, fixtureEntity, null)
+
+        console.log("MultiBeams3DItem: item", itemID, "emitters:", headsList.length,
+                    "layout:", headsLayout.width + "x" + headsLayout.height,
+                    "used as:", cellColumns + "x" + cellRows,
+                    "| lens:", focusMinDegrees + "-" + focusMaxDegrees + " deg",
+                    "cone top/bottom:", coneTopRadius.toFixed(4) + "/" + coneBottomRadius.toFixed(2),
+                    "| steps:", beamRaymarchSteps)
     }
 
     function setupScattering(sceneEntity)
@@ -140,9 +221,7 @@ Entity
             sceneEntity.coneMesh.length = distCutoff
 
         for (var i = 0; i < headsList.length; i++)
-        {
             headsList[i].setupScattering(sceneEntity)
-        }
     }
 
     function cleanupScattering()
@@ -157,29 +236,48 @@ Entity
 
     function getHead(headIndex)
     {
+        if (headIndex < 0 || headIndex >= headsList.length)
+            return null
+
         return headsList[headIndex]
     }
 
+    // The C++ side computes a single emitter position and orientation for the
+    // whole bar (headIndex is always 0), so spread the cells over the fixture
+    // body here: evenly across its width and depth, centered on the origin and
+    // rotated by the bar's current orientation matrix.
     function setHeadLightProps(headIndex, pos, matrix)
     {
-        for (var h = 0; h < headsNumber; h++)
+        var count = headsList.length
+        if (count === 0)
+            return
+
+        var cellWidth = phySize.x / cellColumns
+        var cellDepth = phySize.z / cellRows
+
+        for (var h = 0; h < count; h++)
         {
-            var head = getHead(h)
-            var hPos = Qt.vector3d(pos.x * h, pos.y, pos.z)
-            head.lightPos = hPos
+            var column = h % cellColumns
+            var row = Math.floor(h / cellColumns)
+            var localPos = Qt.vector4d(-(phySize.x / 2) + ((column + 0.5) * cellWidth), 0,
+                                       -(phySize.z / 2) + ((row + 0.5) * cellDepth), 0)
+
+            var head = headsList[h]
+            head.lightPos = pos.plus(matrix.times(localPos).toVector3d())
             head.lightMatrix = matrix
-            console.log("Setting light info: " + hPos + ", m: " + matrix)
         }
     }
 
     function setHeadIntensity(headIndex, intensity)
     {
-        headsList[headIndex].dimmerValue = intensity
+        if (headIndex >= 0 && headIndex < headsList.length)
+            headsList[headIndex].dimmerValue = intensity
     }
 
     function setHeadRGBColor(headIndex, color)
     {
-        headsList[headIndex].lightColor = color
+        if (headIndex >= 0 && headIndex < headsList.length)
+            headsList[headIndex].lightColor = color
     }
 
     // See Fixture3DItem: timestamp of the previous setPosition() call, used to pace
@@ -235,9 +333,14 @@ Entity
         sAnimator.setShutter(type, low, high)
     }
 
-    function setZoom(value)
+    // Same signature as Fixture3DItem: MainView3D calls this with degrees == true
+    // when the fixture has a fixed zoom set in the monitor properties
+    function setZoom(value, degrees)
     {
-        cutoffAngle = (((((focusMaxDegrees - focusMinDegrees) / 255) * value) + focusMinDegrees) / 2) * (Math.PI / 180)
+        if (degrees)
+            cutoffAngle = (value / 2) * (Math.PI / 180.0)
+        else
+            cutoffAngle = (((((focusMaxDegrees - focusMinDegrees) / 255.0) * value) + focusMinDegrees) / 2.0) * (Math.PI / 180.0)
     }
 
     NumberAnimation on tiltRotation
@@ -305,9 +408,13 @@ Entity
 
     property Texture2D goboTexture: Texture2D { }
 
+    /* headEntity is NOT listed here: it is an Entity, not a Component, so QML
+       rejected it with a "Cannot append ... to a QML list of QComponent*"
+       warning on every item creation. It is already a child of this entity
+       through the default property, which is how it gets drawn and how
+       MainView3D finds it by object name. */
     components: [
         baseMesh,
-        headEntity,
         transform,
         material,
         sceneLayer


### PR DESCRIPTION
## Description

**Summary of Changes:**

Fixtures of type "LED Bar (Beams)" were drawn as a bare cuboid mesh in the 3D view with no light output, so users had to re-type them as Color Changers to see anything. The multi-head code path they use (MultiBeams3DItem plus LightEntity) was an unfinished work in progress.

This PR implements light emission from the heads/emitters of this fixture type (and resolves the past issue mentioned in a comment that would crash the 3D engine).

**Related Issues:**

A further PR will follow to implement a new 3D View Rendering setting: "Fixture Light (%)" to work in tandem with "Smoke amount" to help address the issue where many fixtures casting light together at the stage space cause flat white or full-intensity color, due to fixture light being additive without an exposure or gain setting. This will allow the lighting scene in the 3D view to be made more realistic. 

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
1. Use fixture(s) of type "LED Bar (Beams)" with 1 x 8 (or more) layout that declare no heads/emitters. Activate the light DMX Channels (e.g. in Simple Desk). Open the 3D view. Observe that the fixture(s) cast light.
2. Test with fixtures of type "LED Bar (Beams)" that declare heads/emitters.

**Test Results:**

<img width="1207" height="753" alt="image" src="https://github.com/user-attachments/assets/b75124db-403a-4650-b7e4-12516e2a9fe6" />

**Other**

`make check` passes (one pre-existing `RGBText_Test::load()` font failure, identical before and after). Tested on Linux / Qt 6.11 against a rig with four 3-emitter and six single-emitter bars.

**Not tested on Windows or macOS.** Given the root cause was a uniform type mismatch, the Windows backend is worth a look before merging.

**One code path is untested:** the tilt binding. No fixture in my rig has a Tilt channel; it needs a motorised bar such as an Ayrton MagicBlade.

## Additional Notes

### What this adds

LED Bar (Beams) fixtures currently render as a bare cuboid in the 3D view with no light output, so the only way to see anything is to re-type them as Color Changers. This completes the multi-head code path they already use (`MultiBeams3DItem` + `LightEntity`) so each cell emits a beam.

### Why it did not work

`LightEntity` never declared the pan/tilt angles or the light view/projection matrices that `SpotlightConeEntity` reads as uniforms, so every cone transform collapsed and nothing was drawn.

It also declared `raymarchSteps` as a QML `real`, while `spotlight_scattering.frag` declares the matching uniform as an `int`. Qt3D stores a `real` as a float and passes the raw bytes to `glUniform1iv` without converting, so the shader read the *bit pattern* of the float — 40.0 becomes 1109393408 — and ray marched over a billion times per fragment. That hangs the GPU and resets the display driver, which I believe is the reason the scattering cone carried the `// this hangs your PC` comment. The cone was never the problem; the uniform type was. `Fixture3DItem` has always declared it as an `int`.

### Changes to existing code

**No engine changes.** Everything is in `qmlui`.

`mainview3d.cpp` — one change. `initializeFixture()` only bound a tilt transform when the loaded scene had a base item under the head, which an item drawn without a mesh never has, so motorised beam bars animated a tilt angle nothing applied. The condition now also accepts the no-loader path. `MultiBeams3DItem` is currently the only item type that reaches this code without a scene loader (`PixelBar3DItem`, `Strobe3DItem` and `Generic3DItem` declare no `headEntity`, so `m_headItem` stays null and the whole block is skipped), so nothing else changes behaviour.

`3DView.qml` — `getHead()` returned `undefined` for any gap between `headsNumber` and the real emitter count. The resulting exception aborted `updateFrameGraph()` *after* it had destroyed the previous frame graph, leaving no G-buffer fill, no lighting and no blit, i.e. an unusable 3D view. The head lookups are now guarded, and a shadow map is only requested from emitters that cast shadows.

`LightEntity.qml` / `MultiBeams3DItem.qml` — the rest, described in the commit message. The notable correctness fixes beyond the uniform type: emitters are built once for a valid item ID rather than on every `itemID` change (including the `-1` that `resetItems()` writes on teardown, which rebuilt every emitter into a scene being destroyed); `cleanupScattering()` runs before an emitter is destroyed, since `setupScattering()` re-parents its three cones to the scene root and they were being orphaned; and the emitter grid honours the physical layout only when it matches the mode's head count, because a Pulse LED BAR 320 declares an 8x1 layout while its 4-channel mode declares no head at all, which put its single synthesised emitter at one end of the bar.

### Performance

Cost scales with lit cells, not total cells: `RenderShadowMapFilter` matches no render pass while an emitter is dark, and `SpotlightConeEntity.enabled` does the same for the shading and scattering passes. Ray march steps are additionally scaled by emitter count so a bar costs roughly a fixed budget rather than one spotlight per cell.