### PR TITLE
resources: add the Ledj Stage Par CZ200 3200K

### DIFF
--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -1236,6 +1236,7 @@
     <F n="Ledj-Slimline-9Q8" m="Slimline 9Q8"/>
     <F n="Ledj-Stage-Color-24" m="Stage Color 24"/>
     <F n="Ledj-Stage-Color-Quad" m="Stage Color Quad"/>
+    <F n="Ledj-Stage-Par-CZ200-3200K" m="Stage Par CZ200 3200K"/>
     <F n="Ledj-Tri-LED-back-drop-controller" m="Pro Tri LED back drop controller"/>
   </M>
   <M n="LedProLight">

--- a/resources/fixtures/Ledj/Ledj-Stage-Par-CZ200-3200K.qxf
+++ b/resources/fixtures/Ledj/Ledj-Stage-Par-CZ200-3200K.qxf
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.14.4</Version>
+  <Author>Matt Carter</Author>
+ </Creator>
+ <Manufacturer>Ledj</Manufacturer>
+ <Model>Stage Par CZ200 3200K</Model>
+ <Type>Color Changer</Type>
+ <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Zoom" Preset="BeamZoomSmallBig"/>
+ <Channel Name="Strobe" Default="255">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="31">No function</Capability>
+  <Capability Min="32" Max="63" Preset="ShutterOpen">Open</Capability>
+  <Capability Min="64" Max="95" Preset="StrobeSlowToFast">Strobe (slow-fast)</Capability>
+  <Capability Min="96" Max="127" Preset="ShutterOpen">Open</Capability>
+  <Capability Min="128" Max="159" Preset="PulseSlowToFast">Pulse strobe (slow-fast)</Capability>
+  <Capability Min="160" Max="191" Preset="ShutterOpen">Open</Capability>
+  <Capability Min="192" Max="223" Preset="StrobeRandomSlowToFast">Random strobe (slow-fast)</Capability>
+  <Capability Min="224" Max="255" Preset="ShutterOpen">Open</Capability>
+ </Channel>
+ <Channel Name="Zoom speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255" Preset="FastToSlow">Zoom speed (fast-slow)</Capability>
+ </Channel>
+ <Channel Name="Dimmer curve">
+  <Group Byte="0">Maintenance</Group>
+  <Capability Min="0" Max="50">Default (set on unit)</Capability>
+  <Capability Min="51" Max="100">Linear</Capability>
+  <Capability Min="101" Max="150">Square</Capability>
+  <Capability Min="151" Max="200">Inverse Square</Capability>
+  <Capability Min="201" Max="240">S-Curve</Capability>
+  <Capability Min="241" Max="250">No function</Capability>
+  <Capability Min="251" Max="255">Reset (hold 5 seconds)</Capability>
+ </Channel>
+ <Mode Name="2 channel">
+  <Channel Number="0">Master dimmer</Channel>
+  <Channel Number="1">Zoom</Channel>
+ </Mode>
+ <Mode Name="3 channel">
+  <Channel Number="0">Master dimmer</Channel>
+  <Channel Number="1">Zoom</Channel>
+  <Channel Number="2">Strobe</Channel>
+ </Mode>
+ <Mode Name="5 channel">
+  <Channel Number="0">Master dimmer</Channel>
+  <Channel Number="1">Zoom</Channel>
+  <Channel Number="2">Zoom speed</Channel>
+  <Channel Number="3">Strobe</Channel>
+  <Channel Number="4">Dimmer curve</Channel>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="13800" ColourTemperature="3200"/>
+  <Dimensions Weight="4.3" Width="275" Height="370" Depth="390"/>
+  <Lens Name="Other" DegreesMin="13" DegreesMax="50"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Technical PowerConsumption="205" DmxConnector="5-pin"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION

## Fixture Information

**Manufacturer:** Ledj

**Model:** Stage Par CZ200 3200K

**Mode(s) included:** 2 channel, 3 channel, 5 channel

**Channels used:** 2, 3 and 5 respectively. All channels are 8-bit.

## Testing

- [x] Physical data is included
- [x] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php)
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly

**Test cases and results**

| # | Case | Result |
|---|------|--------|
| 1 | `fixtures-tool.py --validate` on the definition | Pass — 0 errors |
| 2 | Every mode's channel order checked against the manual's DMX chart | Pass |
| 3 | Strobe and dimmer curve capability bands match the manual | Pass |
| 4 | Physical block against the manual's specifications | Pass — 205 W, 370x275x390 mm, 4.3 kg, zoom 13-50 degrees, 5-pin |
| 5 | Definition loads in QLC+ 5 | Pass — no cache or capability warnings |
| 6 | Tested on real fixture hardware - core capabilities only | Works |

Tested on Linux, Qt 6.11.2.

## Source(s) of Information

- Stage Par CZ200 3200K User Manual (order code LEDJ193) — DMX charts, specifications

## Notes

A 200 W warm white COB par with a 13–50 degree motorised zoom. There is no colour mixing: the only intensity control is the master dimmer, so the definition has no colour channels.

**Lumens.** 13800, from the manual's 5877 lux at 2 m at the 50 degree end of the zoom: `flux = lux * distance^2 * 2*pi*(1 - cos(beam / 2))`. As with other zoom fixtures the wide end is used, since the manual's 13° figure of 39362 lux at 2 m measures the hot spot rather than total output. Colour temperature is set to 3200 K, which is what distinguishes this model from the Dual White variant and is part of the model name.

**Fixture type.** `Color Changer`, matching how the library types other single-colour pars. `Dimmer` would arguably be more literal for a fixture with no colour mixing, but both render the same PAR mesh and `Color Changer` is the established convention here. Happy to switch it if you prefer.
