### PR TITLE
qmlui, bugfix: rebuild the 3D view frame graph when the render quality changes

### DIFF
--- a/qmlui/mainview3d.cpp
+++ b/qmlui/mainview3d.cpp
@@ -2616,6 +2616,15 @@ void MainView3D::setRenderQuality(MainView3D::RenderQuality renderQuality)
 
     m_renderQuality = renderQuality;
     emit renderQualityChanged(m_renderQuality);
+
+    // The frame graph is built once, and it reads the flags on each fixture item
+    // that say which passes that fixture needs - flags that follow the render
+    // quality. Changing the quality therefore only flips those flags: the passes
+    // they select are added or dropped when the frame graph is built again, so do
+    // that here. Without it, raising the quality from Low leaves the scene with no
+    // spotlight pass at all until the 3D view is left and entered again.
+    if (m_scene3D)
+        QMetaObject::invokeMethod(m_scene3D, "updateFrameGraph", Q_ARG(QVariant, true));
 }
 
 QStringList MainView3D::stagesList() const


### PR DESCRIPTION

## Description

**Summary of Changes:**

Changing Rendering > Quality in the 3D view only took effect once the view was left and entered again. Most visibly, raising the quality away from Low left the scene with no fixture light at all. `MainView3D::setRenderQuality()` now rebuilds the frame graph, the same way adding or removing a fixture item already does.

**Related Issues:**

None.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style, including:
  - [x] Placing opening braces `{` on a new line for functions and class definitions.
  - [x] Consistent use of spaces and indentation.
- [x] I have tested my changes on the following platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
- [x] I have added or [updated documentation](https://docs.qlcplus.org/) as necessary.

No documentation change necessary.

## Testing

**Test Cases:**

Open a project with a spotlight fixture aimed at the stage, run a scene that lights it, and open the 3D view. The render quality starts at High.

1. Set Rendering > Quality to Low, staying in the 3D view.
2. Leave the 3D view and return to it.
3. Set the quality back to High, staying in the 3D view.
4. Leave the 3D view and return to it.
5. Repeat step 3 for Medium and for Ultra.

**Test Results:**

| # | Expected | Before | After |
|---|---|---|---|
| 1 | Fixtures stop lighting the scene | **Fail** - the beams in the air go, but surfaces stay lit | Pass |
| 2 | Scene dark | Pass - this is where Low finally took effect | Pass |
| 3 | Fixtures light the scene again | **Fail** - stays dark | Pass |
| 4 | Fixtures lit | Pass - this was the workaround | Pass |
| 5 | Fixtures light the scene | **Fail** - stays dark | Pass |

Tested on Linux (Qt 6, Intel iGPU, hardware OpenGL). No crash, GPU error or rendering corruption across the quality transitions.

## Additional Notes

`3DView.qml`'s `updateFrameGraph()` builds the frame graph once, and for each fixture it reads that item's `useScattering` and `useShadows` flags to decide whether to create a shadow map pass, a spotlight shading pass and a scattering pass. Those flags are bound to `View3D.renderQuality`, and at Low quality they are all false, so no spotlight pass is created for any fixture.

`setRenderQuality()` previously only stored the value and emitted the notify signal. The flags flipped, but nothing rebuilt the frame graph, so the passes stayed absent. The frame graph was otherwise only rebuilt on entering the view and on adding or removing a fixture item, which is why leaving the view and coming back appeared to fix it.

`raymarchSteps` is a plain shader uniform and did track the quality live, which is why the dial looked half-applied rather than inert: dropping to Low removed the volumetric beams immediately, but the surface lighting stayed until the frame graph was next built.

The call is guarded on `m_scene3D` so that changing the quality while the 3D view has never been opened stays a no-op, and it uses the same `updateFrameGraph(true)` entry point as `removeFixtureItem()`, which destroys the existing nodes before recreating them.
