### PR TITLE
Keep 3D settings labels within narrow panels

### DIFF
--- a/qmlui/qlcplus_de_DE.ts
+++ b/qmlui/qlcplus_de_DE.ts
@@ -4823,7 +4823,7 @@ Bitte einen anderen Namen angeben.</translation>
     <message>
         <location filename="qml/fixturesfunctions/3DView/SettingsView3D.qml" line="260"/>
         <source>Show FPS</source>
-        <translation>Frames pro Sekunde anzeigen</translation>
+        <translation>FPS anzeigen</translation>
     </message>
     <message>
         <location filename="qml/fixturesfunctions/3DView/SettingsView3D.qml" line="474"/>

--- a/qmlui/qml/ResponsiveFormLabel.qml
+++ b/qmlui/qml/ResponsiveFormLabel.qml
@@ -1,0 +1,17 @@
+import QtQuick
+import QtQuick.Layouts
+import "."
+
+RobotoText
+{
+    property real availableWidth: 0
+    property real reservedControlWidth: 0
+    property real layoutSpacing: 0
+    readonly property real allowedWidth:
+        Math.max(0, availableWidth - reservedControlWidth - layoutSpacing)
+
+    maximumWidth: allowedWidth
+    textElide: Text.ElideRight
+    Layout.minimumWidth: 0
+    Layout.maximumWidth: allowedWidth
+}

--- a/qmlui/qml/RobotoText.qml
+++ b/qmlui/qml/RobotoText.qml
@@ -23,7 +23,9 @@ import "."
 Rectangle
 {
     id: rtRoot
-    width: wrapText ? 100 : leftMargin + textBox.paintedWidth + rightMargin
+    width: wrapText ? 100 : maximumWidth >= 0 ?
+        Math.min(naturalWidth, maximumWidth) :
+        leftMargin + textBox.paintedWidth + rightMargin
     height: UISettings.iconSizeDefault
 
     color: "transparent"
@@ -39,6 +41,9 @@ Rectangle
     property int textVAlign: wrapText ? Text.AlignVCenter : Text.AlignTop
     property alias leftMargin: textBox.x
     property real rightMargin: 0
+    readonly property real naturalWidth: leftMargin + textBox.implicitWidth + rightMargin
+    property real maximumWidth: -1
+    property alias textElide: textBox.elide
 
     Text
     {
@@ -57,4 +62,3 @@ Rectangle
         verticalAlignment: textVAlign
     }
 }
-

--- a/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
+++ b/qmlui/qml/fixturesfunctions/3DView/SettingsView3D.qml
@@ -233,10 +233,18 @@ Rectangle
                         }
 
                         // row 1
-                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Quality") }
+                        ResponsiveFormLabel
+                        {
+                            height: UISettings.listItemHeight
+                            label: qsTr("Quality")
+                            availableWidth: parent.width
+                            reservedControlWidth: UISettings.bigItemHeight
+                            layoutSpacing: parent.columnSpacing
+                        }
                         CustomComboBox
                         {
                             Layout.fillWidth: true
+                            Layout.minimumWidth: UISettings.bigItemHeight
                             height: UISettings.listItemHeight
                             model: [
                                 { mLabel: qsTr("Low"), mValue: MainView3D.LowQuality },
@@ -249,11 +257,19 @@ Rectangle
                         }
 
                         // row 2
-                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Ambient light") }
+                        ResponsiveFormLabel
+                        {
+                            height: UISettings.listItemHeight
+                            label: qsTr("Ambient light")
+                            availableWidth: parent.width
+                            reservedControlWidth: UISettings.bigItemHeight
+                            layoutSpacing: parent.columnSpacing
+                        }
                         CustomSpinBox
                         {
                             id: ambIntSpin
                             Layout.fillWidth: true
+                            Layout.minimumWidth: UISettings.bigItemHeight
                             height: UISettings.listItemHeight
                             from: 0
                             to: 100
@@ -262,11 +278,19 @@ Rectangle
                         }
 
                         // row 3
-                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Smoke amount") }
+                        ResponsiveFormLabel
+                        {
+                            height: UISettings.listItemHeight
+                            label: qsTr("Smoke amount")
+                            availableWidth: parent.width
+                            reservedControlWidth: UISettings.bigItemHeight
+                            layoutSpacing: parent.columnSpacing
+                        }
                         CustomSpinBox
                         {
                             id: smokeSpin
                             Layout.fillWidth: true
+                            Layout.minimumWidth: UISettings.bigItemHeight
                             height: UISettings.listItemHeight
                             from: 0
                             to: 100
@@ -275,12 +299,20 @@ Rectangle
                         }
 
                         // row 4
-                        RobotoText { height: UISettings.listItemHeight; label: qsTr("Show FPS") }
+                        ResponsiveFormLabel
+                        {
+                            height: UISettings.listItemHeight
+                            label: qsTr("Show FPS")
+                            availableWidth: parent.width
+                            reservedControlWidth: UISettings.bigItemHeight
+                            layoutSpacing: parent.columnSpacing
+                        }
                         CustomCheckBox
                         {
                             implicitHeight: UISettings.listItemHeight
                             implicitWidth: implicitHeight
                             checked: View3D ? View3D.frameCountEnabled : false
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                             onToggled: View3D.frameCountEnabled = checked
                         }
 

--- a/qmlui/qml/fixturesfunctions/qmldir
+++ b/qmlui/qml/fixturesfunctions/qmldir
@@ -27,6 +27,7 @@ MultiColorBox 0.1 ../MultiColorBox.qml
 PaletteFanningBox 0.1 ../PaletteFanningBox.qml
 QLCPlusFader 0.1 ../QLCPlusFader.qml
 RobotoText 0.1 ../RobotoText.qml
+ResponsiveFormLabel 0.1 ../ResponsiveFormLabel.qml
 SectionBox 0.1 ../SectionBox.qml
 SidePanel 0.1 ../SidePanel.qml
 TimeEditTool 0.1 ../TimeEditTool.qml

--- a/qmlui/qml/qmldir
+++ b/qmlui/qml/qmldir
@@ -35,6 +35,7 @@ MultiColorBox 0.1 MultiColorBox.qml
 QLCPlusFader 0.1 QLCPlusFader.qml
 QLCPlusKnob 0.1 QLCPlusKnob.qml
 RobotoText 0.1 RobotoText.qml
+ResponsiveFormLabel 0.1 ResponsiveFormLabel.qml
 SectionBox 0.1 SectionBox.qml
 SidePanel 0.1 SidePanel.qml
 TimeEditTool 0.1 TimeEditTool.qml

--- a/qmlui/qmlui.qrc
+++ b/qmlui/qmlui.qrc
@@ -48,6 +48,7 @@
     <file alias="QLCPlusFader.qml">qml/QLCPlusFader.qml</file>
     <file alias="QLCPlusKnob.qml">qml/QLCPlusKnob.qml</file>
     <file alias="RobotoText.qml">qml/RobotoText.qml</file>
+    <file alias="ResponsiveFormLabel.qml">qml/ResponsiveFormLabel.qml</file>
     <file alias="SectionBox.qml">qml/SectionBox.qml</file>
     <file alias="SidePanel.qml">qml/SidePanel.qml</file>
     <file alias="SimpleDesk.qml">qml/SimpleDesk.qml</file>

--- a/qmlui/test/tst_responsiveformlabel.qml
+++ b/qmlui/test/tst_responsiveformlabel.qml
@@ -1,0 +1,62 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+import "../qml" as QLC
+
+TestCase
+{
+    id: testCase
+    name: "ResponsiveFormLabel"
+    when: windowShown
+    width: 420
+    height: 160
+
+    Item
+    {
+        id: owner
+        width: 240
+        height: 40
+
+        GridLayout
+        {
+            id: renderingGrid
+            width: owner.width
+            columns: 2
+            columnSpacing: 5
+
+            QLC.ResponsiveFormLabel
+            {
+                id: fpsLabel
+                label: "Frames pro Sekunde anzeigen"
+                height: 28
+                availableWidth: renderingGrid.width
+                reservedControlWidth: 90
+                layoutSpacing: renderingGrid.columnSpacing
+            }
+
+            Rectangle
+            {
+                id: renderingControl
+                height: 28
+                Layout.fillWidth: true
+                Layout.minimumWidth: 90
+            }
+        }
+    }
+
+    function test_longLabelPreservesControlAndStaysInsideGrid()
+    {
+        wait(0)
+        verify(fpsLabel.naturalWidth > fpsLabel.width)
+        verify(fpsLabel.width > 0)
+        fuzzyCompare(fpsLabel.width,
+                     Math.min(fpsLabel.naturalWidth, fpsLabel.allowedWidth),
+                     0.01)
+        verify(fpsLabel.width <= fpsLabel.allowedWidth)
+        verify(renderingControl.x >= fpsLabel.x + fpsLabel.width +
+               renderingGrid.columnSpacing - 0.01)
+        verify(renderingControl.width >= 90)
+        verify(renderingControl.x + renderingControl.width <=
+               renderingGrid.width + 0.01)
+    }
+}

--- a/qmlui/test/tst_robototext.qml
+++ b/qmlui/test/tst_robototext.qml
@@ -1,0 +1,28 @@
+import QtQuick
+import QtTest
+
+TestCase
+{
+    id: testCase
+    name: "RobotoText"
+
+    function test_longLabelCanBeMiddleElidedWithoutChangingItsValue()
+    {
+        const component = Qt.createComponent("../qml/RobotoText.qml")
+        compare(component.status, Component.Ready, component.errorString())
+
+        const fullPath = "/Users/example/Documents/very/long/path/to/a/show/project.qxw"
+        const label = component.createObject(testCase, {
+            label: fullPath,
+            maximumWidth: 120,
+            textElide: Text.ElideMiddle
+        })
+
+        verify(label !== null, component.errorString())
+        compare(label.label, fullPath)
+        compare(label.width, 120)
+        verify(label.naturalWidth > label.width)
+        compare(label.textElide, Text.ElideMiddle)
+        label.destroy()
+    }
+}


### PR DESCRIPTION
## Why

Long localized labels in the 3D settings panel can squeeze controls out of narrow layouts.

## What changed

Add reusable bounded and elided Roboto text support, use a responsive form label for the 3D settings rows, preserve usable minimum widths for controls, and shorten the German FPS label.

## Expected behavior

Labels stay readable and controls remain inside the settings panel when the window is narrow or the UI language is longer.

## Validation

qmltestrunner: 6 passed, 0 failed.