### PR TITLE
resources: add the Equinox Fusion 140 and 260ZR

### DIFF
--- a/resources/fixtures/Equinox/Equinox-Fusion-140.qxf
+++ b/resources/fixtures/Equinox/Equinox-Fusion-140.qxf
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.14.4</Version>
+  <Author>Matt Carter</Author>
+ </Creator>
+ <Manufacturer>Equinox</Manufacturer>
+ <Model>Fusion 140</Model>
+ <Type>Moving Head</Type>
+ <Channel Name="Pan" Default="127" Preset="PositionPan"/>
+ <Channel Name="Pan fine" Preset="PositionPanFine"/>
+ <Channel Name="Tilt" Default="127" Preset="PositionTilt"/>
+ <Channel Name="Tilt fine" Preset="PositionTiltFine"/>
+ <Channel Name="Pan/tilt speed" Preset="SpeedPanTiltSlowFast"/>
+ <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="9" Preset="ShutterOpen">No function</Capability>
+  <Capability Min="10" Max="255" Preset="StrobeSlowToFast">Strobe (slow-fast)</Capability>
+ </Channel>
+ <Channel Name="Red" Preset="IntensityRed"/>
+ <Channel Name="Green" Preset="IntensityGreen"/>
+ <Channel Name="Blue" Preset="IntensityBlue"/>
+ <Channel Name="White" Preset="IntensityWhite"/>
+ <Channel Name="Amber" Preset="IntensityAmber"/>
+ <Channel Name="UV" Preset="IntensityUV"/>
+ <Channel Name="Colour macros">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="38">Blackout</Capability>
+  <Capability Min="39" Max="44">Red</Capability>
+  <Capability Min="45" Max="50">Green</Capability>
+  <Capability Min="51" Max="56">Blue</Capability>
+  <Capability Min="57" Max="62">White</Capability>
+  <Capability Min="63" Max="68">Amber</Capability>
+  <Capability Min="69" Max="74">UV</Capability>
+  <Capability Min="75" Max="80">Yellow</Capability>
+  <Capability Min="81" Max="86">Magenta</Capability>
+  <Capability Min="87" Max="92">Pastel red</Capability>
+  <Capability Min="93" Max="98">Orange</Capability>
+  <Capability Min="99" Max="104">Hot pink</Capability>
+  <Capability Min="105" Max="110">Cyan</Capability>
+  <Capability Min="111" Max="116">Pastel green</Capability>
+  <Capability Min="117" Max="122">Lime green</Capability>
+  <Capability Min="123" Max="128">Mint green</Capability>
+  <Capability Min="129" Max="134">Pastel blue</Capability>
+  <Capability Min="135" Max="140">Violet</Capability>
+  <Capability Min="141" Max="146">Blue</Capability>
+  <Capability Min="147" Max="152">Pastel amber</Capability>
+  <Capability Min="153" Max="158">White</Capability>
+  <Capability Min="159" Max="164">Coral</Capability>
+  <Capability Min="165" Max="170">White (RGB)</Capability>
+  <Capability Min="171" Max="176">Pastel yellow</Capability>
+  <Capability Min="177" Max="182">Medium yellow</Capability>
+  <Capability Min="183" Max="188">Yellow green</Capability>
+  <Capability Min="189" Max="194">Lavender</Capability>
+  <Capability Min="195" Max="200">Pink</Capability>
+  <Capability Min="201" Max="206">Purple</Capability>
+  <Capability Min="207" Max="212">Rose pink</Capability>
+  <Capability Min="213" Max="218">Pastel pink</Capability>
+  <Capability Min="219" Max="224">Vibrant pink</Capability>
+  <Capability Min="225" Max="230">Sky blue</Capability>
+  <Capability Min="231" Max="236">Light cyan</Capability>
+  <Capability Min="237" Max="242">Medium blue</Capability>
+  <Capability Min="243" Max="248">Pale green</Capability>
+  <Capability Min="249" Max="255">Aqua</Capability>
+ </Channel>
+ <Channel Name="Show selection">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="6">No function</Capability>
+  <Capability Min="7" Max="37">Show 0</Capability>
+  <Capability Min="38" Max="68">Show 1</Capability>
+  <Capability Min="69" Max="99">Show 2</Capability>
+  <Capability Min="100" Max="130">Show 3</Capability>
+  <Capability Min="131" Max="161">Show 4</Capability>
+  <Capability Min="162" Max="192">Show 5</Capability>
+  <Capability Min="193" Max="223">Show 6</Capability>
+  <Capability Min="224" Max="255">Show 7 (forward facing show)</Capability>
+ </Channel>
+ <Channel Name="Sound sensitivity">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="9">No function</Capability>
+  <Capability Min="10" Max="255">Sound active (sensitivity low-high)</Capability>
+ </Channel>
+ <Channel Name="Sound sensitivity / motor reset">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="9">No function</Capability>
+  <Capability Min="10" Max="235">Sound active (sensitivity low-high)</Capability>
+  <Capability Min="236" Max="245">No function</Capability>
+  <Capability Min="246" Max="255">Motor reset (hold 5 seconds)</Capability>
+ </Channel>
+ <Mode Name="2 Channel">
+  <Channel Number="0">Show selection</Channel>
+  <Channel Number="1">Sound sensitivity</Channel>
+ </Mode>
+ <Mode Name="10 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Tilt</Channel>
+  <Channel Number="2">Master dimmer</Channel>
+  <Channel Number="3">Strobe</Channel>
+  <Channel Number="4">Red</Channel>
+  <Channel Number="5">Green</Channel>
+  <Channel Number="6">Blue</Channel>
+  <Channel Number="7">White</Channel>
+  <Channel Number="8">Amber</Channel>
+  <Channel Number="9">UV</Channel>
+ </Mode>
+ <Mode Name="16 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Pan fine</Channel>
+  <Channel Number="2">Tilt</Channel>
+  <Channel Number="3">Tilt fine</Channel>
+  <Channel Number="4">Pan/tilt speed</Channel>
+  <Channel Number="5">Master dimmer</Channel>
+  <Channel Number="6">Strobe</Channel>
+  <Channel Number="7">Red</Channel>
+  <Channel Number="8">Green</Channel>
+  <Channel Number="9">Blue</Channel>
+  <Channel Number="10">White</Channel>
+  <Channel Number="11">Amber</Channel>
+  <Channel Number="12">UV</Channel>
+  <Channel Number="13">Colour macros</Channel>
+  <Channel Number="14">Show selection</Channel>
+  <Channel Number="15">Sound sensitivity / motor reset</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="3400" ColourTemperature="0"/>
+  <Dimensions Weight="4.5" Width="310" Height="262" Depth="155"/>
+  <Lens Name="Other" DegreesMin="35" DegreesMax="35"/>
+  <Focus Type="Head" PanMax="540" TiltMax="180"/>
+  <Technical PowerConsumption="130" DmxConnector="3-pin"/>
+ </Physical>
+</FixtureDefinition>

--- a/resources/fixtures/Equinox/Equinox-Fusion-260ZR.qxf
+++ b/resources/fixtures/Equinox/Equinox-Fusion-260ZR.qxf
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.14.4</Version>
+  <Author>Matt Carter</Author>
+ </Creator>
+ <Manufacturer>Equinox</Manufacturer>
+ <Model>Fusion 260ZR</Model>
+ <Type>Moving Head</Type>
+ <Channel Name="Pan" Default="127" Preset="PositionPan"/>
+ <Channel Name="Pan fine" Preset="PositionPanFine"/>
+ <Channel Name="Tilt" Default="127" Preset="PositionTilt"/>
+ <Channel Name="Tilt fine" Preset="PositionTiltFine"/>
+ <Channel Name="Pan/tilt speed" Preset="SpeedPanTiltFastSlow"/>
+ <Channel Name="Zoom (narrow-wide)" Preset="BeamZoomSmallBig"/>
+ <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="15" Preset="ShutterOpen">No function</Capability>
+  <Capability Min="16" Max="254" Preset="StrobeSlowToFast">Strobe (slow-fast)</Capability>
+  <Capability Min="255" Max="255" Preset="ShutterOpen">No function</Capability>
+ </Channel>
+ <Channel Name="Red" Preset="IntensityRed"/>
+ <Channel Name="Green" Preset="IntensityGreen"/>
+ <Channel Name="Blue" Preset="IntensityBlue"/>
+ <Channel Name="White" Preset="IntensityWhite"/>
+ <Channel Name="Red circle 1" Preset="IntensityRed"/>
+ <Channel Name="Green circle 1" Preset="IntensityGreen"/>
+ <Channel Name="Blue circle 1" Preset="IntensityBlue"/>
+ <Channel Name="White circle 1" Preset="IntensityWhite"/>
+ <Channel Name="Red circle 2" Preset="IntensityRed"/>
+ <Channel Name="Green circle 2" Preset="IntensityGreen"/>
+ <Channel Name="Blue circle 2" Preset="IntensityBlue"/>
+ <Channel Name="White circle 2" Preset="IntensityWhite"/>
+ <Channel Name="Red circle 3" Preset="IntensityRed"/>
+ <Channel Name="Green circle 3" Preset="IntensityGreen"/>
+ <Channel Name="Blue circle 3" Preset="IntensityBlue"/>
+ <Channel Name="White circle 3" Preset="IntensityWhite"/>
+ <Channel Name="Show selection">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="15">No function</Capability>
+  <Capability Min="16" Max="75">Show 1</Capability>
+  <Capability Min="76" Max="135">Show 2</Capability>
+  <Capability Min="136" Max="195">Show 3 (single colours only)</Capability>
+  <Capability Min="196" Max="255">Show 4 (forward facing show)</Capability>
+ </Channel>
+ <Channel Name="Sound sensitivity">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="0">Blackout</Capability>
+  <Capability Min="1" Max="255">Sound sensitivity (low-high)</Capability>
+ </Channel>
+ <Channel Name="Colour macro programs">
+  <Group Byte="0">Colour</Group>
+  <Capability Min="0" Max="15">No function</Capability>
+  <Capability Min="16" Max="122">Colour macros</Capability>
+  <Capability Min="123" Max="181">Colour &amp; Zoom Program 1</Capability>
+  <Capability Min="182" Max="240">Colour &amp; Zoom Program 2</Capability>
+  <Capability Min="241" Max="255">Colour Change (Sound)</Capability>
+ </Channel>
+ <Channel Name="Colour program speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255" Preset="SlowToFast">Colour program speed (slow-fast)</Capability>
+ </Channel>
+ <Channel Name="Reset">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="127">No function</Capability>
+  <Capability Min="128" Max="255">Reset (hold for 5 seconds)</Capability>
+ </Channel>
+ <Mode Name="2 Channel">
+  <Channel Number="0">Show selection</Channel>
+  <Channel Number="1">Sound sensitivity</Channel>
+ </Mode>
+ <Mode Name="8 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Tilt</Channel>
+  <Channel Number="2">Zoom (narrow-wide)</Channel>
+  <Channel Number="3">Master dimmer</Channel>
+  <Channel Number="4">Red</Channel>
+  <Channel Number="5">Green</Channel>
+  <Channel Number="6">Blue</Channel>
+  <Channel Number="7">White</Channel>
+ </Mode>
+ <Mode Name="17 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Pan fine</Channel>
+  <Channel Number="2">Tilt</Channel>
+  <Channel Number="3">Tilt fine</Channel>
+  <Channel Number="4">Pan/tilt speed</Channel>
+  <Channel Number="5">Zoom (narrow-wide)</Channel>
+  <Channel Number="6">Master dimmer</Channel>
+  <Channel Number="7">Strobe</Channel>
+  <Channel Number="8">Red</Channel>
+  <Channel Number="9">Green</Channel>
+  <Channel Number="10">Blue</Channel>
+  <Channel Number="11">White</Channel>
+  <Channel Number="12">Show selection</Channel>
+  <Channel Number="13">Sound sensitivity</Channel>
+  <Channel Number="14">Colour macro programs</Channel>
+  <Channel Number="15">Colour program speed</Channel>
+  <Channel Number="16">Reset</Channel>
+ </Mode>
+ <Mode Name="25 Channel">
+  <Channel Number="0">Pan</Channel>
+  <Channel Number="1">Pan fine</Channel>
+  <Channel Number="2">Tilt</Channel>
+  <Channel Number="3">Tilt fine</Channel>
+  <Channel Number="4">Pan/tilt speed</Channel>
+  <Channel Number="5">Zoom (narrow-wide)</Channel>
+  <Channel Number="6">Master dimmer</Channel>
+  <Channel Number="7">Strobe</Channel>
+  <Channel Number="8">Red circle 1</Channel>
+  <Channel Number="9">Green circle 1</Channel>
+  <Channel Number="10">Blue circle 1</Channel>
+  <Channel Number="11">White circle 1</Channel>
+  <Channel Number="12">Red circle 2</Channel>
+  <Channel Number="13">Green circle 2</Channel>
+  <Channel Number="14">Blue circle 2</Channel>
+  <Channel Number="15">White circle 2</Channel>
+  <Channel Number="16">Red circle 3</Channel>
+  <Channel Number="17">Green circle 3</Channel>
+  <Channel Number="18">Blue circle 3</Channel>
+  <Channel Number="19">White circle 3</Channel>
+  <Channel Number="20">Show selection</Channel>
+  <Channel Number="21">Sound sensitivity</Channel>
+  <Channel Number="22">Colour macro programs</Channel>
+  <Channel Number="23">Colour program speed</Channel>
+  <Channel Number="24">Reset</Channel>
+  <Head>
+   <Channel>8</Channel>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+  </Head>
+  <Head>
+   <Channel>12</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+   <Channel>15</Channel>
+  </Head>
+  <Head>
+   <Channel>16</Channel>
+   <Channel>17</Channel>
+   <Channel>18</Channel>
+   <Channel>19</Channel>
+  </Head>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="14900" ColourTemperature="0"/>
+  <Dimensions Weight="9.7" Width="414" Height="324" Depth="221"/>
+  <Lens Name="Other" DegreesMin="6" DegreesMax="50"/>
+  <Focus Type="Head" PanMax="540" TiltMax="270"/>
+  <Layout Width="1" Height="3"/>
+  <Technical PowerConsumption="290" DmxConnector="3-pin"/>
+ </Physical>
+</FixtureDefinition>

--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -802,6 +802,7 @@
   <M n="Equinox">
     <F n="Equinox-Butterfly-Quad-EQLED100" m="Butterfly Quad EQLED100"/>
     <F n="Equinox-Domin8R-II" m="Domin8R II"/>
+    <F n="Equinox-Fusion-140" m="Fusion 140"/>
     <F n="Equinox-Fusion-50-Mkii" m="Fusion 50 MkII"/>
     <F n="Equinox-Fusion-Orbit-MKII" m="Fusion Orbit MKII"/>
     <F n="Equinox-Fusion-Spot-Max-MKIII" m="Fusion Spot Max MKIII"/>

--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -803,6 +803,7 @@
     <F n="Equinox-Butterfly-Quad-EQLED100" m="Butterfly Quad EQLED100"/>
     <F n="Equinox-Domin8R-II" m="Domin8R II"/>
     <F n="Equinox-Fusion-140" m="Fusion 140"/>
+    <F n="Equinox-Fusion-260ZR" m="Fusion 260ZR"/>
     <F n="Equinox-Fusion-50-Mkii" m="Fusion 50 MkII"/>
     <F n="Equinox-Fusion-Orbit-MKII" m="Fusion Orbit MKII"/>
     <F n="Equinox-Fusion-Spot-Max-MKIII" m="Fusion Spot Max MKIII"/>


### PR DESCRIPTION

## Fixture Information

**Manufacturer:** Equinox

**Model:** Fusion 140 and Fusion 260ZR — two moving head washes, one definition each

**Mode(s) included:**

- Fusion 140 — 2 Channel, 10 Channel, 16 Channel
- Fusion 260ZR — 2 Channel, 8 Channel, 17 Channel, 25 Channel

**Channels used:** as per the mode names. Pan and tilt are 16-bit in the Fusion 140's 16 channel mode and in the Fusion 260ZR's 17 and 25 channel modes (coarse plus fine pairs); all other channels are 8-bit.

## Testing

- [x] Physical data is included
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly

**Test cases and results**

| # | Case | Result |
|---|------|--------|
| 1 | `fixtures-tool.py --validate` on both definitions | Pass — 0 errors |
| 2 | Every mode's channel order checked against each manual's DMX chart | Pass |
| 3 | Fusion 140 colour macro ranges match the manual's 37-entry table | Pass |
| 4 | Fusion 140 physical block against the manual | Pass — 130 W, 310x262x155 mm, 4.5 kg, 35 degrees, pan 540, tilt 180, 3-pin |
| 5 | Fusion 260ZR physical block against the manual | Pass — 290 W, 414x324x221 mm, 9.7 kg, zoom 6-50 degrees, pan 540, tilt 270, 3-pin |
| 6 | Both definitions load in QLC+ 5 | Pass — no cache or capability warnings |
| 7 | 2D view head geometry | Pass — Fusion 140 single head, Fusion 260ZR three heads, one per LED circle |
| 8 | `FixturesMap.xml` regeneration is idempotent after both additions | Pass — no drift |
| 9 | Tested on real fixture hardware - core capabilities only | Works |

Software tests on Linux, Qt 6.11.2.

## Source(s) of Information

- Fusion 140 User Manual (order code EQLED074) — DMX charts, specifications
  www.prolight.co.uk/product_manual/Fusion%20140_Manual.pdf
- Fusion 260ZR User Manual (order code EQLED024) — DMX charts, specifications
  www.prolight.co.uk/product_manual/Fusion%20260ZR_Manual.pdf

## Notes

Two fixtures in one PR because each adds a line to the `Equinox` block of `FixturesMap.xml` at the same position, so as separate PRs the second to be merged would conflict. They are otherwise independent: one commit per fixture, and the definitions do not interact.

### Fusion 140

A 7 x 18 W RGBWAUV moving head wash with a fixed 35 degree beam.

**Lumens.** 3400, from the manual's 2930 lux at 2 m over the 35 degree beam: `flux = lux * distance^2 * 2*pi*(1 - cos(beam / 2))`. The figure is for the whole fixture; the 3D view divides it between the heads it draws.

**Dimmer and strobe are separate channels.** The manual puts a plain 0–100% master dimmer on CH6 (CH3 in the 10 channel mode) and strobe on CH7 (CH4), with 0–9 inactive, and the definition follows it.

**Pan/tilt speed direction.** The manual gives no direction for the pan/tilt speed channel, so `SpeedPanTiltSlowFast` is assumed. The 260ZR manual documents its equivalent channel as fast-slow, so this may want inverting if anyone can confirm against hardware.

**Colour macro names** are the manual's own labels, verbatim — which means "Blue" and "White" each appear twice, at different DMX ranges. Disambiguating them would mean inventing names the manual does not use.

### Fusion 260ZR

A 19 x 12 W RGBW moving head wash with a 6–50 degree motorised zoom.

**Heads.** The LEDs sit in three concentric circles and the 25 channel mode addresses each circle's RGBW separately, so that mode declares a head per circle, each holding only its four colour channels. The 8 and 17 channel modes drive all the LEDs together and declare no head.

**Lumens.** 14900, from the manual's 6316 lux at 2 m at the 50 degree end of the zoom, by the same formula. The wide end is used deliberately — the manual's 6° figure of 40098 lux at 2 m works out to roughly 1380 lm, an order of magnitude lower, because a narrow-beam lux reading measures the hot spot rather than total output.

**Channel details taken from the manual rather than assumed.** Sound sensitivity has DMX 0 as blackout and 1–255 as the sensitivity ramp. Strobe is inactive at 0–15 and again at 255, so it is a custom channel rather than the `ShutterStrobeSlowFast` preset. Pan/tilt speed is documented as fast-slow. Reset is 0–127 inactive, 128–255 reset on a five second hold.
