### PR TITLE
engine/qmlui: render the 3D view photometrically, behind an experimental "Lumens" setting

### DIFF
--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -55,6 +55,7 @@
 #define KXMLQLCMonitorRenderQuality     QStringLiteral("Quality")
 #define KXMLQLCMonitorRenderAmbient     QStringLiteral("Ambient")
 #define KXMLQLCMonitorRenderSmoke       QStringLiteral("Smoke")
+#define KXMLQLCMonitorRenderFxLight     QStringLiteral("FixtureLight")
 #define KXMLQLCMonitorRenderShowFPS     QStringLiteral("ShowFPS")
 #define KXMLQLCMonitorItemName      QStringLiteral("Name")
 #define KXMLQLCMonitorItemRes       QStringLiteral("Res")
@@ -91,6 +92,8 @@
 #define RENDER_DEFAULT_QUALITY  2
 #define RENDER_DEFAULT_AMBIENT  0.6
 #define RENDER_DEFAULT_SMOKE    0.8
+/* Unscaled: a project that has never touched this renders exactly as before */
+#define RENDER_DEFAULT_FXLIGHT  1.0
 
 MonitorProperties::MonitorProperties()
     : m_font(QFont("Arial", 12))
@@ -104,6 +107,7 @@ MonitorProperties::MonitorProperties()
     , m_renderQuality(RENDER_DEFAULT_QUALITY)
     , m_ambientLightIntensity(RENDER_DEFAULT_AMBIENT)
     , m_smokeAmount(RENDER_DEFAULT_SMOKE)
+    , m_fixtureLightIntensity(RENDER_DEFAULT_FXLIGHT)
     , m_showFPS(false)
     , m_showLabels(false)
 {
@@ -119,6 +123,7 @@ void MonitorProperties::reset()
     m_renderQuality = RENDER_DEFAULT_QUALITY;
     m_ambientLightIntensity = RENDER_DEFAULT_AMBIENT;
     m_smokeAmount = RENDER_DEFAULT_SMOKE;
+    m_fixtureLightIntensity = RENDER_DEFAULT_FXLIGHT;
     m_showFPS = false;
     m_fixtureItems.clear();
     m_lightItems.clear();
@@ -729,6 +734,8 @@ bool MonitorProperties::loadXML(QXmlStreamReader &root, const Doc *mainDocument)
                 setAmbientLightIntensity(tAttrs.value(KXMLQLCMonitorRenderAmbient).toString().toDouble());
             if (tAttrs.hasAttribute(KXMLQLCMonitorRenderSmoke))
                 setSmokeAmount(tAttrs.value(KXMLQLCMonitorRenderSmoke).toString().toDouble());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderFxLight))
+                setFixtureLightIntensity(tAttrs.value(KXMLQLCMonitorRenderFxLight).toString().toDouble());
             if (tAttrs.hasAttribute(KXMLQLCMonitorRenderShowFPS))
                 setShowFPS(tAttrs.value(KXMLQLCMonitorRenderShowFPS).toString().toInt() != 0);
             root.skipCurrentElement();
@@ -954,6 +961,7 @@ bool MonitorProperties::saveXML(QXmlStreamWriter *doc, const Doc *mainDocument) 
     doc->writeAttribute(KXMLQLCMonitorRenderQuality, QString::number(renderQuality()));
     doc->writeAttribute(KXMLQLCMonitorRenderAmbient, QString::number(ambientLightIntensity()));
     doc->writeAttribute(KXMLQLCMonitorRenderSmoke, QString::number(smokeAmount()));
+    doc->writeAttribute(KXMLQLCMonitorRenderFxLight, QString::number(fixtureLightIntensity()));
     doc->writeAttribute(KXMLQLCMonitorRenderShowFPS, QString::number(showFPS() ? 1 : 0));
     doc->writeEndElement();
 #endif

--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -50,6 +50,12 @@
 #define KXMLQLCMonitorLightEmitter  QStringLiteral("LightEmitter")
 #define KXMLQLCMonitorStageItem     QStringLiteral("StageItem")
 #define KXMLQLCMonitorMeshItem      QStringLiteral("MeshItem")
+
+#define KXMLQLCMonitorRendering         QStringLiteral("Rendering")
+#define KXMLQLCMonitorRenderQuality     QStringLiteral("Quality")
+#define KXMLQLCMonitorRenderAmbient     QStringLiteral("Ambient")
+#define KXMLQLCMonitorRenderSmoke       QStringLiteral("Smoke")
+#define KXMLQLCMonitorRenderShowFPS     QStringLiteral("ShowFPS")
 #define KXMLQLCMonitorItemName      QStringLiteral("Name")
 #define KXMLQLCMonitorItemRes       QStringLiteral("Res")
 
@@ -79,6 +85,13 @@
 #define GRID_DEFAULT_HEIGHT 3
 #define GRID_DEFAULT_DEPTH  5
 
+/* 3D view rendering defaults. RENDER_DEFAULT_QUALITY matches
+   MainView3D::HighQuality and the other two match the MainView3D members
+   they replace, so a project without a <Rendering> node looks unchanged. */
+#define RENDER_DEFAULT_QUALITY  2
+#define RENDER_DEFAULT_AMBIENT  0.6
+#define RENDER_DEFAULT_SMOKE    0.8
+
 MonitorProperties::MonitorProperties()
     : m_font(QFont("Arial", 12))
     , m_displayMode(DMX)
@@ -88,6 +101,10 @@ MonitorProperties::MonitorProperties()
     , m_gridUnits(Meters)
     , m_pointOfView(Undefined)
     , m_stageType(StageSimple)
+    , m_renderQuality(RENDER_DEFAULT_QUALITY)
+    , m_ambientLightIntensity(RENDER_DEFAULT_AMBIENT)
+    , m_smokeAmount(RENDER_DEFAULT_SMOKE)
+    , m_showFPS(false)
     , m_showLabels(false)
 {
 }
@@ -99,6 +116,10 @@ void MonitorProperties::reset()
     m_pointOfView = Undefined;
     m_stageType = StageSimple;
     m_showLabels = false;
+    m_renderQuality = RENDER_DEFAULT_QUALITY;
+    m_ambientLightIntensity = RENDER_DEFAULT_AMBIENT;
+    m_smokeAmount = RENDER_DEFAULT_SMOKE;
+    m_showFPS = false;
     m_fixtureItems.clear();
     m_lightItems.clear();
     m_genericItems.clear();
@@ -700,6 +721,18 @@ bool MonitorProperties::loadXML(QXmlStreamReader &root, const Doc *mainDocument)
             setGridSize(QVector3D(w, h, d));
             root.skipCurrentElement();
         }
+        else if (root.name() == KXMLQLCMonitorRendering)
+        {
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderQuality))
+                setRenderQuality(tAttrs.value(KXMLQLCMonitorRenderQuality).toString().toInt());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderAmbient))
+                setAmbientLightIntensity(tAttrs.value(KXMLQLCMonitorRenderAmbient).toString().toDouble());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderSmoke))
+                setSmokeAmount(tAttrs.value(KXMLQLCMonitorRenderSmoke).toString().toDouble());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderShowFPS))
+                setShowFPS(tAttrs.value(KXMLQLCMonitorRenderShowFPS).toString().toInt() != 0);
+            root.skipCurrentElement();
+        }
         else if (root.name() == KXMLQLCMonitorStageItem)
         {
             setStageType(StageType(root.readElementText().toInt()));
@@ -915,6 +948,14 @@ bool MonitorProperties::saveXML(QXmlStreamWriter *doc, const Doc *mainDocument) 
 
 #ifdef QMLUI
     doc->writeTextElement(KXMLQLCMonitorStageItem, QString::number(stageType()));
+
+    /* 3D view rendering settings */
+    doc->writeStartElement(KXMLQLCMonitorRendering);
+    doc->writeAttribute(KXMLQLCMonitorRenderQuality, QString::number(renderQuality()));
+    doc->writeAttribute(KXMLQLCMonitorRenderAmbient, QString::number(ambientLightIntensity()));
+    doc->writeAttribute(KXMLQLCMonitorRenderSmoke, QString::number(smokeAmount()));
+    doc->writeAttribute(KXMLQLCMonitorRenderShowFPS, QString::number(showFPS() ? 1 : 0));
+    doc->writeEndElement();
 #endif
 
     // ***********************************************************

--- a/engine/src/monitorproperties.cpp
+++ b/engine/src/monitorproperties.cpp
@@ -56,6 +56,7 @@
 #define KXMLQLCMonitorRenderAmbient     QStringLiteral("Ambient")
 #define KXMLQLCMonitorRenderSmoke       QStringLiteral("Smoke")
 #define KXMLQLCMonitorRenderFxLight     QStringLiteral("FixtureLight")
+#define KXMLQLCMonitorRenderLumens      QStringLiteral("Lumens")
 #define KXMLQLCMonitorRenderShowFPS     QStringLiteral("ShowFPS")
 #define KXMLQLCMonitorItemName      QStringLiteral("Name")
 #define KXMLQLCMonitorItemRes       QStringLiteral("Res")
@@ -94,6 +95,8 @@
 #define RENDER_DEFAULT_SMOKE    0.8
 /* Unscaled: a project that has never touched this renders exactly as before */
 #define RENDER_DEFAULT_FXLIGHT  1.0
+/* Off: every fixture emits the same amount of light, as it always has */
+#define RENDER_DEFAULT_LUMENS   false
 
 MonitorProperties::MonitorProperties()
     : m_font(QFont("Arial", 12))
@@ -108,6 +111,7 @@ MonitorProperties::MonitorProperties()
     , m_ambientLightIntensity(RENDER_DEFAULT_AMBIENT)
     , m_smokeAmount(RENDER_DEFAULT_SMOKE)
     , m_fixtureLightIntensity(RENDER_DEFAULT_FXLIGHT)
+    , m_useFixtureLumens(RENDER_DEFAULT_LUMENS)
     , m_showFPS(false)
     , m_showLabels(false)
 {
@@ -124,6 +128,7 @@ void MonitorProperties::reset()
     m_ambientLightIntensity = RENDER_DEFAULT_AMBIENT;
     m_smokeAmount = RENDER_DEFAULT_SMOKE;
     m_fixtureLightIntensity = RENDER_DEFAULT_FXLIGHT;
+    m_useFixtureLumens = RENDER_DEFAULT_LUMENS;
     m_showFPS = false;
     m_fixtureItems.clear();
     m_lightItems.clear();
@@ -736,6 +741,8 @@ bool MonitorProperties::loadXML(QXmlStreamReader &root, const Doc *mainDocument)
                 setSmokeAmount(tAttrs.value(KXMLQLCMonitorRenderSmoke).toString().toDouble());
             if (tAttrs.hasAttribute(KXMLQLCMonitorRenderFxLight))
                 setFixtureLightIntensity(tAttrs.value(KXMLQLCMonitorRenderFxLight).toString().toDouble());
+            if (tAttrs.hasAttribute(KXMLQLCMonitorRenderLumens))
+                setUseFixtureLumens(tAttrs.value(KXMLQLCMonitorRenderLumens).toString().toInt() != 0);
             if (tAttrs.hasAttribute(KXMLQLCMonitorRenderShowFPS))
                 setShowFPS(tAttrs.value(KXMLQLCMonitorRenderShowFPS).toString().toInt() != 0);
             root.skipCurrentElement();
@@ -962,6 +969,7 @@ bool MonitorProperties::saveXML(QXmlStreamWriter *doc, const Doc *mainDocument) 
     doc->writeAttribute(KXMLQLCMonitorRenderAmbient, QString::number(ambientLightIntensity()));
     doc->writeAttribute(KXMLQLCMonitorRenderSmoke, QString::number(smokeAmount()));
     doc->writeAttribute(KXMLQLCMonitorRenderFxLight, QString::number(fixtureLightIntensity()));
+    doc->writeAttribute(KXMLQLCMonitorRenderLumens, QString::number(useFixtureLumens() ? 1 : 0));
     doc->writeAttribute(KXMLQLCMonitorRenderShowFPS, QString::number(showFPS() ? 1 : 0));
     doc->writeEndElement();
 #endif

--- a/engine/src/monitorproperties.h
+++ b/engine/src/monitorproperties.h
@@ -162,12 +162,18 @@ public:
     inline void setFixtureLightIntensity(qreal intensity) { m_fixtureLightIntensity = intensity; }
     inline qreal fixtureLightIntensity() const { return m_fixtureLightIntensity; }
 
-    /** Get/Set whether the 3D view scales each fixture's light by the "Lumens"
-     *  physical property of its mode, so that a rig of mixed fixtures shows the
-     *  relative output of its members instead of every fixture emitting the
-     *  same amount of light. Off by default: most fixture definitions leave
-     *  Lumens unset, and a project that has never enabled it must render
-     *  exactly as it always has. */
+    /** Get/Set whether the 3D view renders each fixture photometrically: its
+     *  light scaled by the "Lumens" physical property of its mode, so a rig of
+     *  mixed fixtures shows the relative output of its members instead of every
+     *  fixture emitting the same amount of light, and falling off with the
+     *  square of the distance it travels. Off by default: most fixture
+     *  definitions leave Lumens unset, and a project that has never enabled it
+     *  must render exactly as it always has.
+     *
+     *  The feature is still experimental and is labelled as such in the UI. It
+     *  depends on fixture definitions carrying sensible Lumens and lens angle
+     *  figures, and the reference distance it derives does not yet suit rigs
+     *  that mix hung fixtures with floor standing ones. */
     inline void setUseFixtureLumens(bool use) { m_useFixtureLumens = use; }
     inline bool useFixtureLumens() const { return m_useFixtureLumens; }
 

--- a/engine/src/monitorproperties.h
+++ b/engine/src/monitorproperties.h
@@ -153,6 +153,15 @@ public:
     inline void setSmokeAmount(qreal amount) { m_smokeAmount = amount; }
     inline qreal smokeAmount() const { return m_smokeAmount; }
 
+    /** Get/Set the 3D view fixture light intensity: a global multiplier on the
+     *  light fixtures cast on surfaces (1.0 = unscaled). Ambient light governs
+     *  how bright the set is on its own, so this is what sets the balance
+     *  between the two when a rig has enough fixtures to wash the stage out.
+     *  The volumetric beams in the air are not affected: those are already
+     *  scaled by the smoke amount. */
+    inline void setFixtureLightIntensity(qreal intensity) { m_fixtureLightIntensity = intensity; }
+    inline qreal fixtureLightIntensity() const { return m_fixtureLightIntensity; }
+
     /** Get/Set whether the 3D view FPS counter overlay is shown */
     inline void setShowFPS(bool show) { m_showFPS = show; }
     inline bool showFPS() const { return m_showFPS; }
@@ -161,6 +170,7 @@ private:
     int m_renderQuality;
     qreal m_ambientLightIntensity;
     qreal m_smokeAmount;
+    qreal m_fixtureLightIntensity;
     bool m_showFPS;
 
     /********************************************************************

--- a/engine/src/monitorproperties.h
+++ b/engine/src/monitorproperties.h
@@ -137,6 +137,33 @@ private:
     StageType m_stageType;
 
     /********************************************************************
+     * 3D View rendering
+     ********************************************************************/
+public:
+    /** Get/Set the 3D view render quality. The value matches the
+     *  MainView3D::RenderQuality enum (0 = Low ... 3 = Ultra) */
+    inline void setRenderQuality(int quality) { m_renderQuality = quality; }
+    inline int renderQuality() const { return m_renderQuality; }
+
+    /** Get/Set the 3D view ambient light intensity (0.0 - 1.0) */
+    inline void setAmbientLightIntensity(qreal intensity) { m_ambientLightIntensity = intensity; }
+    inline qreal ambientLightIntensity() const { return m_ambientLightIntensity; }
+
+    /** Get/Set the 3D view smoke/haze amount (0.0 - 1.0) */
+    inline void setSmokeAmount(qreal amount) { m_smokeAmount = amount; }
+    inline qreal smokeAmount() const { return m_smokeAmount; }
+
+    /** Get/Set whether the 3D view FPS counter overlay is shown */
+    inline void setShowFPS(bool show) { m_showFPS = show; }
+    inline bool showFPS() const { return m_showFPS; }
+
+private:
+    int m_renderQuality;
+    qreal m_ambientLightIntensity;
+    qreal m_smokeAmount;
+    bool m_showFPS;
+
+    /********************************************************************
      * Items flags
      ********************************************************************/
 public:

--- a/engine/src/monitorproperties.h
+++ b/engine/src/monitorproperties.h
@@ -162,6 +162,15 @@ public:
     inline void setFixtureLightIntensity(qreal intensity) { m_fixtureLightIntensity = intensity; }
     inline qreal fixtureLightIntensity() const { return m_fixtureLightIntensity; }
 
+    /** Get/Set whether the 3D view scales each fixture's light by the "Lumens"
+     *  physical property of its mode, so that a rig of mixed fixtures shows the
+     *  relative output of its members instead of every fixture emitting the
+     *  same amount of light. Off by default: most fixture definitions leave
+     *  Lumens unset, and a project that has never enabled it must render
+     *  exactly as it always has. */
+    inline void setUseFixtureLumens(bool use) { m_useFixtureLumens = use; }
+    inline bool useFixtureLumens() const { return m_useFixtureLumens; }
+
     /** Get/Set whether the 3D view FPS counter overlay is shown */
     inline void setShowFPS(bool show) { m_showFPS = show; }
     inline bool showFPS() const { return m_showFPS; }
@@ -171,6 +180,7 @@ private:
     qreal m_ambientLightIntensity;
     qreal m_smokeAmount;
     qreal m_fixtureLightIntensity;
+    bool m_useFixtureLumens;
     bool m_showFPS;
 
     /********************************************************************

--- a/engine/test/monitorproperties/monitorproperties_test.cpp
+++ b/engine/test/monitorproperties/monitorproperties_test.cpp
@@ -43,6 +43,7 @@ void MonitorProperties_Test::defaults()
     QCOMPARE(mp.ambientLightIntensity(), 0.6);
     QCOMPARE(mp.smokeAmount(), 0.8);
     QCOMPARE(mp.fixtureLightIntensity(), 1.0);
+    QCOMPARE(mp.useFixtureLumens(), false);
     QCOMPARE(mp.showFPS(), false);
     QVERIFY(mp.commonBackgroundImage().isEmpty());
 }
@@ -122,6 +123,7 @@ void MonitorProperties_Test::renderSettingsXML()
     mp.setAmbientLightIntensity(0.25);
     mp.setSmokeAmount(0.9);
     mp.setFixtureLightIntensity(0.4);
+    mp.setUseFixtureLumens(true);
     mp.setShowFPS(true);
 
     QByteArray xmlData;
@@ -150,6 +152,7 @@ void MonitorProperties_Test::renderSettingsXML()
     QCOMPARE(loaded.ambientLightIntensity(), 0.25);
     QCOMPARE(loaded.smokeAmount(), 0.9);
     QCOMPARE(loaded.fixtureLightIntensity(), 0.4);
+    QCOMPARE(loaded.useFixtureLumens(), true);
     QCOMPARE(loaded.showFPS(), true);
 }
 
@@ -190,6 +193,7 @@ void MonitorProperties_Test::reset()
     mp.setRenderQuality(0);
     mp.setAmbientLightIntensity(0.1);
     mp.setSmokeAmount(0.2);
+    mp.setUseFixtureLumens(true);
     mp.setShowFPS(true);
     mp.setFixturePosition(1,0,0,QVector3D(1,2,3));
     mp.setItemName(2,"foo");
@@ -206,6 +210,7 @@ void MonitorProperties_Test::reset()
     QCOMPARE(mp.ambientLightIntensity(), 0.6);
     QCOMPARE(mp.smokeAmount(), 0.8);
     QCOMPARE(mp.fixtureLightIntensity(), 1.0);
+    QCOMPARE(mp.useFixtureLumens(), false);
     QCOMPARE(mp.showFPS(), false);
     QCOMPARE(mp.fixtureItemsID().count(), 0);
     QCOMPARE(mp.lightResources().count(), 0);

--- a/engine/test/monitorproperties/monitorproperties_test.cpp
+++ b/engine/test/monitorproperties/monitorproperties_test.cpp
@@ -42,6 +42,7 @@ void MonitorProperties_Test::defaults()
     QCOMPARE(mp.renderQuality(), 2);
     QCOMPARE(mp.ambientLightIntensity(), 0.6);
     QCOMPARE(mp.smokeAmount(), 0.8);
+    QCOMPARE(mp.fixtureLightIntensity(), 1.0);
     QCOMPARE(mp.showFPS(), false);
     QVERIFY(mp.commonBackgroundImage().isEmpty());
 }
@@ -120,6 +121,7 @@ void MonitorProperties_Test::renderSettingsXML()
     mp.setRenderQuality(3);
     mp.setAmbientLightIntensity(0.25);
     mp.setSmokeAmount(0.9);
+    mp.setFixtureLightIntensity(0.4);
     mp.setShowFPS(true);
 
     QByteArray xmlData;
@@ -147,6 +149,7 @@ void MonitorProperties_Test::renderSettingsXML()
     QCOMPARE(loaded.renderQuality(), 3);
     QCOMPARE(loaded.ambientLightIntensity(), 0.25);
     QCOMPARE(loaded.smokeAmount(), 0.9);
+    QCOMPARE(loaded.fixtureLightIntensity(), 0.4);
     QCOMPARE(loaded.showFPS(), true);
 }
 
@@ -202,6 +205,7 @@ void MonitorProperties_Test::reset()
     QCOMPARE(mp.renderQuality(), 2);
     QCOMPARE(mp.ambientLightIntensity(), 0.6);
     QCOMPARE(mp.smokeAmount(), 0.8);
+    QCOMPARE(mp.fixtureLightIntensity(), 1.0);
     QCOMPARE(mp.showFPS(), false);
     QCOMPARE(mp.fixtureItemsID().count(), 0);
     QCOMPARE(mp.lightResources().count(), 0);

--- a/engine/test/monitorproperties/monitorproperties_test.cpp
+++ b/engine/test/monitorproperties/monitorproperties_test.cpp
@@ -39,6 +39,10 @@ void MonitorProperties_Test::defaults()
     QCOMPARE(mp.pointOfView(), MonitorProperties::Undefined);
     QCOMPARE(mp.stageType(), MonitorProperties::StageSimple);
     QCOMPARE(mp.labelsVisible(), false);
+    QCOMPARE(mp.renderQuality(), 2);
+    QCOMPARE(mp.ambientLightIntensity(), 0.6);
+    QCOMPARE(mp.smokeAmount(), 0.8);
+    QCOMPARE(mp.showFPS(), false);
     QVERIFY(mp.commonBackgroundImage().isEmpty());
 }
 
@@ -109,6 +113,43 @@ void MonitorProperties_Test::lightItemsXML()
     QCOMPARE(loaded.lightPosition("moving_head.dae", 0), QVector3D(1.5f, 2.5f, 3.5f));
 }
 
+void MonitorProperties_Test::renderSettingsXML()
+{
+    Doc doc(this);
+    MonitorProperties mp;
+    mp.setRenderQuality(3);
+    mp.setAmbientLightIntensity(0.25);
+    mp.setSmokeAmount(0.9);
+    mp.setShowFPS(true);
+
+    QByteArray xmlData;
+    QBuffer buffer(&xmlData);
+    QVERIFY(buffer.open(QIODevice::WriteOnly));
+
+    QXmlStreamWriter writer(&buffer);
+    writer.writeStartDocument();
+    QVERIFY(mp.saveXML(&writer, &doc));
+    writer.writeEndDocument();
+    buffer.close();
+
+    MonitorProperties loaded;
+    QXmlStreamReader reader(xmlData);
+    while (reader.readNextStartElement())
+    {
+        if (reader.name() == KXMLQLCMonitorProperties)
+        {
+            QVERIFY(loaded.loadXML(reader, &doc));
+            break;
+        }
+        reader.skipCurrentElement();
+    }
+
+    QCOMPARE(loaded.renderQuality(), 3);
+    QCOMPARE(loaded.ambientLightIntensity(), 0.25);
+    QCOMPARE(loaded.smokeAmount(), 0.9);
+    QCOMPARE(loaded.showFPS(), true);
+}
+
 void MonitorProperties_Test::genericItems()
 {
     MonitorProperties mp;
@@ -143,6 +184,10 @@ void MonitorProperties_Test::reset()
     mp.setPointOfView(MonitorProperties::FrontView);
     mp.setStageType(MonitorProperties::StageBox);
     mp.setLabelsVisible(true);
+    mp.setRenderQuality(0);
+    mp.setAmbientLightIntensity(0.1);
+    mp.setSmokeAmount(0.2);
+    mp.setShowFPS(true);
     mp.setFixturePosition(1,0,0,QVector3D(1,2,3));
     mp.setItemName(2,"foo");
     mp.setCommonBackgroundImage("img.png");
@@ -154,6 +199,10 @@ void MonitorProperties_Test::reset()
     QCOMPARE(mp.pointOfView(), MonitorProperties::Undefined);
     QCOMPARE(mp.stageType(), MonitorProperties::StageSimple);
     QCOMPARE(mp.labelsVisible(), false);
+    QCOMPARE(mp.renderQuality(), 2);
+    QCOMPARE(mp.ambientLightIntensity(), 0.6);
+    QCOMPARE(mp.smokeAmount(), 0.8);
+    QCOMPARE(mp.showFPS(), false);
     QCOMPARE(mp.fixtureItemsID().count(), 0);
     QCOMPARE(mp.lightResources().count(), 0);
     QCOMPARE(mp.genericItemsID().count(), 0);

--- a/engine/test/monitorproperties/monitorproperties_test.cpp
+++ b/engine/test/monitorproperties/monitorproperties_test.cpp
@@ -116,6 +116,9 @@ void MonitorProperties_Test::lightItemsXML()
 
 void MonitorProperties_Test::renderSettingsXML()
 {
+#ifndef QMLUI
+    QSKIP("The 3D view rendering settings are saved only by the QML UI build");
+#else
     Doc doc(this);
     MonitorProperties mp;
     mp.setRenderQuality(3);
@@ -151,6 +154,7 @@ void MonitorProperties_Test::renderSettingsXML()
     QCOMPARE(loaded.smokeAmount(), 0.9);
     QCOMPARE(loaded.fixtureLightIntensity(), 0.4);
     QCOMPARE(loaded.showFPS(), true);
+#endif
 }
 
 void MonitorProperties_Test::genericItems()

--- a/engine/test/monitorproperties/monitorproperties_test.h
+++ b/engine/test/monitorproperties/monitorproperties_test.h
@@ -31,6 +31,7 @@ private slots:
     void fixtureItems();
     void lightItems();
     void lightItemsXML();
+    void renderSettingsXML();
     void genericItems();
     void reset();
 };

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -2704,6 +2704,21 @@ void MainView3D::setSmokeAmount(float smokeAmount)
     emit smokeAmountChanged(smokeAmount);
 }
 
+float MainView3D::fixtureLightIntensity() const
+{
+    return m_monProps->fixtureLightIntensity();
+}
+
+void MainView3D::setFixtureLightIntensity(float intensity)
+{
+    if (float(m_monProps->fixtureLightIntensity()) == intensity)
+        return;
+
+    m_monProps->setFixtureLightIntensity(intensity);
+    m_doc->setModified();
+    emit fixtureLightIntensityChanged(intensity);
+}
+
 void MainView3D::applyRenderSettings()
 {
     // The values already live in m_monProps (set defaults, or loaded from the
@@ -2711,6 +2726,7 @@ void MainView3D::applyRenderSettings()
     emit renderQualityChanged(renderQuality());
     emit ambientIntensityChanged(ambientIntensity());
     emit smokeAmountChanged(smokeAmount());
+    emit fixtureLightIntensityChanged(fixtureLightIntensity());
     applyFrameCountEnabled(m_monProps->showFPS());
 }
 

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -102,6 +102,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_markerEntity(nullptr)
     , m_stageEntity(nullptr)
     , m_referenceCandela(0)
+    , m_referenceThrow(0)
 {
     setContextResource("qrc:/3DView.qml");
     setContextTitle(tr("3D View"));
@@ -856,9 +857,10 @@ void MainView3D::createFixtureItem(quint32 fxID, quint16 headIndex, quint16 link
     if (meshPath.isEmpty() == false)
         newItem->setProperty("itemSource", meshPath);
 
-    // the reference is the brightest emitter in the project, so it can move
+    // both references are taken over the whole project, so either can move
     // whenever a fixture is added
     updateReferenceCandela();
+    updateReferenceThrow();
 }
 
 void MainView3D::setFixtureFlags(quint32 itemID, quint32 flags)
@@ -1680,6 +1682,9 @@ void MainView3D::updateFixturePosition(quint32 itemID, QVector3D pos)
     mesh->m_rootTransform->setTranslation(QVector3D(x, y, z));
 
     updateLightMatrix(mesh, itemID);
+
+    // hanging a fixture higher or lower changes the rig's scale
+    updateReferenceThrow();
 }
 
 QVector3D MainView3D::fixtureExtents(quint32 itemID) const
@@ -2026,6 +2031,7 @@ void MainView3D::removeFixtureItem(quint32 itemID)
     delete mesh;
 
     updateReferenceCandela();
+    updateReferenceThrow();
 
     if (m_scene3D)
         QMetaObject::invokeMethod(m_scene3D, "updateFrameGraph", Q_ARG(QVariant, true));
@@ -2824,11 +2830,52 @@ void MainView3D::updateReferenceCandela()
     emit referenceCandelaChanged(m_referenceCandela);
 }
 
+qreal MainView3D::referenceThrow() const
+{
+    return m_referenceThrow;
+}
+
+void MainView3D::updateReferenceThrow()
+{
+    qreal total = 0;
+    int count = 0;
+
+    // Only the fixtures actually placed in the 3D view have a position, and
+    // only those are part of the rig whose scale is being measured.
+    for (Fixture *fixture : m_doc->fixtures())
+    {
+        if (m_monProps->containsFixture(fixture->id()) == false)
+            continue;
+
+        for (quint32 &subID : m_monProps->fixtureIDList(fixture->id()))
+        {
+            quint16 headIndex = m_monProps->fixtureHeadIndex(subID);
+            quint16 linkedIndex = m_monProps->fixtureLinkedIndex(subID);
+
+            // Positions are stored in millimetres, measured up from the floor,
+            // which is where the shader's world units start too.
+            total += m_monProps->fixturePosition(fixture->id(), headIndex, linkedIndex).y() / 1000.0;
+            count++;
+        }
+    }
+
+    // A rig standing entirely on the floor has no throw to speak of and gets 0,
+    // which the shader reads as "no falloff".
+    qreal reference = count ? total / qreal(count) : 0;
+
+    if (reference == m_referenceThrow)
+        return;
+
+    m_referenceThrow = reference;
+    emit referenceThrowChanged(m_referenceThrow);
+}
+
 void MainView3D::applyRenderSettings()
 {
     // The values already live in m_monProps (set defaults, or loaded from the
     // project). Push them to the QML side / shaders and sync the FPS counter.
     updateReferenceCandela();
+    updateReferenceThrow();
     emit renderQualityChanged(renderQuality());
     emit ambientIntensityChanged(ambientIntensity());
     emit smokeAmountChanged(smokeAmount());

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -2861,6 +2861,12 @@ void MainView3D::updateReferenceThrow()
 
     // A rig standing entirely on the floor has no throw to speak of and gets 0,
     // which the shader reads as "no falloff".
+    //
+    // Known limitation: floor standing fixtures are averaged in with the hung
+    // ones, so a rig that mixes the two pulls the reference below the height
+    // the hung fixtures throw from, and an uplighter close to what it lights
+    // then renders very hot. Weighting or excluding near floor fixtures is left
+    // for a later change; for now the "Fixture light" gain pulls the frame back.
     qreal reference = count ? total / qreal(count) : 0;
 
     if (reference == m_referenceThrow)

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -31,6 +31,7 @@
 #include <QUrl>
 #include <QXmlStreamReader>
 #include <QRegularExpression>
+#include <QtMath>
 
 #include <Qt3DCore/QTransform>
 #include <Qt3DCore/QNode>
@@ -100,7 +101,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_position3DMarkerVisible(false)
     , m_markerEntity(nullptr)
     , m_stageEntity(nullptr)
-    , m_referenceLumens(0)
+    , m_referenceCandela(0)
 {
     setContextResource("qrc:/3DView.qml");
     setContextTitle(tr("3D View"));
@@ -851,13 +852,13 @@ void MainView3D::createFixtureItem(quint32 fxID, quint16 headIndex, quint16 link
     m_entitiesMap[itemID] = mesh;
 
     newItem->setProperty("itemID", itemID);
-    newItem->setProperty("bulbLumens", fixtureEmitterLumens(fixture));
+    newItem->setProperty("bulbCandela", fixtureEmitterCandela(fixture));
     if (meshPath.isEmpty() == false)
         newItem->setProperty("itemSource", meshPath);
 
     // the reference is the brightest emitter in the project, so it can move
     // whenever a fixture is added
-    updateReferenceLumens();
+    updateReferenceCandela();
 }
 
 void MainView3D::setFixtureFlags(quint32 itemID, quint32 flags)
@@ -2024,7 +2025,7 @@ void MainView3D::removeFixtureItem(quint32 itemID)
 
     delete mesh;
 
-    updateReferenceLumens();
+    updateReferenceCandela();
 
     if (m_scene3D)
         QMetaObject::invokeMethod(m_scene3D, "updateFrameGraph", Q_ARG(QVariant, true));
@@ -2742,9 +2743,9 @@ void MainView3D::setUseFixtureLumens(bool use)
     emit useFixtureLumensChanged(use);
 }
 
-qreal MainView3D::referenceLumens() const
+qreal MainView3D::referenceCandela() const
 {
-    return m_referenceLumens;
+    return m_referenceCandela;
 }
 
 qreal MainView3D::fixtureEmitterLumens(Fixture *fixture)
@@ -2777,25 +2778,57 @@ qreal MainView3D::fixtureEmitterLumens(Fixture *fixture)
     return emitters > 1 ? qreal(lumens) / qreal(emitters) : qreal(lumens);
 }
 
-void MainView3D::updateReferenceLumens()
+qreal MainView3D::beamSolidAngle(qreal fullAngleDegrees)
+{
+    if (fullAngleDegrees <= 0 || fullAngleDegrees >= 360)
+        return 0;
+
+    return 2.0 * M_PI * (1.0 - qCos(qDegreesToRadians(fullAngleDegrees / 2.0)));
+}
+
+qreal MainView3D::fixtureEmitterCandela(Fixture *fixture)
+{
+    qreal lumens = fixtureEmitterLumens(fixture);
+    if (lumens <= 0)
+        return 0;
+
+    QLCFixtureMode *mode = fixture->fixtureMode();
+    if (mode == nullptr)
+        return 0;
+
+    // Same fallback the cone geometry uses above, so the photometry describes
+    // the cone that is actually drawn for a definition that gives no lens
+    // angle. It is a constant across all such fixtures, so it does not disturb
+    // their balance against each other.
+    qreal degrees = mode->physical().lensDegreesMax() ?
+                        mode->physical().lensDegreesMax() : 30;
+
+    qreal solidAngle = beamSolidAngle(degrees);
+    if (solidAngle <= 0)
+        return 0;
+
+    return lumens / solidAngle;
+}
+
+void MainView3D::updateReferenceCandela()
 {
     qreal reference = 0;
 
     for (Fixture *fixture : m_doc->fixtures())
-        reference = qMax(reference, fixtureEmitterLumens(fixture));
+        reference = qMax(reference, fixtureEmitterCandela(fixture));
 
-    if (reference == m_referenceLumens)
+    if (reference == m_referenceCandela)
         return;
 
-    m_referenceLumens = reference;
-    emit referenceLumensChanged(m_referenceLumens);
+    m_referenceCandela = reference;
+    emit referenceCandelaChanged(m_referenceCandela);
 }
 
 void MainView3D::applyRenderSettings()
 {
     // The values already live in m_monProps (set defaults, or loaded from the
     // project). Push them to the QML side / shaders and sync the FPS counter.
-    updateReferenceLumens();
+    updateReferenceCandela();
     emit renderQualityChanged(renderQuality());
     emit ambientIntensityChanged(ambientIntensity());
     emit smokeAmountChanged(smokeAmount());

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -100,6 +100,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_position3DMarkerVisible(false)
     , m_markerEntity(nullptr)
     , m_stageEntity(nullptr)
+    , m_referenceLumens(0)
 {
     setContextResource("qrc:/3DView.qml");
     setContextTitle(tr("3D View"));
@@ -850,8 +851,13 @@ void MainView3D::createFixtureItem(quint32 fxID, quint16 headIndex, quint16 link
     m_entitiesMap[itemID] = mesh;
 
     newItem->setProperty("itemID", itemID);
+    newItem->setProperty("bulbLumens", fixtureEmitterLumens(fixture));
     if (meshPath.isEmpty() == false)
         newItem->setProperty("itemSource", meshPath);
+
+    // the reference is the brightest emitter in the project, so it can move
+    // whenever a fixture is added
+    updateReferenceLumens();
 }
 
 void MainView3D::setFixtureFlags(quint32 itemID, quint32 flags)
@@ -2018,6 +2024,8 @@ void MainView3D::removeFixtureItem(quint32 itemID)
 
     delete mesh;
 
+    updateReferenceLumens();
+
     if (m_scene3D)
         QMetaObject::invokeMethod(m_scene3D, "updateFrameGraph", Q_ARG(QVariant, true));
 }
@@ -2719,14 +2727,80 @@ void MainView3D::setFixtureLightIntensity(float intensity)
     emit fixtureLightIntensityChanged(intensity);
 }
 
+bool MainView3D::useFixtureLumens() const
+{
+    return m_monProps->useFixtureLumens();
+}
+
+void MainView3D::setUseFixtureLumens(bool use)
+{
+    if (m_monProps->useFixtureLumens() == use)
+        return;
+
+    m_monProps->setUseFixtureLumens(use);
+    m_doc->setModified();
+    emit useFixtureLumensChanged(use);
+}
+
+qreal MainView3D::referenceLumens() const
+{
+    return m_referenceLumens;
+}
+
+qreal MainView3D::fixtureEmitterLumens(Fixture *fixture)
+{
+    if (fixture == nullptr)
+        return 0;
+
+    QLCFixtureMode *mode = fixture->fixtureMode();
+    if (mode == nullptr)
+        return 0;
+
+    // QLCPhysical lives on the mode, which falls back to the definition's
+    // global <Physical> when the mode doesn't override it. There is no
+    // per-head physical, so this is the output of the whole fixture.
+    int lumens = mode->physical().bulbLumens();
+    if (lumens <= 0)
+        return 0;
+
+    // Split it between the emitters the 3D view actually draws: a Dimmer gets
+    // one lamp per channel, everything else one per head (a separate item per
+    // head for moving heads, cells within a single item for the bars). Without
+    // this an 8 cell bar would cast eight times the light of a moving head
+    // with the same figure in its definition.
+    // A mode that declares no <Head> gets none: QLCFixtureMode synthesizes
+    // nothing, so heads() is 0 there. That is a single emitter fixture, which
+    // is what falling through to the undivided figure below gives it.
+    quint32 emitters = fixture->type() == QLCFixtureDef::Dimmer ?
+                           fixture->channels() : quint32(fixture->heads());
+
+    return emitters > 1 ? qreal(lumens) / qreal(emitters) : qreal(lumens);
+}
+
+void MainView3D::updateReferenceLumens()
+{
+    qreal reference = 0;
+
+    for (Fixture *fixture : m_doc->fixtures())
+        reference = qMax(reference, fixtureEmitterLumens(fixture));
+
+    if (reference == m_referenceLumens)
+        return;
+
+    m_referenceLumens = reference;
+    emit referenceLumensChanged(m_referenceLumens);
+}
+
 void MainView3D::applyRenderSettings()
 {
     // The values already live in m_monProps (set defaults, or loaded from the
     // project). Push them to the QML side / shaders and sync the FPS counter.
+    updateReferenceLumens();
     emit renderQualityChanged(renderQuality());
     emit ambientIntensityChanged(ambientIntensity());
     emit smokeAmountChanged(smokeAmount());
     emit fixtureLightIntensityChanged(fixtureLightIntensity());
+    emit useFixtureLumensChanged(useFixtureLumens());
     applyFrameCountEnabled(m_monProps->showFPS());
 }
 

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -1241,17 +1241,17 @@ void MainView3D::initializeFixture(quint32 itemID, QEntity *fxEntity, const QSce
 
         Qt3DCore::QTransform *transform = getTransform(meshRef->m_headItem);
 
-        if (baseItem != nullptr)
+        // A mesh based fixture only tilts if the loaded scene has a base item
+        // under the head, i.e. it is a moving head or a scanner. An item drawn
+        // without a mesh has no base to look for: its head entity IS the movable
+        // part, so a Tilt channel is enough. Without the second case, a motorized
+        // beam bar would animate a tilt angle that nothing ever applies.
+        if ((baseItem != nullptr || loader == nullptr) && transform != nullptr &&
+            fixture->channelNumber(QLCChannel::Tilt, QLCChannel::MSB) != QLCChannel::invalid())
         {
-            if (fixture->channelNumber(QLCChannel::Tilt, QLCChannel::MSB) != QLCChannel::invalid())
-            {
-                // If there is a base item and a tilt channel,
-                // this is either a moving head or a scanner
-                if (transform != nullptr)
-                    QMetaObject::invokeMethod(meshRef->m_rootItem, "bindTiltTransform",
-                            Q_ARG(QVariant, QVariant::fromValue(transform)),
-                            Q_ARG(QVariant, tiltDeg));
-            }
+            QMetaObject::invokeMethod(meshRef->m_rootItem, "bindTiltTransform",
+                    Q_ARG(QVariant, QVariant::fromValue(transform)),
+                    Q_ARG(QVariant, tiltDeg));
         }
 
         meshRef->m_rootItem->setProperty("focusMinDegrees", focusMin);

--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -99,10 +99,7 @@ MainView3D::MainView3D(QQuickView *view, Doc *doc, QObject *parent)
     , m_position3DMarker(QVector3D())
     , m_position3DMarkerVisible(false)
     , m_markerEntity(nullptr)
-    , m_renderQuality(HighQuality)
     , m_stageEntity(nullptr)
-    , m_ambientIntensity(0.6)
-    , m_smokeAmount(0.8)
 {
     setContextResource("qrc:/3DView.qml");
     setContextTitle(tr("3D View"));
@@ -179,6 +176,10 @@ void MainView3D::slotRefreshView()
     // recreate the stage entity and notify the UI to update the selector
     createStage();
     emit stageIndexChanged(m_monProps->stageType());
+
+    // re-apply the persisted "Rendering" settings (quality, ambient light,
+    // smoke, show FPS) that may have changed on project load
+    applyRenderSettings();
 
     for (Fixture *fixture : m_doc->fixtures())
     {
@@ -391,6 +392,18 @@ bool MainView3D::frameCountEnabled() const
 }
 
 void MainView3D::setFrameCountEnabled(bool enable)
+{
+    if (m_frameCountEnabled == enable)
+        return;
+
+    applyFrameCountEnabled(enable);
+
+    // persist the choice in the project (see MonitorProperties)
+    m_monProps->setShowFPS(enable);
+    m_doc->setModified();
+}
+
+void MainView3D::applyFrameCountEnabled(bool enable)
 {
     if (m_frameCountEnabled == enable)
         return;
@@ -2606,16 +2619,17 @@ void MainView3D::setPosition3DMarkerVisible(bool visible)
 
 MainView3D::RenderQuality MainView3D::renderQuality() const
 {
-    return m_renderQuality;
+    return RenderQuality(m_monProps->renderQuality());
 }
 
 void MainView3D::setRenderQuality(MainView3D::RenderQuality renderQuality)
 {
-    if (m_renderQuality == renderQuality)
+    if (m_monProps->renderQuality() == int(renderQuality))
         return;
 
-    m_renderQuality = renderQuality;
-    emit renderQualityChanged(m_renderQuality);
+    m_monProps->setRenderQuality(int(renderQuality));
+    m_doc->setModified();
+    emit renderQualityChanged(renderQuality);
 }
 
 QStringList MainView3D::stagesList() const
@@ -2662,30 +2676,42 @@ void MainView3D::createStage()
 
 float MainView3D::ambientIntensity() const
 {
-    return m_ambientIntensity;
+    return m_monProps->ambientLightIntensity();
 }
 
 void MainView3D::setAmbientIntensity(float ambientIntensity)
 {
-    if (m_ambientIntensity == ambientIntensity)
+    if (float(m_monProps->ambientLightIntensity()) == ambientIntensity)
         return;
 
-    m_ambientIntensity = ambientIntensity;
-    emit ambientIntensityChanged(m_ambientIntensity);
+    m_monProps->setAmbientLightIntensity(ambientIntensity);
+    m_doc->setModified();
+    emit ambientIntensityChanged(ambientIntensity);
 }
 
 float MainView3D::smokeAmount() const
 {
-    return m_smokeAmount;
+    return m_monProps->smokeAmount();
 }
 
 void MainView3D::setSmokeAmount(float smokeAmount)
 {
-    if (m_smokeAmount == smokeAmount)
+    if (float(m_monProps->smokeAmount()) == smokeAmount)
         return;
 
-    m_smokeAmount = smokeAmount;
-    emit smokeAmountChanged(m_smokeAmount);
+    m_monProps->setSmokeAmount(smokeAmount);
+    m_doc->setModified();
+    emit smokeAmountChanged(smokeAmount);
+}
+
+void MainView3D::applyRenderSettings()
+{
+    // The values already live in m_monProps (set defaults, or loaded from the
+    // project). Push them to the QML side / shaders and sync the FPS counter.
+    emit renderQualityChanged(renderQuality());
+    emit ambientIntensityChanged(ambientIntensity());
+    emit smokeAmountChanged(smokeAmount());
+    applyFrameCountEnabled(m_monProps->showFPS());
 }
 
 bool MainView3D::rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -110,6 +110,8 @@ class MainView3D final : public PreviewContext
     Q_PROPERTY(float ambientIntensity READ ambientIntensity WRITE setAmbientIntensity NOTIFY ambientIntensityChanged)
     Q_PROPERTY(float smokeAmount READ smokeAmount WRITE setSmokeAmount NOTIFY smokeAmountChanged)
     Q_PROPERTY(float fixtureLightIntensity READ fixtureLightIntensity WRITE setFixtureLightIntensity NOTIFY fixtureLightIntensityChanged)
+    Q_PROPERTY(bool useFixtureLumens READ useFixtureLumens WRITE setUseFixtureLumens NOTIFY useFixtureLumensChanged)
+    Q_PROPERTY(qreal referenceLumens READ referenceLumens NOTIFY referenceLumensChanged)
 
     Q_PROPERTY(bool frameCountEnabled READ frameCountEnabled WRITE setFrameCountEnabled NOTIFY frameCountEnabledChanged)
     Q_PROPERTY(int FPS READ FPS NOTIFY FPSChanged)
@@ -517,6 +519,22 @@ public:
     float fixtureLightIntensity() const;
     void setFixtureLightIntensity(float intensity);
 
+    /** Scale each fixture's light by the "Lumens" of its mode, so a rig of
+     *  mixed fixtures shows their relative output */
+    bool useFixtureLumens() const;
+    void setUseFixtureLumens(bool use);
+
+    /** Lumens of the brightest emitter in the project, i.e. the output that
+     *  renders unscaled when useFixtureLumens is on. 0 when no fixture in the
+     *  project carries lumens data, which turns the scaling into a no-op. */
+    qreal referenceLumens() const;
+
+    /** Lumens of a single emitter of $fixture: the "Lumens" of its mode (or of
+     *  the fixture definition, when the mode inherits it) divided between the
+     *  emitters the 3D view draws for that fixture. 0 when the definition
+     *  carries no lumens data. */
+    static qreal fixtureEmitterLumens(Fixture *fixture);
+
     Q_INVOKABLE void pickEntity(const float &aspect, const QVector2D &ndcMousePos, int modifiers) const;
 
 protected:
@@ -526,6 +544,11 @@ protected:
      *  to the running scene and notify the QML side. Called on project load /
      *  when the 3D view becomes visible. Does not mark the project modified. */
     void applyRenderSettings();
+
+    /** Recompute referenceLumens() from the fixtures currently in the project
+     *  and notify the QML side if it moved. Called whenever the set of
+     *  fixtures changes, since the reference is the maximum over all of them. */
+    void updateReferenceLumens();
     QVector3D unprojectToWorld(const float &aspect, const QVector2D &ndcMousePos) const;
     bool rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,
                            const QVector3D &center, const QVector3D &extents, float &hitDistance) const;
@@ -539,6 +562,8 @@ signals:
     void ambientIntensityChanged(qreal ambientIntensity);
     void smokeAmountChanged(float smokeAmount);
     void fixtureLightIntensityChanged(float fixtureLightIntensity);
+    void useFixtureLumensChanged(bool useFixtureLumens);
+    void referenceLumensChanged(qreal referenceLumens);
 
 private:
     /* The "Rendering" settings (quality, ambient light, smoke, show FPS) are
@@ -551,6 +576,9 @@ private:
 
     /** Reference to the selected stage Entity */
     QEntity *m_stageEntity;
+
+    /** Cached maximum of fixtureEmitterLumens() over the project's fixtures */
+    qreal m_referenceLumens;
 };
 
 #endif // MAINVIEW3D_H

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -111,7 +111,7 @@ class MainView3D final : public PreviewContext
     Q_PROPERTY(float smokeAmount READ smokeAmount WRITE setSmokeAmount NOTIFY smokeAmountChanged)
     Q_PROPERTY(float fixtureLightIntensity READ fixtureLightIntensity WRITE setFixtureLightIntensity NOTIFY fixtureLightIntensityChanged)
     Q_PROPERTY(bool useFixtureLumens READ useFixtureLumens WRITE setUseFixtureLumens NOTIFY useFixtureLumensChanged)
-    Q_PROPERTY(qreal referenceLumens READ referenceLumens NOTIFY referenceLumensChanged)
+    Q_PROPERTY(qreal referenceCandela READ referenceCandela NOTIFY referenceCandelaChanged)
 
     Q_PROPERTY(bool frameCountEnabled READ frameCountEnabled WRITE setFrameCountEnabled NOTIFY frameCountEnabledChanged)
     Q_PROPERTY(int FPS READ FPS NOTIFY FPSChanged)
@@ -524,16 +524,28 @@ public:
     bool useFixtureLumens() const;
     void setUseFixtureLumens(bool use);
 
-    /** Lumens of the brightest emitter in the project, i.e. the output that
-     *  renders unscaled when useFixtureLumens is on. 0 when no fixture in the
-     *  project carries lumens data, which turns the scaling into a no-op. */
-    qreal referenceLumens() const;
+    /** Luminous intensity of the brightest emitter in the project, i.e. the
+     *  output that renders unscaled when useFixtureLumens is on. 0 when no
+     *  fixture in the project carries the data, which turns the scaling into
+     *  a no-op. */
+    qreal referenceCandela() const;
 
     /** Lumens of a single emitter of $fixture: the "Lumens" of its mode (or of
      *  the fixture definition, when the mode inherits it) divided between the
      *  emitters the 3D view draws for that fixture. 0 when the definition
      *  carries no lumens data. */
     static qreal fixtureEmitterLumens(Fixture *fixture);
+
+    /** Luminous intensity of a single emitter of $fixture, in candela: its
+     *  lumens spread over the solid angle of its beam at the widest the lens
+     *  opens. This, not the raw flux, is what the renderer's light intensity
+     *  behaves like, since nothing in the shading divides by the area the cone
+     *  covers. 0 when the definition carries no lumens data. */
+    static qreal fixtureEmitterCandela(Fixture *fixture);
+
+    /** Solid angle, in steradian, of a cone of full angle $fullAngleDegrees:
+     *  2*pi*(1 - cos(angle / 2)). 0 for an angle outside (0, 360). */
+    static qreal beamSolidAngle(qreal fullAngleDegrees);
 
     Q_INVOKABLE void pickEntity(const float &aspect, const QVector2D &ndcMousePos, int modifiers) const;
 
@@ -545,10 +557,10 @@ protected:
      *  when the 3D view becomes visible. Does not mark the project modified. */
     void applyRenderSettings();
 
-    /** Recompute referenceLumens() from the fixtures currently in the project
+    /** Recompute referenceCandela() from the fixtures currently in the project
      *  and notify the QML side if it moved. Called whenever the set of
      *  fixtures changes, since the reference is the maximum over all of them. */
-    void updateReferenceLumens();
+    void updateReferenceCandela();
     QVector3D unprojectToWorld(const float &aspect, const QVector2D &ndcMousePos) const;
     bool rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,
                            const QVector3D &center, const QVector3D &extents, float &hitDistance) const;
@@ -563,7 +575,7 @@ signals:
     void smokeAmountChanged(float smokeAmount);
     void fixtureLightIntensityChanged(float fixtureLightIntensity);
     void useFixtureLumensChanged(bool useFixtureLumens);
-    void referenceLumensChanged(qreal referenceLumens);
+    void referenceCandelaChanged(qreal referenceCandela);
 
 private:
     /* The "Rendering" settings (quality, ambient light, smoke, show FPS) are
@@ -577,8 +589,8 @@ private:
     /** Reference to the selected stage Entity */
     QEntity *m_stageEntity;
 
-    /** Cached maximum of fixtureEmitterLumens() over the project's fixtures */
-    qreal m_referenceLumens;
+    /** Cached maximum of fixtureEmitterCandela() over the project's fixtures */
+    qreal m_referenceCandela;
 };
 
 #endif // MAINVIEW3D_H

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -109,6 +109,7 @@ class MainView3D final : public PreviewContext
     Q_PROPERTY(int stageIndex READ stageIndex WRITE setStageIndex NOTIFY stageIndexChanged)
     Q_PROPERTY(float ambientIntensity READ ambientIntensity WRITE setAmbientIntensity NOTIFY ambientIntensityChanged)
     Q_PROPERTY(float smokeAmount READ smokeAmount WRITE setSmokeAmount NOTIFY smokeAmountChanged)
+    Q_PROPERTY(float fixtureLightIntensity READ fixtureLightIntensity WRITE setFixtureLightIntensity NOTIFY fixtureLightIntensityChanged)
 
     Q_PROPERTY(bool frameCountEnabled READ frameCountEnabled WRITE setFrameCountEnabled NOTIFY frameCountEnabledChanged)
     Q_PROPERTY(int FPS READ FPS NOTIFY FPSChanged)
@@ -512,6 +513,10 @@ public:
     float smokeAmount() const;
     void setSmokeAmount(float smokeAmount);
 
+    /** Global multiplier on the light fixtures cast on surfaces */
+    float fixtureLightIntensity() const;
+    void setFixtureLightIntensity(float intensity);
+
     Q_INVOKABLE void pickEntity(const float &aspect, const QVector2D &ndcMousePos, int modifiers) const;
 
 protected:
@@ -533,6 +538,7 @@ signals:
     void stageIndexChanged(int stageIndex);
     void ambientIntensityChanged(qreal ambientIntensity);
     void smokeAmountChanged(float smokeAmount);
+    void fixtureLightIntensityChanged(float fixtureLightIntensity);
 
 private:
     /* The "Rendering" settings (quality, ambient light, smoke, show FPS) are

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -112,6 +112,7 @@ class MainView3D final : public PreviewContext
     Q_PROPERTY(float fixtureLightIntensity READ fixtureLightIntensity WRITE setFixtureLightIntensity NOTIFY fixtureLightIntensityChanged)
     Q_PROPERTY(bool useFixtureLumens READ useFixtureLumens WRITE setUseFixtureLumens NOTIFY useFixtureLumensChanged)
     Q_PROPERTY(qreal referenceCandela READ referenceCandela NOTIFY referenceCandelaChanged)
+    Q_PROPERTY(qreal referenceThrow READ referenceThrow NOTIFY referenceThrowChanged)
 
     Q_PROPERTY(bool frameCountEnabled READ frameCountEnabled WRITE setFrameCountEnabled NOTIFY frameCountEnabledChanged)
     Q_PROPERTY(int FPS READ FPS NOTIFY FPSChanged)
@@ -530,6 +531,14 @@ public:
      *  a no-op. */
     qreal referenceCandela() const;
 
+    /** Distance, in metres, at which fixture light lands unscaled once the
+     *  inverse square falloff is applied: the mean height above the floor of
+     *  the fixtures placed in the project, which is what tells a club rig from
+     *  an arena one. Derived rather than asked for, since the 3D view is
+     *  already a to-scale model of the venue. 0 when nothing is placed above
+     *  the floor, which turns the falloff off. */
+    qreal referenceThrow() const;
+
     /** Lumens of a single emitter of $fixture: the "Lumens" of its mode (or of
      *  the fixture definition, when the mode inherits it) divided between the
      *  emitters the 3D view draws for that fixture. 0 when the definition
@@ -561,6 +570,13 @@ protected:
      *  and notify the QML side if it moved. Called whenever the set of
      *  fixtures changes, since the reference is the maximum over all of them. */
     void updateReferenceCandela();
+
+    /** Recompute referenceThrow() from the positions of the fixtures placed in
+     *  the project and notify the QML side if it moved. Called whenever a
+     *  fixture is added, removed or moved. Deliberately independent of pan and
+     *  tilt: a reference that tracked where the heads point would make the
+     *  whole frame breathe as they move. */
+    void updateReferenceThrow();
     QVector3D unprojectToWorld(const float &aspect, const QVector2D &ndcMousePos) const;
     bool rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,
                            const QVector3D &center, const QVector3D &extents, float &hitDistance) const;
@@ -576,6 +592,7 @@ signals:
     void fixtureLightIntensityChanged(float fixtureLightIntensity);
     void useFixtureLumensChanged(bool useFixtureLumens);
     void referenceCandelaChanged(qreal referenceCandela);
+    void referenceThrowChanged(qreal referenceThrow);
 
 private:
     /* The "Rendering" settings (quality, ambient light, smoke, show FPS) are
@@ -591,6 +608,10 @@ private:
 
     /** Cached maximum of fixtureEmitterCandela() over the project's fixtures */
     qreal m_referenceCandela;
+
+    /** Cached mean height above the floor, in metres, of the project's placed
+     *  fixture items */
+    qreal m_referenceThrow;
 };
 
 #endif // MAINVIEW3D_H

--- a/qmlui/mainview3d.h
+++ b/qmlui/mainview3d.h
@@ -207,6 +207,12 @@ protected slots:
     void slotFrameProcessed();
 
 private:
+    /** Apply the FPS counter enabled state to the running scene (attach/detach
+     *  the QFrameAction, reset counters, notify QML). Unlike setFrameCountEnabled()
+     *  this does not persist the value nor mark the project modified, so it is
+     *  safe to call while loading a project. */
+    void applyFrameCountEnabled(bool enable);
+
     /** Create the QFrameAction (if needed) and attach it to the current
      *  scene root entity. Called both when the user enables the FPS counter
      *  and whenever the 3D scene is (re)initialized, so the setting survives
@@ -510,6 +516,11 @@ public:
 
 protected:
     void createStage();
+
+    /** Re-apply the "Rendering" settings persisted in the project (MonitorProperties)
+     *  to the running scene and notify the QML side. Called on project load /
+     *  when the 3D view becomes visible. Does not mark the project modified. */
+    void applyRenderSettings();
     QVector3D unprojectToWorld(const float &aspect, const QVector2D &ndcMousePos) const;
     bool rayIntersectsAABB(const QVector3D &rayOrigin, const QVector3D &rayDir,
                            const QVector3D &center, const QVector3D &extents, float &hitDistance) const;
@@ -524,19 +535,16 @@ signals:
     void smokeAmountChanged(float smokeAmount);
 
 private:
-    RenderQuality m_renderQuality;
+    /* The "Rendering" settings (quality, ambient light, smoke, show FPS) are
+       stored in the project through MonitorProperties (m_monProps), so they
+       persist in the workspace file. The getters/setters below proxy to it,
+       the same way stageIndex() does. */
 
     QStringList m_stagesList;
     QStringList m_stageResourceList;
 
     /** Reference to the selected stage Entity */
     QEntity *m_stageEntity;
-
-    /** Ambient light amount (0.0 - 1.0) */
-    float m_ambientIntensity;
-
-    /** Smoke amount (0.0 - 1.0) */
-    float m_smokeAmount;
 };
 
 #endif // MAINVIEW3D_H

--- a/qmlui/qml/fixturesfunctions/3DView/3DView.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/3DView.qml
@@ -115,6 +115,8 @@ Rectangle
                     for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                     {
                         headEntity = fixtureItem.getHead(iHead)
+                        if (!headEntity)
+                            continue
 
                         component.createObject(frameGraph.myShadowFrameGraphNode,
                         {
@@ -236,11 +238,14 @@ Rectangle
                 for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                 {
                     headEntity = fixtureItem.getHead(iHead)
+                    if (!headEntity)
+                        continue
 
                     component.createObject(frameGraph.myCameraSelector,
                     {
                         "gBuffer": gBufferTarget,
-                        "shadowTex": headEntity.depthTex,
+                        // heads that don't cast shadows have no shadow map at all
+                        "shadowTex": fixtureItem.useShadows ? headEntity.depthTex : null,
                         "useShadows": fixtureItem.useShadows,
                         "spotlightShadingLayer": headEntity.spotlightShadingLayer,
                         "frameTarget": frameTarget
@@ -269,6 +274,8 @@ Rectangle
                 for (iHead = 0; iHead < fixtureItem.headsNumber; iHead++)
                 {
                     headEntity = fixtureItem.getHead(iHead)
+                    if (!headEntity)
+                        continue
 
                     component.createObject(frameGraph.myCameraSelector,
                     {
@@ -282,7 +289,7 @@ Rectangle
                         "frontDepth": depthTarget,
                         "gBuffer": gBufferTarget,
                         "spotlightScatteringLayer": headEntity.spotlightScatteringLayer,
-                        "shadowTex": headEntity.depthTex,
+                        "shadowTex": fixtureItem.useShadows ? headEntity.depthTex : null,
                         "frameTarget": frameTarget,
                         "useShadows": fixtureItem.useShadows
                     });

--- a/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
@@ -100,17 +100,30 @@ Entity
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
-    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
-       property of its mode. 0 when the fixture definition carries no data */
-    property real bulbLumens: 0
-    /* Relative output of this fixture: its lumens against the brightest emitter
-       in the project, so the reference fixture stays at the brightness it has
-       always rendered at and everything else falls in below it. 1.0 (unscaled)
-       when the "Lumens" setting is off, when this definition has no lumens, or
-       when no fixture in the project has any. */
+    /* Luminous intensity of a single emitter of this fixture, in candela: the
+       "Lumens" physical property of its mode spread over the solid angle of the
+       beam at the widest the lens opens. 0 when the definition has no data */
+    property real bulbCandela: 0
+    /* How far the current zoom concentrates the beam, as the ratio of the two
+       cone solid angles: 1.0 at the widest the lens opens, rising as the beam
+       closes in, which is what a zoom does to the light it lays on a surface */
+    property real beamConcentration:
+    {
+        var widest = (focusMaxDegrees / 2.0) * (Math.PI / 180.0)
+        if (widest <= 0 || cutoffAngle <= 0)
+            return 1.0
+        return (1.0 - Math.cos(widest)) / (1.0 - Math.cos(cutoffAngle))
+    }
+    /* Relative output of this fixture: its intensity against the brightest
+       emitter in the project, so the reference fixture stays at the brightness
+       it has always rendered at and everything else falls in around it. Goes
+       above 1.0 on a beam zoomed in past its widest, which the tone mapping in
+       gamma_correct.frag rolls off. 1.0 (unscaled) when the "Lumens" setting is
+       off, when this definition has no lumens, or when no fixture in the
+       project has any. */
     property real lumensScale:
-        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
-            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+        (View3D && View3D.useFixtureLumens && bulbCandela > 0 && View3D.referenceCandela > 0) ?
+            (bulbCandela / View3D.referenceCandela) * beamConcentration : 1.0
 
     property real lightIntensity: dimmerValue * shutterValue * lumensScale
     property real dimmerValue: 0

--- a/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Fixture3DItem.qml
@@ -100,7 +100,19 @@ Entity
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
-    property real lightIntensity: dimmerValue * shutterValue
+    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
+       property of its mode. 0 when the fixture definition carries no data */
+    property real bulbLumens: 0
+    /* Relative output of this fixture: its lumens against the brightest emitter
+       in the project, so the reference fixture stays at the brightness it has
+       always rendered at and everything else falls in below it. 1.0 (unscaled)
+       when the "Lumens" setting is off, when this definition has no lumens, or
+       when no fixture in the project has any. */
+    property real lumensScale:
+        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
+            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+
+    property real lightIntensity: dimmerValue * shutterValue * lumensScale
     property real dimmerValue: 0
     property real shutterValue: sAnimator.shutterValue
     property color lightColor: Qt.rgba(0, 0, 0, 1)

--- a/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
@@ -26,6 +26,12 @@ import Qt3D.Extras
 import "Math3DView.js" as Math3D
 import "."
 
+/*
+  A single light emitter of a multi-beam fixture (see MultiBeams3DItem).
+  It plays the role Fixture3DItem plays for a one-head fixture: it owns the
+  three spotlight cones and exposes the uniforms the spotlight shaders read.
+  It has no geometry of its own - the bar mesh is drawn by the parent item.
+*/
 Entity
 {
     id: beamEntity
@@ -39,15 +45,23 @@ Entity
     property vector3d lightPos: Qt.vector3d(0, 0, 0)
     property vector3d lightDir: Qt.vector3d(0, 0, 0)
 
-    /* Orientation of the parent bar. SpotlightConeEntity and the shading/
-       scattering shaders need a pan/tilt angle to place and aim each beam;
-       when they are missing the cone model matrix collapses and nothing is
-       drawn. LED bars never pan, and tilt (motorised bars) is pushed down
-       from the parent through tiltRotation. */
+    /* Orientation of the emitter. SpotlightConeEntity and the shading/scattering
+       shaders need a pan/tilt angle to place and aim the cone; when they are
+       missing the cone model matrix collapses and nothing is drawn. LED bars
+       never pan, and tilt (motorized bars) is pushed down from the parent item. */
     property real panRotation: 0
     property real tiltRotation: 0
 
-    property real raymarchSteps
+    /* This MUST stay an int. It ends up in the "raymarchSteps" uniform of
+       spotlight_scattering.frag, which is declared as an int, and Qt3D does not
+       convert: a QML real is stored as a float and its raw bytes are handed to
+       glUniform1iv, so the shader would read the *bit pattern* of the float
+       (40.0 becomes 1109393408) and ray march for over a billion iterations.
+       That hangs the GPU, which is why the scattering cone below used to be
+       commented out with a "this hangs your PC" note. Fixture3DItem declares
+       the same property as an int. */
+    property int raymarchSteps: 0
+
     property real cutoffAngle
     property real distCutoff
     property real headLength
@@ -58,14 +72,18 @@ Entity
     property Texture2D goboTexture
     property real goboRotation: 0
 
-    /* Spotlight matrices — same math as Fixture3DItem.qml. These are read as
+    /* Spotlight matrices - same math as Fixture3DItem.qml. These are read as
        uniforms by SpotlightConeEntity; the per-head lightPos and lightMatrix
-       are provided by the parent via setHeadLightProps(). */
+       are provided by the parent through setHeadLightProps(). */
     property matrix4x4 lightMatrix
     property matrix4x4 lightViewMatrix:
         Math3D.getLightViewMatrix(lightMatrix, panRotation, tiltRotation, lightPos)
+    // getLightProjectionMatrix() divides by (coneBottomRadius / coneTopRadius - 1),
+    // so a not-yet-known aperture would produce a degenerate matrix
     property matrix4x4 lightProjectionMatrix:
-        Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle)
+        coneTopRadius > 0 && coneBottomRadius > coneTopRadius ?
+            Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle) :
+            Qt.matrix4x4()
     property matrix4x4 lightViewProjectionMatrix: lightProjectionMatrix.times(lightViewMatrix)
     property matrix4x4 lightViewProjectionScaleAndOffsetMatrix:
         Math3D.getLightViewProjectionScaleOffsetMatrix(lightViewProjectionMatrix)
@@ -74,40 +92,25 @@ Entity
     readonly property Layer outputDepthLayer: Layer { }
     readonly property Layer spotlightScatteringLayer: Layer { }
 
-    property Transform headTransform: Transform { translation: Qt.vector3d(0.1 * headIndex, 0, 0) }
+    /* Shadow map of this emitter. It is what makes the beam stop at the first
+       surface it hits: spotlight_shading.frag has no distance bound of its own,
+       so without a shadow map the cone lights every G-buffer texel inside its
+       projection - through walls and everything behind them.
 
-    function setupScattering(sceneEntity)
-    {
-        shadingCone.coneEffect = sceneEntity.spotlightShadingEffect
-        shadingCone.parent = sceneEntity
-        shadingCone.spotlightConeMesh = sceneEntity.coneMesh
-
-        // Volumetric beam in the air. This mirrors Fixture3DItem: the cost is
-        // governed by raymarchSteps, which is 0 on Low render quality.
-        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
-        scatteringCone.parent = sceneEntity
-        scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
-
-        outDepthCone.coneEffect = sceneEntity.outputFrontDepthEffect
-        outDepthCone.parent = sceneEntity
-        outDepthCone.spotlightConeMesh = sceneEntity.coneMesh
-    }
-
-    function cleanupScattering()
-    {
-        if (shadingCone)
-            shadingCone.destroy()
-        if (scatteringCone)
-            scatteringCone.destroy()
-        if (outDepthCone)
-            outDepthCone.destroy()
-    }
+       Same size as Fixture3DItem, deliberately. The frustum covers exactly the
+       cone, so what matters is resolution per degree of aperture, and a bar is
+       not the narrow emitter it might seem: real definitions of this type carry
+       lenses of 40 and even 120 degrees, against the 30 of a typical PAR. A
+       smaller map is therefore coarser here than for a single head fixture, not
+       finer, and a coarse map is what makes a wide beam fail its own shadow
+       test and emit nothing at all. */
+    property int shadowMapSize: 1024
 
     property Texture2D depthTex:
         Texture2D
         {
-            width: 1024
-            height: 1024
+            width: shadowMapSize
+            height: shadowMapSize
             format: Texture.D32F
             generateMipMaps: false
             magnificationFilter: Texture.Nearest
@@ -131,6 +134,36 @@ Entity
             ] // attachments
         }
 
+    function setupScattering(sceneEntity)
+    {
+        shadingCone.coneEffect = sceneEntity.spotlightShadingEffect
+        shadingCone.parent = sceneEntity
+        shadingCone.spotlightConeMesh = sceneEntity.coneMesh
+
+        // Volumetric beam in the air. As in Fixture3DItem, its cost is governed
+        // by raymarchSteps, which is 0 on Low render quality.
+        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
+        scatteringCone.parent = sceneEntity
+        scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
+
+        outDepthCone.coneEffect = sceneEntity.outputFrontDepthEffect
+        outDepthCone.parent = sceneEntity
+        outDepthCone.spotlightConeMesh = sceneEntity.coneMesh
+    }
+
+    /* Must be called before this entity is destroyed: setupScattering() moves the
+       three cones under the scene root, so they do not go away with their
+       declaring entity and would be left in the scene bound to a dead object. */
+    function cleanupScattering()
+    {
+        if (shadingCone)
+            shadingCone.destroy()
+        if (scatteringCone)
+            scatteringCone.destroy()
+        if (outDepthCone)
+            outDepthCone.destroy()
+    }
+
     /* Cone meshes used for scattering. These get re-parented to
        the main Scene entity via setupScattering */
     SpotlightConeEntity
@@ -151,8 +184,4 @@ Entity
         coneLayer: outputDepthLayer
         fxEntity: beamEntity
     }
-
-    components: [
-        headTransform
-    ]
 } // Entity

--- a/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
@@ -33,7 +33,10 @@ Entity
     property int headIndex
     property real dimmerValue: 0
     property real shutterValue: 1.0
-    property real lightIntensity: dimmerValue * shutterValue
+    /* Relative output of the parent fixture. See MultiBeams3DItem, which
+       pushes it down to every emitter of the bar */
+    property real lumensScale: 1.0
+    property real lightIntensity: dimmerValue * shutterValue * lumensScale
 
     property color lightColor: Qt.rgba(0, 0, 0, 1)
     property vector3d lightPos: Qt.vector3d(0, 0, 0)

--- a/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/LightEntity.qml
@@ -32,21 +32,43 @@ Entity
 
     property int headIndex
     property real dimmerValue: 0
-    property real shutterValue: 0
+    property real shutterValue: 1.0
     property real lightIntensity: dimmerValue * shutterValue
 
     property color lightColor: Qt.rgba(0, 0, 0, 1)
     property vector3d lightPos: Qt.vector3d(0, 0, 0)
     property vector3d lightDir: Qt.vector3d(0, 0, 0)
 
+    /* Orientation of the parent bar. SpotlightConeEntity and the shading/
+       scattering shaders need a pan/tilt angle to place and aim each beam;
+       when they are missing the cone model matrix collapses and nothing is
+       drawn. LED bars never pan, and tilt (motorised bars) is pushed down
+       from the parent through tiltRotation. */
+    property real panRotation: 0
+    property real tiltRotation: 0
+
     property real raymarchSteps
     property real cutoffAngle
     property real distCutoff
     property real headLength
-    property real coneBottomRadius
     property real coneTopRadius
+    /* Derived exactly like Fixture3DItem so that changing the beam aperture
+       (zoom) keeps the cone geometry consistent. */
+    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
     property Texture2D goboTexture
     property real goboRotation: 0
+
+    /* Spotlight matrices — same math as Fixture3DItem.qml. These are read as
+       uniforms by SpotlightConeEntity; the per-head lightPos and lightMatrix
+       are provided by the parent via setHeadLightProps(). */
+    property matrix4x4 lightMatrix
+    property matrix4x4 lightViewMatrix:
+        Math3D.getLightViewMatrix(lightMatrix, panRotation, tiltRotation, lightPos)
+    property matrix4x4 lightProjectionMatrix:
+        Math3D.getLightProjectionMatrix(distCutoff, coneBottomRadius, coneTopRadius, headLength, cutoffAngle)
+    property matrix4x4 lightViewProjectionMatrix: lightProjectionMatrix.times(lightViewMatrix)
+    property matrix4x4 lightViewProjectionScaleAndOffsetMatrix:
+        Math3D.getLightViewProjectionScaleOffsetMatrix(lightViewProjectionMatrix)
 
     readonly property Layer spotlightShadingLayer: Layer { }
     readonly property Layer outputDepthLayer: Layer { }
@@ -60,7 +82,9 @@ Entity
         shadingCone.parent = sceneEntity
         shadingCone.spotlightConeMesh = sceneEntity.coneMesh
 
-        //scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect // this hangs your PC
+        // Volumetric beam in the air. This mirrors Fixture3DItem: the cost is
+        // governed by raymarchSteps, which is 0 on Low render quality.
+        scatteringCone.coneEffect = sceneEntity.spotlightScatteringEffect
         scatteringCone.parent = sceneEntity
         scatteringCone.spotlightConeMesh = sceneEntity.coneMesh
 

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -81,7 +81,7 @@ Entity
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
-    property real shutterValue: 1.0
+    property real shutterValue: sAnimator.shutterValue
     property vector3d lightDir: Math3D.getLightDirection(transform, 0, tiltTransform)
 
     property var headsList: []
@@ -113,18 +113,20 @@ Entity
             if (component.status === Component.Error)
                 console.log("Error loading component:", component.errorString())
 
+            // Bind the shared beam properties to the parent so that render
+            // quality, zoom, shutter and tilt keep updating every head after
+            // creation. coneBottomRadius is derived inside LightEntity.
             var headNode = component.createObject(fixtureEntity,
             {
                 "headIndex": i,
-                "lightDir": lightDir,
-                "shutterValue": shutterValue,
-                "raymarchSteps": raymarchSteps,
-                "cutoffAngle": cutoffAngle,
+                "lightDir": Qt.binding(function() { return fixtureEntity.lightDir }),
+                "shutterValue": Qt.binding(function() { return fixtureEntity.shutterValue }),
+                "raymarchSteps": Qt.binding(function() { return fixtureEntity.raymarchSteps }),
+                "cutoffAngle": Qt.binding(function() { return fixtureEntity.cutoffAngle }),
+                "tiltRotation": Qt.binding(function() { return fixtureEntity.tiltRotation }),
                 "distCutoff": distCutoff,
                 "headLength": headLength,
-                "coneBottomRadius": coneBottomRadius,
                 "coneTopRadius": coneTopRadius,
-                "tiltRotation": tiltRotation,
                 "goboTexture": goboTexture
             });
 
@@ -160,26 +162,37 @@ Entity
         return headsList[headIndex]
     }
 
+    // The C++ side computes a single emitter position/orientation for the whole
+    // bar (headIndex is always 0). Spread the beams evenly across the bar's
+    // physical width, centered on the fixture origin and rotated by the bar's
+    // current orientation matrix.
     function setHeadLightProps(headIndex, pos, matrix)
     {
-        for (var h = 0; h < headsNumber; h++)
+        var n = headsList.length
+        if (n === 0)
+            return
+
+        var spacing = (n > 1) ? (phySize.x / n) : 0
+        for (var h = 0; h < n; h++)
         {
-            var head = getHead(h)
-            var hPos = Qt.vector3d(pos.x * h, pos.y, pos.z)
-            head.lightPos = hPos
+            var localX = (h - (n - 1) / 2) * spacing
+            var worldOffset = matrix.times(Qt.vector4d(localX, 0, 0, 0)).toVector3d()
+            var head = headsList[h]
+            head.lightPos = pos.plus(worldOffset)
             head.lightMatrix = matrix
-            console.log("Setting light info: " + hPos + ", m: " + matrix)
         }
     }
 
     function setHeadIntensity(headIndex, intensity)
     {
-        headsList[headIndex].dimmerValue = intensity
+        if (headIndex >= 0 && headIndex < headsList.length)
+            headsList[headIndex].dimmerValue = intensity
     }
 
     function setHeadRGBColor(headIndex, color)
     {
-        headsList[headIndex].lightColor = color
+        if (headIndex >= 0 && headIndex < headsList.length)
+            headsList[headIndex].lightColor = color
     }
 
     // See Fixture3DItem: timestamp of the previous setPosition() call, used to pace

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -82,6 +82,18 @@ Entity
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
     property real shutterValue: sAnimator.shutterValue
+    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
+       property of its mode. 0 when the fixture definition carries no data */
+    property real bulbLumens: 0
+    /* Relative output of this fixture: its lumens against the brightest emitter
+       in the project, so the reference fixture stays at the brightness it has
+       always rendered at and everything else falls in below it. 1.0 (unscaled)
+       when the "Lumens" setting is off, when this definition has no lumens, or
+       when no fixture in the project has any. */
+    property real lumensScale:
+        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
+            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+
     property vector3d lightDir: Math3D.getLightDirection(transform, 0, tiltTransform)
 
     property var headsList: []
@@ -121,6 +133,7 @@ Entity
                 "headIndex": i,
                 "lightDir": Qt.binding(function() { return fixtureEntity.lightDir }),
                 "shutterValue": Qt.binding(function() { return fixtureEntity.shutterValue }),
+                "lumensScale": Qt.binding(function() { return fixtureEntity.lumensScale }),
                 "raymarchSteps": Qt.binding(function() { return fixtureEntity.raymarchSteps }),
                 "cutoffAngle": Qt.binding(function() { return fixtureEntity.cutoffAngle }),
                 "tiltRotation": Qt.binding(function() { return fixtureEntity.tiltRotation }),

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -124,17 +124,30 @@ Entity
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
     property real shutterValue: sAnimator.shutterValue
-    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
-       property of its mode. 0 when the fixture definition carries no data */
-    property real bulbLumens: 0
-    /* Relative output of this fixture: its lumens against the brightest emitter
-       in the project, so the reference fixture stays at the brightness it has
-       always rendered at and everything else falls in below it. 1.0 (unscaled)
-       when the "Lumens" setting is off, when this definition has no lumens, or
-       when no fixture in the project has any. */
+    /* Luminous intensity of a single emitter of this fixture, in candela: the
+       "Lumens" physical property of its mode spread over the solid angle of the
+       beam at the widest the lens opens. 0 when the definition has no data */
+    property real bulbCandela: 0
+    /* How far the current zoom concentrates the beam, as the ratio of the two
+       cone solid angles: 1.0 at the widest the lens opens, rising as the beam
+       closes in, which is what a zoom does to the light it lays on a surface */
+    property real beamConcentration:
+    {
+        var widest = (focusMaxDegrees / 2.0) * (Math.PI / 180.0)
+        if (widest <= 0 || cutoffAngle <= 0)
+            return 1.0
+        return (1.0 - Math.cos(widest)) / (1.0 - Math.cos(cutoffAngle))
+    }
+    /* Relative output of this fixture: its intensity against the brightest
+       emitter in the project, so the reference fixture stays at the brightness
+       it has always rendered at and everything else falls in around it. Goes
+       above 1.0 on a beam zoomed in past its widest, which the tone mapping in
+       gamma_correct.frag rolls off. 1.0 (unscaled) when the "Lumens" setting is
+       off, when this definition has no lumens, or when no fixture in the
+       project has any. */
     property real lumensScale:
-        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
-            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+        (View3D && View3D.useFixtureLumens && bulbCandela > 0 && View3D.referenceCandela > 0) ?
+            (bulbCandela / View3D.referenceCandela) * beamConcentration : 1.0
 
     property vector3d lightDir: Math3D.getLightDirection(transform, null, tiltTransform)
 

--- a/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/MultiBeams3DItem.qml
@@ -45,6 +45,22 @@ Entity
         updateHeads()
     }
 
+    /* Number of emitters across the bar width and along its depth.
+
+       The physical layout describes the cell grid of the fixture body, which is
+       NOT required to agree with the number of heads the selected mode declares.
+       The Pulse LED BAR 320 is an 8x1 bar whose 4 channel mode declares no head
+       at all, so the engine synthesises a single one covering every channel:
+       laying that one emitter out on an 8 wide grid puts it in cell 0, i.e. at
+       one end of the bar instead of across it. Only trust the layout when it
+       accounts for exactly the emitters we have; otherwise put them in one row. */
+    readonly property bool layoutMatchesHeads:
+        headsLayout.width * headsLayout.height === headsNumber
+    readonly property int cellColumns:
+        layoutMatchesHeads ? headsLayout.width : Math.max(1, headsNumber)
+    readonly property int cellRows:
+        layoutMatchesHeads ? headsLayout.height : 1
+
     /* **************** Tilt properties (motorized bars) **************** */
     property real tiltMaxDegrees: 270
     property real tiltSpeed: 4000 // in milliseconds
@@ -60,7 +76,15 @@ Entity
 
     /* **************** Rendering quality properties **************** */
     property bool useScattering: View3D.renderQuality === MainView3D.LowQuality ? false : true
+
+    /* Shadows are not optional for this renderer: spotlight_shading.frag bounds
+       the beam with the emitter's shadow map and nothing else, so an emitter
+       without one lights everything inside its cone projection, straight through
+       the walls of the stage environment. The per emitter cost is bounded from
+       two sides: RenderShadowMapFilter matches no render pass while a cell is
+       dark, and LightEntity uses a smaller map than a single head fixture. */
     property bool useShadows: View3D.renderQuality === MainView3D.LowQuality ? false : true
+
     property int raymarchSteps:
     {
         switch(View3D.renderQuality)
@@ -70,19 +94,37 @@ Entity
             case MainView3D.HighQuality: return 40
             case MainView3D.UltraQuality: return 80
         }
+        return 0
     }
 
-    /* **************** Spotlight cone properties **************** */
-    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
-    property real coneTopRadius: transform ? (0.24023 / 2) * transform.scale3D.x * 0.7 : 0.0 // (diameter / 2) * scale * magic number
+    /* Ray march steps of a single beam. The volumetric scattering pass runs once
+       per emitter, so a bar would otherwise cost as much as headsNumber separate
+       spotlights. Spend the budget of about four spotlights on the whole bar
+       instead, with a floor that still reads as a beam: the cones of a bar are
+       thin, so they need far fewer samples than a wide spotlight cone. */
+    readonly property int beamRaymarchSteps:
+        raymarchSteps <= 0 ? 0
+                           : Math.max(6, Math.min(raymarchSteps,
+                                                  Math.round((raymarchSteps * 4) / Math.max(1, headsNumber))))
 
-    property real headLength: 0.5 * transform.scale3D.x
+    /* **************** Spotlight cone properties **************** */
+    /* Radius of a single cell, rather than the lens radius of a PAR mesh that
+       this item does not have. The 0.7 factor matches Fixture3DItem, where it
+       compensates the mesh lens being slightly larger than the emitting surface. */
+    property real coneTopRadius:
+        Math.max(0.005, 0.5 * 0.7 * Math.min(phySize.x / cellColumns, phySize.z / cellRows))
+    property real coneBottomRadius: distCutoff * Math.tan(cutoffAngle) + coneTopRadius
+
+    /* Depth of the emitter inside the fixture body. Fixture3DItem takes this from
+       the loaded mesh; a bar is drawn as a plain cuboid, so its own height is the
+       closest equivalent. */
+    property real headLength: Math.max(0.01, phySize.y)
 
     /* ********************* Light properties ********************* */
     /* ****** These are bound to uniforms in ScreenQuadEntity ***** */
 
     property real shutterValue: sAnimator.shutterValue
-    property vector3d lightDir: Math3D.getLightDirection(transform, 0, tiltTransform)
+    property vector3d lightDir: Math3D.getLightDirection(transform, null, tiltTransform)
 
     property var headsList: []
 
@@ -99,41 +141,78 @@ Entity
     {
         var i
 
-        // delete existing heads first
+        // Delete the existing heads first. setupScattering() re-parents the three
+        // cones of a head to the scene root, so they do not die with it: without
+        // cleanupScattering() they would be left in the scene, still bound to a
+        // destroyed emitter, and every rebuild would add three more.
         for (i = headsList.length - 1; i >= 0; i--)
+        {
+            headsList[i].cleanupScattering()
             headsList[i].destroy()
+        }
 
         headsList = []
 
+        // itemID is invalid while the item is being built - MainView3D sets the
+        // real one right after creation - and MainView3D::resetItems() sets it
+        // back to -1 when the 3D view is torn down. Building a set of heads in
+        // either case is pure waste, and in the teardown case it allocates
+        // emitters into a scene that is being destroyed.
+        if (itemID < 0 || headsNumber <= 0)
+            return
+
+        var component = Qt.createComponent("LightEntity.qml")
+        if (component.status !== Component.Ready)
+        {
+            console.warn("MultiBeams3DItem: cannot load LightEntity.qml:", component.errorString())
+            return
+        }
+
         for (i = 0; i < headsNumber; i++)
         {
-            console.log("Item " + itemID + " creating head - " + i)
-
-            var component = Qt.createComponent("LightEntity.qml");
-            if (component.status === Component.Error)
-                console.log("Error loading component:", component.errorString())
-
-            // Bind the shared beam properties to the parent so that render
-            // quality, zoom, shutter and tilt keep updating every head after
-            // creation. coneBottomRadius is derived inside LightEntity.
+            // Everything shared with the parent is bound rather than copied: most
+            // of these are only known once MainView3D::initializeFixture() has run,
+            // which happens below, and render quality, zoom, shutter and tilt keep
+            // changing afterwards.
             var headNode = component.createObject(fixtureEntity,
             {
                 "headIndex": i,
+                "enabled": Qt.binding(function() { return fixtureEntity.enabled }),
                 "lightDir": Qt.binding(function() { return fixtureEntity.lightDir }),
                 "shutterValue": Qt.binding(function() { return fixtureEntity.shutterValue }),
-                "raymarchSteps": Qt.binding(function() { return fixtureEntity.raymarchSteps }),
+                "raymarchSteps": Qt.binding(function() { return fixtureEntity.beamRaymarchSteps }),
                 "cutoffAngle": Qt.binding(function() { return fixtureEntity.cutoffAngle }),
                 "tiltRotation": Qt.binding(function() { return fixtureEntity.tiltRotation }),
-                "distCutoff": distCutoff,
-                "headLength": headLength,
-                "coneTopRadius": coneTopRadius,
-                "goboTexture": goboTexture
+                "distCutoff": Qt.binding(function() { return fixtureEntity.distCutoff }),
+                "headLength": Qt.binding(function() { return fixtureEntity.headLength }),
+                "coneTopRadius": Qt.binding(function() { return fixtureEntity.coneTopRadius }),
+                "goboTexture": Qt.binding(function() { return fixtureEntity.goboTexture })
             });
+
+            if (headNode === null)
+            {
+                console.warn("MultiBeams3DItem: cannot create head", i, "of item", itemID)
+                break
+            }
 
             headsList.push(headNode)
         }
 
+        // 3DView.qml walks headsNumber heads when it builds the frame graph, so
+        // this must never promise more emitters than actually exist
+        if (headsList.length !== headsNumber)
+            headsNumber = headsList.length
+
+        // initializeFixture() is what hands us phySize and the lens angles, so the
+        // beam geometry logged below is only meaningful once it has returned
         View3D.initializeFixture(itemID, fixtureEntity, null)
+
+        console.log("MultiBeams3DItem: item", itemID, "emitters:", headsList.length,
+                    "layout:", headsLayout.width + "x" + headsLayout.height,
+                    "used as:", cellColumns + "x" + cellRows,
+                    "| lens:", focusMinDegrees + "-" + focusMaxDegrees + " deg",
+                    "cone top/bottom:", coneTopRadius.toFixed(4) + "/" + coneBottomRadius.toFixed(2),
+                    "| steps:", beamRaymarchSteps)
     }
 
     function setupScattering(sceneEntity)
@@ -142,9 +221,7 @@ Entity
             sceneEntity.coneMesh.length = distCutoff
 
         for (var i = 0; i < headsList.length; i++)
-        {
             headsList[i].setupScattering(sceneEntity)
-        }
     }
 
     function cleanupScattering()
@@ -159,26 +236,34 @@ Entity
 
     function getHead(headIndex)
     {
+        if (headIndex < 0 || headIndex >= headsList.length)
+            return null
+
         return headsList[headIndex]
     }
 
-    // The C++ side computes a single emitter position/orientation for the whole
-    // bar (headIndex is always 0). Spread the beams evenly across the bar's
-    // physical width, centered on the fixture origin and rotated by the bar's
-    // current orientation matrix.
+    // The C++ side computes a single emitter position and orientation for the
+    // whole bar (headIndex is always 0), so spread the cells over the fixture
+    // body here: evenly across its width and depth, centered on the origin and
+    // rotated by the bar's current orientation matrix.
     function setHeadLightProps(headIndex, pos, matrix)
     {
-        var n = headsList.length
-        if (n === 0)
+        var count = headsList.length
+        if (count === 0)
             return
 
-        var spacing = (n > 1) ? (phySize.x / n) : 0
-        for (var h = 0; h < n; h++)
+        var cellWidth = phySize.x / cellColumns
+        var cellDepth = phySize.z / cellRows
+
+        for (var h = 0; h < count; h++)
         {
-            var localX = (h - (n - 1) / 2) * spacing
-            var worldOffset = matrix.times(Qt.vector4d(localX, 0, 0, 0)).toVector3d()
+            var column = h % cellColumns
+            var row = Math.floor(h / cellColumns)
+            var localPos = Qt.vector4d(-(phySize.x / 2) + ((column + 0.5) * cellWidth), 0,
+                                       -(phySize.z / 2) + ((row + 0.5) * cellDepth), 0)
+
             var head = headsList[h]
-            head.lightPos = pos.plus(worldOffset)
+            head.lightPos = pos.plus(matrix.times(localPos).toVector3d())
             head.lightMatrix = matrix
         }
     }
@@ -248,9 +333,14 @@ Entity
         sAnimator.setShutter(type, low, high)
     }
 
-    function setZoom(value)
+    // Same signature as Fixture3DItem: MainView3D calls this with degrees == true
+    // when the fixture has a fixed zoom set in the monitor properties
+    function setZoom(value, degrees)
     {
-        cutoffAngle = (((((focusMaxDegrees - focusMinDegrees) / 255) * value) + focusMinDegrees) / 2) * (Math.PI / 180)
+        if (degrees)
+            cutoffAngle = (value / 2) * (Math.PI / 180.0)
+        else
+            cutoffAngle = (((((focusMaxDegrees - focusMinDegrees) / 255.0) * value) + focusMinDegrees) / 2.0) * (Math.PI / 180.0)
     }
 
     NumberAnimation on tiltRotation
@@ -318,9 +408,13 @@ Entity
 
     property Texture2D goboTexture: Texture2D { }
 
+    /* headEntity is NOT listed here: it is an Entity, not a Component, so QML
+       rejected it with a "Cannot append ... to a QML list of QComponent*"
+       warning on every item creation. It is already a child of this entity
+       through the default property, which is how it gets drawn and how
+       MainView3D finds it by object name. */
     components: [
         baseMesh,
-        headEntity,
         transform,
         material,
         sceneLayer

--- a/qmlui/qml/fixturesfunctions/3DView/PixelBar3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/PixelBar3DItem.qml
@@ -118,7 +118,12 @@ Entity
             {
                 id: headDelegate
                 property real dimmerValue: 0
-                property real lightIntensity: dimmerValue * shutterValue
+                /* Scaled by the global "Fixture light" setting, like the spotlight
+                   passes are. These cells are emissive geometry rather than a cone,
+                   so their own surface IS the whole light contribution of the
+                   fixture: scaling it here scales that contribution exactly once. */
+                property real lightIntensity:
+                    dimmerValue * shutterValue * (View3D ? View3D.fixtureLightIntensity : 1.0)
                 property real headWidth: phySize.x / headsLayout.width
                 property real headHeight: phySize.z / headsLayout.height
                 property color lightColor: Qt.rgba(0, 0, 0, 1)

--- a/qmlui/qml/fixturesfunctions/3DView/PixelBar3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/PixelBar3DItem.qml
@@ -41,17 +41,18 @@ Entity
     property bool useScattering: false
     property bool useShadows: false
     property real shutterValue: sAnimator.shutterValue
-    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
-       property of its mode. 0 when the fixture definition carries no data */
-    property real bulbLumens: 0
-    /* Relative output of this fixture: its lumens against the brightest emitter
-       in the project, so the reference fixture stays at the brightness it has
-       always rendered at and everything else falls in below it. 1.0 (unscaled)
-       when the "Lumens" setting is off, when this definition has no lumens, or
-       when no fixture in the project has any. */
+    /* Luminous intensity of a single emitter of this fixture, in candela: the
+       "Lumens" physical property of its mode spread over the solid angle of the
+       beam at the widest the lens opens. 0 when the definition has no data */
+    property real bulbCandela: 0
+    /* Relative output of this fixture: its intensity against the brightest
+       emitter in the project, so the reference fixture stays at the brightness
+       it has always rendered at and everything else falls in around it. 1.0
+       (unscaled) when the "Lumens" setting is off, when this definition has no
+       lumens, or when no fixture in the project has any. */
     property real lumensScale:
-        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
-            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+        (View3D && View3D.useFixtureLumens && bulbCandela > 0 && View3D.referenceCandela > 0) ?
+            bulbCandela / View3D.referenceCandela : 1.0
 
 
     onItemIDChanged:

--- a/qmlui/qml/fixturesfunctions/3DView/PixelBar3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/PixelBar3DItem.qml
@@ -41,6 +41,18 @@ Entity
     property bool useScattering: false
     property bool useShadows: false
     property real shutterValue: sAnimator.shutterValue
+    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
+       property of its mode. 0 when the fixture definition carries no data */
+    property real bulbLumens: 0
+    /* Relative output of this fixture: its lumens against the brightest emitter
+       in the project, so the reference fixture stays at the brightness it has
+       always rendered at and everything else falls in below it. 1.0 (unscaled)
+       when the "Lumens" setting is off, when this definition has no lumens, or
+       when no fixture in the project has any. */
+    property real lumensScale:
+        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
+            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+
 
     onItemIDChanged:
     {
@@ -123,7 +135,8 @@ Entity
                    so their own surface IS the whole light contribution of the
                    fixture: scaling it here scales that contribution exactly once. */
                 property real lightIntensity:
-                    dimmerValue * shutterValue * (View3D ? View3D.fixtureLightIntensity : 1.0)
+                    dimmerValue * shutterValue * lumensScale *
+                    (View3D ? View3D.fixtureLightIntensity : 1.0)
                 property real headWidth: phySize.x / headsLayout.width
                 property real headHeight: phySize.z / headsLayout.height
                 property color lightColor: Qt.rgba(0, 0, 0, 1)

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -229,6 +229,7 @@ Rectangle
                         Component.onCompleted:
                         {
                             ambIntSpin.value = View3D.ambientIntensity * 100
+                            fxLightSpin.value = View3D.fixtureLightIntensity * 100
                             smokeSpin.value = View3D.smokeAmount * 100
                         }
 
@@ -262,6 +263,19 @@ Rectangle
                         }
 
                         // row 3
+                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Fixture light") }
+                        CustomSpinBox
+                        {
+                            id: fxLightSpin
+                            Layout.fillWidth: true
+                            height: UISettings.listItemHeight
+                            from: 0
+                            to: 200
+                            suffix: "%"
+                            onValueModified: View3D.fixtureLightIntensity = value / 100
+                        }
+
+                        // row 4
                         RobotoText { height: UISettings.listItemHeight; label: qsTr("Smoke amount") }
                         CustomSpinBox
                         {
@@ -274,7 +288,7 @@ Rectangle
                             onValueModified: View3D.smokeAmount = value / 100
                         }
 
-                        // row 4
+                        // row 5
                         RobotoText { height: UISettings.listItemHeight; label: qsTr("Show FPS") }
                         CustomCheckBox
                         {

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -276,6 +276,16 @@ Rectangle
                         }
 
                         // row 4
+                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Lumens") }
+                        CustomCheckBox
+                        {
+                            implicitHeight: UISettings.listItemHeight
+                            implicitWidth: implicitHeight
+                            checked: View3D ? View3D.useFixtureLumens : false
+                            onToggled: View3D.useFixtureLumens = checked
+                        }
+
+                        // row 5
                         RobotoText { height: UISettings.listItemHeight; label: qsTr("Smoke amount") }
                         CustomSpinBox
                         {
@@ -288,7 +298,7 @@ Rectangle
                             onValueModified: View3D.smokeAmount = value / 100
                         }
 
-                        // row 5
+                        // row 6
                         RobotoText { height: UISettings.listItemHeight; label: qsTr("Show FPS") }
                         CustomCheckBox
                         {
@@ -298,7 +308,7 @@ Rectangle
                             onToggled: View3D.frameCountEnabled = checked
                         }
 
-                        // row 5
+                        // row 7
                         RobotoText { height: UISettings.listItemHeight; label: qsTr("Show fixture groups") }
                         CustomCheckBox
                         {

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -276,7 +276,7 @@ Rectangle
                         }
 
                         // row 4
-                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Lumens") }
+                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Lumens (experimental)") }
                         CustomCheckBox
                         {
                             implicitHeight: UISettings.listItemHeight

--- a/qmlui/qml/fixturesfunctions/3DView/SpotlightShadingFilter.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SpotlightShadingFilter.qml
@@ -34,7 +34,11 @@ TechniqueFilter
         Parameter { name: "normalTex"; value: gBuffer ? gBuffer.normal : null },
         Parameter { name: "depthTex"; value: gBuffer ? gBuffer.depth : null },
         Parameter { name: "shadowTex"; value: shadowTex },
-        Parameter { name: "useShadows"; value: (useShadows ? 1 : 0) }
+        Parameter { name: "useShadows"; value: (useShadows ? 1 : 0) },
+        // Global gain on the light fixtures cast on surfaces. Supplied here, at
+        // the frame graph level, so it applies once to every fixture rather than
+        // having to be threaded through each item type's lightIntensity.
+        Parameter { name: "fixtureLightIntensity"; value: View3D ? View3D.fixtureLightIntensity : 1.0 }
     ]
 
     RenderStateSet

--- a/qmlui/qml/fixturesfunctions/3DView/SpotlightShadingFilter.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SpotlightShadingFilter.qml
@@ -38,7 +38,17 @@ TechniqueFilter
         // Global gain on the light fixtures cast on surfaces. Supplied here, at
         // the frame graph level, so it applies once to every fixture rather than
         // having to be threaded through each item type's lightIntensity.
-        Parameter { name: "fixtureLightIntensity"; value: View3D ? View3D.fixtureLightIntensity : 1.0 }
+        Parameter { name: "fixtureLightIntensity"; value: View3D ? View3D.fixtureLightIntensity : 1.0 },
+        // Distance at which fixture light lands unscaled, for the inverse square
+        // falloff. Derived from the rig rather than set by the user, and gated
+        // by the same opt in as the photometric scaling it completes, so a
+        // project that has not enabled Lumens renders as it always has. Also
+        // frame graph level, for the same reason.
+        Parameter
+        {
+            name: "referenceThrow"
+            value: View3D && View3D.useFixtureLumens ? View3D.referenceThrow : 0.0
+        }
     ]
 
     RenderStateSet

--- a/qmlui/qml/fixturesfunctions/3DView/Strobe3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Strobe3DItem.qml
@@ -42,6 +42,18 @@ Entity
     property bool useScattering: false
     property bool useShadows: false
     property real shutterValue: sAnimator.shutterValue
+    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
+       property of its mode. 0 when the fixture definition carries no data */
+    property real bulbLumens: 0
+    /* Relative output of this fixture: its lumens against the brightest emitter
+       in the project, so the reference fixture stays at the brightness it has
+       always rendered at and everything else falls in below it. 1.0 (unscaled)
+       when the "Lumens" setting is off, when this definition has no lumens, or
+       when no fixture in the project has any. */
+    property real lumensScale:
+        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
+            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+
 
     onItemIDChanged:
     {
@@ -104,7 +116,8 @@ Entity
                    so their own surface IS the whole light contribution of the
                    fixture: scaling it here scales that contribution exactly once. */
                 property real lightIntensity:
-                    dimmerValue * shutterValue * (View3D ? View3D.fixtureLightIntensity : 1.0)
+                    dimmerValue * shutterValue * lumensScale *
+                    (View3D ? View3D.fixtureLightIntensity : 1.0)
                 property real headWidth: phySize.x / headsLayout.width
                 property real headHeight: phySize.z / headsLayout.height
                 property color lightColor: Qt.rgba(0, 0, 0, 1)

--- a/qmlui/qml/fixturesfunctions/3DView/Strobe3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Strobe3DItem.qml
@@ -42,17 +42,18 @@ Entity
     property bool useScattering: false
     property bool useShadows: false
     property real shutterValue: sAnimator.shutterValue
-    /* Lumens of a single emitter of this fixture, from the "Lumens" physical
-       property of its mode. 0 when the fixture definition carries no data */
-    property real bulbLumens: 0
-    /* Relative output of this fixture: its lumens against the brightest emitter
-       in the project, so the reference fixture stays at the brightness it has
-       always rendered at and everything else falls in below it. 1.0 (unscaled)
-       when the "Lumens" setting is off, when this definition has no lumens, or
-       when no fixture in the project has any. */
+    /* Luminous intensity of a single emitter of this fixture, in candela: the
+       "Lumens" physical property of its mode spread over the solid angle of the
+       beam at the widest the lens opens. 0 when the definition has no data */
+    property real bulbCandela: 0
+    /* Relative output of this fixture: its intensity against the brightest
+       emitter in the project, so the reference fixture stays at the brightness
+       it has always rendered at and everything else falls in around it. 1.0
+       (unscaled) when the "Lumens" setting is off, when this definition has no
+       lumens, or when no fixture in the project has any. */
     property real lumensScale:
-        (View3D && View3D.useFixtureLumens && bulbLumens > 0 && View3D.referenceLumens > 0) ?
-            Math.min(1.0, bulbLumens / View3D.referenceLumens) : 1.0
+        (View3D && View3D.useFixtureLumens && bulbCandela > 0 && View3D.referenceCandela > 0) ?
+            bulbCandela / View3D.referenceCandela : 1.0
 
 
     onItemIDChanged:

--- a/qmlui/qml/fixturesfunctions/3DView/Strobe3DItem.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/Strobe3DItem.qml
@@ -99,7 +99,12 @@ Entity
             {
                 id: headDelegate
                 property real dimmerValue: 0
-                property real lightIntensity: dimmerValue * shutterValue
+                /* Scaled by the global "Fixture light" setting, like the spotlight
+                   passes are. These cells are emissive geometry rather than a cone,
+                   so their own surface IS the whole light contribution of the
+                   fixture: scaling it here scales that contribution exactly once. */
+                property real lightIntensity:
+                    dimmerValue * shutterValue * (View3D ? View3D.fixtureLightIntensity : 1.0)
                 property real headWidth: phySize.x / headsLayout.width
                 property real headHeight: phySize.z / headsLayout.height
                 property color lightColor: Qt.rgba(0, 0, 0, 1)

--- a/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_shading.frag
+++ b/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_shading.frag
@@ -54,6 +54,17 @@ uniform float headLength;
 // spotlight_scattering.frag, through the smoke amount.
 uniform float fixtureLightIntensity;
 
+// Distance, in world units, at which fixture light lands unscaled: the mean
+// height of the rig above the floor, derived from the project. Light that has
+// travelled further is dimmed by the square of the ratio and light that has
+// travelled less is brightened, as illuminance does in the room. Normalising on
+// the rig's own scale keeps the frame's overall exposure where it was, so this
+// term changes the balance between near and far throws without acting as a
+// second global gain on top of fixtureLightIntensity. 0 disables it, which is
+// how this pass has always rendered: a beam lands the same brightness however
+// far it has travelled.
+uniform float referenceThrow;
+
 void main()
 {
 
@@ -81,10 +92,21 @@ void main()
     float r = coneTopRadius + (coneBottomRadius - coneTopRadius) * ((abs(q.z) - 0.5 * headLength) / coneDistCutoff);
     vec2 tc = (mat2x2(goboRotation.x, goboRotation.y, goboRotation.z, goboRotation.w) * ((-q.xy) * (1.0 / r))) * 0.5 + 0.5;
 
+    // Distance the light has travelled to reach this fragment, measured along
+    // the beam axis from the emitter, the same quantity the cone radius above
+    // is a function of. Floored so a surface up against the lens cannot divide
+    // the intensity to infinity.
+    float falloff = 1.0;
+    if (referenceThrow > 0.0)
+    {
+        float beamDist = max(abs(q.z) - 0.5 * headLength, 0.25);
+        falloff = (referenceThrow * referenceThrow) / (beamDist * beamDist);
+    }
+
     vec4 gSample = SAMPLE_TEX2D(goboTex, tc.xy);
     float goboMask = gSample.a * gSample.r;
 
-    vec3 finalColor = fixtureLightIntensity * shadowMask * goboMask * lightColor * lightIntensity * max(0, dot(normal, -lightDir)) * albedo;
+    vec3 finalColor = fixtureLightIntensity * falloff * shadowMask * goboMask * lightColor * lightIntensity * max(0, dot(normal, -lightDir)) * albedo;
 
     MGL_FRAG_COLOR = vec4(finalColor, 1.0);
     //MGL_FRAG_COLOR = vec4(1.0, 0.0, 0.0, 1.0);

--- a/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_shading.frag
+++ b/qmlui/qml/fixturesfunctions/3DView/shaders/spotlight_shading.frag
@@ -49,6 +49,11 @@ uniform sampler2D shadowTex;
 
 uniform float headLength;
 
+// Global gain on fixture light landing on surfaces, from the 3D view
+// Rendering settings. The volumetric beams have their own scaling in
+// spotlight_scattering.frag, through the smoke amount.
+uniform float fixtureLightIntensity;
+
 void main()
 {
 
@@ -79,7 +84,7 @@ void main()
     vec4 gSample = SAMPLE_TEX2D(goboTex, tc.xy);
     float goboMask = gSample.a * gSample.r;
 
-    vec3 finalColor = shadowMask * goboMask * lightColor * lightIntensity * max(0, dot(normal, -lightDir)) * albedo;
+    vec3 finalColor = fixtureLightIntensity * shadowMask * goboMask * lightColor * lightIntensity * max(0, dot(normal, -lightDir)) * albedo;
 
     MGL_FRAG_COLOR = vec4(finalColor, 1.0);
     //MGL_FRAG_COLOR = vec4(1.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
## Description

**Summary of Changes:**

Every fixture in the 3D view emits the same amount of light regardless of what it is, and that light lands just as brightly however far it has travelled. A large stage wash and a small LED PAR lay identical pools, and a fixture hung at 2 m looks the same as the same fixture hung at 4 m. This adds an opt-in **Lumens (experimental)** setting to the 3D view "Rendering" settings that renders the rig photometrically instead, so a mixed rig shows the balance it would really have.

Three things change when it is ticked:

* **Each fixture is scaled by its real output.** The `Lumens` value already present in fixture definitions, spread over the solid angle of the beam at the widest the lens opens, so what reaches the shader is luminous intensity in candela. That, not flux, is what the renderer's light intensity behaves like, because nothing in the shading divides by the area the cone covers. Two fixtures of equal lumens therefore differ by their beam angle, as they do in the room. The reference is the brightest emitter in the project by intensity, so that fixture keeps the brightness it had.
* **Zoom concentrates the light.** A moving beam closing down now brightens the pool it lays rather than only shrinking it, by the ratio of the cone's solid angle at its widest to its solid angle now.
* **Light falls off with the distance it travels**, by the inverse square, as illuminance does in the room. The distance at which light lands unscaled is *derived* from the project rather than asked for: the mean height above the floor of the fixtures placed in it, recomputed whenever a fixture is added, removed or moved.

Code:

* `MonitorProperties` gains a `useFixtureLumens` flag, saved as the `Lumens` attribute of the existing `<Rendering>` node, so the choice persists in the workspace.
* `MainView3D` computes each fixture's per-emitter lumens and candela, the project's reference candela (the brightest emitter) and its reference throw (the rig's mean hang height), and exposes them to QML.
* `Fixture3DItem`, `MultiBeams3DItem` / `LightEntity`, `PixelBar3DItem` and `Strobe3DItem` fold a `lumensScale` into their `lightIntensity`, so the scale reaches every fixture type exactly once.
* `spotlight_shading.frag` applies the inverse square term against the derived reference, gated on the same opt-in.
* A checkbox in the 3D view "Rendering" settings, labelled "Lumens (experimental)".

The setting is **off by default and existing workspaces are untouched**: a project with no `Lumens` attribute loads with it off and renders exactly as it does today.

This PR is part of a series of related changes to improve the realism of the 3D View.

**Related Issues:**

This sits on top of two of my open PRs, both in the same 3D view series:

* Depends on #2116 — *engine/qmlui: persist the 3D View "Rendering" and "Scale" lock settings in the project file*. That PR adds the `<Rendering>` node this feature stores its `Lumens` attribute in.
* Depends on #2117 — *engine/qmlui: add a "Fixture light" intensity setting to the 3D view*. That PR adds the global gain this feature is designed to compose with: **Lumens** sets the balance between fixtures, **Fixture light** sets the overall level. #2117 is itself based on #2116.
* Builds on #2115 — *qmlui: render light beams for LED Bar (Beams) fixtures in the 3D view* (merged), whose per-head beams this feature scales individually.

Because #2116 and #2117 are not merged yet, this PR is based on the #2117 branch and its diff therefore includes both of theirs. The commits new to this PR are the last four:

| commit | |
|---|---|
| `baa21851e` | scale 3D view fixture light by the fixture's Lumens |
| `635892115` | scale 3D view fixture light by intensity, not by flux |
| `c5e201cc5` | fall off 3D view fixture light over the distance it travels |
| `b90b1a8e7` | mark the 3D view "Lumens" setting experimental |

Everything else in the diff belongs to #2116 and #2117 and should be reviewed there. Reviewing or merging those two first will shrink this one to the four commits above.

Plus a merge of `master`. #2115 reached `master` by a different route than this branch's history took, so `LightEntity.qml` and `MultiBeams3DItem.qml` conflicted even though both sides carry the same code; they are resolved to `master`'s content plus the properties this PR adds, and the diff for those two files is now only those additions.

Documentation is a companion change to docs.qlcplus.org: mcallegari/qlcplus-docs#135.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [ ] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

## Testing

**Test Cases:**

Brightness figures are measured from screenshots by inverting the tone map in `gamma_correct.frag` and subtracting the ambient level, so they are proportional to the light actually cast. Render quality High, ambient 5%, smoke off.

*Relative output.* Three PARs hung at the same height so the falloff term is equal across them: A at 10000 lm / 25°, B at 10000 lm / 50°, C at 20000 lm / 50°. Predicted intensities against A are 1.000, 0.253 and 0.506.

1. All three with the setting off — equally bright, i.e. unchanged.
2. All three with the setting on — each scaled to its candela against the brightest emitter.
3. A fixture whose definition leaves Lumens unset renders at the reference level, never dark.
4. Effect of the flux-to-candela correction across fixture types, one of each, against the previous revision of this branch.

*Distance falloff.* Two identical PARs, one at 2 m and one at 4 m, so a 3 m derived reference.

5. Setting off — the two lay equally bright pools, as every release so far has rendered.
6. Setting on — the lower fixture lays the brighter pool, by the inverse square of the distance.
7. The same rig doubled in size, at 4 m and 8 m in a taller room, to confirm the derived reference makes the look independent of the venue's scale.
8. Moving a fixture up or down in the 3D view rebalances the rig live.

*Persistence and compatibility.*

9. Setting persists to the workspace on save and is restored on load.
10. Project with no `Lumens` attribute loads with the setting off and renders unchanged.
11. `MonitorProperties` unit tests cover defaults, XML round trip and reset.

*On a real rig.*

12. A full rig with the setting off and on, judged by eye.

**Test Results:**

| # | Result | Notes |
|---|--------|-------|
| 1 | Pass | Equal within sampling noise |
| 2 | Pass | Measured 1.000 / 0.260 / 0.506 against predicted 1.000 / 0.253 / 0.506. Note A and B carry identical lumens and differ four-fold on beam angle alone |
| 3 | Pass | Renders at the reference level, the same as with the setting off |
| 4 | Pass | Against the flux-scaled revision: a 120° blinder falls to 0.20, a 35° wash rises to 2.03, a 40° bar to 1.54, and two fixtures sharing a 50° widest lens are unchanged at 1.00 and 1.01 |
| 5 | Pass | Ratio 1.000 |
| 6 | Pass | Ratio 1.000 → 4.14, against 4.0 predicted by 1/d²; the excess is the emitter sitting a little below its stated hang height |
| 7 | Pass | Ratio 4.10, and the doubled rig renders at 0.96 and 0.98 of the smaller rig's levels — the look does not change with the size of the venue |
| 8 | Pass | Dragging a fixture down makes its light more intense, dragging it up less intense |
| 9 | Pass | `<Rendering ... Lumens="1"/>` written on save; reopened project reproduced the render without touching the checkbox |
| 10 | Pass | Attribute stripped by hand; matches test 1 |
| 11 | Pass | `monitorproperties_test`: 9 passed, 0 failed on this branch, 10 passed, 0 failed on a build merged with the beam softness work |
| 12 | Pass | See screenshots below |

Tested on Linux, Qt 6.11.2, Mesa llvmpipe.

## Screenshots

Screenshots, with the setting off and on. The flat magenta of the "off" renders is every fixture emitting the same amount of light, at the same intensity however far it has travelled.

**With the LED Bar (Beams) stage wash fixtures at uniform height**

`WithoutLumens.png` - current state
<img width="1702" height="860" alt="WithoutLumens" src="https://github.com/user-attachments/assets/67390d4d-680f-41c9-98a2-90722860fa41" />
`WithLumens.png` - shows how this feature can help make a scene more realistic
<img width="1702" height="860" alt="WithLumens" src="https://github.com/user-attachments/assets/4da8492a-3a3d-4431-81c1-9df0032ac4fe" />

**With the LED Bar (Beams) stage wash fixtures at different heights**

`WithoutLumens-Demo1.png` - current state - intensity is the same regardless of distance
<img width="1702" height="860" alt="WithoutLumens-Demo1" src="https://github.com/user-attachments/assets/5c5ebd49-4349-4810-82ce-35355f745661" />
`WithLumens-Demo1.png` - shows how distance now affects intensity
<img width="1702" height="860" alt="WithLumens-Demo1" src="https://github.com/user-attachments/assets/ffc6eeb3-1753-4740-9b0f-26120bb950eb" />

## Additional Notes

**Why the feature is marked experimental.** The look it produces may still change, and two limitations are worth stating plainly. It depends on fixture definitions carrying sensible `Lumens` and lens angle figures, and many do not (see coverage below). And the derived reference averages every placed fixture together, so a rig that mixes hung fixtures with floor standing ones pulls the reference below the height the hung fixtures throw from, and an uplighter close to what it lights renders very hot. Weighting or excluding near-floor fixtures is left for a later change; the **Fixture light** gain from #2117 pulls the frame back in the meantime.

**Why intensity rather than flux.** The first revision of this work fed each fixture's luminous flux straight into the renderer's light intensity. Nothing in `spotlight_shading.frag` divides by the area the cone covers — the gobo mask is sampled in normalised cone coordinates, so a wide beam lights a larger patch at the same brightness per pixel as a narrow one. The uniform therefore behaves as luminous intensity, and putting flux in it made two fixtures of equal output equally bright however tightly either one focused. Dividing by the solid angle of the beam, `2π(1 - cos(angle / 2))`, fixes that and makes zoom a live multiplier on top. It can push the intensity above 1.0, which is fine: the frame buffer is RGBA32F and `gamma_correct.frag` tone maps with `1 - exp(-x)`, so it rolls off rather than clipping.

**Why the falloff reference is derived and not a setting.** A prototype exposed it as a "Light falloff" distance in metres. That was wrong twice over. The 3D view is already a to-scale model of the venue — the grid is given in metres and fixtures sit at the heights they are really hung at — so the difference between a club and an arena is in the project already, and any number typed in can disagree with the rig actually built. More concretely, a reference distance reaches the shader only as a constant multiplying every fragment, which is exactly what the **Fixture light** gain already does; it would have been a second global exposure control wearing a physical name. Deriving it from the rig's own scale leaves the frame's overall exposure where it was and changes only the balance between near and far throws, which test 7 measures.

The reference depends only on where fixtures hang, never on pan and tilt. A reference that tracked where the heads point would make the whole frame breathe as they move.

**Why relative rather than absolute.** Each fixture is measured against the brightest emitter in the project, so the brightest fixture renders close to as it always has and everything else falls in below it. An absolute reference was rejected because a rig made entirely of small LED PARs would render uniformly dark and need the gain wound up to compensate. The trade-off is that adding a brighter fixture rescales everything below it.

**Per emitter, not per fixture.** `QLCPhysical` hangs off `QLCFixtureMode` (falling back to the definition's global `<Physical>`) and there is no per-head physical, so the value describes the whole fixture. It is divided between the emitters the 3D view draws — one lamp per channel for a Dimmer, one per head otherwise. Without that an 8 cell bar would cast eight times the light of a moving head carrying the same figure. That division is unchanged by the candela and falloff commits and was measured on an earlier revision: a 3-head bar's cells at 0.738 of a 2-head bar's, against 0.737 expected.

**A fixture with no lens angle** falls back to the same 30° the cone geometry already falls back to, so the photometry describes the cone actually drawn. That constant is shared by every such fixture and so does not disturb their balance against each other.

**Backwards compatibility was the governing constraint.** Nothing about an existing project may look different after this change, and there are three independent guards:

1. The setting defaults to off, and a workspace saved before this change has no `Lumens` attribute, so it loads off. Existing projects render exactly as they do today (tests 5 and 10).
2. With the setting on, a fixture whose definition has no lumens data renders at the reference level — the brightness it has always had. It never goes dark (test 3).
3. With the setting on in a project where no fixture has the data, the reference is 0, every scale collapses to 1.0 and the falloff term is skipped, so the whole feature is a no-op rather than a surprise.

**Library coverage.** The data exists but is far from universal, which is why "unknown" had to be a first-class case rather than an edge case:

| | count | share |
|---|---|---|
| Fixture definitions in the library | 1735 | |
| ...with a `<Physical>` block | 1735 | 100% |
| ...giving a non-zero `Lumens` | 612 | 35% |
| Fixture modes | 5040 | |
| ...resolving to a non-zero `Lumens` | 2020 | 40% |

Of the 612 definitions that do carry the value, 286 are Moving Heads and 190 Colour Changers — the cone-casting types this setting affects most — plus 41 Scanners, 45 LED bars and 17 Strobes. As definitions gain the value the setting simply gets more accurate.

**Scope of the falloff.** Only the surface shading pass is affected. The volumetric beam in `spotlight_scattering.frag` would need the term applied per raymarch sample and is left alone for now, so a beam in smoke still reads at full length.

