### PR TITLE
resources: type the Pulse LED BAR 320 as an LED Bar (Beams)

### DIFF
--- a/resources/fixtures/Pulse/Pulse-LEDBAR-320.qxf
+++ b/resources/fixtures/Pulse/Pulse-LEDBAR-320.qxf
@@ -4,11 +4,11 @@
  <Creator>
   <Name>Q Light Controller Plus</Name>
   <Version>4.12.1 GIT</Version>
-  <Author>Allan Rhynas</Author>
+  <Author>Allan Rhynas + Matt Carter</Author>
  </Creator>
  <Manufacturer>Pulse</Manufacturer>
  <Model>LED BAR 320</Model>
- <Type>LED Bar (Pixels)</Type>
+ <Type>LED Bar (Beams)</Type>
  <Channel Name="Colour Presets">
   <Group Byte="0">Colour</Group>
   <Capability Min="0" Max="7">Off</Capability>
@@ -91,12 +91,92 @@
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
  </Mode>
  <Mode Name="Mode 2 (d-P2)">
   <Channel Number="0">Red</Channel>
   <Channel Number="1">Green</Channel>
   <Channel Number="2">Blue</Channel>
   <Channel Number="3">Master Dimmer</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
  </Mode>
  <Mode Name="Mode 3 (d-P3)">
   <Channel Number="0">Red, Heads 1-2</Channel>
@@ -214,9 +294,49 @@
   <Channel Number="4">Speed</Channel>
   <Channel Number="5">Flash Frequency</Channel>
   <Channel Number="6">Master Dimmer</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
  </Mode>
  <Physical>
-  <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+  <Bulb Type="LED" Lumens="1000" ColourTemperature="0"/>
   <Dimensions Weight="1.9" Width="1025" Height="65" Depth="65"/>
   <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>


### PR DESCRIPTION

## Description

**Summary of Changes:**

Retypes the Pulse LED BAR 320 from LED Bar (Pixels) to LED Bar (Beams), declares eight heads on the modes that drive the whole bar as one colour, and adds the missing `Lumens`.

**Related Issues:**

Builds on the LED Bar (Beams) beam rendering added in #2115.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

No documentation change necessary.

## Testing

**Test Cases:**

| # | Case | Result |
|---|------|--------|
| 1 | `fixtures-tool.py --validate` on the definition | Pass — 0 errors |
| 2 | Channel counts per mode unchanged from the previous definition | Pass — 3 / 4 / 14 / 26 / 2 / 7 |
| 3 | Head counts per mode | Pass — 8 / 8 / 4 / 8 / 0 / 8 |
| 4 | Definition loads in QLC+ 5 | Pass — no cache warnings |
| 5 | 2D view draws eight heads across the bar in a whole-bar mode | Pass |
| 6 | An existing project referencing the definition still resolves | Pass — mode names and channel counts unchanged |
| 7 | Tested on real fixture hardware - core capabilities only | Works |

**Test Results:**

All pass. Tested on Linux, Qt 6.11.2.

## Additional Notes

**Why retype it.** The LED BAR 320 is 320 LEDs in a 1 m housing. On stage it lays down a wash bright enough to read as beams, rather than the faint per-pixel glow that LED Bar (Pixels) renders, so LED Bar (Beams) is the closer match to what the fixture actually does. This was established against the real fixture, not inferred from the specification.

**Why eight heads.** `MainView3D` sets `headsNumber` from `fixture->heads()`, so a mode that declares no head renders one central beam regardless of how wide the bar is. Modes 1, 2 and 6 drive all eight physical segments as a single colour, so eight identical heads over the same RGB channels give the 3D view eight emitters to spread along the housing without changing what any DMX channel does. It also makes the already declared `Layout 8x1` match the head count, so `MultiBeams3DItem` honours it instead of falling back to a single row — the fallback `layoutMatchesHeads` guard exists precisely because this fixture previously declared no heads.

Mode 5 is left alone: it has only colour preset and speed channels, so a head there would have nothing to drive.

Mode 3 keeps its four heads and mode 4 its eight, matching the four and eight zones those modes really address.

**Backwards compatibility.** The model name, all six mode names, and every channel and its order are unchanged, so existing projects keep resolving and keep their DMX behaviour. The `<Version>` is deliberately left at its original value: mode names carrying the word "mode" are grandfathered below 4.12.7, and renaming the modes to satisfy that rule would break the fixture reference in existing shows for no functional gain.

**Lumens.** 1000, and unlike the other fixtures in this batch it is an **estimate**: Pulse publish no photometric data for the LED BAR 320, and none appears in the manual. It is in the right band for a 36 W RGB bar and gives a sensible relative brightness against fixtures with real figures, but it should be treated as a placeholder rather than a measurement. Happy to drop it if you would rather the field stayed unset than carried an estimate.

## Source(s) of Information

- Pulse LEDBAR 320 User Manual — DMX profiles d-P1 to d-P6, specifications
  www.pulse-audio.co.uk/wp-content/uploads/LEDBAR320_UM.pdf
- Product page: www.pulse-audio.co.uk/product/ledbar-320/
