### PR TITLE
Make Actions menu submenus fit and receive clicks reliably

### DIFF
--- a/qmlui/qml/ActionsMenu.qml
+++ b/qmlui/qml/ActionsMenu.qml
@@ -29,11 +29,52 @@ Popup
 {
     id: menuRoot
     padding: 0
+    contentWidth: requiredMenuWidth()
+    contentHeight: actionsMenuEntries.implicitHeight
+    width: contentWidth
+    height: contentHeight
 
-    property Item submenuItem: null
+    property var submenuItem: null
     property int flagSize: UISettings.iconSizeDefault * 1.5
 
-    onClosed: submenuItem = null
+    onSubmenuItemChanged:
+    {
+        if (submenuItem !== recentFilesPopup)
+            recentFilesPopup.close()
+        if (submenuItem !== networkMenuPopup)
+            networkMenuPopup.close()
+        if (submenuItem !== languageMenuPopup)
+            languageMenuPopup.close()
+    }
+
+    onClosed:
+    {
+        submenuItem = null
+        closeSubmenus()
+    }
+
+    function showSubmenu(popup)
+    {
+        submenuItem = popup
+        if (!popup.opened)
+            popup.open()
+    }
+
+    function closeSubmenus()
+    {
+        recentFilesPopup.close()
+        networkMenuPopup.close()
+        languageMenuPopup.close()
+    }
+
+    function requiredMenuWidth()
+    {
+        let requiredWidth = 0
+        for (let index = 0; index < actionsMenuEntries.children.length; ++index)
+            requiredWidth = Math.max(requiredWidth,
+                                     actionsMenuEntries.children[index].implicitWidth)
+        return requiredWidth
+    }
 
     function handleSaveAction()
     {
@@ -208,19 +249,273 @@ Popup
         }
     }
 
+    ActionsMenuGeometry
+    {
+        id: recentMenuGeometry
+        mainMenuWidth: menuRoot.width
+        requestedSubmenuWidth: Math.max(mainMenuWidth, mainView.width * 0.55)
+        windowWidth: mainView.width
+        popupLeft: menuRoot.x
+        margin: 8
+    }
+
+    ActionsMenuGeometry
+    {
+        id: networkMenuGeometry
+        mainMenuWidth: menuRoot.width
+        requestedSubmenuWidth: Math.max(mainMenuWidth,
+                                        networkColumn.implicitWidth)
+        windowWidth: mainView.width
+        popupLeft: menuRoot.x
+        margin: 8
+    }
+
+    ActionsMenuGeometry
+    {
+        id: languageMenuGeometry
+        mainMenuWidth: menuRoot.width
+        requestedSubmenuWidth: Math.max(mainMenuWidth,
+                                        languageColumn.implicitWidth)
+        windowWidth: mainView.width
+        popupLeft: menuRoot.x
+        margin: 8
+    }
+
+    RecentFilesPopup
+    {
+        id: recentFilesPopup
+        parent: menuRoot.contentItem
+        x: recentMenuGeometry.submenuX
+        y: fileOpen.y
+        width: recentMenuGeometry.submenuWidth
+        recentFiles: qlcplus.recentFiles
+
+        onFileSelected: function(filePath) {
+            if (qlcplus.docModified)
+            {
+                saveFirstPopup.action = filePath
+                saveFirstPopup.open()
+            }
+            else
+            {
+                menuRoot.close()
+                qlcplus.loadWorkspace(filePath)
+            }
+        }
+
+        onClosed:
+        {
+            if (submenuItem === recentFilesPopup)
+                submenuItem = null
+        }
+    }
+
+    ActionsSubmenuPopup
+    {
+        id: networkMenuPopup
+        parent: menuRoot.contentItem
+        x: networkMenuGeometry.submenuX
+        y: networkEntry.y
+        width: networkMenuGeometry.submenuWidth
+        height: networkColumn.implicitHeight
+
+        contentItem:
+            Column
+            {
+                id: networkColumn
+                width: networkMenuPopup.width
+
+                ContextMenuEntry
+                {
+                    id: startServer
+                    objectName: "networkServerEntry"
+                    entryText: qsTr("Server setup")
+
+                    onClicked:
+                    {
+                        submenuItem = null
+                        menuRoot.close()
+                        pNetServer.open()
+                    }
+                }
+
+                ContextMenuEntry
+                {
+                    id: connectToServer
+                    objectName: "networkClientEntry"
+                    entryText: qsTr("Client setup")
+
+                    onClicked:
+                    {
+                        submenuItem = null
+                        menuRoot.close()
+                        pNetClient.open()
+                    }
+                }
+            }
+
+        onClosed:
+        {
+            if (submenuItem === networkMenuPopup)
+                submenuItem = null
+        }
+    }
+
+    PopupNetworkServer
+    {
+        id: pNetServer
+        implicitWidth: Math.min(UISettings.bigItemHeight * 4,
+                                mainView.width / 3)
+    }
+
+    PopupNetworkClient
+    {
+        id: pNetClient
+        implicitWidth: Math.min(UISettings.bigItemHeight * 4,
+                                mainView.width / 3)
+    }
+
+    ActionsSubmenuPopup
+    {
+        id: languageMenuPopup
+        parent: menuRoot.contentItem
+        x: languageMenuGeometry.submenuX
+        y: Math.max(0, Math.min(languageEntry.y + languageEntry.height - height,
+                                mainView.height - menuRoot.y - height - 8))
+        width: languageMenuGeometry.submenuWidth
+        height: languageColumn.implicitHeight
+
+        contentItem:
+            GridLayout
+            {
+                id: languageColumn
+                width: languageMenuPopup.width
+                columns: 2
+                columnSpacing: 0
+                rowSpacing: 0
+
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_ca_ES"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_ca.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Catalan")
+                    onClicked: setLanguage("ca_ES")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_nl_NL"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_nl.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Dutch")
+                    onClicked: setLanguage("nl_NL")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_en_EN"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_uk_us.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("English")
+                    onClicked: setLanguage("en_EN")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_fr_FR"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_fr.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("French")
+                    onClicked: setLanguage("fr_FR")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_de_DE"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_de.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("German")
+                    onClicked: setLanguage("de_DE")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_it_IT"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_it.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Italian")
+                    onClicked: setLanguage("it_IT")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_ja_JP"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_jp.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Japanese")
+                    onClicked: setLanguage("ja_JP")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_pl_PL"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_pl.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Polish")
+                    onClicked: setLanguage("pl_PL")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_ru_RU"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_ru.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Russian")
+                    onClicked: setLanguage("ru_RU")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_es_ES"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_es.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Spanish")
+                    onClicked: setLanguage("es_ES")
+                }
+                ContextMenuEntry
+                {
+                    objectName: "languageEntry_uk_UA"
+                    Layout.fillWidth: true
+                    imgSource: "qrc:/flag_ua.svg"
+                    iconWidth: flagSize
+                    entryText: qsTr("Ukrainian")
+                    onClicked: setLanguage("uk_UA")
+                }
+            }
+
+        onClosed:
+        {
+            if (submenuItem === languageMenuPopup)
+                submenuItem = null
+        }
+    }
+
     background:
         Rectangle
         {
             //radius: 2
+            anchors.fill: parent
             border.width: 1
             border.color: UISettings.bgStronger
             color: UISettings.bgStrong
-            height: actionsMenuEntries.height
         }
 
     Column
     {
         id: actionsMenuEntries
+        width: menuRoot.contentWidth
 
         ContextMenuEntry
         {
@@ -259,44 +554,7 @@ Popup
 
                 menuRoot.close()
             }
-            onEntered: submenuItem = recentMenu
-
-            Rectangle
-            {
-                id: recentMenu
-                x: menuRoot.width
-                width: recentColumn.width
-                height: recentColumn.height
-                color: UISettings.bgStrong
-                visible: submenuItem === recentMenu
-
-                Column
-                {
-                    id: recentColumn
-                    Repeater
-                    {
-                        model: qlcplus.recentFiles
-                        delegate:
-                            ContextMenuEntry
-                            {
-                                entryText: modelData
-                                onClicked:
-                                {
-                                    if (qlcplus.docModified)
-                                    {
-                                        saveFirstPopup.open()
-                                        saveFirstPopup.action = entryText
-                                    }
-                                    else
-                                    {
-                                        menuRoot.close()
-                                        qlcplus.loadWorkspace(entryText)
-                                    }
-                                }
-                            }
-                        }
-                }
-            }
+            onEntered: showSubmenu(recentFilesPopup)
         }
 
         ContextMenuEntry
@@ -393,68 +651,13 @@ Popup
         }
         ContextMenuEntry
         {
+            id: networkEntry
             imgSource: "qrc:/network.svg"
             //faSource: FontAwesome.fa_network_wired
             //faColor: "darkseagreen"
             entryText: qsTr("Network")
-            onEntered: submenuItem = networkMenu
-
-            onClicked:
-            {
-                if (Qt.platform.os === "android")
-                    submenuItem = networkMenu
-            }
-
-            Rectangle
-            {
-                id: networkMenu
-                x: menuRoot.width
-                width: networkColumn.width
-                height: networkColumn.height
-                color: UISettings.bgStrong
-                visible: submenuItem === networkMenu
-
-                Column
-                {
-                    id: networkColumn
-
-                    ContextMenuEntry
-                    {
-                        id: startServer
-                        entryText: qsTr("Server setup")
-
-                        onClicked:
-                        {
-                            menuRoot.close()
-                            pNetServer.open()
-                        }
-
-                        PopupNetworkServer
-                        {
-                            id: pNetServer
-                            implicitWidth: Math.min(UISettings.bigItemHeight * 4, mainView.width / 3)
-                        }
-                    }
-
-                    ContextMenuEntry
-                    {
-                        id: connectToServer
-                        entryText: qsTr("Client setup")
-
-                        onClicked:
-                        {
-                            menuRoot.close()
-                            pNetClient.open()
-                        }
-
-                        PopupNetworkClient
-                        {
-                            id: pNetClient
-                            implicitWidth: Math.min(UISettings.bigItemHeight * 4, mainView.width / 3)
-                        }
-                    }
-                }
-            }
+            onEntered: showSubmenu(networkMenuPopup)
+            onClicked: showSubmenu(networkMenuPopup)
         }
 
         ContextMenuEntry
@@ -509,124 +712,12 @@ Popup
 
         ContextMenuEntry
         {
+            id: languageEntry
             faSource: FontAwesome.fa_earth_europe
             faColor: "deepskyblue"
             entryText: qsTr("Language")
-            onEntered: submenuItem = languageMenu
-
-            onClicked:
-            {
-                if (Qt.platform.os === "android")
-                    submenuItem = languageMenu
-            }
-
-            Rectangle
-            {
-                id: languageMenu
-                x: menuRoot.width
-                y: -height + parent.height
-                width: languageColumn.width
-                height: languageColumn.height
-                color: UISettings.bgStrong
-                visible: submenuItem === languageMenu
-
-                GridLayout
-                {
-                    id: languageColumn
-                    columns: 2
-                    columnSpacing: 0
-                    rowSpacing: 0
-
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_ca.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Catalan")
-                        onClicked: setLanguage("ca_ES")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_nl.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Dutch")
-                        onClicked: setLanguage("nl_NL")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_uk_us.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("English")
-                        onClicked: setLanguage("en_EN")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_fr.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("French")
-                        onClicked: setLanguage("fr_FR")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_de.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("German")
-                        onClicked: setLanguage("de_DE")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_it.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Italian")
-                        onClicked: setLanguage("it_IT")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_jp.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Japanese")
-                        onClicked: setLanguage("ja_JP")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_pl.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Polish")
-                        onClicked: setLanguage("pl_PL")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_ru.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Russian")
-                        onClicked: setLanguage("ru_RU")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_es.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Spanish")
-                        onClicked: setLanguage("es_ES")
-                    }
-                    ContextMenuEntry
-                    {
-                        Layout.fillWidth: true
-                        imgSource: "qrc:/flag_ua.svg"
-                        iconWidth: flagSize
-                        entryText: qsTr("Ukrainian")
-                        onClicked: setLanguage("uk_UA")
-                    }
-                }
-            }
+            onEntered: showSubmenu(languageMenuPopup)
+            onClicked: showSubmenu(languageMenuPopup)
         }
 
         ContextMenuEntry
@@ -650,4 +741,3 @@ Popup
         }
     }
 }
-

--- a/qmlui/qml/ActionsMenuGeometry.qml
+++ b/qmlui/qml/ActionsMenuGeometry.qml
@@ -1,0 +1,16 @@
+import QtQml
+
+QtObject
+{
+    property real mainMenuWidth: 0
+    property real requestedSubmenuWidth: 0
+    property real windowWidth: 0
+    property real popupLeft: 0
+    property real margin: 0
+
+    readonly property real submenuX: Math.max(0, mainMenuWidth)
+    readonly property real maximumSubmenuWidth: Math.max(
+        0, windowWidth - popupLeft - submenuX - margin)
+    readonly property real submenuWidth: Math.min(
+        Math.max(0, requestedSubmenuWidth), maximumSubmenuWidth)
+}

--- a/qmlui/qml/ActionsSubmenuPopup.qml
+++ b/qmlui/qml/ActionsSubmenuPopup.qml
@@ -1,0 +1,38 @@
+/*
+  Q Light Controller Plus
+  ActionsSubmenuPopup.qml
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import QtQuick
+import QtQuick.Controls
+
+import "."
+
+Popup
+{
+    padding: 0
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    background:
+        Rectangle
+        {
+            anchors.fill: parent
+            border.width: 1
+            border.color: UISettings.bgStronger
+            color: UISettings.bgStrong
+        }
+}

--- a/qmlui/qml/ContextMenuEntry.qml
+++ b/qmlui/qml/ContextMenuEntry.qml
@@ -35,10 +35,12 @@ Rectangle
     property color bgColor: "transparent"
     property color hoverColor: UISettings.highlight
     property color pressColor: UISettings.highlightPressed
+    property real labelMaximumWidth: -1
+    property int labelElide: Text.ElideNone
 
     property int iconHeight: UISettings.iconSizeDefault
     property int iconWidth: iconHeight
-    property int itemWidth: entryRow.width + 20
+    property int itemWidth: entryRow.implicitWidth + 20
 
     signal clicked
     signal entered
@@ -99,10 +101,13 @@ Rectangle
 
         RobotoText
         {
+            id: entryLabel
             label: entryText
             height: baseMenuEntry.height
             fontSize: UISettings.textSizeDefault
             fontBold: true
+            maximumWidth: baseMenuEntry.labelMaximumWidth
+            textElide: baseMenuEntry.labelElide
         }
     }
 

--- a/qmlui/qml/RecentFilesPopup.qml
+++ b/qmlui/qml/RecentFilesPopup.qml
@@ -1,0 +1,68 @@
+/*
+  Q Light Controller Plus
+  RecentFilesPopup.qml
+
+  Copyright (c) Massimo Callegari
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import QtQuick
+import QtQuick.Controls
+
+import "."
+
+Popup
+{
+    id: recentFilesPopup
+    padding: 0
+    height: recentFilesColumn.implicitHeight
+
+    property var recentFiles: []
+
+    signal fileSelected(string filePath)
+
+    background:
+        Rectangle
+        {
+            anchors.fill: parent
+            border.width: 1
+            border.color: UISettings.bgStronger
+            color: UISettings.bgStrong
+        }
+
+    contentItem:
+        Column
+        {
+            id: recentFilesColumn
+            width: recentFilesPopup.width
+
+            Repeater
+            {
+                model: recentFilesPopup.recentFiles
+
+                delegate:
+                    ContextMenuEntry
+                    {
+                        objectName: "recentFileEntry_" + index
+
+                        property string filePath: modelData
+
+                        entryText: filePath
+                        labelMaximumWidth: Math.max(0, recentFilesPopup.width - 30)
+                        labelElide: Text.ElideMiddle
+                        onClicked: recentFilesPopup.fileSelected(filePath)
+                    }
+            }
+        }
+}

--- a/qmlui/qml/RobotoText.qml
+++ b/qmlui/qml/RobotoText.qml
@@ -23,7 +23,9 @@ import "."
 Rectangle
 {
     id: rtRoot
-    width: wrapText ? 100 : leftMargin + textBox.paintedWidth + rightMargin
+    width: wrapText ? 100 : maximumWidth >= 0 ?
+        Math.min(naturalWidth, maximumWidth) :
+        leftMargin + textBox.paintedWidth + rightMargin
     height: UISettings.iconSizeDefault
 
     color: "transparent"
@@ -39,6 +41,9 @@ Rectangle
     property int textVAlign: wrapText ? Text.AlignVCenter : Text.AlignTop
     property alias leftMargin: textBox.x
     property real rightMargin: 0
+    readonly property real naturalWidth: leftMargin + textBox.implicitWidth + rightMargin
+    property real maximumWidth: -1
+    property alias textElide: textBox.elide
 
     Text
     {
@@ -57,4 +62,3 @@ Rectangle
         verticalAlignment: textVAlign
     }
 }
-

--- a/qmlui/qml/qmldir
+++ b/qmlui/qml/qmldir
@@ -1,6 +1,7 @@
 singleton UISettings 1.0 UISettings.qml
 singleton FontAwesome 1.0 FontAwesomeVariables.qml
 
+ActionsSubmenuPopup 0.1 ActionsSubmenuPopup.qml
 ChaserStepDelegate 0.1 ChaserStepDelegate.qml
 ChaserWidget 0.1 ChaserWidget.qml
 ColorTool 0.1 ColorTool.qml

--- a/qmlui/qmlui.qrc
+++ b/qmlui/qmlui.qrc
@@ -4,6 +4,9 @@
 
     <!-- Common components -->
     <file alias="ActionsMenu.qml">qml/ActionsMenu.qml</file>
+    <file alias="ActionsMenuGeometry.qml">qml/ActionsMenuGeometry.qml</file>
+    <file alias="ActionsSubmenuPopup.qml">qml/ActionsSubmenuPopup.qml</file>
+    <file alias="RecentFilesPopup.qml">qml/RecentFilesPopup.qml</file>
     <file alias="BeatGeneratorsPanel.qml">qml/BeatGeneratorsPanel.qml</file>
     <file alias="ChannelToolLoader.qml">qml/ChannelToolLoader.qml</file>
     <file alias="ChaserStepDelegate.qml">qml/ChaserStepDelegate.qml</file>

--- a/qmlui/test/tst_actionsmenugeometry.qml
+++ b/qmlui/test/tst_actionsmenugeometry.qml
@@ -1,0 +1,50 @@
+import QtQuick
+import QtTest
+
+TestCase
+{
+    id: testCase
+    name: "ActionsMenuGeometry"
+
+    property Component geometryComponent
+
+    function initTestCase()
+    {
+        geometryComponent = Qt.createComponent("../qml/ActionsMenuGeometry.qml")
+        compare(geometryComponent.status, Component.Ready,
+                geometryComponent.errorString())
+    }
+
+    function test_submenuStartsAfterMainMenuAndFitsWindow()
+    {
+        const geometry = geometryComponent.createObject(testCase, {
+            mainMenuWidth: 190,
+            requestedSubmenuWidth: 900,
+            windowWidth: 1024,
+            popupLeft: 1,
+            margin: 8
+        })
+
+        compare(geometry.submenuX, 190)
+        compare(geometry.maximumSubmenuWidth, 825)
+        compare(geometry.submenuWidth, 825)
+        verify(geometry.popupLeft + geometry.submenuX +
+               geometry.submenuWidth + geometry.margin <= geometry.windowWidth)
+        geometry.destroy()
+    }
+
+    function test_normalRequestedWidthIsPreserved()
+    {
+        const geometry = geometryComponent.createObject(testCase, {
+            mainMenuWidth: 180,
+            requestedSubmenuWidth: 420,
+            windowWidth: 1200,
+            popupLeft: 1,
+            margin: 8
+        })
+
+        compare(geometry.submenuX, 180)
+        compare(geometry.submenuWidth, 420)
+        geometry.destroy()
+    }
+}

--- a/qmlui/test/tst_actionssubmenupopup.qml
+++ b/qmlui/test/tst_actionssubmenupopup.qml
@@ -1,0 +1,59 @@
+import QtQuick
+import QtTest
+import "../qml" as QLC
+
+TestCase
+{
+    id: testCase
+    name: "ActionsSubmenuPopup"
+    when: windowShown
+    width: 640
+    height: 320
+    visible: true
+
+    property string selectedAction: ""
+
+    Item
+    {
+        id: narrowOwner
+        width: 120
+        height: 48
+    }
+
+    QLC.ActionsSubmenuPopup
+    {
+        id: submenuPopup
+        parent: narrowOwner
+        x: narrowOwner.width
+        width: 260
+        height: submenuEntry.height
+
+        contentItem: QLC.ContextMenuEntry
+        {
+            id: submenuEntry
+            objectName: "submenuEntry"
+            width: submenuPopup.width
+            entryText: "Server setup"
+            onClicked: testCase.selectedAction = "server"
+        }
+    }
+
+    function init()
+    {
+        selectedAction = ""
+        submenuPopup.open()
+        tryCompare(submenuPopup, "opened", true)
+    }
+
+    function cleanup()
+    {
+        submenuPopup.close()
+    }
+
+    function test_entryOutsideOwnerHitAreaIsClickable()
+    {
+        mouseClick(submenuEntry, submenuEntry.width / 2,
+                   submenuEntry.height / 2, Qt.LeftButton)
+        compare(selectedAction, "server")
+    }
+}

--- a/qmlui/test/tst_recentfilespopup.qml
+++ b/qmlui/test/tst_recentfilespopup.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtTest
+
+TestCase
+{
+    id: testCase
+    name: "RecentFilesPopup"
+    when: windowShown
+    width: 800
+    height: 500
+
+    property Component popupComponent
+    property var popup
+    property string selectedPath: ""
+
+    Item
+    {
+        id: narrowOwner
+        width: 120
+        height: 48
+    }
+
+    function initTestCase()
+    {
+        popupComponent = Qt.createComponent("../qml/RecentFilesPopup.qml")
+        compare(popupComponent.status, Component.Ready,
+                popupComponent.errorString())
+    }
+
+    function init()
+    {
+        selectedPath = ""
+        popup = popupComponent.createObject(narrowOwner, {
+            x: narrowOwner.width,
+            y: 0,
+            width: 460,
+            recentFiles: [ "/tmp/short-owner/full-project-path.qxw" ]
+        })
+        verify(popup !== null)
+        popup.fileSelected.connect(function(filePath) {
+            selectedPath = filePath
+        })
+        popup.open()
+        tryCompare(popup, "opened", true)
+    }
+
+    function cleanup()
+    {
+        popup.close()
+        popup.destroy()
+        popup = null
+    }
+
+    function test_entryOutsideOwnerHitAreaEmitsFullPath()
+    {
+        const entry = findChild(popup.contentItem, "recentFileEntry_0")
+        verify(entry !== null)
+        mouseClick(entry, entry.width / 2, entry.height / 2, Qt.LeftButton)
+        compare(selectedPath, "/tmp/short-owner/full-project-path.qxw")
+    }
+}


### PR DESCRIPTION
## Why

Recent files, network actions, and language choices are nested inside the main menu. On narrow windows or when a submenu extends outside the parent bounds, labels can be clipped and entries can become difficult to click.

## What changed

Move submenu content into dedicated popup components, calculate safe submenu geometry against the window, constrain long recent-file labels, and add focused component tests.

## Expected behavior

Submenus stay within the available window area, long paths remain identifiable, and entries remain clickable even when the submenu lies outside the main menu bounds.

## Validation

qmltestrunner: 10 passed, 0 failed.