### PR TITLE
Keep unavailable I/O plugins visible and configurable

### DIFF
--- a/qmlui/inputoutputmanager.cpp
+++ b/qmlui/inputoutputmanager.cpp
@@ -64,6 +64,8 @@ InputOutputManager::InputOutputManager(QQuickView *view, Doc *doc, QObject *pare
     connect(m_ioMap, SIGNAL(universeAdded(quint32)), this, SIGNAL(universeNamesChanged()));
     connect(m_ioMap, SIGNAL(universeRemoved(quint32)), this, SIGNAL(universesListModelChanged()));
     connect(m_ioMap, SIGNAL(universeRemoved(quint32)), this, SIGNAL(universeNamesChanged()));
+    connect(m_ioMap, SIGNAL(pluginConfigurationChanged(QString,bool)),
+            this, SIGNAL(ioSourcesChanged()));
     connect(m_ioMap, SIGNAL(beat()), this, SIGNAL(beat()), Qt::QueuedConnection);
     connect(m_ioMap, SIGNAL(beatGeneratorTypeChanged()), this, SLOT(slotBeatTypeChanged()));
     connect(m_ioMap, SIGNAL(bpmNumberChanged(int)), this, SIGNAL(bpmNumberChanged(int)));
@@ -72,6 +74,7 @@ InputOutputManager::InputOutputManager(QQuickView *view, Doc *doc, QObject *pare
 void InputOutputManager::slotDocLoaded()
 {
     emit universesListModelChanged();
+    emit ioSourcesChanged();
 }
 
 /*********************************************************************
@@ -518,8 +521,10 @@ QVariant InputOutputManager::universeInputSources(int universe)
     foreach (QString pluginName,  m_ioMap->inputPluginNames())
     {
         QLCIOPlugin *plugin = m_doc->ioPluginCache()->plugin(pluginName);
+        QStringList pluginLines = m_ioMap->pluginInputs(pluginName);
+        bool sourceAdded = false;
         int i = 0;
-        foreach (QString pLine, m_ioMap->pluginInputs(pluginName))
+        foreach (QString pLine, pluginLines)
         {
             if (pluginName == currPlugin && i == currLine)
             {
@@ -535,9 +540,28 @@ QVariant InputOutputManager::universeInputSources(int universe)
                 lineMap.insert("name", pLine);
                 lineMap.insert("line", i);
                 lineMap.insert("plugin", pluginName);
+                lineMap.insert("available", true);
+                lineMap.insert("canConfigure", plugin->canConfigure());
+                lineMap.insert("status", QString());
                 inputSources.append(lineMap);
+                sourceAdded = true;
             }
             i++;
+        }
+
+        if (sourceAdded == false)
+        {
+            QVariantMap pluginMap;
+            pluginMap.insert("universe", universe);
+            pluginMap.insert("name", pluginName);
+            pluginMap.insert("line", -1);
+            pluginMap.insert("plugin", pluginName);
+            pluginMap.insert("available", false);
+            pluginMap.insert("canConfigure", plugin->canConfigure());
+            pluginMap.insert("status", pluginLines.isEmpty() ?
+                             tr("No input lines detected") :
+                             tr("No unpatched input lines available"));
+            inputSources.append(pluginMap);
         }
     }
 
@@ -559,8 +583,10 @@ QVariant InputOutputManager::universeOutputSources(int universe)
     foreach (QString pluginName,  m_ioMap->outputPluginNames())
     {
         QLCIOPlugin *plugin = m_doc->ioPluginCache()->plugin(pluginName);
+        QStringList pluginLines = m_ioMap->pluginOutputs(pluginName);
+        bool sourceAdded = false;
         int i = 0;
-        foreach (QString pLine, m_ioMap->pluginOutputs(pluginName))
+        foreach (QString pLine, pluginLines)
         {
             if (pluginName == currPlugin && i == currLine)
             {
@@ -576,9 +602,28 @@ QVariant InputOutputManager::universeOutputSources(int universe)
                 lineMap.insert("name", pLine);
                 lineMap.insert("line", i);
                 lineMap.insert("plugin", pluginName);
+                lineMap.insert("available", true);
+                lineMap.insert("canConfigure", plugin->canConfigure());
+                lineMap.insert("status", QString());
                 outputSources.append(lineMap);
+                sourceAdded = true;
             }
             i++;
+        }
+
+        if (sourceAdded == false)
+        {
+            QVariantMap pluginMap;
+            pluginMap.insert("universe", universe);
+            pluginMap.insert("name", pluginName);
+            pluginMap.insert("line", -1);
+            pluginMap.insert("plugin", pluginName);
+            pluginMap.insert("available", false);
+            pluginMap.insert("canConfigure", plugin->canConfigure());
+            pluginMap.insert("status", pluginLines.isEmpty() ?
+                             tr("No output lines detected") :
+                             tr("No unpatched output lines available"));
+            outputSources.append(pluginMap);
         }
     }
 
@@ -739,6 +784,13 @@ void InputOutputManager::configurePlugin(bool input)
             m_ioMap->configurePlugin(pluginName);
         }
     }
+}
+
+void InputOutputManager::configurePluginByName(QString pluginName)
+{
+    QLCIOPlugin *plugin = m_doc->ioPluginCache()->plugin(pluginName);
+    if (plugin != nullptr && plugin->canConfigure())
+        m_ioMap->configurePlugin(pluginName);
 }
 
 bool InputOutputManager::inputCanConfigure() const
@@ -1044,4 +1096,3 @@ void InputOutputManager::setBpmNumber(int bpmNumber)
     m_ioMap->setBpmNumber(bpmNumber);
     emit bpmNumberChanged(bpmNumber);
 }
-

--- a/qmlui/inputoutputmanager.h
+++ b/qmlui/inputoutputmanager.h
@@ -172,11 +172,13 @@ public:
     Q_INVOKABLE void setInputProfile(int universe, QString profileName);
 
     Q_INVOKABLE void configurePlugin(bool input);
+    Q_INVOKABLE void configurePluginByName(QString pluginName);
 
     bool inputCanConfigure() const;
     bool outputCanConfigure() const;
 
 signals:
+    void ioSourcesChanged();
     void inputCanConfigureChanged();
     void outputCanConfigureChanged();
 

--- a/qmlui/qlcplus_de_DE.ts
+++ b/qmlui/qlcplus_de_DE.ts
@@ -2167,6 +2167,26 @@ in diesen Bereich ziehen</translation>
         <source>Internal generator</source>
         <translation>Interner Taktgenerator</translation>
     </message>
+    <message>
+        <location filename="inputoutputmanager.cpp" line="455"/>
+        <source>No input lines detected</source>
+        <translation>Keine Eingänge erkannt</translation>
+    </message>
+    <message>
+        <location filename="inputoutputmanager.cpp" line="456"/>
+        <source>No unpatched input lines available</source>
+        <translation>Keine freien Eingänge verfügbar</translation>
+    </message>
+    <message>
+        <location filename="inputoutputmanager.cpp" line="517"/>
+        <source>No output lines detected</source>
+        <translation>Keine Ausgänge erkannt</translation>
+    </message>
+    <message>
+        <location filename="inputoutputmanager.cpp" line="518"/>
+        <source>No unpatched output lines available</source>
+        <translation>Keine freien Ausgänge verfügbar</translation>
+    </message>
 </context>
 <context>
     <name>InputPatchItem</name>
@@ -2899,6 +2919,14 @@ Ungespeicherte Änderungen gehen verloren.</translation>
         <location filename="qml/fixtureeditor/PhysicalProperties.qml" line="346"/>
         <source>DMX Connector</source>
         <translation>DMX-Anschluss</translation>
+    </message>
+</context>
+<context>
+    <name>PluginDragItem</name>
+    <message>
+        <location filename="qml/inputoutput/PluginDragItem.qml" line="80"/>
+        <source>click to configure</source>
+        <translation>zum Konfigurieren klicken</translation>
     </message>
 </context>
 <context>

--- a/qmlui/qml/inputoutput/GenericHelpers.js
+++ b/qmlui/qml/inputoutput/GenericHelpers.js
@@ -1,0 +1,8 @@
+.import "../../js/GenericHelpers.js" as SharedHelpers
+
+// Source-tree bridge for QML tests. The application resource collection keeps
+// GenericHelpers.js and PluginDragItem.qml together at the qrc root.
+function pluginIconFromName(pluginName)
+{
+    return SharedHelpers.pluginIconFromName(pluginName)
+}

--- a/qmlui/qml/inputoutput/PluginDragItem.qml
+++ b/qmlui/qml/inputoutput/PluginDragItem.qml
@@ -34,6 +34,11 @@ Rectangle
     property string pluginName
     property string pluginLine
     property string lineName
+    property bool sourceAvailable: true
+    property bool canConfigure: false
+    property string statusText: ""
+
+    opacity: sourceAvailable ? 1.0 : 0.65
 
     Row
     {
@@ -70,7 +75,9 @@ Rectangle
         {
             height: pluginDragItem.height
             width: pluginDragItem.width - pIcon.width
-            label: lineName
+            label: sourceAvailable ? lineName :
+                       pluginName + "\n" + statusText +
+                       (canConfigure ? " (" + qsTr("click to configure") + ")" : "")
             wrapText: true
         }
     }

--- a/qmlui/qml/inputoutput/PluginsList.qml
+++ b/qmlui/qml/inputoutput/PluginsList.qml
@@ -28,19 +28,31 @@ Rectangle
 
     property int universeIndex: 0
     property bool isInput: false
+    readonly property int sourcesCount: uniListView.count
+
+    function refreshSources()
+    {
+        uniListView.model = isInput ?
+                    ioManager.universeInputSources(universeIndex) :
+                    ioManager.universeOutputSources(universeIndex)
+    }
+
+    function activateSource(pluginName, available, canConfigure)
+    {
+        if (available === false && canConfigure === true)
+            ioManager.configurePluginByName(pluginName)
+    }
 
     function loadSources(input)
     {
-        if (input === true)
-        {
-            uniListView.model = ioManager.universeInputSources(universeIndex)
-            isInput = true
-        }
-        else
-        {
-            uniListView.model = ioManager.universeOutputSources(universeIndex)
-            isInput = false
-        }
+        isInput = input
+        refreshSources()
+    }
+
+    Connections
+    {
+        target: ioManager
+        function onIoSourcesChanged() { pluginsContainer.refreshSources() }
     }
 
     ListView
@@ -61,12 +73,18 @@ Rectangle
                     width: pluginsContainer.width
                     height: parent.height
 
-                    drag.target: pluginItem
+                    drag.target: pluginItem.sourceAvailable ? pluginItem : null
                     drag.threshold: height / 2
+
+                    onClicked:
+                        pluginsContainer.activateSource(pluginItem.pluginName,
+                                                        pluginItem.sourceAvailable,
+                                                        pluginItem.canConfigure)
 
                     onReleased:
                     {
-                        if (pluginItem.Drag.target !== null)
+                        if (pluginItem.sourceAvailable === true &&
+                            pluginItem.Drag.target !== null)
                         {
                             pluginItem.Drag.drop()
                             if (pluginsContainer.isInput === false)
@@ -92,6 +110,7 @@ Rectangle
                     PluginDragItem
                     {
                         id: pluginItem
+                        objectName: "pluginSource_" + index
                         x: 3
                         color: delegateRoot.pressed ? UISettings.highlightPressed : "transparent"
 
@@ -103,8 +122,11 @@ Rectangle
                         pluginName: modelData.plugin
                         lineName: modelData.name
                         pluginLine: modelData.line
+                        sourceAvailable: modelData.available !== false
+                        canConfigure: modelData.canConfigure === true
+                        statusText: modelData.status || ""
 
-                        Drag.active: delegateRoot.drag.active
+                        Drag.active: sourceAvailable && delegateRoot.drag.active
                         Drag.source: pluginItem
                         //Drag.hotSpot.x: width / 2
                         //Drag.hotSpot.y: height / 2
@@ -123,4 +145,3 @@ Rectangle
             } // Item
     } // ListView
 }
-

--- a/qmlui/test/tst_pluginslist.qml
+++ b/qmlui/test/tst_pluginslist.qml
@@ -1,0 +1,177 @@
+import QtQuick
+import QtTest
+import "../qml/inputoutput" as QLC
+
+TestCase
+{
+    id: testCase
+    name: "PluginsList"
+    when: windowShown
+    width: 420
+    height: 320
+
+    property string configuredPlugin: ""
+
+    property QtObject ioManager: QtObject
+    {
+        signal ioSourcesChanged()
+
+        property var outputSources: [
+            {
+                universe: 0,
+                name: "127.0.0.1",
+                line: 0,
+                plugin: "ArtNet",
+                available: true,
+                canConfigure: false,
+                status: ""
+            },
+            {
+                universe: 0,
+                name: "DMX USB",
+                line: -1,
+                plugin: "DMX USB",
+                available: false,
+                canConfigure: true,
+                status: "No available output lines"
+            }
+        ]
+
+        function universeInputSources(universe)
+        {
+            return []
+        }
+
+        function universeOutputSources(universe)
+        {
+            return outputSources
+        }
+
+        function configurePluginByName(pluginName)
+        {
+            testCase.configuredPlugin = pluginName
+        }
+    }
+
+    QLC.PluginsList
+    {
+        id: pluginsList
+        width: parent.width
+        height: parent.height
+    }
+
+    function init()
+    {
+        configuredPlugin = ""
+        ioManager.outputSources = [
+            {
+                universe: 0,
+                name: "127.0.0.1",
+                line: 0,
+                plugin: "ArtNet",
+                available: true,
+                canConfigure: false,
+                status: ""
+            },
+            {
+                universe: 0,
+                name: "DMX USB",
+                line: -1,
+                plugin: "DMX USB",
+                available: false,
+                canConfigure: true,
+                status: "No available output lines"
+            }
+        ]
+        pluginsList.loadSources(false)
+        wait(0)
+    }
+
+    function test_unavailablePluginStaysVisibleAndConfigurable()
+    {
+        compare(pluginsList.sourcesCount, 2)
+
+        const dmxUsbItem = findChild(pluginsList, "pluginSource_1")
+        verify(dmxUsbItem !== null)
+        compare(dmxUsbItem.pluginName, "DMX USB")
+        compare(dmxUsbItem.sourceAvailable, false)
+
+        pluginsList.activateSource(dmxUsbItem.pluginName,
+                                   dmxUsbItem.sourceAvailable,
+                                   dmxUsbItem.canConfigure)
+        compare(configuredPlugin, "DMX USB")
+    }
+
+    function test_configurationChangeRefreshesOpenList()
+    {
+        ioManager.outputSources = [
+            {
+                universe: 0,
+                name: "127.0.0.1",
+                line: 0,
+                plugin: "ArtNet",
+                available: true,
+                canConfigure: false,
+                status: ""
+            },
+            {
+                universe: 0,
+                name: "FT232R USB UART (S/N: AG0KM73D)",
+                line: 0,
+                plugin: "DMX USB",
+                available: true,
+                canConfigure: true,
+                status: ""
+            }
+        ]
+
+        ioManager.ioSourcesChanged()
+        tryCompare(pluginsList, "sourcesCount", 2)
+
+        const dmxUsbItem = findChild(pluginsList, "pluginSource_1")
+        verify(dmxUsbItem !== null)
+        compare(dmxUsbItem.sourceAvailable, true)
+        compare(dmxUsbItem.lineName, "FT232R USB UART (S/N: AG0KM73D)")
+    }
+
+    function test_loadedPluginsWithoutOutputLinesStayInDeviceList()
+    {
+        const missingPlugins = [ "DMX USB", "HID", "MIDI", "Peperoni", "uDMX" ]
+        const sources = [
+            {
+                universe: 0,
+                name: "127.0.0.1",
+                line: 0,
+                plugin: "ArtNet",
+                available: true,
+                canConfigure: false,
+                status: ""
+            }
+        ]
+
+        for (let i = 0; i < missingPlugins.length; i++)
+        {
+            sources.push({
+                universe: 0,
+                name: missingPlugins[i],
+                line: -1,
+                plugin: missingPlugins[i],
+                available: false,
+                canConfigure: i === 0,
+                status: "No output lines detected"
+            })
+        }
+
+        ioManager.outputSources = sources
+        ioManager.ioSourcesChanged()
+        tryCompare(pluginsList, "sourcesCount", 6)
+
+        for (let i = 0; i < missingPlugins.length; i++)
+        {
+            const item = findChild(pluginsList, "pluginSource_" + (i + 1))
+            verify(item !== null)
+            compare(item.pluginName, missingPlugins[i])
+            compare(item.sourceAvailable, false)
+        }
+    }
+}


### PR DESCRIPTION
## Why

When an I/O plugin has no currently free lines, hiding it makes configuration and recovery difficult.

## What changed

Keep loaded I/O plugins visible, show the unavailable-line state, allow the plugin configuration action, refresh the list after configuration, and update the related German strings.

## Expected behavior

Users can still see and configure an I/O plugin even when no free input or output line is available.

## Validation

qmltestrunner: 5 passed, 0 failed.