### PR TITLE
qmlui: clip the fixture name column in the Fixture Manager

### DIFF
--- a/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
+++ b/qmlui/qml/fixturesfunctions/FixtureNodeDelegate.qml
@@ -146,6 +146,9 @@ Column
             {
                 id: nodeLabel
                 Layout.fillWidth: true
+                // names longer than the column would otherwise be painted
+                // over the neighbouring items
+                clip: true
                 text: textLabel
                 originalText: text
 


### PR DESCRIPTION
## Description

**Summary of Changes:**

Sets `clip: true` on the fixture name text input in `FixtureNodeDelegate.qml`, so a name wider than the Name column is cut off at the column boundary instead of being painted over the fixture icon and past the left edge of the Fixture Manager panel.

**Related Issues:**

None filed.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

No documentation changes are required.

## Testing

**Test Cases:**

| # | Test case | Result | Notes |
|---|---|---|---|
| 1 | Build QLC+ 5 (`qmlui=ON`) | Pass | Qt 6.11.2, Linux, no new warnings |
| 2 | Fixture Manager in property editing mode, names longer than the Name column | Pass | Names now stop at the column edge; before the change they were drawn over the fixture icon and outside the panel |
| 3 | Fixture Manager in normal mode, same names | Pass | Same overflow existed there against the DMX address column and is likewise gone |
| 4 | Names shorter than the column | Pass | Unchanged |
| 5 | Renaming a fixture from the panel | Pass | Inline editing, selection highlight and confirmation still work; the edited text is clipped at the same boundary |
| 6 | Fixture channel and head rows, group rows | Pass | Unaffected; they use different delegates |

**Test Results:**

All cases pass. Case 2 is the reported behaviour; before/after screenshots are attached below.

## Additional Notes

The name is shown by a `CustomTextInput` (a `TextInput`) with `Layout.fillWidth: true`. The layout shrinks it to the space left by the fixed-width Mode/Flags/Can fade/Behaviour/Modifier columns, at which point the input scrolls its content so the end of the name stays visible — which is the useful end to see, since the distinguishing part of a fixture name is usually its suffix. `TextInput` does not clip by default, so the overflowing head of the string was still painted, overlapping the icon and everything to the left of the panel.

`clip: true` on this one item keeps that scrolling behaviour and only stops the painting at the item's bounds. The shared `CustomTextInput` was deliberately left alone: it is also used by the show manager track delegate, the input/output universe item and the generic tree node delegate, where the text is not bounded by a neighbouring column and clipping would be a visible change for no benefit here.

## Screenshots
Before:
<img width="1010" height="230" alt="13-fixture-name-clipping-before" src="https://github.com/user-attachments/assets/9c6f3584-80f2-4c34-b06c-bb530ebc4a0c" />
After:
<img width="1010" height="230" alt="13-fixture-name-clipping-after" src="https://github.com/user-attachments/assets/8b1afea6-5001-48db-8e12-3464c9fad3f4" />
