### PR TITLE
Keep RGB matrix color controls inside narrow panels

### DIFF
--- a/qmlui/qml/RGBMatrixColorRow.qml
+++ b/qmlui/qml/RGBMatrixColorRow.qml
@@ -1,0 +1,114 @@
+import QtQuick
+import QtQuick.Layouts
+import "."
+
+GridLayout
+{
+    id: root
+    columns: 4
+    columnSpacing: 4
+    rowSpacing: 0
+    Layout.fillWidth: true
+    Layout.minimumWidth: 0
+
+    property int firstColorIndex: -1
+    property int secondColorIndex: -1
+    property bool firstResetVisible: false
+    property bool secondResetVisible: false
+    property string firstResetTooltip: ""
+    property string secondResetTooltip: ""
+    property alias firstColor: firstColorButton.color
+    property alias secondColor: secondColorButton.color
+    signal colorClicked(int colorIndex, var previewButton)
+    signal resetClicked(int colorIndex)
+
+    Rectangle
+    {
+        id: firstColorButton
+        objectName: "rgbColorButton_" + root.firstColorIndex
+        visible: root.firstColorIndex >= 0
+        Layout.fillWidth: true
+        Layout.minimumWidth: 0
+        Layout.fillHeight: true
+        radius: 5
+        border.width: 2
+        border.color: firstColorMouse.containsMouse ? "white" : UISettings.bgLight
+
+        MouseArea
+        {
+            id: firstColorMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.colorClicked(root.firstColorIndex, firstColorButton)
+        }
+    }
+
+    Item
+    {
+        visible: root.firstColorIndex >= 0
+        Layout.preferredWidth: root.height
+        Layout.minimumWidth: root.height
+        Layout.maximumWidth: root.height
+        Layout.fillHeight: true
+
+        IconButton
+        {
+            objectName: "rgbColorReset_" + root.firstColorIndex
+            anchors.fill: parent
+            visible: root.firstResetVisible
+            faSource: FontAwesome.fa_xmark
+            faColor: "darkred"
+            tooltip: root.firstResetTooltip
+            onClicked:
+            {
+                firstColorButton.color = "transparent"
+                root.resetClicked(root.firstColorIndex)
+            }
+        }
+    }
+
+    Rectangle
+    {
+        id: secondColorButton
+        objectName: "rgbColorButton_" + root.secondColorIndex
+        visible: root.secondColorIndex >= 0
+        Layout.fillWidth: true
+        Layout.minimumWidth: 0
+        Layout.fillHeight: true
+        radius: 5
+        border.width: 2
+        border.color: secondColorMouse.containsMouse ? "white" : UISettings.bgLight
+
+        MouseArea
+        {
+            id: secondColorMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.colorClicked(root.secondColorIndex, secondColorButton)
+        }
+    }
+
+    Item
+    {
+        visible: root.secondColorIndex >= 0
+        Layout.preferredWidth: root.height
+        Layout.minimumWidth: root.height
+        Layout.maximumWidth: root.height
+        Layout.fillHeight: true
+
+        IconButton
+        {
+            objectName: "rgbColorReset_" + root.secondColorIndex
+            anchors.fill: parent
+            visible: root.secondResetVisible
+            faSource: FontAwesome.fa_xmark
+            faColor: "darkred"
+            tooltip: root.secondResetTooltip
+            onClicked:
+            {
+                secondColorButton.color = "transparent"
+                root.resetClicked(root.secondColorIndex)
+            }
+        }
+    }
+}

--- a/qmlui/qml/fixturesfunctions/RGBMatrixEditor.qml
+++ b/qmlui/qml/fixturesfunctions/RGBMatrixEditor.qml
@@ -41,11 +41,15 @@ Rectangle
     onAlgoColorsChanged:
     {
         var cCount = rgbMatrixEditor.algoColorsCount
-        color1Button.color = algoColors[0]
-        color2Button.color = cCount > 1 && rgbMatrixEditor.hasColorAtIndex(1) ? algoColors[1] : "transparent"
-        color3Button.color = cCount > 2 && rgbMatrixEditor.hasColorAtIndex(2) ? algoColors[2] : "transparent"
-        color4Button.color = cCount > 3 && rgbMatrixEditor.hasColorAtIndex(3) ? algoColors[3] : "transparent"
-        color5Button.color = cCount > 4 && rgbMatrixEditor.hasColorAtIndex(4) ? algoColors[4] : "transparent"
+        primaryColorRow.firstColor = algoColors[0]
+        primaryColorRow.secondColor = cCount > 1 &&
+                rgbMatrixEditor.hasColorAtIndex(1) ? algoColors[1] : "transparent"
+        secondaryColorRow.firstColor = cCount > 2 &&
+                rgbMatrixEditor.hasColorAtIndex(2) ? algoColors[2] : "transparent"
+        secondaryColorRow.secondColor = cCount > 3 &&
+                rgbMatrixEditor.hasColorAtIndex(3) ? algoColors[3] : "transparent"
+        finalColorRow.firstColor = cCount > 4 &&
+                rgbMatrixEditor.hasColorAtIndex(4) ? algoColors[4] : "transparent"
     }
 
     TimeEditTool
@@ -299,82 +303,26 @@ Rectangle
                     }
                 }
 
-                Row
+                RGBMatrixColorRow
                 {
-                    //width: editorColumn.colWidth
+                    id: primaryColorRow
                     Layout.columnSpan: 2
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
                     height: editorColumn.itemsHeight
-                    spacing: 4
-
-                    Rectangle
-                    {
-                        id: color1Button
-                        width: UISettings.iconSizeDefault * 2
-                        height: editorColumn.itemsHeight
-                        radius: 5
-                        border.color: color1MouseArea.containsMouse ? "white" : UISettings.bgLight
-                        border.width: 2
-                        visible: rgbMatrixEditor.algoColorsCount > 0 ? true : false
-
-                        MouseArea
-                        {
-                            id: color1MouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            onClicked:
-                            {
-                                if (colorTool.visible)
-                                    colorTool.hide()
-                                else
-                                    colorTool.showTool(0, color1Button)
-                            }
-                        }
+                    visible: rgbMatrixEditor.algoColorsCount > 0
+                    firstColorIndex: visible ? 0 : -1
+                    secondColorIndex: rgbMatrixEditor.algoColorsCount > 1 ? 1 : -1
+                    secondResetVisible: secondColorIndex >= 0
+                    secondResetTooltip: qsTr("Reset color 2")
+                    onColorClicked: function(colorIndex, previewButton) {
+                        if (colorTool.visible)
+                            colorTool.hide()
+                        else
+                            colorTool.showTool(colorIndex, previewButton)
                     }
-                    Rectangle
-                    {
-                        width: UISettings.listItemHeight
-                        height: width
-                        color: "transparent"
-                        visible: rgbMatrixEditor.algoColorsCount > 2 ? true : false
-                    }
-
-                    Rectangle
-                    {
-                        id: color2Button
-                        width: UISettings.iconSizeDefault * 2
-                        height: editorColumn.itemsHeight
-                        radius: 5
-                        border.color: color2MouseArea.containsMouse ? "white" : UISettings.bgLight
-                        border.width: 2
-                        visible: rgbMatrixEditor.algoColorsCount > 1 ? true : false
-
-                        MouseArea
-                        {
-                            id: color2MouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            onClicked:
-                            {
-                                if (colorTool.visible)
-                                    colorTool.hide()
-                                else
-                                    colorTool.showTool(1, color2Button)
-                            }
-                        }
-                    }
-                    IconButton
-                    {
-                        width: UISettings.listItemHeight
-                        height: width
-                        faSource: FontAwesome.fa_xmark
-                        faColor: "darkred"
-                        tooltip: qsTr("Reset color 2")
-                        visible: rgbMatrixEditor.algoColorsCount > 1 ? true : false
-                        onClicked:
-                        {
-                            color2Button.color = "transparent"
-                            rgbMatrixEditor.resetColorAtIndex(1)
-                        }
+                    onResetClicked: function(colorIndex) {
+                        rgbMatrixEditor.resetColorAtIndex(colorIndex)
                     }
                 }
 
@@ -388,90 +336,28 @@ Rectangle
                     visible: rgbMatrixEditor.algoColorsCount > 4 ? true : false
                 }
 
-                Row
+                RGBMatrixColorRow
                 {
+                    id: secondaryColorRow
                     Layout.columnSpan: 2
-                    //width: editorColumn.colWidth
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
                     height: editorColumn.itemsHeight
-                    spacing: 4
-                    visible: rgbMatrixEditor.algoColorsCount > 4 ? true : false
-
-                    Rectangle
-                    {
-                        id: color3Button
-                        width: UISettings.iconSizeDefault * 2
-                        height: editorColumn.itemsHeight
-                        radius: 5
-                        border.color: color3MouseArea.containsMouse ? "white" : UISettings.bgLight
-                        border.width: 2
-                        visible: rgbMatrixEditor.algoColorsCount > 2 ? true : false
-
-                        MouseArea
-                        {
-                            id: color3MouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            onClicked:
-                            {
-                                if (colorTool.visible)
-                                    colorTool.hide()
-                                else
-                                    colorTool.showTool(2, color3Button)
-                            }
-                        }
+                    visible: rgbMatrixEditor.algoColorsCount > 4
+                    firstColorIndex: visible ? 2 : -1
+                    secondColorIndex: visible ? 3 : -1
+                    firstResetVisible: visible
+                    secondResetVisible: visible
+                    firstResetTooltip: qsTr("Reset color 3")
+                    secondResetTooltip: qsTr("Reset color 4")
+                    onColorClicked: function(colorIndex, previewButton) {
+                        if (colorTool.visible)
+                            colorTool.hide()
+                        else
+                            colorTool.showTool(colorIndex, previewButton)
                     }
-                    IconButton
-                    {
-                        width: UISettings.listItemHeight
-                        height: width
-                        faSource: FontAwesome.fa_xmark
-                        faColor: "darkred"
-                        tooltip: qsTr("Reset color 3")
-                        visible: rgbMatrixEditor.algoColorsCount > 2 ? true : false
-                        onClicked:
-                        {
-                            color3Button.color = "transparent"
-                            rgbMatrixEditor.resetColorAtIndex(2)
-                        }
-                    }
-
-                    Rectangle
-                    {
-                        id: color4Button
-                        width: UISettings.iconSizeDefault * 2
-                        height: editorColumn.itemsHeight
-                        radius: 5
-                        border.color: color4MouseArea.containsMouse ? "white" : UISettings.bgLight
-                        border.width: 2
-                        visible: rgbMatrixEditor.algoColorsCount > 3 ? true : false
-
-                        MouseArea
-                        {
-                            id: color4MouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            onClicked:
-                            {
-                                if (colorTool.visible)
-                                    colorTool.hide()
-                                else
-                                    colorTool.showTool(3, color4Button)
-                            }
-                        }
-                    }
-                    IconButton
-                    {
-                        width: UISettings.listItemHeight
-                        height: width
-                        faSource: FontAwesome.fa_xmark
-                        faColor: "darkred"
-                        tooltip: qsTr("Reset color 4")
-                        visible: rgbMatrixEditor.algoColorsCount > 3 ? true : false
-                        onClicked:
-                        {
-                            color4Button.color = "transparent"
-                            rgbMatrixEditor.resetColorAtIndex(3)
-                        }
+                    onResetClicked: function(colorIndex) {
+                        rgbMatrixEditor.resetColorAtIndex(colorIndex)
                     }
                 }
 
@@ -485,51 +371,25 @@ Rectangle
                     visible: rgbMatrixEditor.algoColorsCount > 4 ? true : false
                 }
 
-                Row
+                RGBMatrixColorRow
                 {
+                    id: finalColorRow
                     Layout.columnSpan: 2
-                    //width: editorColumn.colWidth
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
                     height: editorColumn.itemsHeight
-                    spacing: 4
-                    visible: rgbMatrixEditor.algoColorsCount > 4 ? true : false
-
-                    Rectangle
-                    {
-                        id: color5Button
-                        width: UISettings.iconSizeDefault * 2
-                        height: editorColumn.itemsHeight
-                        radius: 5
-                        border.color: color5MouseArea.containsMouse ? "white" : UISettings.bgLight
-                        border.width: 2
-                        visible: rgbMatrixEditor.algoColorsCount > 4 ? true : false
-
-                        MouseArea
-                        {
-                            id: color5MouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            onClicked:
-                            {
-                                if (colorTool.visible)
-                                    colorTool.hide()
-                                else
-                                    colorTool.showTool(4, color5Button)
-                            }
-                        }
+                    visible: rgbMatrixEditor.algoColorsCount > 4
+                    firstColorIndex: visible ? 4 : -1
+                    firstResetVisible: visible
+                    firstResetTooltip: qsTr("Reset color 5")
+                    onColorClicked: function(colorIndex, previewButton) {
+                        if (colorTool.visible)
+                            colorTool.hide()
+                        else
+                            colorTool.showTool(colorIndex, previewButton)
                     }
-                    IconButton
-                    {
-                        width: UISettings.listItemHeight
-                        height: width
-                        faSource: FontAwesome.fa_xmark
-                        faColor: "darkred"
-                        tooltip: qsTr("Reset color 5")
-                        visible: rgbMatrixEditor.algoColorsCount > 4 ? true : false
-                        onClicked:
-                        {
-                            color5Button.color = "transparent"
-                            rgbMatrixEditor.resetColorAtIndex(4)
-                        }
+                    onResetClicked: function(colorIndex) {
+                        rgbMatrixEditor.resetColorAtIndex(colorIndex)
                     }
                 }
             }

--- a/qmlui/qml/fixturesfunctions/qmldir
+++ b/qmlui/qml/fixturesfunctions/qmldir
@@ -26,6 +26,7 @@ MenuBarEntry 0.1 ../MenuBarEntry.qml
 MultiColorBox 0.1 ../MultiColorBox.qml
 PaletteFanningBox 0.1 ../PaletteFanningBox.qml
 QLCPlusFader 0.1 ../QLCPlusFader.qml
+RGBMatrixColorRow 0.1 ../RGBMatrixColorRow.qml
 RobotoText 0.1 ../RobotoText.qml
 SectionBox 0.1 ../SectionBox.qml
 SidePanel 0.1 ../SidePanel.qml

--- a/qmlui/qml/qmldir
+++ b/qmlui/qml/qmldir
@@ -34,6 +34,7 @@ MenuBarEntry 0.1 MenuBarEntry.qml
 MultiColorBox 0.1 MultiColorBox.qml
 QLCPlusFader 0.1 QLCPlusFader.qml
 QLCPlusKnob 0.1 QLCPlusKnob.qml
+RGBMatrixColorRow 0.1 RGBMatrixColorRow.qml
 RobotoText 0.1 RobotoText.qml
 SectionBox 0.1 SectionBox.qml
 SidePanel 0.1 SidePanel.qml

--- a/qmlui/qmlui.qrc
+++ b/qmlui/qmlui.qrc
@@ -47,6 +47,7 @@
     <file alias="PaletteFanningBox.qml">qml/PaletteFanningBox.qml</file>
     <file alias="QLCPlusFader.qml">qml/QLCPlusFader.qml</file>
     <file alias="QLCPlusKnob.qml">qml/QLCPlusKnob.qml</file>
+    <file alias="RGBMatrixColorRow.qml">qml/RGBMatrixColorRow.qml</file>
     <file alias="RobotoText.qml">qml/RobotoText.qml</file>
     <file alias="SectionBox.qml">qml/SectionBox.qml</file>
     <file alias="SidePanel.qml">qml/SidePanel.qml</file>

--- a/qmlui/test/tst_rgbmatrixcolorrow.qml
+++ b/qmlui/test/tst_rgbmatrixcolorrow.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtTest
+import "../qml" as QLC
+
+TestCase
+{
+    id: testCase
+    name: "RGBMatrixColorRow"
+    when: windowShown
+    width: 420
+    height: 180
+    visible: true
+
+    QLC.RGBMatrixColorRow
+    {
+        id: colorRow
+        width: 200
+        height: 28
+        firstColorIndex: 2
+        secondColorIndex: 3
+        firstResetVisible: true
+        secondResetVisible: true
+        firstColor: "red"
+        secondColor: "blue"
+    }
+
+    SignalSpy
+    {
+        id: resetSpy
+        target: colorRow
+        signalName: "resetClicked"
+    }
+
+    function init()
+    {
+        resetSpy.clear()
+        colorRow.width = 200
+        wait(0)
+    }
+
+    function test_rightResetRemainsInsideReducedWidth()
+    {
+        const rightReset = findChild(colorRow, "rgbColorReset_3")
+        const firstSwatch = findChild(colorRow, "rgbColorButton_2")
+        const secondSwatch = findChild(colorRow, "rgbColorButton_3")
+        verify(rightReset !== null)
+        verify(firstSwatch.width > 0)
+        verify(secondSwatch.width > 0)
+        const resetPosition = rightReset.mapToItem(colorRow, 0, 0)
+        verify(resetPosition.x >= -0.01)
+        verify(resetPosition.x + rightReset.width <= colorRow.width + 0.01)
+    }
+
+    function test_rightResetEmitsItsColorIndex()
+    {
+        const rightReset = findChild(colorRow, "rgbColorReset_3")
+        verify(colorRow.visible, "row must be visible")
+        verify(colorRow.secondResetVisible, "right reset flag must be true")
+        verify(rightReset.parent.visible, "right reset slot must be visible")
+        verify(rightReset.visible, "right reset button must be visible")
+        verify(rightReset.enabled)
+        verify(rightReset.width > 0)
+        verify(rightReset.height > 0)
+        mouseClick(rightReset, rightReset.width / 2,
+                   rightReset.height / 2, Qt.LeftButton)
+        compare(resetSpy.count, 1)
+        compare(resetSpy.signalArguments[0][0], 3)
+    }
+}


### PR DESCRIPTION
## Why

The RGB matrix editor color controls can extend beyond the available panel width, leaving the reset control outside the usable row.

## What changed

Extract the color control row into a reusable component and constrain its layout so the color picker, value field, and reset action remain together.

## Expected behavior

RGB matrix color controls remain visible and usable at narrow panel widths.

## Validation

qmltestrunner: 4 passed, 0 failed.