### PR TITLE
Make workspace file actions wait for dialogs to close

### DIFF
--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -33,19 +33,42 @@ Popup
     property Item submenuItem: null
     property int flagSize: UISettings.iconSizeDefault * 1.5
 
-    onClosed: submenuItem = null
+    onClosed:
+    {
+        submenuItem = null
+        openFileCoordinator.completeDismissal()
+        recentFileCoordinator.completeDismissal()
+    }
 
     function handleSaveAction()
     {
         if (qlcplus.fileName())
-            qlcplus.saveWorkspace(qlcplus.fileName())
+        {
+            if (qlcplus.saveWorkspace(qlcplus.fileName()))
+                pendingWorkspaceAction.dispatch(false)
+            else
+                pendingWorkspaceAction.cancel()
+        }
         else
             openDialog(App.SaveAsMode)
     }
 
+    function handleOpenAction()
+    {
+        if (qlcplus.docModified)
+        {
+            pendingWorkspaceAction.action = "#OPEN"
+            saveFirstPopup.open()
+        }
+        else
+            openDialog(App.OpenMode)
+
+        menuRoot.close()
+    }
+
     function saveBeforeExit()
     {
-        saveFirstPopup.action = "#EXIT"
+        pendingWorkspaceAction.action = "#EXIT"
         saveFirstPopup.open()
     }
 
@@ -82,7 +105,7 @@ Popup
         }
 
         if (Qt.platform.os === "linux")
-            customDialog.open()
+            customDialogLoader.item.open()
         else
             nativeDialog.open()
     }
@@ -90,6 +113,8 @@ Popup
     function handleAccept()
     {
         console.log("Selected file: " + dialogSelectedFile)
+
+        let dispatchPendingActionOnClose = false
 
         switch (dialogOpMode)
         {
@@ -106,10 +131,10 @@ Popup
             case App.SaveMode:
             case App.SaveAsMode:
             {
-                qlcplus.saveWorkspace(dialogSelectedFile)
-
-                if (saveFirstPopup.action == "#EXIT")
-                    qlcplus.exit()
+                if (qlcplus.saveWorkspace(dialogSelectedFile))
+                    dispatchPendingActionOnClose = pendingWorkspaceAction.hasAction
+                else
+                    pendingWorkspaceAction.cancel()
             }
             break
             case App.ImportMode:
@@ -122,6 +147,8 @@ Popup
             }
             break
         }
+
+        return dispatchPendingActionOnClose
     }
 
     FileDialog
@@ -136,25 +163,138 @@ Popup
         {
             dialogSelectedFile = selectedFile
             dialogCurrentFolder = currentFolder
-            handleAccept()
+            if (handleAccept())
+            {
+                nativeDialogSaveCoordinator.trigger()
+                if (!visible)
+                    nativeDialogSaveCoordinator.completeDismissal()
+            }
+        }
+
+        onRejected: pendingWorkspaceAction.cancel()
+        onVisibleChanged:
+        {
+            if (!visible)
+                nativeDialogSaveCoordinator.completeDismissal()
         }
     }
 
-    PopupFolderBrowser
+    PlatformPopupLoader
     {
-        id: customDialog
-        title: dialogTitle
-        currentFolder: dialogCurrentFolder
-        nameFilters: dialogNameFilters
-        standardButtons: Dialog.Cancel |
-            ((dialogOpMode === App.SaveMode | dialogOpMode === App.SaveAsMode) ? Dialog.Save : Dialog.Open)
+        id: customDialogLoader
 
-        onAccepted:
+        sourceComponent: Component
         {
-            dialogSelectedFile = currentFolder + folderSeparator() + selectedFile
-            dialogCurrentFolder = currentFolder
-            handleAccept()
+            PopupFolderBrowser
+            {
+                title: dialogTitle
+                currentFolder: dialogCurrentFolder
+                nameFilters: dialogNameFilters
+                standardButtons: Dialog.Cancel |
+                    ((dialogOpMode === App.SaveMode | dialogOpMode === App.SaveAsMode) ? Dialog.Save : Dialog.Open)
+
+                onAccepted:
+                {
+                    dialogSelectedFile = currentFolder + folderSeparator() + selectedFile
+                    dialogCurrentFolder = currentFolder
+                    if (handleAccept())
+                        customDialogSaveCoordinator.trigger()
+                }
+
+                onRejected: pendingWorkspaceAction.cancel()
+
+                onClosed:
+                {
+                    customDialogSaveCoordinator.completeDismissal()
+                }
+            }
         }
+    }
+
+    DeferredPopupAction
+    {
+        id: openFileCoordinator
+
+        onDismissRequested:
+        {
+            submenuItem = null
+            menuRoot.close()
+        }
+        onActionRequested: handleOpenAction()
+    }
+
+    DeferredPopupAction
+    {
+        id: recentFileCoordinator
+
+        property string filePath: ""
+
+        onDismissRequested:
+        {
+            submenuItem = null
+            menuRoot.close()
+        }
+        onActionRequested:
+        {
+            const selectedFilePath = filePath
+            filePath = ""
+
+            if (qlcplus.docModified)
+            {
+                pendingWorkspaceAction.action = selectedFilePath
+                saveFirstPopup.open()
+            }
+            else
+                qlcplus.loadWorkspace(selectedFilePath)
+        }
+    }
+
+    PendingWorkspaceAction
+    {
+        id: pendingWorkspaceAction
+
+        onOpenRequested: openDialog(App.OpenMode)
+        onNewRequested: qlcplus.newWorkspace()
+        onExitRequested: function(discardChanges) {
+            qlcplus.exit(discardChanges)
+        }
+        onRecentRequested: function(filePath) {
+            qlcplus.loadWorkspace(filePath)
+        }
+    }
+
+    DeferredPopupAction
+    {
+        id: saveFirstCoordinator
+
+        property int selectedRole: Dialog.Cancel
+
+        onDismissRequested: saveFirstPopup.close()
+        onActionRequested:
+        {
+            if (selectedRole === Dialog.Yes)
+                handleSaveAction()
+            else if (selectedRole === Dialog.No)
+                pendingWorkspaceAction.dispatch(true)
+            else
+                pendingWorkspaceAction.cancel()
+
+            selectedRole = Dialog.Cancel
+        }
+    }
+
+    DeferredPopupAction
+    {
+        id: customDialogSaveCoordinator
+
+        onActionRequested: pendingWorkspaceAction.dispatch(false)
+    }
+
+    DeferredPopupAction
+    {
+        id: nativeDialogSaveCoordinator
+
+        onActionRequested: pendingWorkspaceAction.dispatch(false)
     }
 
     CustomPopupDialog
@@ -166,45 +306,18 @@ Popup
         message: qsTr("Do you wish to save the current project first?\nChanges will be lost if you don't save them.")
         standardButtons: Dialog.Yes | Dialog.No | Dialog.Cancel
 
-        property string action: ""
+        onClosed:
+        {
+            if (saveFirstCoordinator.pending)
+                saveFirstCoordinator.completeDismissal()
+            else
+                pendingWorkspaceAction.cancel()
+        }
 
         onClicked: function(role)
         {
-            if (role === Dialog.Yes)
-            {
-                if (qlcplus.fileName())
-                {
-                    console.log("YES clicked 1")
-                    qlcplus.saveWorkspace(qlcplus.fileName())
-                    if (action == "#EXIT")
-                        qlcplus.exit()
-                }
-                else
-                {
-                    console.log("YES clicked 2")
-                    //openDialog(App.SaveMode)
-                    handleSaveAction()
-                    if (action == "#EXIT")
-                        return
-                }
-            }
-            else if (role === Dialog.No)
-            {
-                if (action == "#OPEN")
-                    openDialog(App.OpenMode)
-                else if (action == "#NEW")
-                    qlcplus.newWorkspace()
-                else if (action == "#EXIT")
-                    qlcplus.exit(true)
-                else
-                    qlcplus.loadWorkspace(action)
-            }
-            else if (role === Dialog.Cancel)
-            {
-                console.log("Cancel clicked")
-            }
-
-            action = ""
+            saveFirstCoordinator.selectedRole = role
+            saveFirstCoordinator.trigger()
         }
     }
 
@@ -231,7 +344,7 @@ Popup
             {
                 if (qlcplus.docModified)
                 {
-                    saveFirstPopup.action = "#NEW"
+                    pendingWorkspaceAction.action = "#NEW"
                     saveFirstPopup.open()
                 }
                 else
@@ -247,18 +360,7 @@ Popup
             id: fileOpen
             imgSource: "qrc:/fileopen.svg"
             entryText: qsTr("Open file")
-            onClicked:
-            {
-                if (qlcplus.docModified)
-                {
-                    saveFirstPopup.action = "#OPEN"
-                    saveFirstPopup.open()
-                }
-                else
-                    openDialog(App.OpenMode)
-
-                menuRoot.close()
-            }
+            onClicked: openFileCoordinator.trigger()
             onEntered: submenuItem = recentMenu
 
             Rectangle
@@ -282,16 +384,8 @@ Popup
                                 entryText: modelData
                                 onClicked:
                                 {
-                                    if (qlcplus.docModified)
-                                    {
-                                        saveFirstPopup.open()
-                                        saveFirstPopup.action = entryText
-                                    }
-                                    else
-                                    {
-                                        menuRoot.close()
-                                        qlcplus.loadWorkspace(entryText)
-                                    }
+                                    recentFileCoordinator.filePath = entryText
+                                    recentFileCoordinator.trigger()
                                 }
                             }
                         }
@@ -650,4 +744,3 @@ Popup
         }
     }
 }
-

--- a/qmlui/qml/DeferredPopupAction.qml
+++ b/qmlui/qml/DeferredPopupAction.qml
@@ -1,0 +1,26 @@
+import QtQml
+
+QtObject
+{
+    id: coordinator
+
+    property bool pending: false
+
+    signal dismissRequested()
+    signal actionRequested()
+
+    function trigger()
+    {
+        pending = true
+        dismissRequested()
+    }
+
+    function completeDismissal()
+    {
+        if (!pending)
+            return
+
+        pending = false
+        actionRequested()
+    }
+}

--- a/qmlui/qml/MainView.qml
+++ b/qmlui/qml/MainView.qml
@@ -120,6 +120,12 @@ Rectangle
         actionsMenu.saveBeforeExit()
     }
 
+    Shortcut
+    {
+        sequence: StandardKey.Open
+        onActivated: actionsMenu.handleOpenAction()
+    }
+
     function loadResource(qmlRes)
     {
         mainViewLoader.source = qmlRes

--- a/qmlui/qml/PendingWorkspaceAction.qml
+++ b/qmlui/qml/PendingWorkspaceAction.qml
@@ -1,0 +1,32 @@
+import QtQml
+
+QtObject
+{
+    property string action: ""
+    readonly property bool hasAction: action.length > 0
+
+    signal openRequested()
+    signal newRequested()
+    signal exitRequested(bool discardChanges)
+    signal recentRequested(string filePath)
+
+    function dispatch(discardChanges)
+    {
+        const pendingAction = action
+        action = ""
+
+        if (pendingAction === "#OPEN")
+            openRequested()
+        else if (pendingAction === "#NEW")
+            newRequested()
+        else if (pendingAction === "#EXIT")
+            exitRequested(discardChanges)
+        else if (pendingAction.length > 0)
+            recentRequested(pendingAction)
+    }
+
+    function cancel()
+    {
+        action = ""
+    }
+}

--- a/qmlui/qml/PlatformPopupLoader.qml
+++ b/qmlui/qml/PlatformPopupLoader.qml
@@ -1,0 +1,25 @@
+/*
+  Q Light Controller Plus
+  PlatformPopupLoader.qml
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import QtQuick
+
+Loader
+{
+    active: Qt.platform.os === "linux"
+}

--- a/qmlui/qmlui.qrc
+++ b/qmlui/qmlui.qrc
@@ -24,6 +24,8 @@
     <file alias="CustomTextEdit.qml">qml/CustomTextEdit.qml</file>
     <file alias="CustomTextInput.qml">qml/CustomTextInput.qml</file>
     <file alias="DayTimeTool.qml">qml/DayTimeTool.qml</file>
+    <file alias="DeferredPopupAction.qml">qml/DeferredPopupAction.qml</file>
+    <file alias="PendingWorkspaceAction.qml">qml/PendingWorkspaceAction.qml</file>
     <file alias="DMXAddressTool.qml">qml/DMXAddressTool.qml</file>
     <file alias="DMXAddressWidget.qml">qml/DMXAddressWidget.qml</file>
     <file alias="DMXPercentageButton.qml">qml/DMXPercentageButton.qml</file>
@@ -45,6 +47,7 @@
     <file alias="MenuBarEntry.qml">qml/MenuBarEntry.qml</file>
     <file alias="MultiColorBox.qml">qml/MultiColorBox.qml</file>
     <file alias="PaletteFanningBox.qml">qml/PaletteFanningBox.qml</file>
+    <file alias="PlatformPopupLoader.qml">qml/PlatformPopupLoader.qml</file>
     <file alias="QLCPlusFader.qml">qml/QLCPlusFader.qml</file>
     <file alias="QLCPlusKnob.qml">qml/QLCPlusKnob.qml</file>
     <file alias="RobotoText.qml">qml/RobotoText.qml</file>

--- a/qmlui/test/tst_deferredpopupaction.qml
+++ b/qmlui/test/tst_deferredpopupaction.qml
@@ -1,0 +1,77 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+TestCase
+{
+    id: testCase
+    name: "DeferredPopupAction"
+
+    property Component actionComponent
+    property var events: []
+    property int eventCount: 0
+
+    Component
+    {
+        id: popupComponent
+
+        Popup
+        {
+            exit: Transition
+            {
+                NumberAnimation
+                {
+                    property: "opacity"
+                    from: 1
+                    to: 0
+                    duration: 80
+                }
+            }
+        }
+    }
+
+    function initTestCase()
+    {
+        actionComponent = Qt.createComponent("../qml/DeferredPopupAction.qml")
+        compare(actionComponent.status, Component.Ready,
+                actionComponent.errorString())
+    }
+
+    function test_runsActionOnlyAfterPopupClosed()
+    {
+        events = []
+        eventCount = 0
+        const action = actionComponent.createObject(testCase)
+        const popup = popupComponent.createObject(testCase)
+        action.dismissRequested.connect(function() {
+            events.push("dismiss")
+            ++eventCount
+            popup.close()
+        })
+        action.actionRequested.connect(function() {
+            events.push("action")
+            ++eventCount
+        })
+        popup.closed.connect(function() {
+            events.push("closed")
+            ++eventCount
+            action.completeDismissal()
+        })
+
+        popup.open()
+        tryCompare(popup, "opened", true)
+
+        action.trigger()
+        compare(eventCount, 1)
+        compare(events[0], "dismiss")
+
+        tryCompare(testCase, "eventCount", 3)
+        compare(events[1], "closed")
+        compare(events[2], "action")
+
+        action.completeDismissal()
+        compare(eventCount, 3)
+        popup.destroy()
+        action.destroy()
+    }
+}

--- a/qmlui/test/tst_pendingworkspaceaction.qml
+++ b/qmlui/test/tst_pendingworkspaceaction.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import QtTest
+
+TestCase
+{
+    id: testCase
+    name: "PendingWorkspaceAction"
+
+    property Component actionComponent
+
+    function initTestCase()
+    {
+        actionComponent = Qt.createComponent("../qml/PendingWorkspaceAction.qml")
+        compare(actionComponent.status, Component.Ready,
+                actionComponent.errorString())
+    }
+
+    function test_dispatchesEverySupportedActionAndClearsIt()
+    {
+        const action = actionComponent.createObject(testCase)
+        const events = []
+        const recentPath = "/Users/example/Documents/Shows/Very Long Project.qxw"
+
+        action.openRequested.connect(function() { events.push("open") })
+        action.newRequested.connect(function() { events.push("new") })
+        action.exitRequested.connect(function(discardChanges) {
+            events.push("exit:" + discardChanges)
+        })
+        action.recentRequested.connect(function(filePath) {
+            events.push("recent:" + filePath)
+        })
+
+        action.action = "#OPEN"
+        action.dispatch(false)
+        compare(action.action, "")
+
+        action.action = "#NEW"
+        action.dispatch(false)
+
+        action.action = "#EXIT"
+        action.dispatch(true)
+
+        action.action = recentPath
+        action.dispatch(false)
+
+        compare(events, ["open", "new", "exit:true", "recent:" + recentPath])
+        compare(action.action, "")
+        action.destroy()
+    }
+
+    function test_actionSurvivesUntilSaveActuallyDispatchesIt()
+    {
+        const action = actionComponent.createObject(testCase)
+        let openCount = 0
+        action.openRequested.connect(function() { ++openCount })
+
+        action.action = "#OPEN"
+        wait(20)
+        compare(action.action, "#OPEN")
+        compare(openCount, 0)
+
+        action.dispatch(false)
+        compare(openCount, 1)
+        compare(action.action, "")
+        action.destroy()
+    }
+
+    function test_cancelClearsWithoutDispatching()
+    {
+        const action = actionComponent.createObject(testCase)
+        let signalCount = 0
+        action.openRequested.connect(function() { ++signalCount })
+
+        action.action = "#OPEN"
+        action.cancel()
+
+        compare(action.action, "")
+        compare(signalCount, 0)
+        action.destroy()
+    }
+}

--- a/qmlui/test/tst_platformpopuploader.qml
+++ b/qmlui/test/tst_platformpopuploader.qml
@@ -1,0 +1,39 @@
+import QtQuick
+import QtTest
+
+import "../qml"
+
+TestCase
+{
+    id: testCase
+    name: "PlatformPopupLoader"
+
+    property bool customPopupCreated: false
+
+    Component
+    {
+        id: popupFactory
+
+        QtObject
+        {
+            Component.onCompleted: testCase.customPopupCreated = true
+        }
+    }
+
+    PlatformPopupLoader
+    {
+        id: popupLoader
+        sourceComponent: popupFactory
+    }
+
+    function test_linuxPopupIsNotCreatedOnNativeDialogPlatforms()
+    {
+        if (Qt.platform.os === "linux")
+            skip("Linux intentionally uses the custom folder browser")
+
+        compare(popupLoader.active, false)
+        compare(popupLoader.status, Loader.Null)
+        compare(popupLoader.item, null)
+        compare(customPopupCreated, false)
+    }
+}


### PR DESCRIPTION
## Why

Open, new, recent-file, save, and exit actions can race with native or custom file dialogs. A follow-up action must wait until the preceding confirmation or dialog has actually closed.

## What changed

Add small reusable components for deferred popup actions and pending workspace actions, separate native and Linux custom dialog handling, and route the standard Open shortcut through the same flow.

## Expected behavior

Save confirmations and file dialogs complete cleanly before Open, New, Recent, or Exit is dispatched. Cancelled or failed saves do not trigger the pending action.

## Validation

qmltestrunner: 11 passed, 0 failed.