### PR TITLE
Fix high-resolution trackpad zoom in the 2D view

### DIFF
--- a/qmlui/qml/fixturesfunctions/2DView.qml
+++ b/qmlui/qml/fixturesfunctions/2DView.qml
@@ -329,10 +329,16 @@ Rectangle
 
                 onWheel: (wheel)=>
                 {
-                    //console.log("Wheel delta: " + wheel.angleDelta.y)
-                    if (wheel.angleDelta.y > 0)
+                    // High-resolution trackpads can send wheel events whose
+                    // angle delta is zero. Do not treat a neutral or purely
+                    // horizontal event as a request to zoom out.
+                    var deltaY = wheel.angleDelta.y
+                    if (deltaY === 0)
+                        deltaY = wheel.pixelDelta.y
+
+                    if (deltaY > 0)
                         setZoom(0.5)
-                    else
+                    else if (deltaY < 0)
                         setZoom(-0.5)
                 }
             }


### PR DESCRIPTION
## Why

On high-resolution trackpads, Qt can report vertical motion through pixelDelta while angleDelta is zero. The previous condition treated that event as a zoom-out request, which made trackpad zoom unreliable.

## What changed

Use the vertical wheel delta that is actually available and ignore neutral or horizontal-only events. The change is limited to the 2D view zoom handler.

## Expected behavior

Pinch or scroll zoom follows the trackpad direction and magnitude without unexpected zoom-out steps.

## Validation

The change is platform-specific event handling and will be covered by the upstream CI matrix.