### PR TITLE
Guard optional Qt 6 FFmpeg plugin installation on macOS

### DIFF
--- a/platforms/macos/CMakeLists.txt
+++ b/platforms/macos/CMakeLists.txt
@@ -102,7 +102,9 @@ install(FILES ${QT_PLUGINS_DIR}/imageformats/libqsvg.dylib DESTINATION ${INSTALL
 # multimedia
 if(QT_MAJOR_VERSION GREATER 5)
     install(FILES ${QT_PLUGINS_DIR}/multimedia/libdarwinmediaplugin.dylib DESTINATION ${INSTALLROOT}/${PLUGINDIR}/multimedia)
-    install(FILES ${QT_PLUGINS_DIR}/multimedia/libffmpegmediaplugin.dylib DESTINATION ${INSTALLROOT}/${PLUGINDIR}/multimedia)
+    if(EXISTS "${QT_PLUGINS_DIR}/multimedia/libffmpegmediaplugin.dylib")
+        install(FILES ${QT_PLUGINS_DIR}/multimedia/libffmpegmediaplugin.dylib DESTINATION ${INSTALLROOT}/${PLUGINDIR}/multimedia)
+    endif()
 else()
     install(FILES ${QT_PLUGINS_DIR}/audio/libqtaudio_coreaudio.dylib DESTINATION ${INSTALLROOT}/${PLUGINDIR}/audio)
     install(FILES ${QT_PLUGINS_DIR}/mediaservice/libqavfmediaplayer.dylib DESTINATION ${INSTALLROOT}/${PLUGINDIR}/mediaservice)


### PR DESCRIPTION
## Why

Some Qt 6 macOS installations do not include the optional FFmpeg multimedia plugin. A mandatory install rule makes the build fail even though the plugin is not required.

## What changed

Install the optional Qt 6 FFmpeg plugin only when the file exists.

## Expected behavior

macOS packaging succeeds with Qt installations that provide the plugin and also with installations that omit it.

## Validation

CMake-only change; the full upstream CI matrix should verify the packaging step.