### PR TITLE
resources: improve the American DJ Jolt 300 definition

### DIFF
--- a/resources/fixtures/American_DJ/American-DJ-Jolt-300.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Jolt-300.qxf
@@ -8,7 +8,7 @@
  </Creator>
  <Manufacturer>American DJ</Manufacturer>
  <Model>Jolt 300</Model>
- <Type>LED Bar (Beams)</Type>
+ <Type>LED Bar (Pixels)</Type>
  <Channel Name="Red" Preset="IntensityRed"/>
  <Channel Name="Green" Preset="IntensityGreen"/>
  <Channel Name="Blue" Preset="IntensityBlue"/>

--- a/resources/fixtures/American_DJ/American-DJ-Jolt-300.qxf
+++ b/resources/fixtures/American_DJ/American-DJ-Jolt-300.qxf
@@ -4,11 +4,11 @@
  <Creator>
   <Name>Q Light Controller Plus</Name>
   <Version>4.12.7 GIT</Version>
-  <Author>David Gouronc</Author>
+  <Author>David Gouronc + Matt Carter</Author>
  </Creator>
  <Manufacturer>American DJ</Manufacturer>
  <Model>Jolt 300</Model>
- <Type>Other</Type>
+ <Type>LED Bar (Beams)</Type>
  <Channel Name="Red" Preset="IntensityRed"/>
  <Channel Name="Green" Preset="IntensityGreen"/>
  <Channel Name="Blue" Preset="IntensityBlue"/>
@@ -25,7 +25,74 @@
  <Channel Name="Green 3" Preset="IntensityGreen"/>
  <Channel Name="Blue 3" Preset="IntensityBlue"/>
  <Channel Name="White 3" Preset="IntensityWhite"/>
- <Channel Name="Color macro" Preset="ColorMacro"/>
+ <Channel Name="Color macro">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="0">Off</Capability>
+  <Capability Min="1" Max="4" Preset="ColorMacro" Res1="#a0ffff">Color 1</Capability>
+  <Capability Min="5" Max="8" Preset="ColorMacro" Res1="#a0fff4">Color 2</Capability>
+  <Capability Min="9" Max="12" Preset="ColorMacro" Res1="#9affbd">Color 3</Capability>
+  <Capability Min="13" Max="16" Preset="ColorMacro" Res1="#c8ffa6">Color 4</Capability>
+  <Capability Min="17" Max="20" Preset="ColorMacro" Res1="#edff9a">Color 5</Capability>
+  <Capability Min="21" Max="24" Preset="ColorMacro" Res1="#ffffa6">Color 6</Capability>
+  <Capability Min="25" Max="28" Preset="ColorMacro" Res1="#ffff9a">Color 7</Capability>
+  <Capability Min="29" Max="32" Preset="ColorMacro" Res1="#ffff94">Color 8</Capability>
+  <Capability Min="33" Max="36" Preset="ColorMacro" Res1="#fff39a">Color 9</Capability>
+  <Capability Min="37" Max="40" Preset="ColorMacro" Res1="#ffc794">Color 10</Capability>
+  <Capability Min="41" Max="44" Preset="ColorMacro" Res1="#ffab97">Color 11</Capability>
+  <Capability Min="45" Max="48" Preset="ColorMacro" Res1="#ff8e94">Color 12</Capability>
+  <Capability Min="49" Max="52" Preset="ColorMacro" Res1="#ffa6d9">Color 13</Capability>
+  <Capability Min="53" Max="56" Preset="ColorMacro" Res1="#ffbaff">Color 14</Capability>
+  <Capability Min="57" Max="60" Preset="ColorMacro" Res1="#ffc0ff">Color 15</Capability>
+  <Capability Min="61" Max="64" Preset="ColorMacro" Res1="#ffbaff">Color 16</Capability>
+  <Capability Min="65" Max="68" Preset="ColorMacro" Res1="#ffaeff">Color 17</Capability>
+  <Capability Min="69" Max="72" Preset="ColorMacro" Res1="#f0b4ff">Color 18</Capability>
+  <Capability Min="73" Max="76" Preset="ColorMacro" Res1="#b19aff">Color 19</Capability>
+  <Capability Min="77" Max="80" Preset="ColorMacro" Res1="#9ab1ff">Color 20</Capability>
+  <Capability Min="81" Max="84" Preset="ColorMacro" Res1="#86d7ff">Color 21</Capability>
+  <Capability Min="85" Max="88" Preset="ColorMacro" Res1="#9affff">Color 22</Capability>
+  <Capability Min="89" Max="92" Preset="ColorMacro" Res1="#9affff">Color 23</Capability>
+  <Capability Min="93" Max="96" Preset="ColorMacro" Res1="#ffffff">Color 24</Capability>
+  <Capability Min="97" Max="100" Preset="ColorMacro" Res1="#ffffff">Color 25</Capability>
+  <Capability Min="101" Max="104" Preset="ColorMacro" Res1="#ffffff">Color 26</Capability>
+  <Capability Min="105" Max="108" Preset="ColorMacro" Res1="#ffffff">Color 27</Capability>
+  <Capability Min="109" Max="112" Preset="ColorMacro" Res1="#ffffff">Color 28</Capability>
+  <Capability Min="113" Max="116" Preset="ColorMacro" Res1="#ffffff">Color 29</Capability>
+  <Capability Min="117" Max="120" Preset="ColorMacro" Res1="#c764ff">Color 30</Capability>
+  <Capability Min="121" Max="124" Preset="ColorMacro" Res1="#ffffff">Color 31</Capability>
+  <Capability Min="125" Max="128" Preset="ColorMacro" Res1="#ffffff">Color 32</Capability>
+  <Capability Min="129" Max="132" Preset="ColorMacro" Res1="#ffce8f">Color 33</Capability>
+  <Capability Min="133" Max="136" Preset="ColorMacro" Res1="#feb199">Color 34</Capability>
+  <Capability Min="137" Max="140" Preset="ColorMacro" Res1="#fec08a">Color 35</Capability>
+  <Capability Min="141" Max="144" Preset="ColorMacro" Res1="#fea562">Color 36</Capability>
+  <Capability Min="145" Max="148" Preset="ColorMacro" Res1="#fe7900">Color 37</Capability>
+  <Capability Min="149" Max="152" Preset="ColorMacro" Res1="#b01100">Color 38</Capability>
+  <Capability Min="153" Max="156" Preset="ColorMacro" Res1="#60000b">Color 39</Capability>
+  <Capability Min="157" Max="160" Preset="ColorMacro" Res1="#ea8bab">Color 40</Capability>
+  <Capability Min="161" Max="164" Preset="ColorMacro" Res1="#e00561">Color 41</Capability>
+  <Capability Min="165" Max="168" Preset="ColorMacro" Res1="#af4dad">Color 42</Capability>
+  <Capability Min="169" Max="172" Preset="ColorMacro" Res1="#7782c7">Color 43</Capability>
+  <Capability Min="173" Max="176" Preset="ColorMacro" Res1="#93a4d4">Color 44</Capability>
+  <Capability Min="177" Max="180" Preset="ColorMacro" Res1="#5802a3">Color 45</Capability>
+  <Capability Min="181" Max="184" Preset="ColorMacro" Res1="#002656">Color 46</Capability>
+  <Capability Min="185" Max="188" Preset="ColorMacro" Res1="#008ed0">Color 47</Capability>
+  <Capability Min="189" Max="192" Preset="ColorMacro" Res1="#3494d1">Color 48</Capability>
+  <Capability Min="193" Max="196" Preset="ColorMacro" Res1="#0186c9">Color 49</Capability>
+  <Capability Min="197" Max="200" Preset="ColorMacro" Res1="#0091d4">Color 50</Capability>
+  <Capability Min="201" Max="204" Preset="ColorMacro" Res1="#0079c0">Color 51</Capability>
+  <Capability Min="205" Max="208" Preset="ColorMacro" Res1="#0081b8">Color 52</Capability>
+  <Capability Min="209" Max="212" Preset="ColorMacro" Res1="#005373">Color 53</Capability>
+  <Capability Min="213" Max="216" Preset="ColorMacro" Res1="#0061a6">Color 54</Capability>
+  <Capability Min="217" Max="220" Preset="ColorMacro" Res1="#0164a7">Color 55</Capability>
+  <Capability Min="221" Max="224" Preset="ColorMacro" Res1="#002856">Color 56</Capability>
+  <Capability Min="225" Max="228" Preset="ColorMacro" Res1="#d1dbb6">Color 57</Capability>
+  <Capability Min="229" Max="232" Preset="ColorMacro" Res1="#2aa555">Color 58</Capability>
+  <Capability Min="233" Max="236" Preset="ColorMacro" Res1="#002e23">Color 59</Capability>
+  <Capability Min="237" Max="240" Preset="ColorMacro" Res1="#086bde">Color 60</Capability>
+  <Capability Min="241" Max="244" Preset="ColorMacro" Res1="#ff0000">Color 61</Capability>
+  <Capability Min="245" Max="248" Preset="ColorMacro" Res1="#00ff00">Color 62</Capability>
+  <Capability Min="249" Max="252" Preset="ColorMacro" Res1="#0000ff">Color 63</Capability>
+  <Capability Min="253" Max="255" Preset="ColorMacro" Res1="#ffffff">Color 64</Capability>
+ </Channel>
  <Channel Name="Auto Programs">
   <Group Byte="0">Effect</Group>
   <Capability Min="0" Max="15">No Function</Capability>
@@ -70,14 +137,14 @@
  </Channel>
  <Channel Name="Shutter &amp; Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="31" Preset="ShutterClose">Closed (LED's Off)</Capability>
-  <Capability Min="32" Max="63" Preset="ShutterOpen">Open (LED's On)</Capability>
+  <Capability Min="0" Max="31" Preset="ShutterClose">Closed (LEDs Off)</Capability>
+  <Capability Min="32" Max="63" Preset="ShutterOpen">Open (LEDs On)</Capability>
   <Capability Min="64" Max="95" Preset="StrobeSlowToFast">Strobing Slow-Fast</Capability>
-  <Capability Min="96" Max="127" Preset="ShutterOpen">Open (LED's On)</Capability>
+  <Capability Min="96" Max="127" Preset="ShutterOpen">Open (LEDs On)</Capability>
   <Capability Min="128" Max="159" Preset="PulseSlowToFast">Pulse Effect</Capability>
-  <Capability Min="160" Max="191" Preset="ShutterOpen">Open (LED's On)</Capability>
+  <Capability Min="160" Max="191" Preset="ShutterOpen">Open (LEDs On)</Capability>
   <Capability Min="192" Max="223" Preset="StrobeRandomSlowToFast">Random Strobing Slow-Fast</Capability>
-  <Capability Min="224" Max="255" Preset="ShutterOpen">Open (LED’s On)</Capability>
+  <Capability Min="224" Max="255" Preset="ShutterOpen">Open (LEDs On)</Capability>
  </Channel>
  <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
  <Channel Name="Dimmer : modes &amp; delay times">
@@ -112,14 +179,14 @@
  </Channel>
  <Channel Name="RGB Shutter &amp; Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="31" Preset="ShutterClose">Closed (LED's Off)</Capability>
-  <Capability Min="32" Max="63" Preset="ShutterOpen">Open (LED's On)</Capability>
+  <Capability Min="0" Max="31" Preset="ShutterClose">Closed (LEDs Off)</Capability>
+  <Capability Min="32" Max="63" Preset="ShutterOpen">Open (LEDs On)</Capability>
   <Capability Min="64" Max="95" Preset="StrobeSlowToFast">Strobing Slow-Fast</Capability>
-  <Capability Min="96" Max="127" Preset="ShutterOpen">Open (LED's On)</Capability>
+  <Capability Min="96" Max="127" Preset="ShutterOpen">Open (LEDs On)</Capability>
   <Capability Min="128" Max="159" Preset="PulseSlowToFast">Pulse Effect</Capability>
-  <Capability Min="160" Max="191" Preset="ShutterOpen">Open (LED's On)</Capability>
+  <Capability Min="160" Max="191" Preset="ShutterOpen">Open (LEDs On)</Capability>
   <Capability Min="192" Max="223" Preset="StrobeRandomSlowToFast">Random Strobing Slow-Fast</Capability>
-  <Capability Min="224" Max="255" Preset="ShutterOpen">Open (LED’s On)</Capability>
+  <Capability Min="224" Max="255" Preset="ShutterOpen">Open (LEDs On)</Capability>
  </Channel>
  <Channel Name="RGB Master dimmer" Preset="IntensityDimmer"/>
  <Channel Name="RGB Dimmer : modes &amp; delay times">
@@ -154,14 +221,14 @@
  </Channel>
  <Channel Name="White Shutter &amp; Strobe">
   <Group Byte="0">Shutter</Group>
-  <Capability Min="0" Max="31">Closed (LED's Off)</Capability>
-  <Capability Min="32" Max="63">Open (LED's On)</Capability>
+  <Capability Min="0" Max="31">Closed (LEDs Off)</Capability>
+  <Capability Min="32" Max="63">Open (LEDs On)</Capability>
   <Capability Min="64" Max="95">Strobing Slow-Fast</Capability>
-  <Capability Min="96" Max="127">Open (LED's On)</Capability>
+  <Capability Min="96" Max="127">Open (LEDs On)</Capability>
   <Capability Min="128" Max="159">Pulse Effect</Capability>
-  <Capability Min="160" Max="191">Open (LED's On)</Capability>
+  <Capability Min="160" Max="191">Open (LEDs On)</Capability>
   <Capability Min="192" Max="223">Random Strobing Slow-Fast</Capability>
-  <Capability Min="224" Max="255">Open (LED’s On)</Capability>
+  <Capability Min="224" Max="255">Open (LEDs On)</Capability>
  </Channel>
  <Channel Name="White Master dimmer" Preset="IntensityDimmer"/>
  <Channel Name="White Dimmer : modes &amp; delay times 1">
@@ -378,7 +445,7 @@
   </Head>
  </Mode>
  <Physical>
-  <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+  <Bulb Type="LED" Lumens="12900" ColourTemperature="6000"/>
   <Dimensions Weight="4.75" Width="389" Height="143" Depth="213"/>
   <Lens Name="Other" DegreesMin="120" DegreesMax="120"/>
   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>


### PR DESCRIPTION

## Description

**Summary of Changes:**

Expands the Jolt 300's colour macro channel into the 64 macros of the manual's chart, sets the fixture type to LED Bar (Pixels), adds the missing `Lumens` and white LED colour temperature, and normalises `LED's` to `LEDs` in the shutter capability labels.

**Related Issues:**

None.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

No documentation change necessary.
## Testing

**Test Cases:**

| # | Case | Result |
|---|------|--------|
| 1 | `fixtures-tool.py --validate` on the definition | Pass — 0 errors |
| 2 | Colour macro DMX ranges tile 0–255 with no gap or overlap | Pass — asserted while generating from the chart |
| 3 | Every mode channel reference resolves after the macro channel was rewritten | Pass — no unresolved references |
| 4 | Macro channel appears in exactly the modes the manual's chart marks | Pass — 8 Channel (ch5), A10 Channel (ch5), A18 Channel (ch13) |
| 5 | Every mode's channel order re-checked against the manual's DMX chart | Pass — including B10 placing White on ch7, and B18 splitting the whites to ch13–15 |
| 6 | Definition loads in QLC+ 5 | Pass — no cache or capability warnings |
| 7 | 2D view head geometry | Pass — three heads, matching the three RGB sections |
| 8 | Tested on real fixture hardware - core capabilities only | Works |

**Test Results:**

All pass. Tested on Linux, Qt 6.11.2.

## Additional Notes

**Fixture type.** The Jolt 300 has three independently controllable RGB sections, which the definition already declared as three heads with a 3×1 layout, but its type was `Other`, which renders nothing meaningful in the 3D view. It is typed here as LED Bar (Pixels), the three sections being pixels of the bar; this follows the maintainer's review of the Pulse LED BAR 320, where a bar of this kind was judged a pixel bar rather than a set of beam emitters. An earlier revision of this PR used LED Bar (Beams).

**Colour macros.** The channel was a bare `Preset="ColorMacro"`, i.e. one undifferentiated 0–255 range with no capability data. The manual's chart gives an RGB **and white** intensity per macro, but a `Res1` swatch has no white channel. Dropping white would render macro 64 — white LEDs only, RGB all zero — as black. The swatch therefore folds white in additively with a clamp, `min(255, R + W)` per component, the way the emitters mix. Macro 64 comes out white and macro 32 stays white; the cost is that the macro 1–31 pastels read slightly less saturated in the swatch than their raw RGB triples. This affects only the swatch and the Stage Wizard's colour picking — the rendered beam colour comes from the RGBW intensity channels, not from `Res1`. DMX 0 is left as a plain capability rather than a `ColorMacro` of black.

Macros are named as the manual names them (`Color 1` … `Color 64`) rather than given invented descriptive names; the swatches carry the colour.

**Lumens.** 12900, from ADJ's published 4113 lux at 1 m over the 120° beam: `flux = lux * distance^2 * 2*pi*(1 - cos(beam / 2))`. The figure is for the whole fixture; the 3D view divides it between the heads it draws. Colour temperature 6000 K is ADJ's figure for the white LEDs.

**Left alone deliberately.** The manual gives Program 21 as 156–161 and Program 22 as 162–169, while the definition has 156–162 / 163–169. Every other program in that table is exactly 7 values wide and the manual's own numbers break the pattern only here, so this reads as a typo in the manual and the existing values were kept.

## Source(s) of Information

- ADJ Jolt 300 User Manual — DMX chart pages 11–14, colour macro chart pages 15–16
- ADJ Jolt 300 cut sheet — light source, sections, electrical, dimensions
- Product page: www.adj.com/jolt-300
