### PR TITLE
engine: don't drop channel modifiers missing from the modifiers cache from the project file

### DIFF
--- a/engine/src/doc.cpp
+++ b/engine/src/doc.cpp
@@ -596,6 +596,8 @@ bool Doc::replaceFixtures(QList<Fixture*> newFixturesList)
             ChannelModifier *chMod = fixture->channelModifier(s);
             if (chMod != NULL)
                 newFixture->setChannelModifier(s, chMod);
+            else
+                newFixture->setUnknownChannelModifier(s, fixture->channelModifierName(s));
         }
 
         m_fixtures.insert(id, newFixture);

--- a/engine/src/fixture.cpp
+++ b/engine/src/fixture.cpp
@@ -546,16 +546,34 @@ void Fixture::setChannelModifier(quint32 idx, ChannelModifier *mod)
     if (mod == NULL)
     {
         m_channelModifiers.remove(idx);
+        m_channelModifierNames.remove(idx);
         return;
     }
 
     qDebug() << Q_FUNC_INFO << idx << mod->name();
     m_channelModifiers[idx] = mod;
+    m_channelModifierNames[idx] = mod->name();
 }
 
 ChannelModifier *Fixture::channelModifier(quint32 idx)
 {
     return m_channelModifiers.value(idx, NULL);
+}
+
+void Fixture::setUnknownChannelModifier(quint32 idx, const QString &name)
+{
+    if (idx >= channels() || name.isEmpty())
+        return;
+
+    /* No modifier instance to apply, but remember the name so that saving
+     * the project doesn't discard the user's setting */
+    m_channelModifiers.remove(idx);
+    m_channelModifierNames[idx] = name;
+}
+
+QString Fixture::channelModifierName(quint32 idx) const
+{
+    return m_channelModifierNames.value(idx, QString());
 }
 
 /*********************************************************************
@@ -1149,7 +1167,7 @@ bool Fixture::loadXML(QXmlStreamReader &xmlDoc, Doc *doc,
     QList<int> forcedHTP;
     QList<int> forcedLTP;
     QList<quint32>modifierIndices;
-    QList<ChannelModifier *>modifierPointers;
+    QStringList modifierNames;
 
     if (xmlDoc.name() != KXMLFixture)
     {
@@ -1236,12 +1254,8 @@ bool Fixture::loadXML(QXmlStreamReader &xmlDoc, Doc *doc,
             {
                 quint32 chIdx = attrs.value(KXMLFixtureChannelIndex).toString().toUInt();
                 QString modName = attrs.value(KXMLFixtureModifierName).toString();
-                ChannelModifier *chMod = doc->modifiersCache()->modifier(modName);
-                if (chMod != NULL)
-                {
-                    modifierIndices.append(chIdx);
-                    modifierPointers.append(chMod);
-                }
+                modifierIndices.append(chIdx);
+                modifierNames.append(modName);
                 xmlDoc.skipCurrentElement();
             }
         }
@@ -1354,7 +1368,26 @@ bool Fixture::loadXML(QXmlStreamReader &xmlDoc, Doc *doc,
     setForcedHTPChannels(forcedHTP);
     setForcedLTPChannels(forcedLTP);
     for (int i = 0; i < modifierIndices.count(); i++)
-        setChannelModifier(modifierIndices.at(i), modifierPointers.at(i));
+    {
+        QString modName = modifierNames.at(i);
+        ChannelModifier *chMod = doc->modifiersCache()->modifier(modName);
+
+        if (chMod != NULL)
+        {
+            setChannelModifier(modifierIndices.at(i), chMod);
+        }
+        else
+        {
+            /* The template is not installed on this system. Keep the name so
+             * that saving the project preserves it, and tell the user about it */
+            setUnknownChannelModifier(modifierIndices.at(i), modName);
+            qWarning() << Q_FUNC_INFO << "Channel modifier" << modName << "of fixture" << name
+                       << "is not available in the modifiers cache";
+            doc->appendToErrorLog(QString("Channel modifier <b>%1</b> of fixture <b>%2</b> "
+                                          "is not available and will have no effect")
+                                  .arg(modName).arg(name));
+        }
+    }
     setID(id);
 
     return true;
@@ -1445,19 +1478,17 @@ bool Fixture::saveXML(QXmlStreamWriter *doc) const
     }
 
     {
-        QMapIterator<quint32, ChannelModifier *> it(m_channelModifiers);
+        QMapIterator<quint32, QString> it(m_channelModifierNames);
         while (it.hasNext())
         {
             it.next();
-            quint32 ch = it.key();
-            ChannelModifier *mod = it.value();
-            if (mod != NULL)
-            {
-                doc->writeStartElement(KXMLFixtureChannelModifier);
-                doc->writeAttribute(KXMLFixtureChannelIndex, QString::number(ch));
-                doc->writeAttribute(KXMLFixtureModifierName, mod->name());
-                doc->writeEndElement();
-            }
+            if (it.value().isEmpty())
+                continue;
+
+            doc->writeStartElement(KXMLFixtureChannelModifier);
+            doc->writeAttribute(KXMLFixtureChannelIndex, QString::number(it.key()));
+            doc->writeAttribute(KXMLFixtureModifierName, it.value());
+            doc->writeEndElement();
         }
     }
 

--- a/engine/src/fixture.h
+++ b/engine/src/fixture.h
@@ -327,6 +327,15 @@ public:
      *  Returns NULL if no modifier has been assigned */
     ChannelModifier *channelModifier(quint32 idx);
 
+    /** Set the name of the ChannelModifier assigned to the channel with the
+     *  given $idx, when the modifier itself is not available in the modifiers
+     *  cache. This keeps the project information intact on the next save */
+    void setUnknownChannelModifier(quint32 idx, const QString &name);
+
+    /** Get the name of the ChannelModifier assigned to the channel with the
+     *  given $idx. Returns an empty string if no modifier has been assigned */
+    QString channelModifierName(quint32 idx) const;
+
 protected:
     /** Find and store channel numbers (pan, tilt, intensity) */
     void findChannels() const;
@@ -354,6 +363,12 @@ protected:
      *  This is basically the place to store them to be saved/loaded
      *  on the project XML file */
     QMap<quint32, ChannelModifier*> m_channelModifiers;
+
+    /** Hash holding the pair <channel index, modifier name>
+     *  This mirrors m_channelModifiers and is the reference used when saving,
+     *  so that a modifier missing from the modifiers cache is still written
+     *  back to the project file instead of being silently dropped */
+    QMap<quint32, QString> m_channelModifierNames;
 
     /*********************************************************************
      * Channel info

--- a/engine/src/fixtureremapper.cpp
+++ b/engine/src/fixtureremapper.cpp
@@ -104,6 +104,8 @@ QList<QPair<quint32, quint32>> FixtureRemapper::autoConnectFixtures(Fixture *src
                 ChannelModifier *chMod = src->channelModifier(s);
                 if (chMod != nullptr)
                     tgt->setChannelModifier(s, chMod);
+                else
+                    tgt->setUnknownChannelModifier(s, src->channelModifierName(s));
             }
         }
         else

--- a/engine/test/fixture/fixture_test.cpp
+++ b/engine/test/fixture/fixture_test.cpp
@@ -28,6 +28,7 @@
 #include "qlccapability.h"
 #include "qlcconfig.h"
 #include "qlcfile.h"
+#include "qlcmodifierscache.h"
 
 #include "fixture_test.h"
 #include "fixture.h"
@@ -1015,5 +1016,75 @@ void Fixture_Test::save()
     fxi.setFixtureDefinition(fixtureDef, fixtureMode);
     info = fxi.status();
 }*/
+
+/* A channel modifier template that is not installed on the current system
+ * must not be dropped: the assignment has to survive a load/save cycle,
+ * otherwise opening and saving a project silently destroys it */
+void Fixture_Test::unknownChannelModifier()
+{
+    QVERIFY(m_doc->modifiersCache()->modifier("Nonexistent Template") == NULL);
+
+    QBuffer buffer;
+    buffer.open(QIODevice::WriteOnly | QIODevice::Text);
+    QXmlStreamWriter xmlWriter(&buffer);
+
+    xmlWriter.writeStartElement("Fixture");
+    xmlWriter.writeTextElement("Channels", "18");
+    xmlWriter.writeTextElement("Name", "Foobar");
+    xmlWriter.writeTextElement("Universe", "3");
+    xmlWriter.writeTextElement("Model", "Foobar");
+    xmlWriter.writeTextElement("Mode", "Foobar");
+    xmlWriter.writeTextElement("Manufacturer", "Foobar");
+    xmlWriter.writeTextElement("ID", "43");
+    xmlWriter.writeTextElement("Address", "100");
+    xmlWriter.writeTextElement("ForcedHTP", "3");
+    xmlWriter.writeStartElement("Modifier");
+    xmlWriter.writeAttribute("Channel", "3");
+    xmlWriter.writeAttribute("Name", "Nonexistent Template");
+    xmlWriter.writeEndElement();
+    xmlWriter.writeEndDocument();
+    xmlWriter.setDevice(NULL);
+    buffer.close();
+
+    buffer.open(QIODevice::ReadOnly | QIODevice::Text);
+    QXmlStreamReader xmlReader(&buffer);
+    xmlReader.readNextStartElement();
+
+    QVERIFY(Fixture::loader(xmlReader, m_doc) == true);
+
+    Fixture *fxi = m_doc->fixture(43);
+    QVERIFY(fxi != NULL);
+    /* No instance to apply, but the name is remembered */
+    QVERIFY(fxi->channelModifier(3) == NULL);
+    QVERIFY(fxi->channelModifierName(3) == "Nonexistent Template");
+
+    QBuffer outBuffer;
+    outBuffer.open(QIODevice::WriteOnly | QIODevice::Text);
+    QXmlStreamWriter outWriter(&outBuffer);
+    outWriter.writeStartElement("TestRoot");
+    QVERIFY(fxi->saveXML(&outWriter) == true);
+    outWriter.setDevice(NULL);
+    outBuffer.close();
+
+    outBuffer.open(QIODevice::ReadOnly | QIODevice::Text);
+    QXmlStreamReader outReader(&outBuffer);
+    outReader.readNextStartElement();
+    QVERIFY(outReader.name().toString() == "TestRoot");
+    outReader.readNextStartElement();
+    QVERIFY(outReader.name().toString() == "Fixture");
+
+    bool modifierFound = false;
+    while (outReader.readNextStartElement())
+    {
+        if (outReader.name().toString() == "Modifier")
+        {
+            QVERIFY(outReader.attributes().value("Channel").toString() == "3");
+            QVERIFY(outReader.attributes().value("Name").toString() == "Nonexistent Template");
+            modifierFound = true;
+        }
+        outReader.skipCurrentElement();
+    }
+    QVERIFY(modifierFound == true);
+}
 
 QTEST_APPLESS_MAIN(Fixture_Test)

--- a/engine/test/fixture/fixture_test.h
+++ b/engine/test/fixture/fixture_test.h
@@ -53,6 +53,7 @@ private slots:
     void loadWrongID();
     void loader();
     void save();
+    void unknownChannelModifier();
     //void status();
 
 private:


### PR DESCRIPTION
## Description

**Summary of Changes:**

Stops `Fixture::loadXML()` from discarding a `<Modifier>` element whose template is missing from the modifiers cache. The modifier name is now stored alongside the resolved `ChannelModifier` pointer and is what `saveXML()` writes, so an unresolved modifier round-trips through a load/save cycle instead of being deleted from the project file.

Since the system modifier set is fixed at install time and the user set is whatever happens to be in ~/.qlcplus/modifierstemplates, a workspace authored on one machine can reference a modifier by name that simply isn't present in the cache on another — a user-authored template that was never copied across, or a template added in a newer QLC+ than the one opening the file. Currently the user is unaware when the channel modifier in the project file is lost.

**Related Issues:**

None filed. Found while investigating fixtures that had stopped emitting light due to shutter closed in the 3D view of a V4 project that had been opened and saved on a (built) V5 system where `MODIFIERSTEMPLATEDIR` at one point did not resolve.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [ ] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**

| # | Test case | Result | Notes |
|---|---|---|---|
| 1 | Build QLC+ 5 (`qmlui=ON`) | Pass | Qt 6.11.2, Linux, no new compiler warnings |
| 2 | Build QLC+ 4 (`qmlui=OFF`) | Pass | Qt 6.11.2, Linux, no new compiler warnings |
| 3 | Engine and plugin test suite | Pass | 1131 passed; only the pre-existing `RGBText_Test::load()` font-rendering failure under Qt 6.11, unrelated to this change |
| 4 | `Fixture_Test::unknownChannelModifier()` — new | Pass | A `<Modifier>` naming a template absent from the cache loads with `channelModifier()` null but `channelModifierName()` set, and is written back out by `saveXML()` |
| 5 | Open + save a project, templates **available**, before and after the change | Pass | 18-channel fixtures with `Always Full` on two shutter channels: 32 `<Modifier>` elements and 4 `<ForcedHTP>` lists preserved either way; no diff in the saved file |
| 6 | Open + save the same project, templates **unavailable**, before the change | Pass (bug reproduced) | All 32 `<Modifier>` elements silently removed from the saved file; the 4 `<ForcedHTP>` lists remained |
| 7 | Open + save the same project, templates **unavailable**, after the change | Pass | All 32 `<Modifier>` elements and 4 `<ForcedHTP>` lists preserved; a warning is logged and an entry added to the document error log for each unresolved modifier |
| 8 | Runtime effect on a forced-HTP shutter channel | Pass | With the modifier present the channel sits at 255; loading a file damaged by case 6 leaves the same channel at 0 |
| 9 | Assigning and clearing a modifier from the QLC+ 5 Fixture Manager | Pass | Channel Modifiers Editor opens with the loaded template selected; switching it to `Always Off` writes that name to the file, and selecting `None` removes the stored name so the `<Modifier>` element disappears on the next save |

**Test Results:**

All cases pass. Case 6 is the failing behaviour on `master` and case 7 the same scenario with the change applied.

## Additional Notes

`Fixture::loadXML()` resolved every `<Modifier>` element against `Doc::modifiersCache()` at parse time and dropped the element outright when `modifier(name)` returned `NULL`. `saveXML()` then rebuilt the modifier list from the surviving pointers, so opening and saving a project on a system where the templates were not reachable permanently deleted every channel modifier assignment in it, with nothing shown to the user.

The consequence is not cosmetic, because `<ForcedHTP>` is stored separately and needs no cache, so it always survives. A shutter channel set to *Forced HTP* with an *Always Full* modifier keeps being treated as an intensity channel and so is reset by `Universe::zeroIntensityChannels()` on every tick — but the reset value comes from `m_modifiedZeroValues`, which is 255 only while the modifier is attached. Once the modifier is gone the channel is pinned at 0 and the fixture stops emitting light.

The change is deliberately conservative about run-time behaviour: an unresolved modifier still has no effect on the output, which is unavoidable without the template. Only the project data is preserved, so that reinstalling or restoring the template restores the intended behaviour. `Doc::replaceFixtures()` and `FixtureRemapper::autoConnectFixtures()` carry the stored name across as well, so the address tool and the fixture remapper do not reintroduce the loss.

One thing a reviewer may want to weigh separately: the error-log entry this adds is not visible in QLC+ 5. `App::loadXML()` in `qmlui/app.cpp` still has the "some errors occurred while loading the project" dialog commented out behind a `// TODO: emit a signal to inform the QML UI to display an error message`, so on QLC+ 5 the only trace is the `qWarning()` on the console. QLC+ 4 shows the error log as usual. Wiring up the QML dialog felt out of scope here, but it is what would have made this class of problem visible to the user in the first place.
