### PR TITLE
resources: add Oppsk Wall Washer Light Bar fixture

### DIFF
--- a/resources/fixtures/FixturesMap.xml
+++ b/resources/fixtures/FixturesMap.xml
@@ -1445,6 +1445,9 @@
   <M n="NJD">
     <F n="NJD-Spectre" m="Spectre"/>
   </M>
+  <M n="Oppsk">
+    <F n="Oppsk-Wall-Washer-Light-Bar" m="Wall Washer Light Bar"/>
+  </M>
   <M n="Optima_Lighting">
     <F n="Optima-Lighting-PAR64-LED" m="PAR64 LED"/>
   </M>

--- a/resources/fixtures/Oppsk/Oppsk-Wall-Washer-Light-Bar.qxf
+++ b/resources/fixtures/Oppsk/Oppsk-Wall-Washer-Light-Bar.qxf
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE FixtureDefinition>
+<FixtureDefinition xmlns="http://www.qlcplus.org/FixtureDefinition">
+ <Creator>
+  <Name>Q Light Controller Plus</Name>
+  <Version>4.14.4</Version>
+  <Author>Branson Matheson</Author>
+ </Creator>
+ <Manufacturer>Oppsk</Manufacturer>
+ <Model>Wall Washer Light Bar</Model>
+ <Type>LED Bar (Pixels)</Type>
+ <Channel Name="Master Dimmer" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Strobe">
+  <Group Byte="0">Shutter</Group>
+  <Capability Min="0" Max="9">No function</Capability>
+  <Capability Min="10" Max="255">Strobe (slow to fast)</Capability>
+ </Channel>
+ <Channel Name="All Red" Preset="IntensityRed"/>
+ <Channel Name="All Green" Preset="IntensityGreen"/>
+ <Channel Name="All Blue" Preset="IntensityBlue"/>
+ <Channel Name="All White" Preset="IntensityWhite"/>
+ <Channel Name="Background Red" Preset="IntensityRed"/>
+ <Channel Name="Background Green" Preset="IntensityGreen"/>
+ <Channel Name="Background Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB Pattern Effect">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="5">No function</Capability>
+  <Capability Min="6" Max="11">Pattern Effect 1</Capability>
+  <Capability Min="12" Max="17">Pattern Effect 2</Capability>
+  <Capability Min="18" Max="23">Pattern Effect 3</Capability>
+  <Capability Min="24" Max="29">Pattern Effect 4</Capability>
+  <Capability Min="30" Max="35">Pattern Effect 5</Capability>
+  <Capability Min="36" Max="41">Pattern Effect 6</Capability>
+  <Capability Min="42" Max="47">Pattern Effect 7</Capability>
+  <Capability Min="48" Max="53">Pattern Effect 8</Capability>
+  <Capability Min="54" Max="59">Pattern Effect 9</Capability>
+  <Capability Min="60" Max="65">Pattern Effect 10</Capability>
+  <Capability Min="66" Max="71">Pattern Effect 11</Capability>
+  <Capability Min="72" Max="77">Pattern Effect 12</Capability>
+  <Capability Min="78" Max="83">Pattern Effect 13</Capability>
+  <Capability Min="84" Max="89">Pattern Effect 14</Capability>
+  <Capability Min="90" Max="95">Pattern Effect 15</Capability>
+  <Capability Min="96" Max="101">Pattern Effect 16</Capability>
+  <Capability Min="102" Max="107">Pattern Effect 17</Capability>
+  <Capability Min="108" Max="113">Pattern Effect 18</Capability>
+  <Capability Min="114" Max="119">Pattern Effect 19</Capability>
+  <Capability Min="120" Max="125">Pattern Effect 20</Capability>
+  <Capability Min="126" Max="131">Pattern Effect 21</Capability>
+  <Capability Min="132" Max="137">Pattern Effect 22</Capability>
+  <Capability Min="138" Max="143">Pattern Effect 23</Capability>
+  <Capability Min="144" Max="149">Pattern Effect 24</Capability>
+  <Capability Min="150" Max="155">Pattern Effect 25</Capability>
+  <Capability Min="156" Max="161">Pattern Effect 26</Capability>
+  <Capability Min="162" Max="167">Pattern Effect 27</Capability>
+  <Capability Min="168" Max="173">Pattern Effect 28</Capability>
+  <Capability Min="174" Max="179">Pattern Effect 29</Capability>
+  <Capability Min="180" Max="185">Pattern Effect 30</Capability>
+  <Capability Min="186" Max="191">Pattern Effect 31</Capability>
+  <Capability Min="192" Max="197">Pattern Effect 32</Capability>
+  <Capability Min="198" Max="203">Pattern Effect 33</Capability>
+  <Capability Min="204" Max="209">Pattern Effect 34</Capability>
+  <Capability Min="210" Max="215">Pattern Effect 35</Capability>
+  <Capability Min="216" Max="221">Pattern Effect 36</Capability>
+  <Capability Min="222" Max="227">Pattern Effect 37</Capability>
+  <Capability Min="228" Max="233">Auto Effect (cycles Pattern Effect 1-37)</Capability>
+  <Capability Min="234" Max="236">Sound 1</Capability>
+  <Capability Min="237" Max="239">Sound 2</Capability>
+  <Capability Min="240" Max="242">Sound 3</Capability>
+  <Capability Min="243" Max="255">Sound 4</Capability>
+ </Channel>
+ <Channel Name="White Pattern Effect">
+  <Group Byte="0">Effect</Group>
+  <Capability Min="0" Max="6">No function</Capability>
+  <Capability Min="7" Max="13">Effect 1</Capability>
+  <Capability Min="14" Max="20">Effect 2</Capability>
+  <Capability Min="21" Max="27">Effect 3</Capability>
+  <Capability Min="28" Max="34">Effect 4</Capability>
+  <Capability Min="35" Max="41">Effect 5</Capability>
+  <Capability Min="42" Max="48">Effect 6</Capability>
+  <Capability Min="49" Max="55">Effect 7</Capability>
+  <Capability Min="56" Max="62">Effect 8</Capability>
+  <Capability Min="63" Max="69">Effect 9</Capability>
+  <Capability Min="70" Max="76">Effect 10</Capability>
+  <Capability Min="77" Max="83">Effect 11</Capability>
+  <Capability Min="84" Max="90">Effect 12</Capability>
+  <Capability Min="91" Max="97">Effect 13</Capability>
+  <Capability Min="98" Max="104">Effect 14</Capability>
+  <Capability Min="105" Max="111">Effect 15</Capability>
+  <Capability Min="112" Max="118">Effect 16</Capability>
+  <Capability Min="119" Max="125">Effect 17</Capability>
+  <Capability Min="126" Max="132">Effect 18</Capability>
+  <Capability Min="133" Max="139">Effect 19</Capability>
+  <Capability Min="140" Max="146">Effect 20</Capability>
+  <Capability Min="147" Max="153">Effect 21</Capability>
+  <Capability Min="154" Max="160">Effect 22</Capability>
+  <Capability Min="161" Max="167">Effect 23</Capability>
+  <Capability Min="168" Max="174">Effect 24</Capability>
+  <Capability Min="175" Max="181">Effect 25</Capability>
+  <Capability Min="182" Max="188">Effect 26</Capability>
+  <Capability Min="189" Max="195">Effect 27</Capability>
+  <Capability Min="196" Max="202">Effect 28</Capability>
+  <Capability Min="203" Max="209">Effect 29</Capability>
+  <Capability Min="210" Max="216">Effect 30</Capability>
+  <Capability Min="217" Max="223">Effect 31</Capability>
+  <Capability Min="224" Max="230">Effect 32</Capability>
+  <Capability Min="231" Max="255">Auto Effect (cycles Effect 1-32)</Capability>
+ </Channel>
+ <Channel Name="DMX Program Speed">
+  <Group Byte="0">Speed</Group>
+  <Capability Min="0" Max="255">Effect speed (slow to fast)</Capability>
+ </Channel>
+ <Channel Name="RGB-1 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-1 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-1 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-2 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-2 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-2 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-3 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-3 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-3 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-4 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-4 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-4 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-5 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-5 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-5 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-6 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-6 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-6 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-7 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-7 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-7 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-8 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-8 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-8 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-9 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-9 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-9 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-10 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-10 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-10 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-11 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-11 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-11 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-12 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-12 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-12 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-13 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-13 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-13 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-14 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-14 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-14 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-15 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-15 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-15 Blue" Preset="IntensityBlue"/>
+ <Channel Name="RGB-16 Red" Preset="IntensityRed"/>
+ <Channel Name="RGB-16 Green" Preset="IntensityGreen"/>
+ <Channel Name="RGB-16 Blue" Preset="IntensityBlue"/>
+ <Channel Name="W-1 White" Preset="IntensityWhite"/>
+ <Channel Name="W-2 White" Preset="IntensityWhite"/>
+ <Channel Name="W-3 White" Preset="IntensityWhite"/>
+ <Channel Name="W-4 White" Preset="IntensityWhite"/>
+ <Channel Name="W-5 White" Preset="IntensityWhite"/>
+ <Channel Name="W-6 White" Preset="IntensityWhite"/>
+ <Channel Name="W-7 White" Preset="IntensityWhite"/>
+ <Channel Name="W-8 White" Preset="IntensityWhite"/>
+ <Channel Name="W-9 White" Preset="IntensityWhite"/>
+ <Channel Name="W-10 White" Preset="IntensityWhite"/>
+ <Channel Name="W-11 White" Preset="IntensityWhite"/>
+ <Channel Name="W-12 White" Preset="IntensityWhite"/>
+ <Channel Name="W-13 White" Preset="IntensityWhite"/>
+ <Channel Name="W-14 White" Preset="IntensityWhite"/>
+ <Channel Name="W-15 White" Preset="IntensityWhite"/>
+ <Channel Name="W-16 White" Preset="IntensityWhite"/>
+ <Mode Name="6ch">
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">Strobe</Channel>
+  <Channel Number="2">All Red</Channel>
+  <Channel Number="3">All Green</Channel>
+  <Channel Number="4">All Blue</Channel>
+  <Channel Number="5">All White</Channel>
+ </Mode>
+ <Mode Name="9ch">
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">All Red</Channel>
+  <Channel Number="2">All Green</Channel>
+  <Channel Number="3">All Blue</Channel>
+  <Channel Number="4">All White</Channel>
+  <Channel Number="5">Strobe</Channel>
+  <Channel Number="6">RGB Pattern Effect</Channel>
+  <Channel Number="7">White Pattern Effect</Channel>
+  <Channel Number="8">DMX Program Speed</Channel>
+ </Mode>
+ <Mode Name="12ch">
+  <Channel Number="0">Master Dimmer</Channel>
+  <Channel Number="1">All Red</Channel>
+  <Channel Number="2">All Green</Channel>
+  <Channel Number="3">All Blue</Channel>
+  <Channel Number="4">All White</Channel>
+  <Channel Number="5">Strobe</Channel>
+  <Channel Number="6">Background Red</Channel>
+  <Channel Number="7">Background Green</Channel>
+  <Channel Number="8">Background Blue</Channel>
+  <Channel Number="9">RGB Pattern Effect</Channel>
+  <Channel Number="10">White Pattern Effect</Channel>
+  <Channel Number="11">DMX Program Speed</Channel>
+ </Mode>
+ <Mode Name="32ch">
+  <Channel Number="0">RGB-1 Red</Channel>
+  <Channel Number="1">RGB-1 Green</Channel>
+  <Channel Number="2">RGB-1 Blue</Channel>
+  <Channel Number="3">RGB-2 Red</Channel>
+  <Channel Number="4">RGB-2 Green</Channel>
+  <Channel Number="5">RGB-2 Blue</Channel>
+  <Channel Number="6">RGB-3 Red</Channel>
+  <Channel Number="7">RGB-3 Green</Channel>
+  <Channel Number="8">RGB-3 Blue</Channel>
+  <Channel Number="9">RGB-4 Red</Channel>
+  <Channel Number="10">RGB-4 Green</Channel>
+  <Channel Number="11">RGB-4 Blue</Channel>
+  <Channel Number="12">RGB-5 Red</Channel>
+  <Channel Number="13">RGB-5 Green</Channel>
+  <Channel Number="14">RGB-5 Blue</Channel>
+  <Channel Number="15">RGB-6 Red</Channel>
+  <Channel Number="16">RGB-6 Green</Channel>
+  <Channel Number="17">RGB-6 Blue</Channel>
+  <Channel Number="18">RGB-7 Red</Channel>
+  <Channel Number="19">RGB-7 Green</Channel>
+  <Channel Number="20">RGB-7 Blue</Channel>
+  <Channel Number="21">RGB-8 Red</Channel>
+  <Channel Number="22">RGB-8 Green</Channel>
+  <Channel Number="23">RGB-8 Blue</Channel>
+  <Channel Number="24">W-1 White</Channel>
+  <Channel Number="25">W-2 White</Channel>
+  <Channel Number="26">W-3 White</Channel>
+  <Channel Number="27">W-4 White</Channel>
+  <Channel Number="28">W-5 White</Channel>
+  <Channel Number="29">W-6 White</Channel>
+  <Channel Number="30">W-7 White</Channel>
+  <Channel Number="31">W-8 White</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>3</Channel>
+   <Channel>4</Channel>
+   <Channel>5</Channel>
+  </Head>
+  <Head>
+   <Channel>6</Channel>
+   <Channel>7</Channel>
+   <Channel>8</Channel>
+  </Head>
+  <Head>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+  </Head>
+  <Head>
+   <Channel>12</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+  </Head>
+  <Head>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+   <Channel>17</Channel>
+  </Head>
+  <Head>
+   <Channel>18</Channel>
+   <Channel>19</Channel>
+   <Channel>20</Channel>
+  </Head>
+  <Head>
+   <Channel>21</Channel>
+   <Channel>22</Channel>
+   <Channel>23</Channel>
+  </Head>
+  <Head>
+   <Channel>24</Channel>
+  </Head>
+  <Head>
+   <Channel>25</Channel>
+  </Head>
+  <Head>
+   <Channel>26</Channel>
+  </Head>
+  <Head>
+   <Channel>27</Channel>
+  </Head>
+  <Head>
+   <Channel>28</Channel>
+  </Head>
+  <Head>
+   <Channel>29</Channel>
+  </Head>
+  <Head>
+   <Channel>30</Channel>
+  </Head>
+  <Head>
+   <Channel>31</Channel>
+  </Head>
+ </Mode>
+ <Mode Name="64ch">
+  <Channel Number="0">RGB-1 Red</Channel>
+  <Channel Number="1">RGB-1 Green</Channel>
+  <Channel Number="2">RGB-1 Blue</Channel>
+  <Channel Number="3">RGB-2 Red</Channel>
+  <Channel Number="4">RGB-2 Green</Channel>
+  <Channel Number="5">RGB-2 Blue</Channel>
+  <Channel Number="6">RGB-3 Red</Channel>
+  <Channel Number="7">RGB-3 Green</Channel>
+  <Channel Number="8">RGB-3 Blue</Channel>
+  <Channel Number="9">RGB-4 Red</Channel>
+  <Channel Number="10">RGB-4 Green</Channel>
+  <Channel Number="11">RGB-4 Blue</Channel>
+  <Channel Number="12">RGB-5 Red</Channel>
+  <Channel Number="13">RGB-5 Green</Channel>
+  <Channel Number="14">RGB-5 Blue</Channel>
+  <Channel Number="15">RGB-6 Red</Channel>
+  <Channel Number="16">RGB-6 Green</Channel>
+  <Channel Number="17">RGB-6 Blue</Channel>
+  <Channel Number="18">RGB-7 Red</Channel>
+  <Channel Number="19">RGB-7 Green</Channel>
+  <Channel Number="20">RGB-7 Blue</Channel>
+  <Channel Number="21">RGB-8 Red</Channel>
+  <Channel Number="22">RGB-8 Green</Channel>
+  <Channel Number="23">RGB-8 Blue</Channel>
+  <Channel Number="24">RGB-9 Red</Channel>
+  <Channel Number="25">RGB-9 Green</Channel>
+  <Channel Number="26">RGB-9 Blue</Channel>
+  <Channel Number="27">RGB-10 Red</Channel>
+  <Channel Number="28">RGB-10 Green</Channel>
+  <Channel Number="29">RGB-10 Blue</Channel>
+  <Channel Number="30">RGB-11 Red</Channel>
+  <Channel Number="31">RGB-11 Green</Channel>
+  <Channel Number="32">RGB-11 Blue</Channel>
+  <Channel Number="33">RGB-12 Red</Channel>
+  <Channel Number="34">RGB-12 Green</Channel>
+  <Channel Number="35">RGB-12 Blue</Channel>
+  <Channel Number="36">RGB-13 Red</Channel>
+  <Channel Number="37">RGB-13 Green</Channel>
+  <Channel Number="38">RGB-13 Blue</Channel>
+  <Channel Number="39">RGB-14 Red</Channel>
+  <Channel Number="40">RGB-14 Green</Channel>
+  <Channel Number="41">RGB-14 Blue</Channel>
+  <Channel Number="42">RGB-15 Red</Channel>
+  <Channel Number="43">RGB-15 Green</Channel>
+  <Channel Number="44">RGB-15 Blue</Channel>
+  <Channel Number="45">RGB-16 Red</Channel>
+  <Channel Number="46">RGB-16 Green</Channel>
+  <Channel Number="47">RGB-16 Blue</Channel>
+  <Channel Number="48">W-1 White</Channel>
+  <Channel Number="49">W-2 White</Channel>
+  <Channel Number="50">W-3 White</Channel>
+  <Channel Number="51">W-4 White</Channel>
+  <Channel Number="52">W-5 White</Channel>
+  <Channel Number="53">W-6 White</Channel>
+  <Channel Number="54">W-7 White</Channel>
+  <Channel Number="55">W-8 White</Channel>
+  <Channel Number="56">W-9 White</Channel>
+  <Channel Number="57">W-10 White</Channel>
+  <Channel Number="58">W-11 White</Channel>
+  <Channel Number="59">W-12 White</Channel>
+  <Channel Number="60">W-13 White</Channel>
+  <Channel Number="61">W-14 White</Channel>
+  <Channel Number="62">W-15 White</Channel>
+  <Channel Number="63">W-16 White</Channel>
+  <Head>
+   <Channel>0</Channel>
+   <Channel>1</Channel>
+   <Channel>2</Channel>
+  </Head>
+  <Head>
+   <Channel>3</Channel>
+   <Channel>4</Channel>
+   <Channel>5</Channel>
+  </Head>
+  <Head>
+   <Channel>6</Channel>
+   <Channel>7</Channel>
+   <Channel>8</Channel>
+  </Head>
+  <Head>
+   <Channel>9</Channel>
+   <Channel>10</Channel>
+   <Channel>11</Channel>
+  </Head>
+  <Head>
+   <Channel>12</Channel>
+   <Channel>13</Channel>
+   <Channel>14</Channel>
+  </Head>
+  <Head>
+   <Channel>15</Channel>
+   <Channel>16</Channel>
+   <Channel>17</Channel>
+  </Head>
+  <Head>
+   <Channel>18</Channel>
+   <Channel>19</Channel>
+   <Channel>20</Channel>
+  </Head>
+  <Head>
+   <Channel>21</Channel>
+   <Channel>22</Channel>
+   <Channel>23</Channel>
+  </Head>
+  <Head>
+   <Channel>24</Channel>
+   <Channel>25</Channel>
+   <Channel>26</Channel>
+  </Head>
+  <Head>
+   <Channel>27</Channel>
+   <Channel>28</Channel>
+   <Channel>29</Channel>
+  </Head>
+  <Head>
+   <Channel>30</Channel>
+   <Channel>31</Channel>
+   <Channel>32</Channel>
+  </Head>
+  <Head>
+   <Channel>33</Channel>
+   <Channel>34</Channel>
+   <Channel>35</Channel>
+  </Head>
+  <Head>
+   <Channel>36</Channel>
+   <Channel>37</Channel>
+   <Channel>38</Channel>
+  </Head>
+  <Head>
+   <Channel>39</Channel>
+   <Channel>40</Channel>
+   <Channel>41</Channel>
+  </Head>
+  <Head>
+   <Channel>42</Channel>
+   <Channel>43</Channel>
+   <Channel>44</Channel>
+  </Head>
+  <Head>
+   <Channel>45</Channel>
+   <Channel>46</Channel>
+   <Channel>47</Channel>
+  </Head>
+  <Head>
+   <Channel>48</Channel>
+  </Head>
+  <Head>
+   <Channel>49</Channel>
+  </Head>
+  <Head>
+   <Channel>50</Channel>
+  </Head>
+  <Head>
+   <Channel>51</Channel>
+  </Head>
+  <Head>
+   <Channel>52</Channel>
+  </Head>
+  <Head>
+   <Channel>53</Channel>
+  </Head>
+  <Head>
+   <Channel>54</Channel>
+  </Head>
+  <Head>
+   <Channel>55</Channel>
+  </Head>
+  <Head>
+   <Channel>56</Channel>
+  </Head>
+  <Head>
+   <Channel>57</Channel>
+  </Head>
+  <Head>
+   <Channel>58</Channel>
+  </Head>
+  <Head>
+   <Channel>59</Channel>
+  </Head>
+  <Head>
+   <Channel>60</Channel>
+  </Head>
+  <Head>
+   <Channel>61</Channel>
+  </Head>
+  <Head>
+   <Channel>62</Channel>
+  </Head>
+  <Head>
+   <Channel>63</Channel>
+  </Head>
+ </Mode>
+ <Physical>
+  <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="1.9" Width="1005" Height="65" Depth="60"/>
+  <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+  <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
+  <Layout Width="8" Height="4"/>
+  <Technical PowerConsumption="100" DmxConnector="3-pin"/>
+ </Physical>
+</FixtureDefinition>


### PR DESCRIPTION
## Fixture Information

**Manufacturer:** Oppsk

**Model:** Wall Washer Light Bar

**Mode(s) included:** 6ch, 9ch, 12ch, 32ch, 64ch (matches the hardware's own DMX-mode menu exactly)

**Channels used:** 64 (largest mode)

## Testing

- [x] Physical data is included (1005x65x60mm, 1.9kg, 100W, 3-pin XLR DMX — from the manufacturer's user guide)
- [ ] Fixture has been tested using the online [fixture validator](https://www.qlcplus.org/fixture_validator.php) — **this link 404s**, same as noted in #2142; validated locally instead via `resources/fixtures/scripts/check` (xmllint/fixtures-tool.py/FixturesMap.xml — same validation CI runs): 1739/1739 fixtures schema-valid, 0 errors, FixturesMap.xml schema-valid. Additionally cross-checked the two effect-channel and the strobe-channel capability ranges programmatically for full 0-255 coverage with no gaps or overlaps.
- [x] Channel modes do not include the word "mode" in them
- [x] Capabilities are labeled and ordered clearly

## Source(s) of Information

Manufacturer's user guide: OK-103-288WL_User_Guide (PDF), specifically the DMX Signal Connection / channel tables on pages 3-9. Every channel and capability range in this definition was checked directly against that document's per-mode tables.

## Notes

The five modes here are exactly the five the fixture's own control panel lets you select (page 4 of the guide: "DMX mode Addr: 6CH/9CH/12CH/32CH/64CH") — no additional modes were invented.
