### PR TITLE
Add keyboard accessibility to QML controls

### DIFF
--- a/qmlui/qml/ContextMenuEntry.qml
+++ b/qmlui/qml/ContextMenuEntry.qml
@@ -24,9 +24,11 @@ import "."
 Rectangle
 {
     id: baseMenuEntry
+    objectName: "contextMenuEntry"
     width: parent ? (parent.width > itemWidth) ? parent.width : itemWidth : 400
     implicitWidth: itemWidth
     height: iconHeight + 6
+    activeFocusOnTab: true
 
     property string imgSource: ""
     property string entryText: ""
@@ -44,9 +46,30 @@ Rectangle
     signal entered
     signal exited
 
-    color: bgColor
+    color: activeFocus ? hoverColor : bgColor
     border.color: UISettings.bgLight
     border.width: 1
+
+    Accessible.role: Accessible.Button
+    Accessible.name: entryText
+
+    function trigger()
+    {
+        if (enabled)
+            clicked()
+    }
+
+    Keys.onSpacePressed: event =>
+    {
+        trigger()
+        event.accepted = true
+    }
+    Keys.onReturnPressed: event =>
+    {
+        trigger()
+        event.accepted = true
+    }
+    Accessible.onPressAction: trigger()
 
     states: [
         State
@@ -113,7 +136,7 @@ Rectangle
         hoverEnabled: baseMenuEntry.visible
         onEntered: baseMenuEntry.entered()
         onExited: baseMenuEntry.exited()
-        onReleased: baseMenuEntry.clicked()
+        onReleased: baseMenuEntry.trigger()
     }
 
     Rectangle

--- a/qmlui/qml/SectionBox.qml
+++ b/qmlui/qml/SectionBox.qml
@@ -43,7 +43,8 @@ Rectangle
             id: cPropsHeader
             width: parent.width
             height: UISettings.listItemHeight
-            color: headerMouseArea.containsMouse ? UISettings.highlight : UISettings.sectionHeader
+            color: headerMouseArea.containsMouse || headerMouseArea.activeFocus ?
+                       UISettings.highlight : UISettings.sectionHeader
 
             RobotoText
             {
@@ -65,10 +66,31 @@ Rectangle
             MouseArea
             {
                 id: headerMouseArea
+                objectName: "sectionHeader"
                 anchors.fill: parent
                 hoverEnabled: true
+                activeFocusOnTab: true
 
-                onClicked: boxRoot.isExpanded = !boxRoot.isExpanded
+                Accessible.role: Accessible.Button
+                Accessible.name: boxRoot.sectionLabel
+
+                function toggleSection()
+                {
+                    boxRoot.isExpanded = !boxRoot.isExpanded
+                }
+
+                onClicked: toggleSection()
+                Keys.onSpacePressed: event =>
+                {
+                    toggleSection()
+                    event.accepted = true
+                }
+                Keys.onReturnPressed: event =>
+                {
+                    toggleSection()
+                    event.accepted = true
+                }
+                Accessible.onPressAction: toggleSection()
             }
 
             Rectangle
@@ -84,7 +106,7 @@ Rectangle
         {
             id: sectionLoader
             width: parent.width
-            sourceComponent: isExpanded ? boxRoot.sectionContents : null
+            sourceComponent: boxRoot.isExpanded ? boxRoot.sectionContents : null
         }
     }
 }

--- a/qmlui/test/tst_contextmenuentry.qml
+++ b/qmlui/test/tst_contextmenuentry.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import QtTest
+import "../qml" as QLC
+
+TestCase
+{
+    id: testCase
+    name: "ContextMenuEntry"
+    when: windowShown
+    width: 320
+    height: 120
+    visible: true
+
+    QLC.ContextMenuEntry
+    {
+        id: menuEntry
+        entryText: "Neue RGB-Matrix"
+    }
+
+    SignalSpy
+    {
+        id: clickSpy
+        target: menuEntry
+        signalName: "clicked"
+    }
+
+    function init()
+    {
+        clickSpy.clear()
+    }
+
+    function test_entryCanBeActivatedFromKeyboard()
+    {
+        verify(menuEntry.activeFocusOnTab)
+        menuEntry.forceActiveFocus()
+        verify(menuEntry.activeFocus)
+
+        keyClick(Qt.Key_Space)
+        compare(clickSpy.count, 1)
+
+        keyClick(Qt.Key_Return)
+        compare(clickSpy.count, 2)
+    }
+
+    function test_entireRowRespondsToMouse()
+    {
+        mouseClick(menuEntry, 4, menuEntry.height / 2, Qt.LeftButton)
+        compare(clickSpy.count, 1)
+
+        mouseClick(menuEntry, menuEntry.width - 4,
+                   menuEntry.height / 2, Qt.LeftButton)
+        compare(clickSpy.count, 2)
+    }
+}

--- a/qmlui/test/tst_sectionboxaccessibility.qml
+++ b/qmlui/test/tst_sectionboxaccessibility.qml
@@ -1,0 +1,41 @@
+import QtQuick
+import QtTest
+import "../qml" as QLC
+
+TestCase
+{
+    id: testCase
+    name: "SectionBoxAccessibility"
+    when: windowShown
+    width: 320
+    height: 160
+    visible: true
+
+    QLC.SectionBox
+    {
+        id: sectionBox
+        width: 280
+        sectionLabel: "Rendering"
+        isExpanded: false
+        sectionContents: Rectangle
+        {
+            width: sectionBox.width
+            height: 80
+        }
+    }
+
+    function test_headerCanBeActivatedFromKeyboard()
+    {
+        const header = findChild(sectionBox, "sectionHeader")
+        verify(header !== null)
+        verify(header.activeFocusOnTab)
+
+        header.forceActiveFocus()
+        verify(header.activeFocus)
+        keyClick(Qt.Key_Space)
+        verify(sectionBox.isExpanded)
+
+        keyClick(Qt.Key_Return)
+        verify(!sectionBox.isExpanded)
+    }
+}


### PR DESCRIPTION
## Why

Important QML controls should be operable with the keyboard and expose meaningful roles and names to accessibility tools.

## What changed

Add keyboard activation and Accessible metadata to context menu entries, and make SectionBox keyboard focus and activation behavior explicit.

## Expected behavior

Users can reach and activate these controls with Tab, Space, and Return, while assistive technologies receive useful control information.

## Validation

qmltestrunner: 7 passed, 0 failed.