### PR TITLE
engine/qmlui: persist the 3D View "Rendering" and "Scale" lock settings in the project file

### DIFF
--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -50,6 +50,12 @@
 #define KXMLQLCMonitorLightEmitter  QStringLiteral("LightEmitter")
 #define KXMLQLCMonitorStageItem     QStringLiteral("StageItem")
 #define KXMLQLCMonitorMeshItem      QStringLiteral("MeshItem")
+
+#define KXMLQLCMonitorRendering         QStringLiteral("Rendering")
+#define KXMLQLCMonitorRenderQuality     QStringLiteral("Quality")
+#define KXMLQLCMonitorRenderAmbient     QStringLiteral("Ambient")
+#define KXMLQLCMonitorRenderSmoke       QStringLiteral("Smoke")
+#define KXMLQLCMonitorRenderShowFPS     QStringLiteral("ShowFPS")
 #define KXMLQLCMonitorItemName      QStringLiteral("Name")
 #define KXMLQLCMonitorItemRes       QStringLiteral("Res")
 
@@ -79,6 +85,13 @@
 #define GRID_DEFAULT_HEIGHT 3
 #define GRID_DEFAULT_DEPTH  5
 
+/* 3D view rendering defaults. RENDER_DEFAULT_QUALITY matches
+   MainView3D::HighQuality and the other two match the MainView3D members
+   they replace, so a project without a <Rendering> node looks unchanged. */
+#define RENDER_DEFAULT_QUALITY  2
+#define RENDER_DEFAULT_AMBIENT  0.6
+#define RENDER_DEFAULT_SMOKE    0.8
+
 MonitorProperties::MonitorProperties()
     : m_font(QFont("Arial", 12))
     , m_displayMode(DMX)
@@ -88,6 +101,10 @@ MonitorProperties::MonitorProperties()
     , m_gridUnits(Meters)
     , m_pointOfView(Undefined)
     , m_stageType(StageSimple)
+    , m_renderQuality(RENDER_DEFAULT_QUALITY)
+    , m_ambientLightIntensity(RENDER_DEFAULT_AMBIENT)
+    , m_smokeAmount(RENDER_DEFAULT_SMOKE)
+    , m_showFPS(false)
     , m_showLabels(false)
 {
 }
@@ -99,6 +116,10 @@ void MonitorProperties::reset()
     m_pointOfView = Undefined;
     m_stageType = StageSimple;
     m_showLabels = false;
+    m_renderQuality = RENDER_DEFAULT_QUALITY;
+    m_ambientLightIntensity = RENDER_DEFAULT_AMBIENT;
+    m_smokeAmount = RENDER_DEFAULT_SMOKE;
+    m_showFPS = false;
     m_fixtureItems.clear();
     m_lightItems.clear();
     m_genericItems.clear();
@@ -700,6 +721,18 @@ bool MonitorProperties::loadXML(QXmlStreamReader &root, const Doc *mainDocument)
             setGridSize(QVector3D(w, h, d));
             root.skipCurrentElement();
         }
+        else if (root.name() == KXMLQLCMonitorRendering)
+        {
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderQuality))
+                setRenderQuality(tAttrs.value(KXMLQLCMonitorRenderQuality).toString().toInt());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderAmbient))
+                setAmbientLightIntensity(tAttrs.value(KXMLQLCMonitorRenderAmbient).toString().toDouble());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderSmoke))
+                setSmokeAmount(tAttrs.value(KXMLQLCMonitorRenderSmoke).toString().toDouble());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderShowFPS))
+                setShowFPS(tAttrs.value(KXMLQLCMonitorRenderShowFPS).toString().toInt() != 0);
+            root.skipCurrentElement();
+        }
         else if (root.name() == KXMLQLCMonitorStageItem)
         {
             setStageType(StageType(root.readElementText().toInt()));
@@ -915,6 +948,14 @@ bool MonitorProperties::saveXML(QXmlStreamWriter *doc, const Doc *mainDocument) 
 
 #ifdef QMLUI
     doc->writeTextElement(KXMLQLCMonitorStageItem, QString::number(stageType()));
+
+    /* 3D view rendering settings */
+    doc->writeStartElement(KXMLQLCMonitorRendering);
+    doc->writeAttribute(KXMLQLCMonitorRenderQuality, QString::number(renderQuality()));
+    doc->writeAttribute(KXMLQLCMonitorRenderAmbient, QString::number(ambientLightIntensity()));
+    doc->writeAttribute(KXMLQLCMonitorRenderSmoke, QString::number(smokeAmount()));
+    doc->writeAttribute(KXMLQLCMonitorRenderShowFPS, QString::number(showFPS() ? 1 : 0));
+    doc->writeEndElement();
 #endif
 
     // ***********************************************************

--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -56,6 +56,8 @@
 #define KXMLQLCMonitorRenderAmbient     QStringLiteral("Ambient")
 #define KXMLQLCMonitorRenderSmoke       QStringLiteral("Smoke")
 #define KXMLQLCMonitorRenderShowFPS     QStringLiteral("ShowFPS")
+
+#define KXMLQLCMonitorScaleLock     QStringLiteral("ScaleLock")
 #define KXMLQLCMonitorItemName      QStringLiteral("Name")
 #define KXMLQLCMonitorItemRes       QStringLiteral("Res")
 
@@ -92,6 +94,10 @@
 #define RENDER_DEFAULT_AMBIENT  0.6
 #define RENDER_DEFAULT_SMOKE    0.8
 
+/* The 3D view "Scale" fields of a generic item start locked together,
+   matching the previous hardcoded state of the QML lock button */
+#define SCALE_DEFAULT_LOCKED    true
+
 MonitorProperties::MonitorProperties()
     : m_font(QFont("Arial", 12))
     , m_displayMode(DMX)
@@ -105,6 +111,7 @@ MonitorProperties::MonitorProperties()
     , m_ambientLightIntensity(RENDER_DEFAULT_AMBIENT)
     , m_smokeAmount(RENDER_DEFAULT_SMOKE)
     , m_showFPS(false)
+    , m_scaleLocked(SCALE_DEFAULT_LOCKED)
     , m_showLabels(false)
 {
 }
@@ -120,6 +127,7 @@ void MonitorProperties::reset()
     m_ambientLightIntensity = RENDER_DEFAULT_AMBIENT;
     m_smokeAmount = RENDER_DEFAULT_SMOKE;
     m_showFPS = false;
+    m_scaleLocked = SCALE_DEFAULT_LOCKED;
     m_fixtureItems.clear();
     m_lightItems.clear();
     m_genericItems.clear();
@@ -733,6 +741,10 @@ bool MonitorProperties::loadXML(QXmlStreamReader &root, const Doc *mainDocument)
                 setShowFPS(tAttrs.value(KXMLQLCMonitorRenderShowFPS).toString().toInt() != 0);
             root.skipCurrentElement();
         }
+        else if (root.name() == KXMLQLCMonitorScaleLock)
+        {
+            setScaleLocked(root.readElementText().toInt() != 0);
+        }
         else if (root.name() == KXMLQLCMonitorStageItem)
         {
             setStageType(StageType(root.readElementText().toInt()));
@@ -956,6 +968,9 @@ bool MonitorProperties::saveXML(QXmlStreamWriter *doc, const Doc *mainDocument) 
     doc->writeAttribute(KXMLQLCMonitorRenderSmoke, QString::number(smokeAmount()));
     doc->writeAttribute(KXMLQLCMonitorRenderShowFPS, QString::number(showFPS() ? 1 : 0));
     doc->writeEndElement();
+
+    /* 3D view editing settings */
+    doc->writeTextElement(KXMLQLCMonitorScaleLock, QString::number(scaleLocked() ? 1 : 0));
 #endif
 
     // ***********************************************************

--- a/engine/src/monitorproperties.h
+++ b/engine/src/monitorproperties.h
@@ -164,6 +164,19 @@ private:
     bool m_showFPS;
 
     /********************************************************************
+     * 3D View editing
+     ********************************************************************/
+public:
+    /** Get/Set whether the 3D view "Scale" X/Y/Z fields of a generic item
+     *  are locked together, i.e. editing one of them scales the item
+     *  uniformly on the three axes */
+    inline void setScaleLocked(bool locked) { m_scaleLocked = locked; }
+    inline bool scaleLocked() const { return m_scaleLocked; }
+
+private:
+    bool m_scaleLocked;
+
+    /********************************************************************
      * Items flags
      ********************************************************************/
 public:

--- a/engine/src/monitorproperties.h
+++ b/engine/src/monitorproperties.h
@@ -137,6 +137,33 @@ private:
     StageType m_stageType;
 
     /********************************************************************
+     * 3D View rendering
+     ********************************************************************/
+public:
+    /** Get/Set the 3D view render quality. The value matches the
+     *  MainView3D::RenderQuality enum (0 = Low ... 3 = Ultra) */
+    inline void setRenderQuality(int quality) { m_renderQuality = quality; }
+    inline int renderQuality() const { return m_renderQuality; }
+
+    /** Get/Set the 3D view ambient light intensity (0.0 - 1.0) */
+    inline void setAmbientLightIntensity(qreal intensity) { m_ambientLightIntensity = intensity; }
+    inline qreal ambientLightIntensity() const { return m_ambientLightIntensity; }
+
+    /** Get/Set the 3D view smoke/haze amount (0.0 - 1.0) */
+    inline void setSmokeAmount(qreal amount) { m_smokeAmount = amount; }
+    inline qreal smokeAmount() const { return m_smokeAmount; }
+
+    /** Get/Set whether the 3D view FPS counter overlay is shown */
+    inline void setShowFPS(bool show) { m_showFPS = show; }
+    inline bool showFPS() const { return m_showFPS; }
+
+private:
+    int m_renderQuality;
+    qreal m_ambientLightIntensity;
+    qreal m_smokeAmount;
+    bool m_showFPS;
+
+    /********************************************************************
      * Items flags
      ********************************************************************/
 public:

--- a/engine/test/monitorproperties/monitorproperties_test.cpp
+++ b/engine/test/monitorproperties/monitorproperties_test.cpp
@@ -43,6 +43,7 @@ void MonitorProperties_Test::defaults()
     QCOMPARE(mp.ambientLightIntensity(), 0.6);
     QCOMPARE(mp.smokeAmount(), 0.8);
     QCOMPARE(mp.showFPS(), false);
+    QCOMPARE(mp.scaleLocked(), true);
     QVERIFY(mp.commonBackgroundImage().isEmpty());
 }
 
@@ -113,14 +114,18 @@ void MonitorProperties_Test::lightItemsXML()
     QCOMPARE(loaded.lightPosition("moving_head.dae", 0), QVector3D(1.5f, 2.5f, 3.5f));
 }
 
-void MonitorProperties_Test::renderSettingsXML()
+void MonitorProperties_Test::view3DSettingsXML()
 {
+#ifndef QMLUI
+    QSKIP("The 3D view settings are saved only by the QML UI build");
+#else
     Doc doc(this);
     MonitorProperties mp;
     mp.setRenderQuality(3);
     mp.setAmbientLightIntensity(0.25);
     mp.setSmokeAmount(0.9);
     mp.setShowFPS(true);
+    mp.setScaleLocked(false);
 
     QByteArray xmlData;
     QBuffer buffer(&xmlData);
@@ -148,6 +153,8 @@ void MonitorProperties_Test::renderSettingsXML()
     QCOMPARE(loaded.ambientLightIntensity(), 0.25);
     QCOMPARE(loaded.smokeAmount(), 0.9);
     QCOMPARE(loaded.showFPS(), true);
+    QCOMPARE(loaded.scaleLocked(), false);
+#endif
 }
 
 void MonitorProperties_Test::genericItems()
@@ -188,6 +195,7 @@ void MonitorProperties_Test::reset()
     mp.setAmbientLightIntensity(0.1);
     mp.setSmokeAmount(0.2);
     mp.setShowFPS(true);
+    mp.setScaleLocked(false);
     mp.setFixturePosition(1,0,0,QVector3D(1,2,3));
     mp.setItemName(2,"foo");
     mp.setCommonBackgroundImage("img.png");
@@ -203,6 +211,7 @@ void MonitorProperties_Test::reset()
     QCOMPARE(mp.ambientLightIntensity(), 0.6);
     QCOMPARE(mp.smokeAmount(), 0.8);
     QCOMPARE(mp.showFPS(), false);
+    QCOMPARE(mp.scaleLocked(), true);
     QCOMPARE(mp.fixtureItemsID().count(), 0);
     QCOMPARE(mp.lightResources().count(), 0);
     QCOMPARE(mp.genericItemsID().count(), 0);

--- a/engine/test/monitorproperties/monitorproperties_test.cpp
+++ b/engine/test/monitorproperties/monitorproperties_test.cpp
@@ -39,6 +39,10 @@ void MonitorProperties_Test::defaults()
     QCOMPARE(mp.pointOfView(), MonitorProperties::Undefined);
     QCOMPARE(mp.stageType(), MonitorProperties::StageSimple);
     QCOMPARE(mp.labelsVisible(), false);
+    QCOMPARE(mp.renderQuality(), 2);
+    QCOMPARE(mp.ambientLightIntensity(), 0.6);
+    QCOMPARE(mp.smokeAmount(), 0.8);
+    QCOMPARE(mp.showFPS(), false);
     QVERIFY(mp.commonBackgroundImage().isEmpty());
 }
 
@@ -109,6 +113,43 @@ void MonitorProperties_Test::lightItemsXML()
     QCOMPARE(loaded.lightPosition("moving_head.dae", 0), QVector3D(1.5f, 2.5f, 3.5f));
 }
 
+void MonitorProperties_Test::renderSettingsXML()
+{
+    Doc doc(this);
+    MonitorProperties mp;
+    mp.setRenderQuality(3);
+    mp.setAmbientLightIntensity(0.25);
+    mp.setSmokeAmount(0.9);
+    mp.setShowFPS(true);
+
+    QByteArray xmlData;
+    QBuffer buffer(&xmlData);
+    QVERIFY(buffer.open(QIODevice::WriteOnly));
+
+    QXmlStreamWriter writer(&buffer);
+    writer.writeStartDocument();
+    QVERIFY(mp.saveXML(&writer, &doc));
+    writer.writeEndDocument();
+    buffer.close();
+
+    MonitorProperties loaded;
+    QXmlStreamReader reader(xmlData);
+    while (reader.readNextStartElement())
+    {
+        if (reader.name() == KXMLQLCMonitorProperties)
+        {
+            QVERIFY(loaded.loadXML(reader, &doc));
+            break;
+        }
+        reader.skipCurrentElement();
+    }
+
+    QCOMPARE(loaded.renderQuality(), 3);
+    QCOMPARE(loaded.ambientLightIntensity(), 0.25);
+    QCOMPARE(loaded.smokeAmount(), 0.9);
+    QCOMPARE(loaded.showFPS(), true);
+}
+
 void MonitorProperties_Test::genericItems()
 {
     MonitorProperties mp;
@@ -143,6 +184,10 @@ void MonitorProperties_Test::reset()
     mp.setPointOfView(MonitorProperties::FrontView);
     mp.setStageType(MonitorProperties::StageBox);
     mp.setLabelsVisible(true);
+    mp.setRenderQuality(0);
+    mp.setAmbientLightIntensity(0.1);
+    mp.setSmokeAmount(0.2);
+    mp.setShowFPS(true);
     mp.setFixturePosition(1,0,0,QVector3D(1,2,3));
     mp.setItemName(2,"foo");
     mp.setCommonBackgroundImage("img.png");
@@ -154,6 +199,10 @@ void MonitorProperties_Test::reset()
     QCOMPARE(mp.pointOfView(), MonitorProperties::Undefined);
     QCOMPARE(mp.stageType(), MonitorProperties::StageSimple);
     QCOMPARE(mp.labelsVisible(), false);
+    QCOMPARE(mp.renderQuality(), 2);
+    QCOMPARE(mp.ambientLightIntensity(), 0.6);
+    QCOMPARE(mp.smokeAmount(), 0.8);
+    QCOMPARE(mp.showFPS(), false);
     QCOMPARE(mp.fixtureItemsID().count(), 0);
     QCOMPARE(mp.lightResources().count(), 0);
     QCOMPARE(mp.genericItemsID().count(), 0);

--- a/engine/test/monitorproperties/monitorproperties_test.h
+++ b/engine/test/monitorproperties/monitorproperties_test.h
@@ -31,6 +31,7 @@ private slots:
     void fixtureItems();
     void lightItems();
     void lightItemsXML();
+    void renderSettingsXML();
     void genericItems();
     void reset();
 };

--- a/engine/test/monitorproperties/monitorproperties_test.h
+++ b/engine/test/monitorproperties/monitorproperties_test.h
@@ -31,7 +31,7 @@ private slots:
     void fixtureItems();
     void lightItems();
     void lightItemsXML();
-    void renderSettingsXML();
+    void view3DSettingsXML();
     void genericItems();
     void reset();
 };

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -1241,17 +1241,17 @@ void MainView3D::initializeFixture(quint32 itemID, QEntity *fxEntity, const QSce
 
         Qt3DCore::QTransform *transform = getTransform(meshRef->m_headItem);
 
-        if (baseItem != nullptr)
+        // A mesh based fixture only tilts if the loaded scene has a base item
+        // under the head, i.e. it is a moving head or a scanner. An item drawn
+        // without a mesh has no base to look for: its head entity IS the movable
+        // part, so a Tilt channel is enough. Without the second case, a motorized
+        // beam bar would animate a tilt angle that nothing ever applies.
+        if ((baseItem != nullptr || loader == nullptr) && transform != nullptr &&
+            fixture->channelNumber(QLCChannel::Tilt, QLCChannel::MSB) != QLCChannel::invalid())
         {
-            if (fixture->channelNumber(QLCChannel::Tilt, QLCChannel::MSB) != QLCChannel::invalid())
-            {
-                // If there is a base item and a tilt channel,
-                // this is either a moving head or a scanner
-                if (transform != nullptr)
-                    QMetaObject::invokeMethod(meshRef->m_rootItem, "bindTiltTransform",
-                            Q_ARG(QVariant, QVariant::fromValue(transform)),
-                            Q_ARG(QVariant, tiltDeg));
-            }
+            QMetaObject::invokeMethod(meshRef->m_rootItem, "bindTiltTransform",
+                    Q_ARG(QVariant, QVariant::fromValue(transform)),
+                    Q_ARG(QVariant, tiltDeg));
         }
 
         meshRef->m_rootItem->setProperty("focusMinDegrees", focusMin);

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -84,6 +84,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_createItemCount(0)
     , m_sceneGeneration(0)
     , m_frameAction(nullptr)
+    , m_frameCountEnabled(false)
     , m_frameCount(0)
     , m_minFrameCount(0)
     , m_maxFrameCount(0)
@@ -272,7 +273,11 @@ void MainView3D::resetItems()
     m_minFrameCount = 0;
     m_maxFrameCount = 0;
     m_avgFrameCount = 1.0;
-    setFrameCountEnabled(false);
+    // Tear down the QFrameAction, since the scene root entity it is attached
+    // to is about to be destroyed, but keep the user's "Show FPS" preference
+    // (m_frameCountEnabled) so it is restored when the 3D scene is rebuilt,
+    // e.g. after switching to another view and back.
+    detachFrameAction();
 }
 
 void MainView3D::resetCameraPosition()
@@ -382,33 +387,51 @@ void MainView3D::setUniverseFilter(quint32 universeFilter)
 
 bool MainView3D::frameCountEnabled() const
 {
-    return m_frameAction != nullptr ? true : false;
+    return m_frameCountEnabled;
 }
 
 void MainView3D::setFrameCountEnabled(bool enable)
 {
+    if (m_frameCountEnabled == enable)
+        return;
+
+    m_frameCountEnabled = enable;
+
     if (enable)
     {
-        m_frameAction = new QFrameAction();
-        connect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
-        if (m_sceneRootEntity)
-            m_sceneRootEntity->addComponent(m_frameAction);
-        m_fpsElapsed.start();
+        attachFrameAction();
     }
     else
     {
-        if (m_frameAction)
-        {
-            disconnect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
-            delete m_frameAction;
-            m_frameAction = nullptr;
-        }
+        detachFrameAction();
         m_frameCount = 0;
         m_minFrameCount = 0;
         m_maxFrameCount = 0;
         m_avgFrameCount = 0;
     }
     emit frameCountEnabledChanged();
+}
+
+void MainView3D::attachFrameAction()
+{
+    if (m_frameAction == nullptr)
+    {
+        m_frameAction = new QFrameAction();
+        connect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
+    }
+    if (m_sceneRootEntity)
+        m_sceneRootEntity->addComponent(m_frameAction);
+    m_fpsElapsed.start();
+}
+
+void MainView3D::detachFrameAction()
+{
+    if (m_frameAction)
+    {
+        disconnect(m_frameAction, &QFrameAction::triggered, this, &MainView3D::slotFrameProcessed);
+        delete m_frameAction;
+        m_frameAction = nullptr;
+    }
 }
 
 void MainView3D::slotFrameProcessed()
@@ -542,8 +565,10 @@ bool MainView3D::initialize3DProperties()
 
     m_initRetryCount = 0;
 
-    if (m_frameAction)
-        m_sceneRootEntity->addComponent(m_frameAction);
+    // re-attach the FPS counter if the user had it enabled: the previous
+    // QFrameAction (if any) was destroyed together with the old scene root
+    if (m_frameCountEnabled)
+        attachFrameAction();
 
     qDebug() << m_sceneRootEntity << m_quadEntity << m_gBuffer;
 

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -181,6 +181,10 @@ void MainView3D::slotRefreshView()
     // smoke, show FPS) that may have changed on project load
     applyRenderSettings();
 
+    // the "Scale" lock is persisted too. It only affects the settings panel,
+    // so notifying the QML side is enough
+    emit scaleLockedChanged();
+
     for (Fixture *fixture : m_doc->fixtures())
     {
         if (m_monProps->containsFixture(fixture->id()))
@@ -2543,6 +2547,22 @@ void MainView3D::setGenericItemsScale(QVector3D scale)
     }
 
     emit genericItemsScaleChanged();
+}
+
+bool MainView3D::scaleLocked() const
+{
+    return m_monProps->scaleLocked();
+}
+
+void MainView3D::setScaleLocked(bool locked)
+{
+    if (m_monProps->scaleLocked() == locked)
+        return;
+
+    // persist the choice in the project (see MonitorProperties)
+    m_monProps->setScaleLocked(locked);
+    m_doc->setModified();
+    emit scaleLockedChanged();
 }
 
 QVector3D MainView3D::position3DMarker() const

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -99,10 +99,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_position3DMarker(QVector3D())
     , m_position3DMarkerVisible(false)
     , m_markerEntity(nullptr)
-    , m_renderQuality(HighQuality)
     , m_stageEntity(nullptr)
-    , m_ambientIntensity(0.6)
-    , m_smokeAmount(0.8)
 {
     setContextResource("qrc:/3DView.qml");
     setContextTitle(tr("3D View"));
@@ -179,6 +176,10 @@ void MainView3D::slotRefreshView()
     // recreate the stage entity and notify the UI to update the selector
     createStage();
     emit stageIndexChanged(m_monProps->stageType());
+
+    // re-apply the persisted "Rendering" settings (quality, ambient light,
+    // smoke, show FPS) that may have changed on project load
+    applyRenderSettings();
 
     for (Fixture *fixture : m_doc->fixtures())
     {
@@ -391,6 +392,18 @@ bool MainView3D::frameCountEnabled() const
 }
 
 void MainView3D::setFrameCountEnabled(bool enable)
+{
+    if (m_frameCountEnabled == enable)
+        return;
+
+    applyFrameCountEnabled(enable);
+
+    // persist the choice in the project (see MonitorProperties)
+    m_monProps->setShowFPS(enable);
+    m_doc->setModified();
+}
+
+void MainView3D::applyFrameCountEnabled(bool enable)
 {
     if (m_frameCountEnabled == enable)
         return;
@@ -2606,16 +2619,17 @@ void MainView3D::setPosition3DMarkerVisible(bool visible)
 
 MainView3D::RenderQuality MainView3D::renderQuality() const
 {
-    return m_renderQuality;
+    return RenderQuality(m_monProps->renderQuality());
 }
 
 void MainView3D::setRenderQuality(MainView3D::RenderQuality renderQuality)
 {
-    if (m_renderQuality == renderQuality)
+    if (m_monProps->renderQuality() == int(renderQuality))
         return;
 
-    m_renderQuality = renderQuality;
-    emit renderQualityChanged(m_renderQuality);
+    m_monProps->setRenderQuality(int(renderQuality));
+    m_doc->setModified();
+    emit renderQualityChanged(renderQuality);
 }
 
 QStringList MainView3D::stagesList() const
@@ -2662,30 +2676,42 @@ void MainView3D::createStage()
 
 float MainView3D::ambientIntensity() const
 {
-    return m_ambientIntensity;
+    return m_monProps->ambientLightIntensity();
 }
 
 void MainView3D::setAmbientIntensity(float ambientIntensity)
 {
-    if (m_ambientIntensity == ambientIntensity)
+    if (float(m_monProps->ambientLightIntensity()) == ambientIntensity)
         return;
 
-    m_ambientIntensity = ambientIntensity;
-    emit ambientIntensityChanged(m_ambientIntensity);
+    m_monProps->setAmbientLightIntensity(ambientIntensity);
+    m_doc->setModified();
+    emit ambientIntensityChanged(ambientIntensity);
 }
 
 float MainView3D::smokeAmount() const
 {
-    return m_smokeAmount;
+    return m_monProps->smokeAmount();
 }
 
 void MainView3D::setSmokeAmount(float smokeAmount)
 {
-    if (m_smokeAmount == smokeAmount)
+    if (float(m_monProps->smokeAmount()) == smokeAmount)
         return;
 
-    m_smokeAmount = smokeAmount;
-    emit smokeAmountChanged(m_smokeAmount);
+    m_monProps->setSmokeAmount(smokeAmount);
+    m_doc->setModified();
+    emit smokeAmountChanged(smokeAmount);
+}
+
+void MainView3D::applyRenderSettings()
+{
+    // The values already live in m_monProps (set defaults, or loaded from the
+    // project). Push them to the QML side / shaders and sync the FPS counter.
+    emit renderQualityChanged(renderQuality());
+    emit ambientIntensityChanged(ambientIntensity());
+    emit smokeAmountChanged(smokeAmount());
+    applyFrameCountEnabled(m_monProps->showFPS());
 }
 
 bool MainView3D::rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -122,6 +122,7 @@ class MainView3D final : public PreviewContext
     Q_PROPERTY(QVector3D genericItemsPosition READ genericItemsPosition WRITE setGenericItemsPosition NOTIFY genericItemsPositionChanged)
     Q_PROPERTY(QVector3D genericItemsRotation READ genericItemsRotation WRITE setGenericItemsRotation NOTIFY genericItemsRotationChanged)
     Q_PROPERTY(QVector3D genericItemsScale READ genericItemsScale WRITE setGenericItemsScale NOTIFY genericItemsScaleChanged)
+    Q_PROPERTY(bool scaleLocked READ scaleLocked WRITE setScaleLocked NOTIFY scaleLockedChanged)
 
     Q_PROPERTY(QVector3D position3DMarker READ position3DMarker WRITE setPosition3DMarker NOTIFY position3DMarkerChanged)
     Q_PROPERTY(bool position3DMarkerVisible READ position3DMarkerVisible WRITE setPosition3DMarkerVisible NOTIFY position3DMarkerVisibleChanged)
@@ -432,6 +433,12 @@ public:
     QVector3D genericItemsScale() const;
     void setGenericItemsScale(QVector3D scale);
 
+    /** Get/Set whether the "Scale" X/Y/Z fields of the 3D view settings panel
+     *  are locked together. Stored in MonitorProperties, so the choice survives
+     *  a view switch and is saved in the project */
+    bool scaleLocked() const;
+    void setScaleLocked(bool locked);
+
     QVector3D position3DMarker() const;
     Q_INVOKABLE void setPosition3DMarker(QVector3D pos);
     bool position3DMarkerVisible() const;
@@ -447,6 +454,7 @@ signals:
     void genericItemsPositionChanged();
     void genericItemsRotationChanged();
     void genericItemsScaleChanged();
+    void scaleLockedChanged();
     void position3DMarkerChanged();
     void position3DMarkerVisibleChanged();
 

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -206,6 +206,18 @@ public:
 protected slots:
     void slotFrameProcessed();
 
+private:
+    /** Create the QFrameAction (if needed) and attach it to the current
+     *  scene root entity. Called both when the user enables the FPS counter
+     *  and whenever the 3D scene is (re)initialized, so the setting survives
+     *  switching to another view and back. */
+    void attachFrameAction();
+
+    /** Detach and destroy the QFrameAction. Must be called before the scene
+     *  root entity is torn down, otherwise Qt3D would delete the action
+     *  (it gets reparented on addComponent) and leave a dangling pointer. */
+    void detachFrameAction();
+
 signals:
     void frameCountEnabledChanged();
     void FPSChanged(int fps);
@@ -216,6 +228,9 @@ signals:
 private:
     QElapsedTimer m_fpsElapsed;
     QFrameAction *m_frameAction;
+    /** User-requested state of the FPS counter, kept independently from
+     *  m_frameAction so it persists across 3D scene teardown/rebuild */
+    bool m_frameCountEnabled;
     int m_frameCount;
     int m_minFrameCount;
     int m_maxFrameCount;

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -207,6 +207,12 @@ protected slots:
     void slotFrameProcessed();
 
 private:
+    /** Apply the FPS counter enabled state to the running scene (attach/detach
+     *  the QFrameAction, reset counters, notify QML). Unlike setFrameCountEnabled()
+     *  this does not persist the value nor mark the project modified, so it is
+     *  safe to call while loading a project. */
+    void applyFrameCountEnabled(bool enable);
+
     /** Create the QFrameAction (if needed) and attach it to the current
      *  scene root entity. Called both when the user enables the FPS counter
      *  and whenever the 3D scene is (re)initialized, so the setting survives
@@ -510,6 +516,11 @@ public:
 
 protected:
     void createStage();
+
+    /** Re-apply the "Rendering" settings persisted in the project (MonitorProperties)
+     *  to the running scene and notify the QML side. Called on project load /
+     *  when the 3D view becomes visible. Does not mark the project modified. */
+    void applyRenderSettings();
     QVector3D unprojectToWorld(const float &aspect, const QVector2D &ndcMousePos) const;
     bool rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,
                            const QVector3D &center, const QVector3D &extents, float &hitDistance) const;
@@ -524,19 +535,16 @@ signals:
     void smokeAmountChanged(float smokeAmount);
 
 private:
-    RenderQuality m_renderQuality;
+    /* The "Rendering" settings (quality, ambient light, smoke, show FPS) are
+       stored in the project through MonitorProperties (m_monProps), so they
+       persist in the workspace file. The getters/setters below proxy to it,
+       the same way stageIndex() does. */
 
     QStringList m_stagesList;
     QStringList m_stageResourceList;
 
     /** Reference to the selected stage Entity */
     QEntity *m_stageEntity;
-
-    /** Ambient light amount (0.0 - 1.0) */
-    float m_ambientIntensity;
-
-    /** Smoke amount (0.0 - 1.0) */
-    float m_smokeAmount;
 };
 
 #endif // MAINVIEW3D_H

--- a/qmlui/qml/fixturesfunctions/3DView/3DView.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/3DView.qml
@@ -115,6 +115,8 @@ Rectangle
                     for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                     {
                         headEntity = fixtureItem.getHead(iHead)
+                        if (!headEntity)
+                            continue
 
                         component.createObject(frameGraph.myShadowFrameGraphNode,
                         {
@@ -236,11 +238,14 @@ Rectangle
                 for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                 {
                     headEntity = fixtureItem.getHead(iHead)
+                    if (!headEntity)
+                        continue
 
                     component.createObject(frameGraph.myCameraSelector,
                     {
                         "gBuffer": gBufferTarget,
-                        "shadowTex": headEntity.depthTex,
+                        // heads that don't cast shadows have no shadow map at all
+                        "shadowTex": fixtureItem.useShadows ? headEntity.depthTex : null,
                         "useShadows": fixtureItem.useShadows,
                         "spotlightShadingLayer": headEntity.spotlightShadingLayer,
                         "frameTarget": frameTarget
@@ -269,6 +274,8 @@ Rectangle
                 for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                 {
                     headEntity = fixtureItem.getHead(iHead)
+                    if (!headEntity)
+                        continue
 
                     component.createObject(frameGraph.myCameraSelector,
                     {
@@ -282,7 +289,7 @@ Rectangle
                         "frontDepth": depthTarget,
                         "gBuffer": gBufferTarget,
                         "spotlightScatteringLayer": headEntity.spotlightScatteringLayer,
-                        "shadowTex": headEntity.depthTex,
+                        "shadowTex": fixtureItem.useShadows ? headEntity.depthTex : null,
                         "frameTarget": frameTarget,
                         "useShadows": fixtureItem.useShadows
                     });

--- a/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
@@ -26,6 +26,12 @@ import Qt3D.Extras
 import "Math3DView.js" as Math3D
 import "."
 
+/*
+  A single light emitter of a multi-beam fixture (see MultiBeams3DItem).
+  It plays the role Fixture3DItem plays for a one-head fixture: it owns the
+  three spotlight cones and exposes the uniforms the spotlight shaders read.
+  It has no geometry of its own - the bar mesh is drawn by the parent item.
+*/
 Entity
 {
     id: beamEntity
@@ -39,15 +45,23 @@ Entity
     property vector3d lightPos: Qt.vector3d(0, 0, 0)
     property vector3d lightDir: Qt.vector3d(0, 0, 0)
 
-    /* Orientation of the parent bar. SpotlightConeEntity and the shading/
-       scattering shaders need a pan/tilt angle to place and aim each beam;
-       when they are missing the cone model matrix collapses and nothing is
-       drawn. LED bars never pan, and tilt (motorised bars) is pushed down
-       from the parent through tiltRotation. */
+    /* Orientation of the emitter. SpotlightConeEntity and the shading/scattering
+       shaders need a pan/tilt angle to place and aim the cone; when they are
+       missing the cone model matrix collapses and nothing is drawn. LED bars
+       never pan, and tilt (motorized bars) is pushed down from the parent item. */
     property real panRotation: 0
     property real tiltRotation: 0
 
-    property real raymarchSteps
+    /* This MUST stay an int. It ends up in the "raymarchSteps" uniform of
+       spotlight_scattering.frag, which is declared as an int, and Qt3D does not
+       convert: a QML real is stored as a float and its raw bytes are handed to
+       glUniform1iv, so the shader would read the *bit pattern* of the float
+       (40.0 becomes 1109393408) and ray march for over a billion iterations.
+       That hangs the GPU, which is why the scattering cone below used to be
+       commented out with a "this hangs your PC" note. Fixture3DItem declares
+       the same property as an int. */
+    property int raymarchSteps: 0
+
     property real cutoffAngle
     property real distCutoff
     property real headLength
@@ -58,14 +72,18 @@ Entity
     property Texture2D goboTexture
     property real goboRotation: 0
 
-    /* Spotlight matrices — same math as Fixture3DItem.qml. These are read as
+    /* Spotlight matrices - same math as Fixture3DItem.qml. These are read as
        uniforms by SpotlightConeEntity; the per-head lightPos and lightMatrix
-       are provided by the parent via setHeadLightProps(). */
+       are provided by the parent through setHeadLightProps(). */
     property matrix4x4 lightMatrix
     property matrix4x4 lightViewMatrix:
         Math3D.getLightViewMatrix(lightMatrix, panRotation, tiltRotation, lightPos)
+    // getLightProjectionMatrix() divides by (coneBottomRadius / coneTopRadius - 1),
+    // so a not-yet-known aperture would produce a degenerate matrix
     property matrix4x4 lightProjectionMatrix:
-        Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle)
+        coneTopRadius > 0 && coneBottomRadius > coneTopRadius ?
+            Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle) :
+            Qt.matrix4x4()
     property matrix4x4 lightViewProjectionMatrix: lightProjectionMatrix.times(lightViewMatrix)
     property matrix4x4 lightViewProjectionScaleAndOffsetMatrix:
         Math3D.getLightViewProjectionScaleOffsetMatrix(lightViewProjectionMatrix)
@@ -74,40 +92,25 @@ Entity
     readonly property Layer outputDepthLayer: Layer { }
     readonly property Layer spotlightScatteringLayer: Layer { }
 
-    property Transform headTransform: Transform { translation: Qt.vector3d(0.1 * headIndex, 0, 0) }
+    /* Shadow map of this emitter. It is what makes the beam stop at the first
+       surface it hits: spotlight_shading.frag has no distance bound of its own,
+       so without a shadow map the cone lights every G-buffer texel inside its
+       projection - through walls and everything behind them.
 
-    function setupScattering(sceneEntity)
-    {
-        shadingCone.coneEffect = sceneEntity.spotlightShadingEffect
-        shadingCone.parent = sceneEntity
-        shadingCone.spotlightConeMesh = sceneEntity.coneMesh
-
-        // Volumetric beam in the air. This mirrors Fixture3DItem: the cost is
-        // governed by raymarchSteps, which is 0 on Low render quality.
-        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
-        scatteringCone.parent = sceneEntity
-        scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
-
-        outDepthCone.coneEffect = sceneEntity.outputFrontDepthEffect
-        outDepthCone.parent = sceneEntity
-        outDepthCone.spotlightConeMesh = sceneEntity.coneMesh
-    }
-
-    function cleanupScattering()
-    {
-        if (shadingCone)
-            shadingCone.destroy()
-        if (scatteringCone)
-            scatteringCone.destroy()
-        if (outDepthCone)
-            outDepthCone.destroy()
-    }
+       Same size as Fixture3DItem, deliberately. The frustum covers exactly the
+       cone, so what matters is resolution per degree of aperture, and a bar is
+       not the narrow emitter it might seem: real definitions of this type carry
+       lenses of 40 and even 120 degrees, against the 30 of a typical PAR. A
+       smaller map is therefore coarser here than for a single head fixture, not
+       finer, and a coarse map is what makes a wide beam fail its own shadow
+       test and emit nothing at all. */
+    property int shadowMapSize: 1024
 
     property Texture2D depthTex:
         Texture2D
         {
-            width: 1024
-            height: 1024
+            width: shadowMapSize
+            height: shadowMapSize
             format: Texture.D32F
             generateMipMaps: false
             magnificationFilter: Texture.Nearest
@@ -131,6 +134,36 @@ Entity
             ] // attachments
         }
 
+    function setupScattering(sceneEntity)
+    {
+        shadingCone.coneEffect = sceneEntity.spotlightShadingEffect
+        shadingCone.parent = sceneEntity
+        shadingCone.spotlightConeMesh = sceneEntity.coneMesh
+
+        // Volumetric beam in the air. As in Fixture3DItem, its cost is governed
+        // by raymarchSteps, which is 0 on Low render quality.
+        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
+        scatteringCone.parent = sceneEntity
+        scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
+
+        outDepthCone.coneEffect = sceneEntity.outputFrontDepthEffect
+        outDepthCone.parent = sceneEntity
+        outDepthCone.spotlightConeMesh = sceneEntity.coneMesh
+    }
+
+    /* Must be called before this entity is destroyed: setupScattering() moves the
+       three cones under the scene root, so they do not go away with their
+       declaring entity and would be left in the scene bound to a dead object. */
+    function cleanupScattering()
+    {
+        if (shadingCone)
+            shadingCone.destroy()
+        if (scatteringCone)
+            scatteringCone.destroy()
+        if (outDepthCone)
+            outDepthCone.destroy()
+    }
+
     /* Cone meshes used for scattering. These get re-parented to
        the main Scene entity via setupScattering */
     SpotlightConeEntity
@@ -151,8 +184,4 @@ Entity
         coneLayer: outputDepthLayer
         fxEntity: beamEntity
     }
-
-    components: [
-        headTransform
-    ]
 } // Entity

--- a/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
@@ -32,21 +32,43 @@ Entity
 
     property int headIndex
     property real dimmerValue: 0
-    property real shutterValue: 0
+    property real shutterValue: 1.0
     property real lightIntensity: dimmerValue * shutterValue
 
     property color lightColor: Qt.rgba(0, 0, 0, 1)
     property vector3d lightPos: Qt.vector3d(0, 0, 0)
     property vector3d lightDir: Qt.vector3d(0, 0, 0)
 
+    /* Orientation of the parent bar. SpotlightConeEntity and the shading/
+       scattering shaders need a pan/tilt angle to place and aim each beam;
+       when they are missing the cone model matrix collapses and nothing is
+       drawn. LED bars never pan, and tilt (motorised bars) is pushed down
+       from the parent through tiltRotation. */
+    property real panRotation: 0
+    property real tiltRotation: 0
+
     property real raymarchSteps
     property real cutoffAngle
     property real distCutoff
     property real headLength
-    property real coneBottomRadius
     property real coneTopRadius
+    /* Derived exactly like Fixture3DItem so that changing the beam aperture
+       (zoom) keeps the cone geometry consistent. */
+    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
     property Texture2D goboTexture
     property real goboRotation: 0
+
+    /* Spotlight matrices — same math as Fixture3DItem.qml. These are read as
+       uniforms by SpotlightConeEntity; the per-head lightPos and lightMatrix
+       are provided by the parent via setHeadLightProps(). */
+    property matrix4x4 lightMatrix
+    property matrix4x4 lightViewMatrix:
+        Math3D.getLightViewMatrix(lightMatrix, panRotation, tiltRotation, lightPos)
+    property matrix4x4 lightProjectionMatrix:
+        Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle)
+    property matrix4x4 lightViewProjectionMatrix: lightProjectionMatrix.times(lightViewMatrix)
+    property matrix4x4 lightViewProjectionScaleAndOffsetMatrix:
+        Math3D.getLightViewProjectionScaleOffsetMatrix(lightViewProjectionMatrix)
 
     readonly property Layer spotlightShadingLayer: Layer { }
     readonly property Layer outputDepthLayer: Layer { }
@@ -60,7 +82,9 @@ Entity
         shadingCone.parent = sceneEntity
         shadingCone.spotlightConeMesh = sceneEntity.coneMesh
 
-        //scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect // this hangs your PC
+        // Volumetric beam in the air. This mirrors Fixture3DItem: the cost is
+        // governed by raymarchSteps, which is 0 on Low render quality.
+        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
         scatteringCone.parent = sceneEntity
         scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
 

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -81,7 +81,7 @@ Entity
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
-    property real shutterValue: 1.0
+    property real shutterValue: sAnimator.shutterValue
     property vector3d lightDir: Math3D.getLightDirection(transform, 0, tiltTransform)
 
     property var headsList: []
@@ -113,18 +113,20 @@ Entity
             if (component.status === Component.Error)
                 console.log("Error loading component:", component.errorString())
 
+            // Bind the shared beam properties to the parent so that render
+            // quality, zoom, shutter and tilt keep updating every head after
+            // creation. coneBottomRadius is derived inside LightEntity.
             var headNode = component.createObject(fixtureEntity,
             {
                 "headIndex": i,
-                "lightDir": lightDir,
-                "shutterValue": shutterValue,
-                "raymarchSteps": raymarchSteps,
-                "cutoffAngle": cutoffAngle,
+                "lightDir": Qt.binding(function() { return fixtureEntity.lightDir }),
+                "shutterValue": Qt.binding(function() { return fixtureEntity.shutterValue }),
+                "raymarchSteps": Qt.binding(function() { return fixtureEntity.raymarchSteps }),
+                "cutoffAngle": Qt.binding(function() { return fixtureEntity.cutoffAngle }),
+                "tiltRotation": Qt.binding(function() { return fixtureEntity.tiltRotation }),
                 "distCutoff": distCutoff,
                 "headLength": headLength,
-                "coneBottomRadius": coneBottomRadius,
                 "coneTopRadius": coneTopRadius,
-                "tiltRotation": tiltRotation,
                 "goboTexture": goboTexture
             });
 
@@ -160,26 +162,37 @@ Entity
         return headsList[headIndex]
     }
 
+    // The C++ side computes a single emitter position/orientation for the whole
+    // bar (headIndex is always 0). Spread the beams evenly across the bar's
+    // physical width, centered on the fixture origin and rotated by the bar's
+    // current orientation matrix.
     function setHeadLightProps(headIndex, pos, matrix)
     {
-        for (var h = 0; h < headsNumber; h++)
+        var n = headsList.length
+        if (n === 0)
+            return
+
+        var spacing = (n > 1) ? (phySize.x / n) : 0
+        for (var h = 0; h < n; h++)
         {
-            var head = getHead(h)
-            var hPos = Qt.vector3d(pos.x * h, pos.y, pos.z)
-            head.lightPos = hPos
+            var localX = (h - (n - 1) / 2) * spacing
+            var worldOffset = matrix.times(Qt.vector4d(localX, 0, 0, 0)).toVector3d()
+            var head = headsList[h]
+            head.lightPos = pos.plus(worldOffset)
             head.lightMatrix = matrix
-            console.log("Setting light info: " + hPos + ", m: " + matrix)
         }
     }
 
     function setHeadIntensity(headIndex, intensity)
     {
-        headsList[headIndex].dimmerValue = intensity
+        if (headIndex >= 0 && headIndex < headsList.length)
+            headsList[headIndex].dimmerValue = intensity
     }
 
     function setHeadRGBColor(headIndex, color)
     {
-        headsList[headIndex].lightColor = color
+        if (headIndex >= 0 && headIndex < headsList.length)
+            headsList[headIndex].lightColor = color
     }
 
     // See Fixture3DItem: timestamp of the previous setPosition() call, used to pace

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -45,6 +45,22 @@ Entity
         updateHeads()
     }
 
+    /* Number of emitters across the bar width and along its depth.
+
+       The physical layout describes the cell grid of the fixture body, which is
+       NOT required to agree with the number of heads the selected mode declares.
+       The Pulse LED BAR 320 is an 8x1 bar whose 4 channel mode declares no head
+       at all, so the engine synthesises a single one covering every channel:
+       laying that one emitter out on an 8 wide grid puts it in cell 0, i.e. at
+       one end of the bar instead of across it. Only trust the layout when it
+       accounts for exactly the emitters we have; otherwise put them in one row. */
+    readonly property bool layoutMatchesHeads:
+        headsLayout.width * headsLayout.height === headsNumber
+    readonly property int cellColumns:
+        layoutMatchesHeads ? headsLayout.width : Math.max(1, headsNumber)
+    readonly property int cellRows:
+        layoutMatchesHeads ? headsLayout.height : 1
+
     /* **************** Tilt properties (motorized bars) **************** */
     property real tiltMaxDegrees: 270
     property real tiltSpeed: 4000 // in milliseconds
@@ -60,7 +76,15 @@ Entity
 
     /* **************** Rendering quality properties **************** */
     property bool useScattering: View3D.renderQuality === MainView3D.LowQuality ? false : true
+
+    /* Shadows are not optional for this renderer: spotlight_shading.frag bounds
+       the beam with the emitter's shadow map and nothing else, so an emitter
+       without one lights everything inside its cone projection, straight through
+       the walls of the stage environment. The per emitter cost is bounded from
+       two sides: RenderShadowMapFilter matches no render pass while a cell is
+       dark, and LightEntity uses a smaller map than a single head fixture. */
     property bool useShadows: View3D.renderQuality === MainView3D.LowQuality ? false : true
+
     property int raymarchSteps:
     {
         switch(View3D.renderQuality)
@@ -70,19 +94,37 @@ Entity
             case MainView3D.HighQuality: return 40
             case MainView3D.UltraQuality: return 80
         }
+        return 0
     }
 
-    /* **************** Spotlight cone properties **************** */
-    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
-    property real coneTopRadius: transform ? (0.24023 / 2) * transform.scale3D.x * 0.7 : 0.0 // (diameter / 2) * scale * magic number
+    /* Ray march steps of a single beam. The volumetric scattering pass runs once
+       per emitter, so a bar would otherwise cost as much as headsNumber separate
+       spotlights. Spend the budget of about four spotlights on the whole bar
+       instead, with a floor that still reads as a beam: the cones of a bar are
+       thin, so they need far fewer samples than a wide spotlight cone. */
+    readonly property int beamRaymarchSteps:
+        raymarchSteps <= 0 ? 0
+                           : Math.max(6, Math.min(raymarchSteps,
+                                                  Math.round((raymarchSteps * 4) / Math.max(1, headsNumber))))
 
-    property real headLength: 0.5 * transform.scale3D.x
+    /* **************** Spotlight cone properties **************** */
+    /* Radius of a single cell, rather than the lens radius of a PAR mesh that
+       this item does not have. The 0.7 factor matches Fixture3DItem, where it
+       compensates the mesh lens being slightly larger than the emitting surface. */
+    property real coneTopRadius:
+        Math.max(0.005, 0.5 * 0.7 * Math.min(phySize.x / cellColumns, phySize.z / cellRows))
+    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
+
+    /* Depth of the emitter inside the fixture body. Fixture3DItem takes this from
+       the loaded mesh; a bar is drawn as a plain cuboid, so its own height is the
+       closest equivalent. */
+    property real headLength: Math.max(0.01, phySize.y)
 
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
     property real shutterValue: sAnimator.shutterValue
-    property vector3d lightDir: Math3D.getLightDirection(transform, 0, tiltTransform)
+    property vector3d lightDir: Math3D.getLightDirection(transform, null, tiltTransform)
 
     property var headsList: []
 
@@ -99,41 +141,78 @@ Entity
     {
         var i
 
-        // delete existing heads first
+        // Delete the existing heads first. setupScattering() re-parents the three
+        // cones of a head to the scene root, so they do not die with it: without
+        // cleanupScattering() they would be left in the scene, still bound to a
+        // destroyed emitter, and every rebuild would add three more.
         for (i = headsList.length - 1; i >= 0; i--)
+        {
+            headsList[i].cleanupScattering()
             headsList[i].destroy()
+        }
 
         headsList = []
 
+        // itemID is invalid while the item is being built - MainView3D sets the
+        // real one right after creation - and MainView3D::resetItems() sets it
+        // back to -1 when the 3D view is torn down. Building a set of heads in
+        // either case is pure waste, and in the teardown case it allocates
+        // emitters into a scene that is being destroyed.
+        if (itemID < 0 || headsNumber <= 0)
+            return
+
+        var component = Qt.createComponent("LightEntity.qml")
+        if (component.status !== Component.Ready)
+        {
+            console.warn("MultiBeams3DItem: cannot load LightEntity.qml:", component.errorString())
+            return
+        }
+
         for (i = 0; i < headsNumber; i++)
         {
-            console.log("Item " + itemID + " creating head - " + i)
-
-            var component = Qt.createComponent("LightEntity.qml");
-            if (component.status === Component.Error)
-                console.log("Error loading component:", component.errorString())
-
-            // Bind the shared beam properties to the parent so that render
-            // quality, zoom, shutter and tilt keep updating every head after
-            // creation. coneBottomRadius is derived inside LightEntity.
+            // Everything shared with the parent is bound rather than copied: most
+            // of these are only known once MainView3D::initializeFixture() has run,
+            // which happens below, and render quality, zoom, shutter and tilt keep
+            // changing afterwards.
             var headNode = component.createObject(fixtureEntity,
             {
                 "headIndex": i,
+                "enabled": Qt.binding(function() { return fixtureEntity.enabled }),
                 "lightDir": Qt.binding(function() { return fixtureEntity.lightDir }),
                 "shutterValue": Qt.binding(function() { return fixtureEntity.shutterValue }),
-                "raymarchSteps": Qt.binding(function() { return fixtureEntity.raymarchSteps }),
+                "raymarchSteps": Qt.binding(function() { return fixtureEntity.beamRaymarchSteps }),
                 "cutoffAngle": Qt.binding(function() { return fixtureEntity.cutoffAngle }),
                 "tiltRotation": Qt.binding(function() { return fixtureEntity.tiltRotation }),
-                "distCutoff": distCutoff,
-                "headLength": headLength,
-                "coneTopRadius": coneTopRadius,
-                "goboTexture": goboTexture
+                "distCutoff": Qt.binding(function() { return fixtureEntity.distCutoff }),
+                "headLength": Qt.binding(function() { return fixtureEntity.headLength }),
+                "coneTopRadius": Qt.binding(function() { return fixtureEntity.coneTopRadius }),
+                "goboTexture": Qt.binding(function() { return fixtureEntity.goboTexture })
             });
+
+            if (headNode === null)
+            {
+                console.warn("MultiBeams3DItem: cannot create head", i, "of item", itemID)
+                break
+            }
 
             headsList.push(headNode)
         }
 
+        // 3DView.qml walks headsNumber heads when it builds the frame graph, so
+        // this must never promise more emitters than actually exist
+        if (headsList.length !== headsNumber)
+            headsNumber = headsList.length
+
+        // initializeFixture() is what hands us phySize and the lens angles, so the
+        // beam geometry logged below is only meaningful once it has returned
         View3D.initializeFixture(itemID, fixtureEntity, null)
+
+        console.log("MultiBeams3DItem: item", itemID, "emitters:", headsList.length,
+                    "layout:", headsLayout.width + "x" + headsLayout.height,
+                    "used as:", cellColumns + "x" + cellRows,
+                    "| lens:", focusMinDegrees + "-" + focusMaxDegrees + " deg",
+                    "cone top/bottom:", coneTopRadius.toFixed(4) + "/" + coneBottomRadius.toFixed(2),
+                    "| steps:", beamRaymarchSteps)
     }
 
     function setupScattering(sceneEntity)
@@ -142,9 +221,7 @@ Entity
             sceneEntity.coneMesh.length = distCutoff
 
         for (var i = 0; i < headsList.length; i++)
-        {
             headsList[i].setupScattering(sceneEntity)
-        }
     }
 
     function cleanupScattering()
@@ -159,26 +236,34 @@ Entity
 
     function getHead(headIndex)
     {
+        if (headIndex < 0 || headIndex >= headsList.length)
+            return null
+
         return headsList[headIndex]
     }
 
-    // The C++ side computes a single emitter position/orientation for the whole
-    // bar (headIndex is always 0). Spread the beams evenly across the bar's
-    // physical width, centered on the fixture origin and rotated by the bar's
-    // current orientation matrix.
+    // The C++ side computes a single emitter position and orientation for the
+    // whole bar (headIndex is always 0), so spread the cells over the fixture
+    // body here: evenly across its width and depth, centered on the origin and
+    // rotated by the bar's current orientation matrix.
     function setHeadLightProps(headIndex, pos, matrix)
     {
-        var n = headsList.length
-        if (n === 0)
+        var count = headsList.length
+        if (count === 0)
             return
 
-        var spacing = (n > 1) ? (phySize.x / n) : 0
-        for (var h = 0; h < n; h++)
+        var cellWidth = phySize.x / cellColumns
+        var cellDepth = phySize.z / cellRows
+
+        for (var h = 0; h < count; h++)
         {
-            var localX = (h - (n - 1) / 2) * spacing
-            var worldOffset = matrix.times(Qt.vector4d(localX, 0, 0, 0)).toVector3d()
+            var column = h % cellColumns
+            var row = Math.floor(h / cellColumns)
+            var localPos = Qt.vector4d(-(phySize.x / 2) + ((column + 0.5) * cellWidth), 0,
+                                       -(phySize.z / 2) + ((row + 0.5) * cellDepth), 0)
+
             var head = headsList[h]
-            head.lightPos = pos.plus(worldOffset)
+            head.lightPos = pos.plus(matrix.times(localPos).toVector3d())
             head.lightMatrix = matrix
         }
     }
@@ -248,9 +333,14 @@ Entity
         sAnimator.setShutter(type, low, high)
     }
 
-    function setZoom(value)
+    // Same signature as Fixture3DItem: MainView3D calls this with degrees == true
+    // when the fixture has a fixed zoom set in the monitor properties
+    function setZoom(value, degrees)
     {
-        cutoffAngle = (((((focusMaxDegrees - focusMinDegrees) / 255) * value) + focusMinDegrees) / 2) * (Math.PI / 180)
+        if (degrees)
+            cutoffAngle = (value / 2) * (Math.PI / 180.0)
+        else
+            cutoffAngle = (((((focusMaxDegrees - focusMinDegrees) / 255.0) * value) + focusMinDegrees) / 2.0) * (Math.PI / 180.0)
     }
 
     NumberAnimation on tiltRotation
@@ -318,9 +408,13 @@ Entity
 
     property Texture2D goboTexture: Texture2D { }
 
+    /* headEntity is NOT listed here: it is an Entity, not a Component, so QML
+       rejected it with a "Cannot append ... to a QML list of QComponent*"
+       warning on every item creation. It is already a child of this entity
+       through the default property, which is how it gets drawn and how
+       MainView3D finds it by object name. */
     components: [
         baseMesh,
-        headEntity,
         transform,
         material,
         sceneLayer

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -280,6 +280,7 @@ Rectangle
                         {
                             implicitHeight: UISettings.listItemHeight
                             implicitWidth: implicitHeight
+                            checked: View3D ? View3D.frameCountEnabled : false
                             onToggled: View3D.frameCountEnabled = checked
                         }
 

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -581,7 +581,21 @@ Rectangle
                                 height: width
                                 imgSource: "qrc:/lock.svg"
                                 checkable: true
-                                checked: true
+                                checked: View3D ? View3D.scaleLocked : true
+                                onToggled: View3D.scaleLocked = checked
+
+                                // clicking a checkable Button assigns "checked" and
+                                // therefore breaks the binding above, so the value
+                                // has to be restored explicitly when it changes on
+                                // the C++ side (e.g. on project load)
+                                Connections
+                                {
+                                    target: View3D
+                                    function onScaleLockedChanged()
+                                    {
+                                        scaleLocked.checked = View3D.scaleLocked
+                                    }
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Description

**Summary of Changes:**

### What this adds

Two 3D view settings are now stored in the project file, so they survive a view switch and a restart instead of reverting to their defaults every time:

- the **Rendering** settings — Quality, Ambient light, Smoke amount and Show FPS;
- the **Scale** X/Y/Z **lock** of the settings panel (the padlock button next to the scale fields of a generic item).

### Why

The Rendering settings were plain runtime members of `MainView3D`, never written to the workspace. A user who dials in ambient light and smoke for a show has to redo it on every launch.

The Scale lock was worse: pure QML state (`IconButton { checked: true }`), so it reverted to "locked" every time the user left the 3D view, because the 3D context — and therefore `SettingsView3D.qml` — is destroyed on a view switch. A user working on a non-uniformly scaled item had to unlock it again after every trip to the Virtual Console or the 2D view.

### Changes to `engine` — to be reviewed and approved

_To be reviewed and approved in the context of the linked set of PRs submitted to improve the 3D view plus other fixes._

The values move into `MonitorProperties`, alongside the stage type and the environment grid. The rendering settings are saved and loaded under a new `<Rendering>` element of the `<Monitor>` node, and the scale lock as a `<ScaleLock>` element next to it — both guarded by `QMLUI` exactly like `<StageItem>`.

A project without those elements keeps the previous defaults — High quality, 0.6 ambient, 0.8 smoke, FPS off, scale axes locked — so **existing projects load and render exactly as they do today**. `monitorproperties_test` is extended with a save/load round trip for the new elements and with checks in the defaults and reset paths.

That round trip test is guarded with `QMLUI`, since the new elements are only written by the QML UI build and the test would otherwise fail in a QLC+ 4 build; it is named `view3DSettingsXML()` as it now covers more than the rendering settings.

### Changes in `qmlui`

`MainView3D`'s getters and setters proxy to `MonitorProperties`, the same way `stageIndex()` already does, and mark the document modified so that changing one of these settings on its own still prompts a save.

On project load, and when the 3D view becomes visible, `MainView3D::applyRenderSettings()` re-applies the persisted values to the running scene and notifies QML without touching the modified flag. `setFrameCountEnabled()` is split so that the load path can apply the FPS state without persisting it or marking the project modified.

The scale lock only affects the settings panel, so `slotRefreshView()` simply notifies the QML side. The lock button binds to the new `scaleLocked` property; since clicking a checkable `Button` assigns `checked` and therefore breaks that binding, a `Connections` handler restores it whenever the value changes on the C++ side.

**Related Issues:**
- Builds on the "Show FPS" fix; that touches the same code and should land first. https://github.com/mcallegari/qlcplus/pull/2114
- This is the prerequisite for the **Fixture light** Rendering setting (a PR to follow) which adds one more attribute to the `<Rendering>` element introduced here.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**
1. Load/create a new project. Go to 3D View. Change the Rendering settings. Save project. Close QLC+ V5. Reopen. Open the same project. Verify the settings have persisted.
2. Add a generic item to the 3D view and select it. Unlock the Scale axes and give X, Y and Z different values. Switch to the Virtual Console and back to the 3D View: the lock is still open and the values are unchanged. Save, restart, reload the project: the lock is still open.

**Test Results:**
Test case 1: Pass
Test case 2: Pass

Smoke test for regressions/bugs: Passed.

**Other**

Builds clean and `make check` passes, with the same single pre-existing `RGBText_Test::load()` font failure seen before the change, plus the new `monitorproperties_test` coverage described above. `monitorproperties_test` was also run against a non-`qmlui` (QLC+ 4) build, where the round trip test is skipped.

Linux / Qt 6.11 only. **Not tested on Windows or macOS.**

## Additional Notes

None.
