### PR TITLE
qmlui: fix Actions menu sub-menus on Qt 6.11, and add file dialog scrollbars

### DIFF
--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -30,7 +30,7 @@ Popup
     id: menuRoot
     padding: 0
 
-    property Item submenuItem: null
+    property var submenuItem: null
     property int flagSize: UISettings.iconSizeDefault * 1.5
 
     onClosed: submenuItem = null
@@ -261,13 +261,11 @@ Popup
             }
             onEntered: submenuItem = recentMenu
 
-            Rectangle
+            SubMenu
             {
                 id: recentMenu
-                x: menuRoot.width
-                width: recentColumn.width
-                height: recentColumn.height
-                color: UISettings.bgStrong
+                parent: fileOpen
+                x: fileOpen.width
                 visible: submenuItem === recentMenu
 
                 Column
@@ -393,6 +391,7 @@ Popup
         }
         ContextMenuEntry
         {
+            id: netEntry
             imgSource: "qrc:/network.svg"
             //faSource: FontAwesome.fa_network_wired
             //faColor: "darkseagreen"
@@ -405,13 +404,11 @@ Popup
                     submenuItem = networkMenu
             }
 
-            Rectangle
+            SubMenu
             {
                 id: networkMenu
-                x: menuRoot.width
-                width: networkColumn.width
-                height: networkColumn.height
-                color: UISettings.bgStrong
+                parent: netEntry
+                x: netEntry.width
                 visible: submenuItem === networkMenu
 
                 Column
@@ -509,6 +506,7 @@ Popup
 
         ContextMenuEntry
         {
+            id: langEntry
             faSource: FontAwesome.fa_earth_europe
             faColor: "deepskyblue"
             entryText: qsTr("Language")
@@ -520,14 +518,12 @@ Popup
                     submenuItem = languageMenu
             }
 
-            Rectangle
+            SubMenu
             {
                 id: languageMenu
-                x: menuRoot.width
-                y: -height + parent.height
-                width: languageColumn.width
-                height: languageColumn.height
-                color: UISettings.bgStrong
+                parent: langEntry
+                x: langEntry.width
+                y: langEntry.height - height
                 visible: submenuItem === languageMenu
 
                 GridLayout

--- a/qmlui/qml/SubMenu.qml
+++ b/qmlui/qml/SubMenu.qml
@@ -1,0 +1,47 @@
+/*
+  Q Light Controller Plus
+  SubMenu.qml
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import QtQuick
+import QtQuick.Controls
+
+import "."
+
+/** A cascading sub-menu, to be placed inside a ContextMenuEntry.
+ *
+ *  This is a Popup rather than a plain Item on purpose: a sub-menu sticks out
+ *  of the bounds of both the entry it belongs to and of the menu Popup itself,
+ *  and Qt skips the delivery of pointer events to such items, so entries would
+ *  neither highlight on hover nor react to clicks.
+ *
+ *  Sub-menus are shown/hidden through the 'visible' property by the menu
+ *  handling them, hence the disabled automatic close policy.
+ */
+Popup
+{
+    padding: 0
+    closePolicy: Popup.NoAutoClose
+
+    background:
+        Rectangle
+        {
+            border.width: 1
+            border.color: UISettings.bgStronger
+            color: UISettings.bgStrong
+        }
+}

--- a/qmlui/qml/popup/PopupFolderBrowser.qml
+++ b/qmlui/qml/popup/PopupFolderBrowser.qml
@@ -108,8 +108,12 @@ CustomPopupDialog
                     id: drivesList
                     SplitView.preferredWidth: popupRoot.width / 3
                     implicitHeight: UISettings.listItemHeight * 8
+                    boundsBehavior: Flickable.StopAtBounds
+                    clip: true
 
                     model: folderBrowser.drivesModel
+
+                    ScrollBar.vertical: CustomScrollBar { }
 
                     property int selectedIndex: -1
 
@@ -160,6 +164,8 @@ CustomPopupDialog
                     clip: true
 
                     model: folderBrowser.folderModel
+
+                    ScrollBar.vertical: CustomScrollBar { }
 
                     property int selectedIndex: -1
 

--- a/qmlui/qml/qmldir
+++ b/qmlui/qml/qmldir
@@ -37,6 +37,7 @@ QLCPlusKnob 0.1 QLCPlusKnob.qml
 RobotoText 0.1 RobotoText.qml
 SectionBox 0.1 SectionBox.qml
 SidePanel 0.1 SidePanel.qml
+SubMenu 0.1 SubMenu.qml
 TimeEditTool 0.1 TimeEditTool.qml
 TreeNodeDelegate 0.1 TreeNodeDelegate.qml
 WindowLoader 0.1 WindowLoader.qml

--- a/qmlui/qmlui.qrc
+++ b/qmlui/qmlui.qrc
@@ -52,6 +52,7 @@
     <file alias="SidePanel.qml">qml/SidePanel.qml</file>
     <file alias="SimpleDesk.qml">qml/SimpleDesk.qml</file>
     <file alias="SingleAxisTool.qml">qml/SingleAxisTool.qml</file>
+    <file alias="SubMenu.qml">qml/SubMenu.qml</file>
     <file alias="TimeEditTool.qml">qml/TimeEditTool.qml</file>
     <file alias="TreeNodeDelegate.qml">qml/TreeNodeDelegate.qml</file>
     <file alias="UISettings.qml">qml/UISettings.qml</file>


### PR DESCRIPTION
## Description

**Summary of Changes:**

### What this fixes

On Qt 6.11 the Actions menu sub-menus are visible but dead to the mouse. Hovering "Open file" still pops out the list of recent projects, but its entries are never highlighted, and clicking one does not open the project — it dismisses the menu instead. The "Network" and "Language" sub-menus behave the same way. Users have to fall back to the file dialog to open a recent project.

Everything works normally up to and including Qt 6.10.

The second, unrelated change in this branch adds the missing scrollbars to the open/save dialog lists. (Happy to split it into its own PR if you would rather keep them apart.)

### Why it broke

This is not a QLC+ regression, it is a behaviour change in Qt.

Qt 6.11 added an event delivery optimisation, `QQuickItemPrivate::effectivelyClipsEventHandlingChildren()`. When an item either clips, or has all of its event-handling children inside its own bounds, pointer and hover delivery to that whole subtree is skipped while the cursor is outside the item. `QQuickDeliveryAgentPrivate::deliverHoverEventRecursive()` consults it for every child:

```cpp
if (childPrivate->effectivelyClipsEventHandlingChildren() &&
    !childPrivate->eventHandlingBounds().contains(childLocalPos)) {
    continue;   // skip this item and everything below it
}
```

The verdict is cached in `eventHandlingChildrenWithinBounds` and only revisited from `transformChanged()`, and two details of that make it come out wrong for our menus.
A "this child sticks out" result is only propagated to a grandparent if the child had not been evaluated yet (`if (!childPriv->eventHandlingChildrenWithinBoundsSet)`), so depending on the order in which items are first hit-tested an ancestor can conclude that everything is inside it when it is not. And `transformChanged()` walks up the parents but stops at the first one that still fully contains the item that moved, so ancestors above that keep a stale `true`.

Our three sub-menus were plain `Rectangle`s at `x: menuRoot.width`, so they stuck out of the bounds of both the `ContextMenuEntry` they were declared in and of the menu `Popup` itself. Once the popup item is wrongly marked as containing all of its event-handling children, nothing at a position outside the popup rectangle reaches the sub-menu any more. The entries still get painted, which is why they look normal, and the press falls through to whatever is underneath — that is also why clicking a recent project dismissed the menu (press-outside close policy) and showed up in the `2DView.qml` mouse handler instead.

### The change

The sub-menus stop overflowing their parent and become popups of their own, through a new `SubMenu.qml`:

```qml
Popup
{
    padding: 0
    closePolicy: Popup.NoAutoClose

    background:
        Rectangle
        {
            border.width: 1
            border.color: UISettings.bgStronger
            color: UISettings.bgStrong
        }
}
```

`ActionsMenu.qml` uses it for the three sub-menus, anchored to the entry each one belongs to:

```qml
SubMenu
{
    id: recentMenu
    parent: fileOpen
    x: fileOpen.width
    visible: submenuItem === recentMenu
    ...
}
```

`submenuItem` becomes a `property var` rather than a `property Item`, since a `Popup` is not an `Item`, and the Network and Language entries get ids (`netEntry`, `langEntry`) so their sub-menus can be positioned against them. The Language sub-menu keeps its bottom alignment, now written as `y: langEntry.height - height`.

The show/hide logic is untouched: the sub-menus are still driven purely by `submenuItem`, which is why their automatic close policy is disabled. The only deliberate visual change is that a sub-menu now draws the same 1px frame as the menu itself.

For the dialog, `PopupFolderBrowser.qml` gets `ScrollBar.vertical: CustomScrollBar { }` on both the file/folder list and the drives list — previously they could only be scrolled with the wheel, with nothing on screen saying there was more to see. The drives list also picks up the `clip: true` and `boundsBehavior: Flickable.StopAtBounds` that the file list already had.


### Backwards compatibility

The Qt change is exclusive to 6.11. `effectivelyClipsEventHandlingChildren` appears in `src/quick/items/qquickitem.cpp` on the `6.11` and `dev` branches of qtdeclarative only, and is absent from `6.5`, `6.7`, `6.8`, `6.9` and `6.10`.

Both the old and the new sub-menu pattern were extracted into standalone `qmltestrunner` cases, using the real `ContextMenuEntry` and the new `SubMenu.qml`, and run against two Qt versions:

| | old pattern (Rectangle) | new pattern (SubMenu popup) |
|---|---|---|
| **Qt 6.10.2** | hover OK, click OK, menu stays open | hover OK, click OK, menu stays open |
| **Qt 6.11.2** | no hover, no click, menu dismissed | hover OK, click OK, menu stays open |

So this repairs 6.11 without regressing 6.10.

Nothing used here is version gated. `Popup`, `closePolicy`, `Popup.NoAutoClose`, `parent` and `background` are all original QtQuick.Controls 2.0 API, available since Qt 5.7, and nested popups are how Qt's own cascading `Menu` has always been built. The `ScrollBar.vertical` attached property is the same vintage, and `CustomScrollBar` is already used in roughly eight other places in qmlui.

**Related Issues:**
None.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

Built and exercised as the real application on Linux/X11 with Qt 6.11.2.

**Test Cases - this code**
- recent-project entries highlight on hover, and clicking one loads the project;
- the Network and Language sub-menus highlight and respond, and the Language one still bottom-aligns to its entry;
- clicking outside still dismisses the menu, whether or not a sub-menu is open;
- the new scrollbar appears in the files pane, and dragging it scrolls the list;
- no new QML warnings.

Sub-menu behaviour on Qt 6.10.2 was checked at the QML level with the isolated test cases above.

The sub-menu behaviour issue did not occur on QLC+ version 5.2.2 and master (2026-09-01) built with Qt <= 6.11.x.

**Test cases - reproduce fault and test backwards compatibility**
  1. Build a pre-PR master or stable version of QLC+ (reported on version 5.2.2) compiled with Qt 6.11.x. Ensure there will be some files in 'recently opened'. Click Actions, hover over "Open file" to reveal the recent items sub-menu. Hover over any recent files sub-menu item. Observe that highlight-on-hover doesn't work. Click the item. The menu is dismissed and the file is NOT opened. (This test reveals the issue and is expected to fail.)
2. Build the app again with this PR applied and with Qt 6.11.x. Observe the same process works correctly. (This test should pass.)
3. Build again with the PR on Qt 6.10.x and confirm there is no issue in that version - check backwards compatibility. (This test should pass.) 

**Test Results:**

* This PR code tests, as described: Passed

Backwards compatibility tests:
1. Failed as expected
3. Passed
4. Passed limited test at QML level only with the same isolated test cases tested with this PR code

## Additional Notes

One thing deliberately left alone: Escape does not close the Actions menu. That is pre-existing — it behaves the same with no sub-menu open, and on both Qt versions.