### PR TITLE
qmlui: normalise the G-buffer normal when shading fixture light

### DIFF
--- a/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_shading.frag
+++ b/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_shading.frag
@@ -57,7 +57,7 @@ void main()
     vec4 u =  viewProjectionMatrix * vec4(fsPos, 1.0);
     vec2 uv = (u.xy / u.w) * 0.5 + vec2(0.5);
     albedo = SAMPLE_TEX2D(albedoTex, uv).rgb;
-    normal = SAMPLE_TEX2D(normalTex, uv).xyz;
+    normal = normalize(SAMPLE_TEX2D(normalTex, uv).xyz);
     float z = SAMPLE_TEX2D(depthTex, uv).r;
 
     vec4 temp = inverseViewProjectionMatrix * vec4(u.x / u.w, u.y / u.w, -1.0 + 2.0 * z, 1.0);


### PR DESCRIPTION
## Description

**Summary of Changes:**

The spotlight shading pass in the 3D view reads its surface normal straight out of the G-buffer, which stores `modelMatrix * vertexNormal` unnormalised. That leaves the normal both shorter than unit length wherever it is interpolated across a face — Lambert shading sags between vertices, so a curved mesh picks up a visible band per row instead of a smooth roll-off — and scaled by the item's model matrix, so a stretched environment object gets brighter (or, under non-uniform scale, wrongly directed) purely from the scale, not the geometry. Adding a `normalize()` around that texture read fixes both, and brings the spotlight pass into line with the directional pass, which already normalises the same texture read. Shadow, gobo, cone and the bloom alpha flag are untouched.

Confined to one GLSL shader in `qmlui`. No `engine` code is touched, and no file format or project data changes.

**Related Issues:**

* Improves rendering of the curtain added on PR #2119 though does not depend on it

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**

| # | Test case | Result | Notes |
|---|---|---|---|
| 1 | Build the full tree | Pass | Qt 6.11.2, Linux, no new compiler warnings |
| 2 | `make check` | Pass | 1131 passed; pre-existing `RGBText_Test::load()` font failure only, present on master |
| 3 | Shader compiles and the 3D view renders | Pass | Deferred pipeline renders normally, no GLSL errors |
| 4 | Unscaled item is unaffected | Pass | Curtain at scale 1 under a wash: mean 43.37 before vs 43.49 after (0.3%, noise) |
| 5 | Scaled item no longer brightens with scale | Pass | Same curtain at `ZScale=2`: mean 52.03 before vs 45.48 after; after the fix it matches the unscaled curtain (45.48 vs 43.49) instead of being ~20% brighter |
| 6 | Change is confined to spotlight-lit curved geometry | Pass | Per-pixel diagnostic of the two Lambert terms is non-zero only on pleated/curved surfaces inside a fixture beam |

**Test Results:**

All cases pass as noted above.

Verified by rendering the same project against a build with and without the change and comparing the frames. Both curtains below are the same mesh lit by identical wash fixtures; the right-hand one is scaled 2x along its surface normal. Before the change its scale alone makes it ~20% brighter than the unscaled one, and after it the two agree, with the unscaled curtain unchanged to within noise.

<img width="1820" height="481" alt="09-3dview-normalize-light-normal-before-after" src="https://github.com/user-attachments/assets/f64960e4-fd72-4c78-a19a-71259aee8cb5" />

A diagnostic build that outputs `|dot(normalize(n), -l) - dot(n, -l)|` shows where the change actually lands: the pleats, where the interpolated normal is shortest between vertices.

<img width="760" height="457" alt="09-3dview-normalize-light-normal-delta" src="https://github.com/user-attachments/assets/dc113054-3f23-4b3b-9150-1488b28fa939" />

Linux / Qt 6 only. **Not tested on Windows or macOS.**

## Additional Notes

The bug is specific to the spotlight pass: `directional.frag` reads the same `normalTex` and already wraps it in `normalize()`, so the two passes were inconsistent before this change. The G-buffer itself is left writing the raw `modelMatrix * vertexNormal` — normalising at the geometry pass instead would touch every consumer of that texture, where this fix only needs to correct the one place that wasn't already doing it.
