### PR TITLE
qmlui: bug: keep the 3D view and custom items list selections in sync

### DIFF
--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -95,6 +95,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_gBuffer(nullptr)
     , m_latestGenericID(0)
     , m_initRetryCount(0)
+    , m_genericPreviousIndex(-1)
     , m_position3DMarker(QVector3D())
     , m_position3DMarkerVisible(false)
     , m_markerEntity(nullptr)
@@ -265,6 +266,8 @@ void MainView3D::resetItems()
     }
     m_genericMap.clear();
     m_genericItemsList->clear();
+    m_genericSelectedItems.clear();
+    m_genericPreviousIndex = -1;
     m_latestGenericID = 0;
     m_createItemCount = 0;
 
@@ -2184,6 +2187,7 @@ void MainView3D::setItemSelection(int itemID, bool enable, int keyModifiers)
                 meshRef->m_rootItem->setProperty("isSelected", false);
                 meshRef->m_selectionBox->setProperty("isSelected", false);
             }
+            updateGenericItemSelection(id, false);
         }
         m_genericSelectedItems.clear();
         emit genericSelectedCountChanged();
@@ -2197,10 +2201,21 @@ void MainView3D::setItemSelection(int itemID, bool enable, int keyModifiers)
         meshRef->m_selectionBox->setProperty("isSelected", enable);
     }
 
+    // an item already selected must not be added a second time: the number of
+    // selected items is what tells a single selection from a multiple one, and
+    // a duplicate makes a single item look like two, hiding the properties
+    // that only apply to one item
     if (enable)
-        m_genericSelectedItems.append(itemID);
+    {
+        if (m_genericSelectedItems.contains(itemID) == false)
+            m_genericSelectedItems.append(itemID);
+    }
     else
+    {
         m_genericSelectedItems.removeAll(itemID);
+    }
+
+    updateGenericItemSelection(itemID, enable);
 
     emit genericSelectedCountChanged();
     emit genericSelectedLockedChanged();
@@ -2212,7 +2227,22 @@ void MainView3D::setItemSelectionByIndex(int index, bool enable, int keyModifier
     if (index < 0 || index >= ids.count())
         return;
 
+    // Shift extends the selection from the row clicked last to this one,
+    // adding every row in between to whatever is selected already
+    if ((keyModifiers & Qt::ShiftModifier) && m_genericPreviousIndex >= 0 &&
+        m_genericPreviousIndex < ids.count())
+    {
+        int first = qMin(index, m_genericPreviousIndex);
+        int last = qMax(index, m_genericPreviousIndex);
+
+        for (int i = first; i <= last; i++)
+            setItemSelection(ids.at(i), true, Qt::ShiftModifier);
+
+        return;
+    }
+
     setItemSelection(ids.at(index), enable, keyModifiers);
+    m_genericPreviousIndex = index;
 }
 
 int MainView3D::genericSelectedCount() const
@@ -2277,6 +2307,7 @@ void MainView3D::removeSelectedGenericItems()
         m_monProps->removeItem(id);
     }
     m_genericSelectedItems.clear();
+    m_genericPreviousIndex = -1;
     emit genericSelectedCountChanged();
     updateGenericItemsList();
 }
@@ -2320,12 +2351,20 @@ void MainView3D::updateGenericItemsList()
         QVariantMap itemMap;
         itemMap.insert("itemID", itemID);
         itemMap.insert("name", m_monProps->itemName(itemID));
-        itemMap.insert("isSelected", false);
+        itemMap.insert("isSelected", m_genericSelectedItems.contains(itemID));
         itemMap.insert("isLocked", (m_monProps->itemFlags(itemID) & MonitorProperties::LockedFlag) ? true : false);
         m_genericItemsList->addDataMap(itemMap);
     }
 
     emit genericItemsListChanged();
+}
+
+void MainView3D::updateGenericItemSelection(quint32 itemID, bool enable)
+{
+    int index = m_monProps->genericItemsID().indexOf(itemID);
+    if (index >= 0)
+        m_genericItemsList->setDataWithRole(m_genericItemsList->index(index, 0),
+                                            "isSelected", enable);
 }
 
 QVariant MainView3D::genericItemsList() const

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -370,9 +370,9 @@ public:
 
     Q_INVOKABLE void setItemSelection(int itemID, bool enable, int keyModifiers);
 
-    /** Select/deselect a generic item by its row $index in the items list model.
-     *  Used to keep the 3D selection in sync with multi-row (range) selections
-     *  performed on the QML list */
+    /** Select/deselect the generic item on row $index of the items list model.
+     *  $keyModifiers has the same meaning as in setItemSelection, plus Shift,
+     *  which extends the selection from the row clicked last to $index */
     Q_INVOKABLE void setItemSelectionByIndex(int index, bool enable, int keyModifiers);
 
     /** Get the number of generic items currently selected */
@@ -419,6 +419,11 @@ public:
 protected:
     void updateGenericItemsList();
 
+    /** Mark the row of item $itemID in the items list model as selected or not.
+     *  The 3D view and the list in the settings panel are two views of the same
+     *  selection, so a click in either one has to be reflected in the other */
+    void updateGenericItemSelection(quint32 itemID, bool enable);
+
 signals:
     void genericItemsListChanged();
     void genericSelectedCountChanged();
@@ -438,6 +443,9 @@ private:
     ListModel *m_genericItemsList;
 
     QList<int> m_genericSelectedItems;
+
+    /** Row of the generic item clicked last, for Shift range selections */
+    int m_genericPreviousIndex;
 
     /** Map of the generic items in the scene */
     QMap<quint32, SceneItem*> m_genericMap;

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -97,20 +97,6 @@ Rectangle
         isUpdating = false
     }
 
-    ModelSelector
-    {
-        id: giSelector
-        onItemsCountChanged: { }
-
-        // keep the 3D view selection in sync with the list selection,
-        // including multi-row (range) selections. Use ControlModifier so
-        // each row is added/removed without clearing the others
-        onItemSelectionChanged: (itemIndex, selected) =>
-        {
-            View3D.setItemSelectionByIndex(itemIndex, selected, Qt.ControlModifier)
-        }
-    }
-
     // catch wheel events over the whole panel so they don't
     // fall through to the 3D view behind and zoom it in/out.
     // This sits below the Flickable, which consumes its own wheel
@@ -759,9 +745,13 @@ Rectangle
                                             anchors.fill: parent
                                             onClicked: (mouse) =>
                                             {
-                                                // giSelector.onItemSelectionChanged keeps the
-                                                // 3D view selection in sync (see above)
-                                                giSelector.selectItem(index, itemsList.model, mouse.modifiers)
+                                                // the 3D view owns the selection and highlights the
+                                                // rows of the items it holds, so a click here and a
+                                                // click on the mesh itself cannot drift apart.
+                                                // A plain click selects this item alone, Ctrl adds
+                                                // or removes it and Shift extends the selection
+                                                var select = (mouse.modifiers & Qt.ControlModifier) ? !isSelected : true
+                                                View3D.setItemSelectionByIndex(index, select, mouse.modifiers)
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Description

**Summary of Changes:**

The 3D view and the Custom items list in the settings panel kept two separate selections, so a click in one could leave an item selected twice and hide the properties that only apply to a single item. `MainView3D` now owns the selection alone and drives the list model's `isSelected` role, and the list forwards the key modifiers it was actually given.

**Related Issues:**

- No dependencies
- A follow-up branch of mine (PR #2128) adds an editable name and a base colour to custom items and depends on this fix — those fields blank out under the same duplicate selection.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

No documentation change necessary.

## Testing

**Test Cases:**

Run against a project holding five custom items, with the Custom items section of the 3D view settings panel open.

1. Select an item's row in the list, click a different item's mesh in the 3D view, then click that second item's row.
2. Click an item's mesh in the 3D view and check which row is highlighted.
3. Plain click a row while another item is selected.
4. Ctrl+click a second row, then Ctrl+click it again.
5. Shift+click a row away from the last one clicked.
6. Select several items and toggle the lock button.
7. Select items, then load another project.

**Test Results:**

| # | Case | Expected | Result |
|---|---|---|---|
| 1 | 3D click then row click | Position/Rotation/Scale keep showing the item's own values | Pass — stays 2407/0/270mm; reads 0/0/0mm before the fix |
| 2 | 3D view click | The item's row is highlighted, the previous one is not | Pass — no row was highlighted before the fix |
| 3 | Plain row click | Replaces the selection | Pass |
| 4 | Ctrl+click twice | Adds the item, then removes it | Pass |
| 5 | Shift+click | Extends the selection over the rows in between | Pass |
| 6 | Lock toggle | Rows stay highlighted | Pass — every highlight was cleared before the fix |
| 7 | Load another project | Nothing is selected | Pass |

Tested on Linux (Debian, Qt 6.11.2) in a nested X server, on the project used to find the problem.

## Additional Notes

The two selections were `MainView3D::m_genericSelectedItems` and a `ModelSelector` private to `SettingsView3D.qml`. A click on a mesh in the 3D view went only to the first, so the `ModelSelector` kept pointing at whatever had been clicked in the list before. Its `resetSelection` then deselected rows that were not the selected ones, leaving the real item in place, and the row click added it a second time: the list forwarded every click with a hard-coded `Qt.ControlModifier`, so `setItemSelection`'s branch that replaces the selection never ran for it. With the same item twice in the list, `genericSelectedCount` reported 2 and `genericItemsPosition`, `genericItemsRotation` and `genericItemsScale` all fell through their `count() == 1` guard to a zero placeholder, so the panel showed 0mm for an item sitting elsewhere in the scene.

The `ModelSelector` has been dropped rather than synchronised, since one owner is what stops the two from drifting apart again. The row delegate now calls `View3D.setItemSelectionByIndex` directly with `mouse.modifiers`, and the range selection it used to provide is tracked by `m_genericPreviousIndex` in `MainView3D`. Selection semantics are unchanged from what the `ModelSelector` gave: a plain click selects one item, Ctrl adds or removes one, Shift extends from the row clicked last.

Two smaller consequences of the same single owner: `updateGenericItemsList` now writes the real selection state into each row instead of `false`, so rebuilding the model no longer clears the highlights (the lock button did this on every press), and `resetItems` clears the selection along with the items it refers to.
