### PR TITLE
New rgbscripts (batch 2)

### DIFF
--- a/resources/rgbscripts/CMakeLists.txt
+++ b/resources/rgbscripts/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SCRIPT_FILES
     blinder.js
     circles.js
     circular.js
+    confetti.js
+    connectdots.js
     evenodd.js
     fill.js
     fillfromcenter.js
@@ -15,11 +17,15 @@ set(SCRIPT_FILES
     fireworks.js
     flyingobjects.js
     gradient.js
+    juggle.js
+    lantern.js
     lines.js
     marquee.js
+    meteor.js
     noise.js
     onebyone.js
     opposite.js
+    pacifica.js
     plasma.js
     randomcolumn.js
     randomfillcolumn.js
@@ -29,15 +35,20 @@ set(SCRIPT_FILES
     randompixelperrowmulticolor.js
     randomrow.js
     randomsingle.js
+    ripple.js
+    shapes.js
     sinewave.js
     snowbubbles.js
     squares.js
     squaresfromcenter.js
+    stagepulse.js
     starfield.js
     stripes.js
     stripesfromcenter.js
     strobe.js
+    twinklefox.js
     verticalfall.js
+    waterflow.js
     waves.js
 )
 

--- a/resources/rgbscripts/confetti.js
+++ b/resources/rgbscripts/confetti.js
@@ -1,0 +1,103 @@
+/*
+  Q Light Controller Plus
+  confetti.js
+
+  FastLED-inspired "Confetti" (random speckles that blink and fade)
+  Ported to QLC+ RGBScript by Branson Matheson
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Development tool access
+var testAlgo;
+
+(function(){
+  var algo = new Object;
+  algo.apiVersion = 2;
+  algo.name = "Confetti";
+  algo.author = "FastLED idea, port by Branson Matheson";
+  algo.acceptColors = 1;
+  algo.properties = new Array();
+
+  algo.density = 20; // 1..100 percent of pixels per frame that may light
+  algo.properties.push("name:density|type:range|display:Density|values:1,100|write:setDensity|read:getDensity");
+  algo.fade = 80; // 0..100
+  algo.properties.push("name:fade|type:range|display:Fade (0-100)|values:0,100|write:setFade|read:getFade");
+
+  var util = new Object;
+  util.initialized = false;
+  util.map = null;
+
+  algo.setDensity = function(v){ algo.density = parseInt(v); };
+  algo.getDensity = function(){ return algo.density; };
+  algo.setFade = function(v){ algo.fade = parseInt(v); };
+  algo.getFade = function(){ return algo.fade; };
+
+  function makeMap(width, height, fill){
+    var m = new Array(height);
+    for (var y=0;y<height;y++){
+      m[y] = new Array(width);
+      for (var x=0;x<width;x++) m[y][x] = fill;
+    }
+    return m;
+  }
+  function scaleColor(rgb, scale255){
+    if (scale255 <= 0) return 0;
+    if (scale255 >= 255) return rgb;
+    var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255;
+    r=Math.floor(r*scale255/255); g=Math.floor(g*scale255/255); b=Math.floor(b*scale255/255);
+    return (r<<16)+(g<<8)+b;
+  }
+  function addColor(dst, add){
+    var dr=(dst>>16)&255,dg=(dst>>8)&255,db=dst&255;
+    var ar=(add>>16)&255,ag=(add>>8)&255,ab=add&255;
+    var nr=dr+ar; if(nr>255)nr=255; var ng=dg+ag; if(ng>255)ng=255; var nb=db+ab; if(nb>255)nb=255;
+    return (nr<<16)+(ng<<8)+nb;
+  }
+  function fadeMap(map, w,h, fadePct){
+    var scale = 255 - Math.floor(fadePct * 255 / 100);
+    for (var y=0;y<h;y++) for (var x=0;x<w;x++) map[y][x] = scaleColor(map[y][x], scale);
+  }
+
+  algo.rgbMap = function(width, height, rgb, step){
+    if (!util.initialized || util.map===null || util.map.length!==height || util.map[0].length!==width){
+      util.map = makeMap(width,height,0);
+      util.initialized=true;
+    }
+
+    // fade current pixels
+    fadeMap(util.map, width, height, algo.fade);
+
+    // sprinkle confetti
+    var total = width * height;
+    var sparks = Math.max(1, Math.floor(total * algo.density / 1000)); // scale density
+    for (var i=0;i<sparks;i++){
+      var x = Math.floor(Math.random()*width);
+      var y = Math.floor(Math.random()*height);
+      var atten = 128 + Math.floor(Math.random()*127); // 128..255
+      var c = scaleColor(rgb, atten);
+      util.map[y][x] = addColor(util.map[y][x], c);
+    }
+
+    var out = makeMap(width,height,0);
+    for (var y=0;y<height;y++) for (var x=0;x<width;x++) out[y][x]=util.map[y][x];
+    return out;
+  };
+
+  algo.rgbMapStepCount = function(width,height){ return 2; };
+
+  testAlgo = algo; return algo;
+})();
+

--- a/resources/rgbscripts/connectdots.js
+++ b/resources/rgbscripts/connectdots.js
@@ -1,0 +1,251 @@
+/*
+  Q Light Controller Plus
+  connectdots.js
+
+  Moving dot clusters connected by lines ("constellations"). Each feature is a
+  cluster of dots that move in straight segments for random durations. All dots
+  in a feature are mutually connected by lines. Features have a lifetime and are
+  regenerated with a new dot count around a base with randomness.
+
+  Colors (API v3):
+  - Color[0] = Line color
+  - Color[1] = Dot color
+
+  Controls
+  - Dots / Feature: base number of dots in each feature
+  - Dot Randomness (%): +/- percent variation around the base
+  - Features: how many features (clusters)
+  - Lifetime (frames): how long a feature lives before respawn
+  - Speed (1..10): movement speed and segment duration scaling
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 3;
+  algo.name = "ConnectDots";
+  algo.author = "Branson Matheson";
+  algo.acceptColors = 2; // [line, dot]
+  algo.properties = [];
+
+  // --- Properties ---
+  algo.baseDots = 18; // 2..100
+  algo.properties.push("name:basedots|type:range|display:Dots / Feature|values:2,100|write:setBaseDots|read:getBaseDots");
+  algo.setBaseDots = function(v){ var n=parseInt(v,10); if(isNaN(n)) n=18; if(n<2) n=2; if(n>100) n=100; algo.baseDots=n; };
+  algo.getBaseDots = function(){ return algo.baseDots; };
+
+  algo.dotRandPct = 40; // 0..100  +/- % of base
+  algo.properties.push("name:dotrand|type:range|display:Dot Randomness (%)|values:0,100|write:setDotRand|read:getDotRand");
+  algo.setDotRand = function(v){ var n=parseInt(v,10); if(isNaN(n)) n=40; if(n<0) n=0; if(n>100) n=100; algo.dotRandPct=n; };
+  algo.getDotRand = function(){ return algo.dotRandPct; };
+
+  algo.featureCount = 2; // 1..8
+  algo.properties.push("name:features|type:range|display:Features|values:1,8|write:setFeatureCount|read:getFeatureCount");
+  algo.setFeatureCount = function(v){ var n=parseInt(v,10); if(isNaN(n)) n=2; if(n<1)n=1; if(n>8)n=8; algo.featureCount=n; };
+  algo.getFeatureCount = function(){ return algo.featureCount; };
+
+  algo.life = 220; // frames 10..1000
+  algo.properties.push("name:lifetime|type:range|display:Lifetime (frames)|values:10,1000|write:setLifetime|read:getLifetime");
+  algo.setLifetime = function(v){ var n=parseInt(v,10); if(isNaN(n)) n=220; if(n<10)n=10; if(n>1000)n=1000; algo.life=n; };
+  algo.getLifetime = function(){ return algo.life; };
+
+  algo.speed = 6; // 1..10
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,10|write:setSpeed|read:getSpeed");
+  algo.setSpeed = function(v){ var n=parseInt(v,10); if(isNaN(n)) n=6; if(n<1)n=1; if(n>10)n=10; algo.speed=n; };
+  algo.getSpeed = function(){ return algo.speed; };
+
+  // Connect mode: "Complete" (all pairs) or "Tree (N-1)" minimal spanning tree
+  var CONNECT_LABELS = ["Complete","Tree (N-1)"];
+  algo.connectModeIndex = 0;
+  algo.properties.push("name:connect|type:list|display:Connect Mode|values:" + CONNECT_LABELS.join(',') + "|write:setConnectMode|read:getConnectMode");
+  algo.setConnectMode = function(label){ for (var i=0;i<CONNECT_LABELS.length;i++){ if (label === CONNECT_LABELS[i]){ algo.connectModeIndex = i; return; } } };
+  algo.getConnectMode = function(){ return CONNECT_LABELS[algo.connectModeIndex]; };
+
+  // Lifetime randomness (per-feature spawn)
+  algo.lifeRandPct = 30; // 0..100
+  algo.properties.push("name:liferand|type:range|display:Lifetime Randomness (%)|values:0,100|write:setLifeRand|read:getLifeRand");
+  algo.setLifeRand = function(v){ var n=parseInt(v,10); if(isNaN(n)) n=30; if(n<0)n=0; if(n>100)n=100; algo.lifeRandPct=n; };
+  algo.getLifeRand = function(){ return algo.lifeRandPct; };
+
+
+  // --- State ---
+  var util = {};
+  util.colors = [0xB0B0B0, 0xFFFFFF]; // line, dot
+  util.features = [];
+  util.lastW = 0; util.lastH = 0; util.frame = 0;
+
+  algo.rgbMapSetColors = function(raw){ if (raw && raw.length){ var out=[]; for(var i=0;i<algo.acceptColors && i<raw.length;i++){ if (raw[i]===raw[i]) out.push(raw[i]); } if(out.length>0) util.colors=out; } };
+  algo.rgbMapGetColors = function(){ return util.colors; };
+
+  // --- Helpers ---
+  function clamp(x,a,b){ return x<a?a:(x>b?b:x); }
+  function makeMap(w,h,fill){ var m=new Array(h); for (var y=0;y<h;y++){ m[y]=new Array(w); for(var x=0;x<w;x++) m[y][x]=fill; } return m; }
+  function addColor(dst, add){ var dr=(dst>>16)&255,dg=(dst>>8)&255,db=dst&255; var ar=(add>>16)&255,ag=(add>>8)&255,ab=add&255; var nr=dr+ar; if(nr>255)nr=255; var ng=dg+ag; if(ng>255)ng=255; var nb=db+ab; if(nb>255)nb=255; return (nr<<16)|(ng<<8)|nb; }
+  function scaleColor(rgb, s255){ if(s255<=0)return 0; if(s255>=255)return rgb; var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255; r=Math.floor(r*s255/255); g=Math.floor(g*s255/255); b=Math.floor(b*s255/255); return (r<<16)|(g<<8)|b; }
+
+  // Bresenham line
+  function drawLine(map,w,h,x0,y0,x1,y1,color){
+    var x= Math.floor(x0), y=Math.floor(y0); var x2=Math.floor(x1), y2=Math.floor(y1);
+    var dx = Math.abs(x2-x), dy = Math.abs(y2-y); var sx = (x<x2)?1:-1; var sy=(y<y2)?1:-1; var err=dx-dy;
+    while(true){ if(x>=0&&x<w&&y>=0&&y<h){ map[y][x] = addColor(map[y][x], color); }
+      if (x===x2 && y===y2) break; var e2=err*2; if(e2>-dy){ err-=dy; x+=sx; } if(e2<dx){ err+=dx; y+=sy; }
+    }
+  }
+
+  function drawDot(map,w,h,xf,yf,color){ var x=Math.floor(xf), y=Math.floor(yf); if(x>=0&&x<w&&y>=0&&y<h){ map[y][x] = addColor(map[y][x], color); }
+    // tiny 4-neighbor glow
+    var dim = scaleColor(color, 120);
+    if (x>0) map[y][x-1] = addColor(map[y][x-1], dim);
+    if (x+1<w) map[y][x+1] = addColor(map[y][x+1], dim);
+    if (y>0) map[y-1][x] = addColor(map[y-1][x], dim);
+    if (y+1<h) map[y+1][x] = addColor(map[y+1][x], dim);
+  }
+
+  // Build a minimal spanning tree (Prim-like), producing exactly N-1 edges
+  function buildEdgesTree(dots){
+    var n = dots.length; var edges = [];
+    if (n <= 1) return edges;
+    var used = new Array(n); for (var i=0;i<n;i++) used[i]=false; used[0]=true; var inCount=1;
+    while (inCount < n){
+      var bi=-1, bj=-1; var best=1e20;
+      for (var i=0;i<n;i++){
+        if (!used[i]) continue; var ai=dots[i];
+        for (var j=0;j<n;j++){
+          if (used[j]) continue; var aj=dots[j];
+          var dx=ai.x-aj.x, dy=ai.y-aj.y; var d=dx*dx+dy*dy;
+          if (d < best){ best=d; bi=i; bj=j; }
+        }
+      }
+      if (bj<0){ // fallback in case of numerical issues
+        for (var k=0;k<n;k++){ if (!used[k]){ bi=0; bj=k; break; } }
+      }
+      edges.push([bi,bj]); used[bj]=true; inCount++;
+    }
+    return edges;
+  }
+
+
+  function randBetween(a,b){ return a + Math.random()*(b-a); }
+  function newVel(speed){ var ang = Math.random()*Math.PI*2; var v = 0.2 + 0.8*(algo.speed/10.0); var s=v*speed; return {vx:Math.cos(ang)*s, vy:Math.sin(ang)*s}; }
+
+  function spawnFeature(w,h){
+    // decide dot count
+    var base = algo.baseDots;
+    var delta = Math.floor(base * (algo.dotRandPct/100.0));
+    var count = base + Math.floor((Math.random()*2-1)*delta);
+    if (count<2) count=2; if (count>200) count=200;
+
+    // place around a random center
+    var cx = randBetween(0.25*w, 0.75*w);
+    var cy = randBetween(0.25*h, 0.75*h);
+    var rad = Math.max(2, Math.min(w,h) * 0.35); // cluster radius
+
+    var dots = new Array(count);
+    for (var i=0;i<count;i++){
+      var r = Math.random()*rad*0.8; var a = Math.random()*Math.PI*2;
+      var x = cx + Math.cos(a)*r; var y = cy + Math.sin(a)*r;
+      var vel = newVel(1.0);
+      var seg = Math.floor(20 + Math.random()*60 * (11-algo.speed)/10.0);
+      dots[i] = {x:x,y:y,vx:vel.vx,vy:vel.vy, seg:seg};
+    }
+    var baseLife = algo.life;
+    var ldelta = Math.floor(baseLife * (algo.lifeRandPct/100.0));
+    var life = baseLife + Math.floor((Math.random()*2-1) * ldelta);
+    if (life < 5) life = 5;
+    return {born:util.frame, life:life, dots:dots};
+  }
+
+  function ensureFeatures(w,h){
+    if (util.lastW!==w || util.lastH!==h){ util.features=[]; util.lastW=w; util.lastH=h; util.frame=0; }
+    while (util.features.length < algo.featureCount){ util.features.push(spawnFeature(w,h)); }
+    if (util.features.length > algo.featureCount){ util.features.length = algo.featureCount; }
+  }
+
+  function updateFeatures(w,h){
+    // respawn expired
+    for (var f=0; f<util.features.length; f++){
+      var feat = util.features[f];
+      if (util.frame - feat.born >= feat.life){ util.features[f] = spawnFeature(w,h); }
+    }
+    // update dots
+    var spd = 1.0; // already scaled inside newVel
+    for (var f2=0; f2<util.features.length; f2++){
+      var fe = util.features[f2]; var dots = fe.dots;
+      for (var i=0;i<dots.length;i++){
+        var d = dots[i]; d.x += d.vx*spd; d.y += d.vy*spd; d.seg -= 1;
+        // bounce on edges
+        if (d.x<0){ d.x=0; d.vx=Math.abs(d.vx); }
+        if (d.x>w-1){ d.x=w-1; d.vx=-Math.abs(d.vx); }
+        if (d.y<0){ d.y=0; d.vy=Math.abs(d.vy); }
+        if (d.y>h-1){ d.y=h-1; d.vy=-Math.abs(d.vy); }
+        if (d.seg<=0){ var nv=newVel(1.0); d.vx=nv.vx; d.vy=nv.vy; d.seg=Math.floor(20 + Math.random()*60 * (11-algo.speed)/10.0); }
+      }
+    }
+  }
+
+  function render(w,h){
+    var map = makeMap(w,h,0);
+    var lineCol = util.colors[0]; var dotCol = (util.colors.length>1?util.colors[1]:util.colors[0]);
+    var lineColDim = scaleColor(lineCol, 160); // softer lines
+
+    for (var f=0; f<util.features.length; f++){
+      var fe = util.features[f]; var n = fe.dots.length; if (n<2) continue;
+      // fade near end of life
+      var lifeLeft = fe.life - (util.frame - fe.born); var fade = clamp(lifeLeft/Math.max(1,fe.life), 0, 1);
+      var lineFade = Math.floor(160 * fade);
+      var dotFade = Math.floor(255 * fade);
+      var lineC = scaleColor(lineCol, lineFade);
+      var dotC = scaleColor(dotCol, dotFade);
+
+      // lines based on connect mode
+      if (algo.connectModeIndex === 0){
+        // Complete graph
+        for (var i=0;i<n;i++){
+          for (var j=i+1;j<n;j++){
+            var a = fe.dots[i], b = fe.dots[j];
+            drawLine(map,w,h,a.x,a.y,b.x,b.y,lineC);
+          }
+        }
+      } else {
+        // Tree (N-1)
+        var edges = buildEdgesTree(fe.dots);
+        for (var e=0;e<edges.length;e++){
+          var i2 = edges[e][0], j2 = edges[e][1];
+          var a2 = fe.dots[i2], b2 = fe.dots[j2];
+          drawLine(map,w,h,a2.x,a2.y,b2.x,b2.y,lineC);
+        }
+      }
+      // dots on top
+      for (var k=0;k<n;k++){
+        var d = fe.dots[k]; drawDot(map,w,h,d.x,d.y,dotC);
+      }
+    }
+    return map;
+  }
+
+  algo.rgbMap = function(width,height,_rgb,_step){
+    ensureFeatures(width,height);
+    updateFeatures(width,height);
+    var out = render(width,height);
+    util.frame += 1;
+    return out;
+  };
+
+  algo.rgbMapStepCount = function(_w,_h){ return 4096; };
+
+  return algo;
+})();
+

--- a/resources/rgbscripts/juggle.js
+++ b/resources/rgbscripts/juggle.js
@@ -1,0 +1,115 @@
+/*
+  Q Light Controller Plus
+  juggle.js
+
+  FastLED-inspired "Juggle" (multiple sinelons with phase offsets)
+  Ported to QLC+ RGBScript by Branson Matheson
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 2;
+  algo.name = "Juggle";
+  algo.author = "FastLED idea, port by Branson Matheson";
+  algo.acceptColors = 1;
+  algo.properties = new Array();
+
+  algo.count = 4; // 1..16 dots
+  algo.properties.push("name:count|type:range|display:Dots|values:1,16|write:setCount|read:getCount");
+  algo.speed = 20; // 1..50
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,50|write:setSpeed|read:getSpeed");
+  algo.fade = 70; // 0..100
+  algo.properties.push("name:fade|type:range|display:Fade (0-100)|values:0,100|write:setFade|read:getFade");
+  algo.tail = 6; // 1..40
+  algo.properties.push("name:tail|type:range|display:Tail Length|values:1,40|write:setTail|read:getTail");
+
+  var util = {};
+  util.initialized = false;
+  util.map = null;
+  util.phase = 0.0;
+
+  algo.setCount = function(v){ algo.count = parseInt(v); };
+  algo.getCount = function(){ return algo.count; };
+  algo.setSpeed = function(v){ algo.speed = parseInt(v); };
+  algo.getSpeed = function(){ return algo.speed; };
+  algo.setFade = function(v){ algo.fade = parseInt(v); };
+  algo.getFade = function(){ return algo.fade; };
+  algo.setTail = function(v){ algo.tail = parseInt(v); };
+  algo.getTail = function(){ return algo.tail; };
+
+  function makeMap(width, height, fill){
+    var m = new Array(height);
+    for (var y=0;y<height;y++){
+      m[y] = new Array(width);
+      for (var x=0;x<width;x++) m[y][x] = fill;
+    }
+    return m;
+  }
+  function scaleColor(rgb, scale255){
+    if (scale255 <= 0) return 0;
+    if (scale255 >= 255) return rgb;
+    var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255;
+    r=Math.floor(r*scale255/255); g=Math.floor(g*scale255/255); b=Math.floor(b*scale255/255);
+    return (r<<16)+(g<<8)+b;
+  }
+  function addColor(dst, add){
+    var dr=(dst>>16)&255,dg=(dst>>8)&255,db=dst&255;
+    var ar=(add>>16)&255,ag=(add>>8)&255,ab=add&255;
+    var nr=dr+ar; if(nr>255)nr=255; var ng=dg+ag; if(ng>255)ng=255; var nb=db+ab; if(nb>255)nb=255;
+    return (nr<<16)+(ng<<8)+nb;
+  }
+  function fadeMap(map, w,h, fadePct){
+    var scale = 255 - Math.floor(fadePct * 255 / 100);
+    for (var y=0;y<h;y++) for (var x=0;x<w;x++) map[y][x] = scaleColor(map[y][x], scale);
+  }
+
+  algo.rgbMap = function(width, height, rgb, _step){
+    if (!util.initialized || util.map===null || util.map.length!==height || util.map[0].length!==width){
+      util.map = makeMap(width,height,0);
+      util.phase=0.0;
+      util.initialized=true;
+    }
+    fadeMap(util.map, width, height, algo.fade);
+
+    var inc = (algo.speed/50.0) * 0.4;
+    util.phase += inc;
+
+    var midY = Math.floor(height/2);
+    for (var i=0;i<algo.count;i++){
+      var offs = (i * (2 * Math.PI / Math.max(1, algo.count)));
+      var s = Math.sin(util.phase + offs);
+      var xPos = Math.floor(((s + 1.0) * 0.5) * (width - 1));
+      for (var d=0; d<=algo.tail; d++){
+        var atten = 255 - Math.floor(255 * (d / (algo.tail+1)));
+        var col = scaleColor(rgb, atten);
+        var x1=xPos-d, x2=xPos+d;
+        if (x1>=0 && x1<width) util.map[midY][x1] = addColor(util.map[midY][x1], col);
+        if (d!==0 && x2>=0 && x2<width) util.map[midY][x2] = addColor(util.map[midY][x2], col);
+      }
+    }
+
+    var out = makeMap(width,height,0);
+    for (var y=0;y<height;y++) for (var x=0;x<width;x++) out[y][x]=util.map[y][x];
+    return out;
+  };
+
+  algo.rgbMapStepCount = function(_width,_height){ return 2; };
+
+  return algo;
+})();
+

--- a/resources/rgbscripts/lantern.js
+++ b/resources/rgbscripts/lantern.js
@@ -1,0 +1,193 @@
+/*
+  Q Light Controller Plus
+  lantern.js
+
+  Organic candle/lantern flame for short LED strips (~30 pixels).
+  The user-selected color is the mid-flame reference; dimmer pixels
+  shift toward dark embers and brighter pixels shift toward warm white.
+
+  Properties:
+    Flare on Start  — bright burst on first activation then fades to normal
+    Flicker Amount  — 0 = slow gentle breathing, 100 = chaotic guttering
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 2;
+  algo.name = "Lantern";
+  algo.author = "Branson Matheson";
+  algo.acceptColors = 1;
+  algo.properties = new Array();
+
+  algo.flareOnStart = 1;
+  algo.properties.push("name:flareOnStart|type:list|display:Flare on Start|values:Yes,No|write:setFlareOnStart|read:getFlareOnStart");
+
+  algo.flickerAmt = 50;
+  algo.properties.push("name:flickerAmt|type:range|display:Flicker Amount|values:0,100|write:setFlickerAmt|read:getFlickerAmt");
+
+  algo.setFlareOnStart = function(v){ algo.flareOnStart = (v === "Yes") ? 1 : 0; };
+  algo.getFlareOnStart = function(){ return (algo.flareOnStart === 1) ? "Yes" : "No"; };
+  algo.setFlickerAmt  = function(v){ var n=parseInt(v,10); if(!isNaN(n)&&n>=0&&n<=100) algo.flickerAmt=n; };
+  algo.getFlickerAmt  = function(){ return algo.flickerAmt; };
+
+  // Flare phases (frame counts):
+  //   0..FLARE_DARK   : all pixels black (lantern unlit)
+  //   FLARE_DARK..FLARE_PEAK : surge to full white (ignition flash)
+  //   FLARE_PEAK..FLARE_END  : cool from white into normal flame
+  var FLARE_DARK = 8;
+  var FLARE_PEAK = 20;
+  var FLARE_END  = 100;
+  var TWO_PI = 6.2831853;
+
+  var util = {};
+  util.initialized = false;
+  util.phase  = 0.0;   // global animation clock
+  util.ph1    = null;  // per-pixel slow-phase offsets
+  util.ph2    = null;  // per-pixel fast-phase offsets
+  util.pixCount = 0;
+  util.flareFrame = 0;
+  util.flaring    = false;
+
+  function clamp(v, lo, hi){ return v<lo?lo:v>hi?hi:v; }
+
+  function lerpColor(a, b, t){
+    if (t<=0) return a; if (t>=1) return b;
+    var ar=(a>>16)&255, ag=(a>>8)&255, ab=a&255;
+    var br=(b>>16)&255, bg=(b>>8)&255, bb=b&255;
+    return ((Math.floor(ar+(br-ar)*t))<<16)|
+           ((Math.floor(ag+(bg-ag)*t))<<8)|
+            Math.floor(ab+(bb-ab)*t);
+  }
+
+  function scaleBrightness(c, k){
+    if (k<=0) return 0; if (k>=1) return c;
+    var r=(c>>16)&255, g=(c>>8)&255, b=c&255;
+    return ((Math.floor(r*k))<<16)|((Math.floor(g*k))<<8)|Math.floor(b*k);
+  }
+
+  // Map normalised heat [0..1] to a colour derived from the base flame colour.
+  // heat < 0.05  → black (unlit)
+  // heat 0..0.5  → dark ember: very dim base colour
+  // heat 0.5..1  → base colour lerped toward warm white tip
+  function heatToColor(base, heat){
+    if (heat < 0.05) return 0x000000;
+
+    if (heat < 0.50){
+      var k = heat / 0.50;          // 0..1
+      k = k * k;                    // quadratic: slow ramp from dark
+      return scaleBrightness(base, 0.05 + k * 0.95);
+    }
+
+    // heat 0.5..1 — base to warm white
+    var t = (heat - 0.50) / 0.50;  // 0..1
+    var hotWhite = lerpColor(0xFFE080, 0xFFFFFF, t * 0.6);
+    return lerpColor(base, hotWhite, t * 0.75);
+  }
+
+  algo.rgbMap = function(width, height, rgb, step){
+    var total = width * height;
+
+    // (Re-)initialise per-pixel state on first call or fixture size change
+    if (!util.initialized || util.pixCount !== total){
+      util.ph1 = new Array(total);
+      util.ph2 = new Array(total);
+      for (var i=0; i<total; i++){
+        util.ph1[i] = Math.random() * TWO_PI;
+        util.ph2[i] = Math.random() * TWO_PI;
+      }
+      util.pixCount   = total;
+      util.phase      = 0.0;
+      util.flareFrame = 0;
+      util.flaring    = (algo.flareOnStart === 1);
+      util.initialized = true;
+    }
+
+    util.phase += 0.09;
+    if (util.phase > 1e6) util.phase = 0.0;
+
+    // Flare: dark silence → white burst → settle into flame
+    var flarePhase = -1; // -1 = no flare
+    if (util.flaring){
+      util.flareFrame++;
+      if (util.flareFrame >= FLARE_END){ util.flaring = false; }
+      else { flarePhase = util.flareFrame; }
+    }
+
+    var fk    = algo.flickerAmt / 100.0;
+    var phase = util.phase;
+
+    // Shared global throb — gives all pixels a common pulse
+    var globalSlow = 0.5 + 0.5 * Math.sin(phase * 0.28);
+    var globalFast = 0.5 + 0.5 * Math.sin(phase * 2.1)
+                              * (0.6 + 0.4 * Math.sin(phase * 0.9));
+
+    var map = new Array(height);
+    var idx = 0;
+
+    for (var y=0; y<height; y++){
+      map[y] = new Array(width);
+
+      for (var x=0; x<width; x++){
+        var p1 = util.ph1[idx];
+        var p2 = util.ph2[idx];
+
+        // Per-pixel slow breathing (independent phase per pixel)
+        var slow = 0.5 + 0.5 * Math.sin(phase * 0.30 + p1);
+
+        // Per-pixel fast flicker: product of two sinusoids = intermittent dips
+        var fast = 0.5 + 0.5 * Math.sin(phase * 3.2 + p2)
+                             * (0.65 + 0.35 * Math.sin(phase * 1.6 + p1 * 0.7));
+
+        // Blend per-pixel and global components
+        var baseHeat    = slow * 0.55 + globalSlow * 0.45;  // smooth
+        var flickerHeat = fast * 0.55 + globalFast * 0.45;  // chaotic
+
+        // Mix by flicker amount; shift range into 0.25..1.0
+        var raw  = baseHeat * (1.0 - fk) + flickerHeat * fk;
+        var heat = clamp(0.25 + raw * 0.75, 0.0, 1.0);
+
+        var col;
+
+        if (flarePhase >= 0){
+          if (flarePhase < FLARE_DARK){
+            // Unlit — black
+            col = 0x000000;
+          } else if (flarePhase < FLARE_PEAK){
+            // Surge: black → full white
+            var t = (flarePhase - FLARE_DARK) / (FLARE_PEAK - FLARE_DARK);
+            col = lerpColor(0x000000, 0xFFFFFF, t * t);
+          } else {
+            // Cool: white → normal flame
+            var t2 = (flarePhase - FLARE_PEAK) / (FLARE_END - FLARE_PEAK);
+            col = lerpColor(0xFFFFFF, heatToColor(rgb, heat), t2 * t2);
+          }
+        } else {
+          col = heatToColor(rgb, heat);
+        }
+
+        map[y][x] = col;
+        idx++;
+      }
+    }
+
+    return map;
+  };
+
+  algo.rgbMapStepCount = function(width, height){ return 256; };
+
+  return algo;
+})();

--- a/resources/rgbscripts/meteor.js
+++ b/resources/rgbscripts/meteor.js
@@ -1,0 +1,147 @@
+/*
+  Q Light Controller Plus
+  meteor.js
+
+  FastLED-inspired "Meteor Rain" (falling meteors with tails)
+  Ported to QLC+ RGBScript by Branson Matheson
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Development tool access
+var testAlgo;
+
+(function(){
+  var algo = new Object;
+  algo.apiVersion = 2;
+  algo.name = "Meteor";
+  algo.author = "FastLED idea, port by Branson Matheson";
+  algo.acceptColors = 1;
+  algo.properties = new Array();
+
+  algo.count = 3; // active meteors
+  algo.properties.push("name:count|type:range|display:Meteors|values:1,10|write:setCount|read:getCount");
+  algo.speed = 20; // 1..50
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,50|write:setSpeed|read:getSpeed");
+  algo.tail = 8; // 1..30
+  algo.properties.push("name:tail|type:range|display:Tail Length|values:1,30|write:setTail|read:getTail");
+  algo.fade = 60; // 0..100, map fade each frame
+  algo.properties.push("name:fade|type:range|display:Fade (0-100)|values:0,100|write:setFade|read:getFade");
+
+  var util = new Object;
+  util.initialized = false;
+  util.map = null;
+  util.meteors = [];
+  util.speedAcc = 0.0;
+
+  algo.setCount = function(v){ algo.count = parseInt(v); };
+  algo.getCount = function(){ return algo.count; };
+  algo.setSpeed = function(v){ algo.speed = parseInt(v); };
+  algo.getSpeed = function(){ return algo.speed; };
+  algo.setTail = function(v){ algo.tail = parseInt(v); };
+  algo.getTail = function(){ return algo.tail; };
+  algo.setFade = function(v){ algo.fade = parseInt(v); };
+  algo.getFade = function(){ return algo.fade; };
+
+  function makeMap(width, height, fill){
+    var m = new Array(height);
+    for (var y=0;y<height;y++){
+      m[y] = new Array(width);
+      for (var x=0;x<width;x++) m[y][x] = fill;
+    }
+    return m;
+  }
+  function scaleColor(rgb, scale255){
+    if (scale255 <= 0) return 0;
+    if (scale255 >= 255) return rgb;
+    var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255;
+    r=Math.floor(r*scale255/255); g=Math.floor(g*scale255/255); b=Math.floor(b*scale255/255);
+    return (r<<16)+(g<<8)+b;
+  }
+  function addColor(dst, add){
+    var dr=(dst>>16)&255,dg=(dst>>8)&255,db=dst&255;
+    var ar=(add>>16)&255,ag=(add>>8)&255,ab=add&255;
+    var nr=dr+ar; if(nr>255)nr=255; var ng=dg+ag; if(ng>255)ng=255; var nb=db+ab; if(nb>255)nb=255;
+    return (nr<<16)+(ng<<8)+nb;
+  }
+  function fadeMap(map, w,h, fadePct){
+    var scale = 255 - Math.floor(fadePct * 255 / 100);
+    for (var y=0;y<h;y++) for (var x=0;x<w;x++) map[y][x] = scaleColor(map[y][x], scale);
+  }
+
+  function spawnMeteor(width){
+    var m = { x: Math.floor(Math.random()*width), y: -1 };
+    return m;
+  }
+
+  algo.rgbMap = function(width, height, rgb, step){
+    if (!util.initialized || util.map===null || util.map.length!==height || util.map[0].length!==width){
+      util.map = makeMap(width,height,0);
+      util.meteors=[];
+      util.speedAcc=0.0;
+      util.initialized=true;
+    }
+
+    // fade background
+    fadeMap(util.map, width, height, algo.fade);
+
+    // speed accumulator controls step movement
+    util.speedAcc += (algo.speed/50.0) * 0.5;
+    var advance = 0;
+    if (util.speedAcc >= 1.0){ advance = Math.floor(util.speedAcc); util.speedAcc -= advance; }
+
+    // move existing meteors
+    for (var a=0; a<advance; a++){
+      for (var i=0;i<util.meteors.length;i++){
+        util.meteors[i].y += 1;
+      }
+    }
+
+    // cull meteors offscreen
+    var next = [];
+    for (var i=0;i<util.meteors.length;i++){
+      if (util.meteors[i].y - algo.tail < height) next.push(util.meteors[i]);
+    }
+    util.meteors = next;
+
+    // spawn new meteors
+    while (util.meteors.length < algo.count){
+      util.meteors.push(spawnMeteor(width));
+    }
+
+    // draw meteors with tails
+    for (var i=0;i<util.meteors.length;i++){
+      var mx = util.meteors[i].x;
+      var my = util.meteors[i].y;
+      for (var t=0; t<=algo.tail; t++){
+        var yy = my - t;
+        if (yy>=0 && yy<height){
+          var atten = 255 - Math.floor(255 * (t/(algo.tail+1)));
+          var col = scaleColor(rgb, atten);
+          util.map[yy][mx] = addColor(util.map[yy][mx], col);
+        }
+      }
+    }
+
+    var out = makeMap(width,height,0);
+    for (var y=0;y<height;y++) for (var x=0;x<width;x++) out[y][x]=util.map[y][x];
+    return out;
+  };
+
+  algo.rgbMapStepCount = function(width,height){ return 2; };
+
+  testAlgo = algo; return algo;
+})();
+

--- a/resources/rgbscripts/pacifica.js
+++ b/resources/rgbscripts/pacifica.js
@@ -1,0 +1,142 @@
+/*
+  Q Light Controller Plus
+  pacifica.js
+
+  FastLED-inspired "Pacifica" layered ocean waves
+  Ported to QLC+ RGBScript
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 3;
+  algo.name = "Pacifica";
+  algo.author = "FastLED idea, port by Branson Matheson";
+  algo.acceptColors = 5; // palette-driven
+  algo.properties = new Array();
+
+  // Controls
+  algo.speed = 20; // 1..50
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,50|write:setSpeed|read:getSpeed");
+  algo.scale = 12; // 4..40 larger -> wider waves
+  algo.properties.push("name:scale|type:range|display:Scale|values:4,40|write:setScale|read:getScale");
+  algo.depth = 60; // 0..100 contribution of deeper layers
+  algo.properties.push("name:depth|type:range|display:Depth|values:0,100|write:setDepth|read:getDepth");
+
+  var util = {};
+  util.initialized = false;
+  util.colors = [];
+  util.t1 = 0; util.t2 = 0; util.t3 = 0;
+
+  algo.setSpeed = function(v){ algo.speed = parseInt(v); };
+  algo.getSpeed = function(){ return algo.speed; };
+  algo.setScale = function(v){ algo.scale = parseInt(v); };
+  algo.getScale = function(){ return algo.scale; };
+  algo.setDepth = function(v){ algo.depth = parseInt(v); };
+  algo.getDepth = function(){ return algo.depth; };
+
+  function defaultPalette(){
+    // Deep ocean blues/teal
+    return [0x002244, 0x004477, 0x0088AA, 0x00AACC, 0x99EEFF];
+  }
+
+  algo.rgbMapSetColors = function(rawColors){
+    if (!Array.isArray(rawColors)) return;
+    util.colors = [];
+    for (var i=0; i<algo.acceptColors; i++){
+      if (i < rawColors.length && rawColors[i]===rawColors[i]) util.colors.push(rawColors[i]);
+    }
+    if (util.colors.length === 0) util.colors = defaultPalette();
+  };
+
+  function getPalette(){
+    if (!util.colors || util.colors.length===0) return defaultPalette();
+    return util.colors;
+  }
+
+  function lerpColor(a, b, t){
+    var ar=(a>>16)&255, ag=(a>>8)&255, ab=a&255;
+    var br=(b>>16)&255, bg=(b>>8)&255, bb=b&255;
+    var r = Math.floor(ar + (br-ar)*t);
+    var g = Math.floor(ag + (bg-ag)*t);
+    var b2 = Math.floor(ab + (bb-ab)*t);
+    return (r<<16) + (g<<8) + b2;
+  }
+
+  function samplePalette(pal, idx){
+    // idx 0..1 -> color in palette
+    if (pal.length===1) return pal[0];
+    var x = idx * (pal.length-1);
+    var i = Math.floor(x), j = Math.min(pal.length-1, i+1);
+    var t = x - i;
+    return lerpColor(pal[i], pal[j], t);
+  }
+
+  function makeMap(w,h,fill){
+    var m=new Array(h); for (var y=0;y<h;y++){ m[y]=new Array(w); for (var x=0;x<w;x++) m[y][x]=fill; } return m;
+  }
+
+  function scaleColor(rgb, scale255){
+    if (scale255<=0) return 0; if (scale255>=255) return rgb;
+    var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255;
+    r=Math.floor(r*scale255/255); g=Math.floor(g*scale255/255); b=Math.floor(b*scale255/255);
+    return (r<<16)+(g<<8)+b;
+  }
+
+  algo.rgbMap = function(width, height, _rgb, _step){
+    if (!util.initialized){ util.t1=0; util.t2=0; util.t3=0; util.initialized=true; }
+
+    // Advance timers with different speeds
+    var sp = algo.speed/50.0;
+    util.t1 += 0.03*sp; util.t2 += 0.019*sp; util.t3 += 0.013*sp;
+
+    var pal = getPalette();
+    var map = makeMap(width, height, 0);
+
+    // Layer weights
+    var w1 = 1.0;
+    var w2 = 0.6 * (algo.depth/100.0);
+    var w3 = 0.4 * (algo.depth/100.0);
+
+    var sc = Math.max(1, algo.scale);
+    var sq = (width>height?width:height);
+
+    for (var y=0;y<height;y++){
+      for (var x=0;x<width;x++){
+        var nx = (x - width/2)/sq; var ny = (y - height/2)/sq;
+        var a1 = Math.sin((nx*sc + util.t1) + Math.sin(ny*sc*0.7 + util.t1*1.3));
+        var a2 = Math.sin((ny*sc*0.6 + util.t2) + Math.sin(nx*sc*0.5 + util.t2*1.2));
+        var a3 = Math.sin(((nx+ny)*sc*0.33 + util.t3));
+        var v = (w1*(a1*0.5+0.5) + w2*(a2*0.5+0.5) + w3*(a3*0.5+0.5)) / (w1+w2+w3);
+        // slight shoreline foam
+        var foam = Math.max(0, Math.sin( (nx*0.8 - ny*0.6) * sc + util.t1*0.7 ));
+        v = Math.min(1, v*0.85 + 0.15*foam);
+        var color = samplePalette(pal, v);
+        // subtle dimming toward edges
+        var ed = 1 - 0.3*(Math.abs(nx)*0.8 + Math.abs(ny)*0.8);
+        map[y][x] = scaleColor(color, Math.max(0, Math.floor(255*ed)));
+      }
+    }
+
+    return map;
+  };
+
+  algo.rgbMapStepCount = function(_width,_height){ return 2; };
+
+  return algo;
+})();
+

--- a/resources/rgbscripts/ripple.js
+++ b/resources/rgbscripts/ripple.js
@@ -1,0 +1,122 @@
+/*
+  Q Light Controller Plus
+  ripple.js
+
+  Expanding ripple circles from random centers
+  Ported from FastLED-style idea to QLC+ RGBScript
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 2;
+  algo.name = "Ripple";
+  algo.author = "Branson Matheson";
+  algo.acceptColors = 1;
+  algo.properties = new Array();
+
+  // Controls
+  algo.density = 20; // spawn chance per frame (0..100)
+  algo.properties.push("name:density|type:range|display:Spawn Rate|values:0,100|write:setDensity|read:getDensity");
+  algo.fade = 75; // 0..100
+  algo.properties.push("name:fade|type:range|display:Fade|values:0,100|write:setFade|read:getFade");
+  algo.thickness = 2; // 1..10
+  algo.properties.push("name:thickness|type:range|display:Ring Thickness|values:1,10|write:setThickness|read:getThickness");
+  algo.speed = 15; // 1..40
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,40|write:setSpeed|read:getSpeed");
+  algo.maxRings = 6; // 1..20
+  algo.properties.push("name:maxRings|type:range|display:Max Rings|values:1,20|write:setMaxRings|read:getMaxRings");
+
+  var util = {};
+  util.initialized = false;
+  util.map = null;
+  util.ripples = [];
+
+  algo.setDensity = function(v){ algo.density = parseInt(v); };
+  algo.getDensity = function(){ return algo.density; };
+  algo.setFade = function(v){ algo.fade = parseInt(v); };
+  algo.getFade = function(){ return algo.fade; };
+  algo.setThickness = function(v){ algo.thickness = parseInt(v); };
+  algo.getThickness = function(){ return algo.thickness; };
+  algo.setSpeed = function(v){ algo.speed = parseInt(v); };
+  algo.getSpeed = function(){ return algo.speed; };
+  algo.setMaxRings = function(v){ algo.maxRings = parseInt(v); };
+  algo.getMaxRings = function(){ return algo.maxRings; };
+
+  function makeMap(w,h){ var m=new Array(h); for (var y=0;y<h;y++){ m[y]=new Array(w); for (var x=0;x<w;x++) m[y][x]=0; } return m; }
+
+  function scaleColor(rgb, scale255){ if (scale255<=0) return 0; var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255; r=Math.floor(r*scale255/255); g=Math.floor(g*scale255/255); b=Math.floor(b*scale255/255); return (r<<16)+(g<<8)+b; }
+
+  function addColor(dst, add){ var r=((dst>>16)&255)+((add>>16)&255); var g=((dst>>8)&255)+((add>>8)&255); var b=(dst&255)+(add&255); if(r>255)r=255; if(g>255)g=255; if(b>255)b=255; return (r<<16)+(g<<8)+b; }
+
+  function fadeMap(map,w,h,fadePct){ var keep = 255 - Math.floor(fadePct*255/100); for (var y=0;y<h;y++) for (var x=0;x<w;x++) map[y][x]=scaleColor(map[y][x], keep); }
+
+  algo.rgbMap = function(width, height, rgb, _step){
+    if (!util.initialized || util.map.length!==height || util.map[0].length!==width){
+      util.map = makeMap(width,height);
+      util.ripples=[];
+      util.initialized=true;
+    }
+
+    // Fade previous frame
+    fadeMap(util.map, width, height, algo.fade);
+
+    // Spawn
+    if (util.ripples.length < algo.maxRings){
+      var chance = Math.random()*100;
+      if (chance < algo.density){
+        util.ripples.push({ x: Math.floor(Math.random()*width), y: Math.floor(Math.random()*height), r: 0 });
+      }
+    }
+
+    // Grow and draw
+    var speed = Math.max(1, algo.speed)/8.0;
+    var newRipples = [];
+    for (var i=0;i<util.ripples.length;i++){
+      var rp = util.ripples[i];
+      rp.r += speed;
+      var maxR = Math.sqrt(width*width + height*height);
+      if (rp.r < maxR){ newRipples.push(rp); }
+
+      var thick = algo.thickness;
+      var rmin = rp.r - thick; if (rmin < 0) rmin = 0;
+      var rmax = rp.r + thick;
+
+      // Draw ring by checking distance window
+      for (var y=0;y<height;y++){
+        for (var x=0;x<width;x++){
+          var dx = x - rp.x; var dy = y - rp.y;
+          var d = Math.sqrt(dx*dx + dy*dy);
+          if (d >= rmin && d <= rmax){
+            // intensity peaks at ring center
+            var t = 1 - Math.abs(d - rp.r)/thick; if (t<0) t=0; if (t>1) t=1;
+            var col = scaleColor(rgb, Math.floor(255*t));
+            util.map[y][x] = addColor(util.map[y][x], col);
+          }
+        }
+      }
+    }
+    util.ripples = newRipples;
+
+    return util.map;
+  };
+
+  algo.rgbMapStepCount = function(_width,_height){ return 256; };
+
+  return algo;
+})();
+

--- a/resources/rgbscripts/shapes.js
+++ b/resources/rgbscripts/shapes.js
@@ -1,0 +1,327 @@
+/*
+  Q Light Controller Plus
+  shapes.js
+
+  Geometric shape renderer (Circle + up to 10-sided polygons) with:
+  - Fill modes: Empty (outline only), Solid, Radial Gradient (inside→outside), Vertical Gradient (top→bottom)
+  - Outline with configurable thickness
+  - Multiple shapes on the same matrix (grid layout)
+  - Size based on percentage of the matrix
+  - Optional rotation (None, Left, Right) with speed
+
+  Colors (acceptColors = 3) — recommended roles:
+  1) Outline color
+  2) Fill/Gradient start
+  3) Fill/Gradient end
+
+  Author: Branson Matheson <branson@sandsite.org>
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 3;
+  algo.name = "Shapes";
+  algo.author = "Branson Matheson <branson@sandsite.org>";
+  algo.acceptColors = 3;
+
+  // --- Properties ---
+  algo.properties = [];
+
+  // Shape selection
+  var SHAPE_LABELS = [
+    "Circle","Triangle (3)","Square (4)","Pentagon (5)","Hexagon (6)",
+    "Heptagon (7)","Octagon (8)","Nonagon (9)","Decagon (10)"
+  ];
+  var SHAPE_SIDES  = [0,3,4,5,6,7,8,9,10]; // 0 means circle
+  algo.shapeIndex = 0; // default: Circle
+  algo.properties.push("name:shape|type:list|display:Shape|values:" + SHAPE_LABELS.join(',') + "|write:setShape|read:getShape");
+  algo.setShape = function(label){
+    for (var i=0;i<SHAPE_LABELS.length;i++){
+      if (label === SHAPE_LABELS[i]){ algo.shapeIndex = i; resetLayout(); return; }
+    }
+  };
+  algo.getShape = function(){ return SHAPE_LABELS[algo.shapeIndex]; };
+
+  // Fill mode
+  var FILL_LABELS = ["Empty","Solid Fill","Radial Gradient","Vertical Gradient"];
+  algo.fillIndex = 1; // default: Solid Fill
+  algo.properties.push("name:fill|type:list|display:Fill|values:" + FILL_LABELS.join(',') + "|write:setFill|read:getFill");
+  algo.setFill = function(label){
+    for (var i=0;i<FILL_LABELS.length;i++){
+      if (label === FILL_LABELS[i]){ algo.fillIndex = i; return; }
+    }
+  };
+  algo.getFill = function(){ return FILL_LABELS[algo.fillIndex]; };
+
+  // Outline size (pixels)
+  algo.outline = 1;
+  algo.properties.push("name:outline|type:range|display:Outline Size (px)|values:0,10|write:setOutline|read:getOutline");
+  algo.setOutline = function(v){ var n = parseInt(v,10); if (isNaN(n)) n = 0; if (n<0)n=0; if (n>10)n=10; algo.outline = n; };
+  algo.getOutline = function(){ return algo.outline; };
+
+  // Number of shapes
+  algo.count = 1;
+  algo.properties.push("name:count|type:range|display:Shape Count|values:1,10|write:setCount|read:getCount");
+  algo.setCount = function(v){ var n = parseInt(v,10); if (isNaN(n)) n = 1; if (n<1)n=1; if (n>10)n=10; algo.count = n; resetLayout(); };
+  algo.getCount = function(){ return algo.count; };
+
+  // Size percentage (relative to min dimension)
+  algo.sizePct = 50;
+  algo.properties.push("name:sizePct|type:range|display:Size (%)|values:5,100|write:setSizePct|read:getSizePct");
+  algo.setSizePct = function(v){ var n = parseInt(v,10); if (isNaN(n)) n = 50; if (n<5)n=5; if (n>100)n=100; algo.sizePct = n; resetLayout(); };
+  algo.getSizePct = function(){ return algo.sizePct; };
+
+  // Rotation
+  var ROT_LABELS = ["None","Left","Right"];
+  algo.rotateIndex = 0; // None
+  algo.properties.push("name:rotate|type:list|display:Rotate|values:" + ROT_LABELS.join(',') + "|write:setRotate|read:getRotate");
+  algo.setRotate = function(label){ for (var i=0;i<ROT_LABELS.length;i++){ if (label === ROT_LABELS[i]){ algo.rotateIndex = i; return; } } };
+  algo.getRotate = function(){ return ROT_LABELS[algo.rotateIndex]; };
+
+  // Rotation speed (steps per frame scalar)
+  algo.rotSpeed = 3;
+  algo.properties.push("name:rotSpeed|type:range|display:Rotation Speed|values:0,10|write:setRotSpeed|read:getRotSpeed");
+  algo.setRotSpeed = function(v){ var n = parseInt(v,10); if(isNaN(n)) n=3; if(n<0)n=0; if(n>10)n=10; algo.rotSpeed=n; };
+  algo.getRotSpeed = function(){ return algo.rotSpeed; };
+
+  // --- Colors ---
+  var util = {};
+  util.colors = [0xFFFFFF, 0xFF8C00, 0xFFFF00]; // outline, fill start, fill end
+  algo.rgbMapSetColors = function(c){ if (c && c.length){ util.colors = c; } };
+  algo.rgbMapGetColors = function(){ return util.colors; };
+
+  // --- Layout/state ---
+  util.shapes = null; // array of {cx,cy,r,angle}
+  util.lastW = 0; util.lastH = 0; util.lastCount = -1; util.lastSize = -1; util.lastShape = -1;
+  function resetLayout(){ util.shapes = null; }
+
+  function ensureLayout(width, height){
+    if (!util.shapes || util.lastW !== width || util.lastH !== height || util.lastCount !== algo.count || util.lastSize !== algo.sizePct || util.lastShape !== algo.shapeIndex){
+      util.lastW = width; util.lastH = height; util.lastCount = algo.count; util.lastSize = algo.sizePct; util.lastShape = algo.shapeIndex;
+      util.shapes = new Array(algo.count);
+
+      // grid arrangement
+      var count = algo.count;
+      var aspect = (height > 0) ? (width / height) : 1.0;
+      var cols = Math.ceil(Math.sqrt(count * aspect)); if (cols < 1) cols = 1;
+      var rows = Math.ceil(count / cols); if (rows < 1) rows = 1;
+      var cellW = width / cols;
+      var cellH = height / rows;
+
+      // base radius from size percentage
+      var baseR = (algo.sizePct / 100.0) * (Math.min(width, height) * 0.5);
+      var idx = 0;
+      for (var r=0; r<rows; r++){
+        var remaining = count - r*cols;
+        var inRow = remaining < cols ? remaining : cols;
+        if (inRow <= 0) break;
+        var offsetX = (cols - inRow) * cellW * 0.5;
+        for (var c=0; c<inRow; c++){
+          var cx = offsetX + (c + 0.5) * cellW;
+          var cy = (r + 0.5) * cellH;
+          var maxCellR = Math.min(cellW, cellH) * 0.45;
+          var rr = baseR; if (rr > maxCellR) rr = maxCellR; if (rr < 1) rr = 1;
+          util.shapes[idx] = { cx: cx, cy: cy, r: rr, angle: 0.0 };
+          idx++;
+        }
+      }
+    }
+  }
+
+  // --- Helpers ---
+  function clamp01(x){ return (x < 0 ? 0 : (x > 1 ? 1 : x)); }
+  function lerp(a,b,t){ return a + (b - a) * t; }
+  function lerpColor(c1, c2, t){
+    var r1=(c1>>16)&255, g1=(c1>>8)&255, b1=c1&255;
+    var r2=(c2>>16)&255, g2=(c2>>8)&255, b2=c2&255;
+    var r=Math.floor(lerp(r1,r2,t)); var g=Math.floor(lerp(g1,g2,t)); var b=Math.floor(lerp(b1,b2,t));
+    return (r<<16) | (g<<8) | b;
+  }
+
+  function buildRegularPolygon(cx, cy, r, sides, angle){
+    var verts = new Array(sides);
+    var a0 = angle - Math.PI/2; // point one vertex upward by default
+    for (var i=0;i<sides;i++){
+      var a = a0 + 2*Math.PI * (i / sides);
+      verts[i] = [ cx + r * Math.cos(a), cy + r * Math.sin(a) ];
+    }
+    return verts;
+  }
+
+  function polygonBounds(verts){
+    var minX=verts[0][0], maxX=verts[0][0];
+    var minY=verts[0][1], maxY=verts[0][1];
+    for (var i=1;i<verts.length;i++){
+      var vx=verts[i][0], vy=verts[i][1];
+      if (vx<minX) minX=vx; if (vx>maxX) maxX=vx; if (vy<minY) minY=vy; if (vy>maxY) maxY=vy;
+    }
+    return {minX:minX, maxX:maxX, minY:minY, maxY:maxY};
+  }
+
+  function pointInPolygon(px, py, verts){
+    var inside = false;
+    var n = verts.length;
+    for (var i=0, j=n-1; i<n; j=i++){
+      var xi=verts[i][0], yi=verts[i][1];
+      var xj=verts[j][0], yj=verts[j][1];
+      var intersect = ((yi > py) !== (yj > py)) && (px < (xj - xi) * (py - yi) / ((yj - yi) || 1e-9) + xi);
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+
+  function dist2PointToSeg(px, py, ax, ay, bx, by){
+    var vx = bx - ax, vy = by - ay;
+    var wx = px - ax, wy = py - ay;
+    var c1 = vx*wx + vy*wy;
+    if (c1 <= 0) { var dx=px-ax, dy=py-ay; return dx*dx + dy*dy; }
+    var c2 = vx*vx + vy*vy;
+    if (c2 <= 0) { var dx2=px-ax, dy2=py-ay; return dx2*dx2 + dy2*dy2; }
+    var t = c1 / c2; if (t >= 1) { var dx3=px-bx, dy3=py-by; return dx3*dx3 + dy3*dy3; }
+    var projx = ax + t*vx, projy = ay + t*vy;
+    var dxp = px - projx, dyp = py - projy;
+    return dxp*dxp + dyp*dyp;
+  }
+
+  function minEdgeDist2(px, py, verts){
+    var n = verts.length; var minD2 = 1e9;
+    for (var i=0;i<n;i++){
+      var j=(i+1)%n; var ax=verts[i][0], ay=verts[i][1]; var bx=verts[j][0], by=verts[j][1];
+      var d2 = dist2PointToSeg(px,py,ax,ay,bx,by);
+      if (d2 < minD2) minD2 = d2;
+    }
+    return minD2;
+  }
+
+  function getColorSafe(arr, idx, fallback){ return (arr && arr.length>idx) ? arr[idx] : fallback; }
+
+  // --- Core render ---
+  algo.rgbMap = function(width, height, _rgb, _step){
+    ensureLayout(width, height);
+
+    // Rotation update per frame
+    var dir = (algo.rotateIndex === 1 ? -1 : (algo.rotateIndex === 2 ? 1 : 0));
+    var dAng = (algo.rotSpeed / 10.0) * dir * 0.25 * Math.PI; // up to ~45°/frame at max speed
+    if (dir !== 0 && dAng !== 0){
+      for (var si=0; si<util.shapes.length; si++){
+        util.shapes[si].angle += dAng;
+        if (util.shapes[si].angle > 1000000) util.shapes[si].angle = 0;
+        if (util.shapes[si].angle < -1000000) util.shapes[si].angle = 0;
+      }
+    }
+
+    // Colors
+    var outlineCol = getColorSafe(util.colors, 0, 0xFFFFFF);
+    var fillA = getColorSafe(util.colors, 1, 0xFF0000);
+    var fillB = getColorSafe(util.colors, 2, 0x0000FF);
+
+    var map = new Array(height);
+    for (var y=0;y<height;y++){
+      var row = new Array(width);
+      for (var x=0;x<width;x++) row[x] = 0x000000;
+      map[y] = row;
+    }
+
+    var outlineT = algo.outline; // thickness in px
+    var outlineHalf2 = (outlineT > 0) ? ( (outlineT*0.5) * (outlineT*0.5) ) : 0;
+
+    for (var si2=0; si2<util.shapes.length; si2++){
+      var S = util.shapes[si2];
+      var cx = S.cx, cy = S.cy, r = S.r, ang = S.angle;
+      var isCircle = (SHAPE_SIDES[algo.shapeIndex] === 0);
+
+      var verts = null, b = null;
+      if (!isCircle){
+        verts = buildRegularPolygon(cx, cy, r, SHAPE_SIDES[algo.shapeIndex], ang);
+        b = polygonBounds(verts);
+      } else {
+        b = {minX: cx - r, maxX: cx + r, minY: cy - r, maxY: cy + r};
+      }
+
+      // Clamp bounds to pixel grid
+      var x0 = Math.max(0, Math.floor(b.minX - outlineT - 1));
+      var x1 = Math.min(width-1, Math.ceil(b.maxX + outlineT + 1));
+      var y0 = Math.max(0, Math.floor(b.minY - outlineT - 1));
+      var y1 = Math.min(height-1, Math.ceil(b.maxY + outlineT + 1));
+
+      // For vertical gradient bounds
+      var vMinY = b.minY, vMaxY = b.maxY; if (vMaxY <= vMinY) vMaxY = vMinY + 1;
+
+      // Render region
+      var rr2 = r*r; // for circle tests
+      var rIn2 = (r - outlineT*0.5); if (rIn2 < 0) rIn2 = 0; rIn2 = rIn2*rIn2;
+      var rOut2 = (r + outlineT*0.5); rOut2 = rOut2*rOut2;
+
+      for (var py = y0; py <= y1; py++){
+        var rowRef = map[py];
+        for (var px = x0; px <= x1; px++){
+          var fx = px + 0.5; var fy = py + 0.5;
+          var inside = false;
+          var onOutline = false;
+
+          if (isCircle){
+            var dx = fx - cx, dy = fy - cy; var d2 = dx*dx + dy*dy;
+            inside = (d2 <= rr2);
+            if (outlineT > 0){ onOutline = (d2 >= rIn2 && d2 <= rOut2); }
+          } else {
+            inside = pointInPolygon(fx, fy, verts);
+            if (outlineT > 0){
+              var md2 = minEdgeDist2(fx, fy, verts);
+              onOutline = (md2 <= outlineHalf2);
+            }
+          }
+
+          // Draw fill
+          if (inside && algo.fillIndex !== 0){ // not Empty
+            var col = fillA;
+            if (algo.fillIndex === 1){
+              col = fillA; // Solid
+            } else if (algo.fillIndex === 2){
+              // Radial gradient (center->edge)
+              var t;
+              if (isCircle){
+                var dx2 = fx - cx, dy2 = fy - cy; t = Math.sqrt(dx2*dx2 + dy2*dy2) / r;
+              } else {
+                // Approx radial by center distance
+                var dx3 = fx - cx, dy3 = fy - cy; var dist = Math.sqrt(dx3*dx3 + dy3*dy3);
+                t = dist / r;
+              }
+              if (t < 0) t = 0; if (t > 1) t = 1;
+              col = lerpColor(fillA, fillB, t);
+            } else if (algo.fillIndex === 3){
+              // Vertical gradient (shape top->bottom)
+              var t2 = (fy - vMinY) / (vMaxY - vMinY); t2 = clamp01(t2);
+              col = lerpColor(fillA, fillB, t2);
+            }
+            rowRef[px] = col;
+          }
+
+          // Draw outline on top
+          if (onOutline && outlineT > 0){
+            rowRef[px] = outlineCol;
+          }
+        }
+      }
+    }
+
+    return map;
+  };
+
+  algo.rgbMapStepCount = function(_width,_height){ return 512; };
+
+  return algo;
+})();
+

--- a/resources/rgbscripts/stagepulse.js
+++ b/resources/rgbscripts/stagepulse.js
@@ -1,0 +1,143 @@
+/*
+  Q Light Controller Plus
+  stagepulse.js
+
+  Concentric ring pulses radiating outward from a fixed impact point.
+  Intended for floor LED matrices — rings expand from the staff stamp point.
+
+  Impact X/Y set the origin as a percentage of the fixture group dimensions.
+  Default (50/50) = center; shift toward an edge to match your stage layout.
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 2;
+  algo.name = "Stage Pulse";
+  algo.author = "Branson Matheson";
+  algo.acceptColors = 1;
+  algo.properties = new Array();
+
+  algo.speed = 8;
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,20|write:setSpeed|read:getSpeed");
+
+  algo.ringSpacing = 12;
+  algo.properties.push("name:ringSpacing|type:range|display:Ring Spacing|values:3,50|write:setRingSpacing|read:getRingSpacing");
+
+  algo.ringWidth = 3;
+  algo.properties.push("name:ringWidth|type:range|display:Ring Width|values:1,12|write:setRingWidth|read:getRingWidth");
+
+  algo.impactX = 50;
+  algo.properties.push("name:impactX|type:range|display:Impact X %|values:0,100|write:setImpactX|read:getImpactX");
+
+  algo.impactY = 50;
+  algo.properties.push("name:impactY|type:range|display:Impact Y %|values:0,100|write:setImpactY|read:getImpactY");
+
+  algo.setSpeed       = function(v){ var n=parseInt(v,10); if(!isNaN(n)&&n>=1&&n<=20)  algo.speed=n; };
+  algo.getSpeed       = function(){ return algo.speed; };
+  algo.setRingSpacing = function(v){ var n=parseInt(v,10); if(!isNaN(n)&&n>=3&&n<=50)  algo.ringSpacing=n; };
+  algo.getRingSpacing = function(){ return algo.ringSpacing; };
+  algo.setRingWidth   = function(v){ var n=parseInt(v,10); if(!isNaN(n)&&n>=1&&n<=12)  algo.ringWidth=n; };
+  algo.getRingWidth   = function(){ return algo.ringWidth; };
+  algo.setImpactX     = function(v){ var n=parseInt(v,10); if(!isNaN(n)&&n>=0&&n<=100) algo.impactX=n; };
+  algo.getImpactX     = function(){ return algo.impactX; };
+  algo.setImpactY     = function(v){ var n=parseInt(v,10); if(!isNaN(n)&&n>=0&&n<=100) algo.impactY=n; };
+  algo.getImpactY     = function(){ return algo.impactY; };
+
+  var util = {};
+  util.rings       = [];
+  util.initialized = false;
+  util.speedAcc    = 0.0;
+
+  function scaleColor(rgb, k255){
+    if(k255<=0) return 0; if(k255>=255) return rgb;
+    var r=(rgb>>16)&255, g=(rgb>>8)&255, b=rgb&255;
+    return ((Math.floor(r*k255/255))<<16)|((Math.floor(g*k255/255))<<8)|Math.floor(b*k255/255);
+  }
+
+  function addColor(a, b){
+    var r=((a>>16)&255)+((b>>16)&255);
+    var g=((a>>8)&255)+((b>>8)&255);
+    var bl=(a&255)+(b&255);
+    if(r>255)r=255; if(g>255)g=255; if(bl>255)bl=255;
+    return (r<<16)+(g<<8)+bl;
+  }
+
+  algo.rgbMap = function(width, height, rgb, step){
+    if(!util.initialized){
+      util.rings    = [{r: 0}];
+      util.speedAcc = 0.0;
+      util.initialized = true;
+    }
+
+    // Advance ring radii
+    util.speedAcc += algo.speed / 8.0;
+    var steps = Math.floor(util.speedAcc);
+    util.speedAcc -= steps;
+    for(var i=0; i<util.rings.length; i++) util.rings[i].r += steps;
+
+    // Spawn a new ring whenever the innermost ring reaches ringSpacing distance
+    // (or there are no rings left at all, e.g. all retired past maxD in one jump)
+    if(util.rings.length === 0 || util.rings[util.rings.length-1].r >= algo.ringSpacing){
+      util.rings.push({r: 0});
+    }
+
+    // Retire rings that have left the stage
+    var maxD = Math.sqrt(width*width + height*height) + algo.ringWidth + 1;
+    var kept = [];
+    for(var i=0; i<util.rings.length; i++){
+      if(util.rings[i].r < maxD) kept.push(util.rings[i]);
+    }
+    util.rings = kept;
+
+    var cx = (width  > 1) ? (width-1)  * (algo.impactX / 100.0) : 0;
+    var cy = (height > 1) ? (height-1) * (algo.impactY / 100.0) : 0;
+    var rw = algo.ringWidth;
+
+    var map = new Array(height);
+    for(var y=0; y<height; y++){
+      map[y] = new Array(width);
+      for(var x=0; x<width; x++){
+        var dx = x - cx, dy = y - cy;
+        var d = Math.sqrt(dx*dx + dy*dy);
+        var col = 0;
+
+        for(var ri=0; ri<util.rings.length; ri++){
+          var rel = d - util.rings[ri].r; // -ve = inside ring, +ve = outside (ahead)
+          if(rel > rw * 0.25 || rel < -rw) continue; // skip far-outside or deep-inside
+
+          var t;
+          if(rel <= 0){
+            // Behind leading edge: bright at front, decaying inward
+            t = Math.exp(rel * 3.0 / rw);
+          } else {
+            // Slight leading glow
+            t = Math.max(0, 1.0 - rel / (rw * 0.25));
+          }
+          col = addColor(col, scaleColor(rgb, Math.floor(255 * t)));
+        }
+
+        map[y][x] = col;
+      }
+    }
+
+    return map;
+  };
+
+  algo.rgbMapStepCount = function(width, height){ return 256; };
+
+  return algo;
+})();

--- a/resources/rgbscripts/twinklefox.js
+++ b/resources/rgbscripts/twinklefox.js
@@ -1,0 +1,227 @@
+/*
+  Q Light Controller Plus
+  twinklefox.js
+
+  FastLED "TwinkleFox" style twinkles with palettes, attack/decay and optional
+  incandescent warming on the fade. Ported to QLC+ RGBScript.
+
+  Controls
+  - Speed (1..10): overall animation rate (attack/decay progression)
+  - Density (0..10): how many twinkles spawn over time
+  - Background (% 0..40): dim background level under twinkles
+  - Palette: set of curated palettes; or provide custom colors (API v3)
+  - Incandescent Warmth (% 0..100): warms the color as it fades (tail becomes amber)
+
+  API: v3 (acceptColors) — if custom colors are provided, they override the selected palette
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 3;
+  algo.name = "TwinkleFox";
+  algo.author = "FastLED idea, port by Branson Matheson";
+  algo.acceptColors = 5; // optional custom palette (engine/UI support at most 5 colors)
+  algo.properties = [];
+
+  // --- Properties ---
+  algo.speed = 6; // 1..10
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,10|write:setSpeed|read:getSpeed");
+  algo.setSpeed = function(v){ var n=parseInt(v,10); if(isNaN(n))n=6; if(n<1)n=1; if(n>10)n=10; algo.speed=n; };
+  algo.getSpeed = function(){ return algo.speed; };
+
+  algo.density = 5; // 0..10
+  algo.properties.push("name:density|type:range|display:Density|values:0,10|write:setDensity|read:getDensity");
+  algo.setDensity = function(v){ var n=parseInt(v,10); if(isNaN(n))n=5; if(n<0)n=0; if(n>10)n=10; algo.density=n; };
+  algo.getDensity = function(){ return algo.density; };
+
+  algo.bg = 0; // 0..40 percent
+  algo.properties.push("name:bg|type:range|display:Background (%)|values:0,40|write:setBg|read:getBg");
+  algo.setBg = function(v){ var n=parseInt(v,10); if(isNaN(n))n=0; if(n<0)n=0; if(n>40)n=40; algo.bg=n; };
+  algo.getBg = function(){ return algo.bg; };
+
+  var PAL_NAMES = ["TwinkleFox","Holly","Ice","RetroC9","Cloud","Party","RedWhite"];
+  algo.palIndex = 0;
+  algo.properties.push("name:palette|type:list|display:Palette|values:" + PAL_NAMES.join(',') + "|write:setPalette|read:getPalette");
+  algo.setPalette = function(label){ for (var i=0;i<PAL_NAMES.length;i++){ if (label===PAL_NAMES[i]){ algo.palIndex=i; return; } } };
+  algo.getPalette = function(){ return PAL_NAMES[algo.palIndex]; };
+
+  algo.warmth = 40; // 0..100
+  algo.properties.push("name:warmth|type:range|display:Incandescent Warmth (%)|values:0,100|write:setWarmth|read:getWarmth");
+  algo.setWarmth = function(v){ var n=parseInt(v,10); if(isNaN(n))n=40; if(n<0)n=0; if(n>100)n=100; algo.warmth=n; };
+  algo.getWarmth = function(){ return algo.warmth; };
+
+  // --- State & helpers ---
+  var util = {};
+  util.colors = [];
+  util.lastW = 0; util.lastH = 0; util.inited = false;
+  util.phase = [];   // per-pixel phase in [ -1 (inactive) , 0..1 active ]
+  util.hueIx = [];   // per-pixel palette index (0..palette.length-1)
+
+  function ensureState(w,h){
+    if (!util.inited || util.lastW!==w || util.lastH!==h){
+      util.lastW=w; util.lastH=h; util.inited=true;
+      util.phase = new Array(h);
+      util.hueIx = new Array(h);
+      for (var y=0;y<h;y++){
+        util.phase[y] = new Array(w);
+        util.hueIx[y] = new Array(w);
+        for (var x=0;x<w;x++){ util.phase[y][x] = -1; util.hueIx[y][x]=0; }
+      }
+    }
+  }
+
+  function makeMap(w,h,fill){ var m=new Array(h); for(var y=0;y<h;y++){ m[y]=new Array(w); for(var x=0;x<w;x++) m[y][x]=fill; } return m; }
+
+  function lerp(a,b,t){ return a + (b-a)*t; }
+  function clamp01(x){ return (x<0?0:(x>1?1:x)); }
+  function lerpColor(c1,c2,t){
+    var r1=(c1>>16)&255,g1=(c1>>8)&255,b1=c1&255;
+    var r2=(c2>>16)&255,g2=(c2>>8)&255,b2=c2&255;
+    var r=Math.floor(lerp(r1,r2,t)), g=Math.floor(lerp(g1,g2,t)), b=Math.floor(lerp(b1,b2,t));
+    return (r<<16)|(g<<8)|b;
+  }
+  function scaleColor(rgb, scale255){ if(scale255<=0)return 0; if(scale255>=255)return rgb; var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255; r=Math.floor(r*scale255/255); g=Math.floor(g*scale255/255); b=Math.floor(b*scale255/255); return (r<<16)|(g<<8)|b; }
+  function addColor(dst, add){ var dr=(dst>>16)&255,dg=(dst>>8)&255,db=dst&255; var ar=(add>>16)&255,ag=(add>>8)&255,ab=add&255; var nr=dr+ar; if(nr>255)nr=255; var ng=dg+ag; if(ng>255)ng=255; var nb=db+ab; if(nb>255)nb=255; return (nr<<16)|(ng<<8)|nb; }
+
+  // Default palettes
+  function palTwinkleFox(){ return [0x3F1F00,0x7F3300,0xFF7F00,0xFFD080,0xFFFFFF]; }
+  function palHolly(){ return [0x002000,0x106010,0x30A030,0xFF0000,0xFFFFFF]; }
+  function palIce(){ return [0x001020,0x003070,0x3FA0FF,0xA0D8FF,0xFFFFFF]; }
+  function palRetroC9(){ return [0xFF0000,0x00FF00,0x0000FF,0xFF6600,0x00FFFF,0xFF00FF,0xFFFFFF]; }
+  function palCloud(){ return [0x000000,0x202020,0x404040,0x808080,0xFFFFFF]; }
+  function palParty(){ return [0xFF0040,0x0040FF,0x40FF00,0xFFD400,0xFF00FF,0x00FFFF]; }
+  function palRedWhite(){ return [0x400000,0x800000,0xFF0000,0xFFFFFF]; }
+
+  function getSelectedPalette(){
+    switch(PAL_NAMES[algo.palIndex]){
+      case 'Holly': return palHolly();
+      case 'Ice': return palIce();
+      case 'RetroC9': return palRetroC9();
+      case 'Cloud': return palCloud();
+      case 'Party': return palParty();
+      case 'RedWhite': return palRedWhite();
+      default: return palTwinkleFox();
+    }
+  }
+
+  algo.rgbMapSetColors = function(raw){
+    util.colors = [];
+    if (raw && raw.length){ for (var i=0;i<algo.acceptColors && i<raw.length;i++){ if (raw[i]===raw[i]) util.colors.push(raw[i]); }
+    }
+  };
+  algo.rgbMapGetColors = function(){ return util.colors; };
+
+  function getPalette(){ return (util.colors && util.colors.length)? util.colors : getSelectedPalette(); }
+
+  function samplePalette(pal, t){ if(pal.length===1) return pal[0]; var x=t*(pal.length-1); var i=Math.floor(x); if(i<0)i=0; var j=(i+1>=pal.length)?pal.length-1:(i+1); var f=x-i; return lerpColor(pal[i], pal[j], f); }
+
+  // Brightness shaping: fast attack, slow decay
+  function attackDecay(phase){ // phase in [0..1]
+    var a=0.18; // attack fraction
+    if (phase < a){ return clamp01(phase / a); }
+    var d = (phase - a) / (1 - a); // 0..1
+    var k = 1.9; // decay exponent
+    return clamp01(1 - Math.pow(d, k));
+  }
+
+  function whitenAtTop(rgb, bright){ // add white near the top brightness
+    var t = (bright>0.8)? ((bright-0.8)/0.2) : 0.0; if (t<0) t=0; if (t>1) t=1;
+    if (t<=0) return rgb;
+    return lerpColor(rgb, 0xFFFFFF, t*0.7);
+  }
+
+  function warmOnFade(rgb, bright, warmthPct){
+    if (warmthPct<=0) return rgb;
+    // Apply more warmth when brightness is low (decay tail)
+    var w = (1 - bright) * (warmthPct/100.0);
+    if (w<=0) return rgb;
+    var r=(rgb>>16)&255,g=(rgb>>8)&255,b=rgb&255;
+    // Pull toward amber: boost red slightly, reduce blue more than green
+    var r2 = Math.min(255, Math.floor(r + 60*w));
+    var g2 = Math.max(0, Math.floor(g - 40*w));
+    var b2 = Math.max(0, Math.floor(b - 90*w));
+    return (r2<<16)|(g2<<8)|b2;
+  }
+
+  function trySpawn(w,h){
+    // Per-pixel spawn probability, scaled by density and speed
+    var base = 0.0025; // baseline ~0.25% per pixel per frame
+    var p = base * (algo.density/10.0) * (0.7 + 0.3*algo.speed/10.0);
+    if (p<=0) return; // no spawns
+    for (var y=0;y<h;y++){
+      for (var x=0;x<w;x++){
+        if (util.phase[y][x] < 0){
+          if (Math.random() < p){
+            util.phase[y][x] = 0.0;
+            util.hueIx[y][x] = Math.floor(Math.random() * 1024) & 1023; // large hue seed
+          }
+        }
+      }
+    }
+  }
+
+  algo.rgbMap = function(width, height, _rgb, _step){
+    ensureState(width,height);
+
+    var pal = getPalette();
+    var out = makeMap(width,height,0);
+
+    // background
+    var bgScale = Math.floor(255 * (algo.bg/100.0));
+    var bgColor = scaleColor(0xFFFFFF, bgScale); // neutral gray background
+    if (bgScale>0){ for (var y=0;y<height;y++){ for (var x=0;x<width;x++){ out[y][x]=bgColor; } } }
+
+    // advance and render twinkles
+    var phaseStep = 0.06 * (algo.speed/10.0); // higher speed -> faster progression
+    if (phaseStep < 0.01) phaseStep = 0.01;
+
+    // spawn new twinkles
+    trySpawn(width,height);
+
+    for (var y=0;y<height;y++){
+      for (var x=0;x<width;x++){
+        var ph = util.phase[y][x];
+        if (ph >= 0){
+          ph += phaseStep;
+          var done = (ph >= 1.0);
+          if (done){ util.phase[y][x] = -1; continue; }
+          util.phase[y][x] = ph;
+          var b = attackDecay(ph); // 0..1
+
+          // choose palette position per pixel seed, drift slowly with y for variety
+          var seed = util.hueIx[y][x];
+          var tpal = ((seed & 1023) / 1023.0);
+          // Small vertical variation
+          tpal = clamp01(tpal * 0.85 + (y/(height>1?height-1:1))*0.15);
+          var baseColor = samplePalette(pal, tpal);
+          // whiten near top and warm on fade
+          var c1 = whitenAtTop(baseColor, b);
+          var c2 = warmOnFade(c1, b, algo.warmth);
+          var col = scaleColor(c2, Math.floor(b*255));
+          out[y][x] = addColor(out[y][x], col);
+        }
+      }
+    }
+
+    return out;
+  };
+
+  algo.rgbMapStepCount = function(_w,_h){ return 100; };
+
+  return algo;
+})();
+

--- a/resources/rgbscripts/waterflow.js
+++ b/resources/rgbscripts/waterflow.js
@@ -1,0 +1,171 @@
+/*
+  Q Light Controller Plus
+  waterflow.js
+
+  Directional water flow with turbulence and caustic glints.
+  Ported to QLC+ RGBScript.
+
+  Copyright (c) Branson Matheson
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+(function(){
+  var algo = {};
+  algo.apiVersion = 3;
+  algo.name = "Water Flow";
+  algo.author = "Branson Matheson";
+  algo.acceptColors = 3; // deep / surface / foam
+  algo.properties = new Array();
+
+  algo.speed = 20;
+  algo.properties.push("name:speed|type:range|display:Speed|values:1,50|write:setSpeed|read:getSpeed");
+
+  algo.direction = 0; // 0=Right 1=Left 2=Down 3=Up
+  algo.properties.push("name:direction|type:list|display:Direction|values:Right,Left,Down,Up|write:setDirection|read:getDirection");
+
+  algo.turbulence = 30;
+  algo.properties.push("name:turbulence|type:range|display:Turbulence|values:0,100|write:setTurbulence|read:getTurbulence");
+
+  algo.caustics = 25;
+  algo.properties.push("name:caustics|type:range|display:Caustics|values:0,100|write:setCaustics|read:getCaustics");
+
+  algo.scale = 10;
+  algo.properties.push("name:scale|type:range|display:Scale|values:1,30|write:setScale|read:getScale");
+
+  var util = {};
+  util.t = 0;
+  util.initialized = false;
+  util.colors = [];
+
+  algo.setSpeed      = function(v){ algo.speed      = parseInt(v); };
+  algo.getSpeed      = function(){ return algo.speed; };
+  algo.setTurbulence = function(v){ algo.turbulence = parseInt(v); };
+  algo.getTurbulence = function(){ return algo.turbulence; };
+  algo.setCaustics   = function(v){ algo.caustics   = parseInt(v); };
+  algo.getCaustics   = function(){ return algo.caustics; };
+  algo.setScale      = function(v){ algo.scale      = parseInt(v); };
+  algo.getScale      = function(){ return algo.scale; };
+
+  algo.setDirection = function(v){
+    if      (v==="Right") algo.direction=0;
+    else if (v==="Left")  algo.direction=1;
+    else if (v==="Down")  algo.direction=2;
+    else                  algo.direction=3;
+  };
+  algo.getDirection = function(){
+    return ["Right","Left","Down","Up"][algo.direction];
+  };
+
+  function defaultPalette(){ return [0x001133, 0x0077BB, 0xCCEEFF]; }
+
+  algo.rgbMapSetColors = function(rawColors){
+    if (!Array.isArray(rawColors)) return;
+    util.colors = [];
+    for (var i=0; i<algo.acceptColors; i++){
+      if (i < rawColors.length && rawColors[i]===rawColors[i]) util.colors.push(rawColors[i]);
+    }
+    if (util.colors.length===0) util.colors = defaultPalette();
+  };
+
+  function getPalette(){ return (util.colors && util.colors.length) ? util.colors : defaultPalette(); }
+
+  function lerpColor(a, b, t){
+    var ar=(a>>16)&255, ag=(a>>8)&255, ab=a&255;
+    var br=(b>>16)&255, bg=(b>>8)&255, bb=b&255;
+    return (Math.floor(ar+(br-ar)*t)<<16) + (Math.floor(ag+(bg-ag)*t)<<8) + Math.floor(ab+(bb-ab)*t);
+  }
+
+  function samplePalette(pal, idx){
+    if (pal.length===1) return pal[0];
+    var x = idx*(pal.length-1), i=Math.floor(x), j=Math.min(pal.length-1,i+1);
+    return lerpColor(pal[i], pal[j], x-i);
+  }
+
+  function scaleColor(rgb, s255){
+    if (s255<=0) return 0; if (s255>=255) return rgb;
+    var r=(rgb>>16)&255, g=(rgb>>8)&255, b=rgb&255;
+    return (Math.floor(r*s255/255)<<16) + (Math.floor(g*s255/255)<<8) + Math.floor(b*s255/255);
+  }
+
+  function sin01(v){ return Math.sin(v)*0.5+0.5; }
+
+  algo.rgbMap = function(width, height, _rgb, _step){
+    if (!util.initialized){ util.t=0; util.initialized=true; }
+
+    var sp    = algo.speed/50.0;
+    var turb  = algo.turbulence/100.0;
+    var camt  = algo.caustics/100.0;
+    var sc    = algo.scale/10.0;
+    var t     = util.t;
+    util.t   += 0.035 * sp;
+
+    var pal = getPalette();
+    var map = new Array(height);
+
+    for (var y=0; y<height; y++){
+      map[y] = new Array(width);
+      for (var x=0; x<width; x++){
+        // Normalize to [0,1]
+        var nx = width>1  ? x/(width-1)  : 0.5;
+        var ny = height>1 ? y/(height-1) : 0.5;
+
+        // Remap so flowPos advances in flow direction, crossPos is perpendicular
+        var fp, cp;
+        switch(algo.direction){
+          case 0: fp=nx;   cp=ny;   break; // right
+          case 1: fp=1-nx; cp=ny;   break; // left
+          case 2: fp=ny;   cp=nx;   break; // down
+          default: fp=1-ny; cp=nx;  break; // up
+        }
+
+        // Primary laminar-flow wave: stripes moving along fp, gently warped by cp
+        var warp = turb * 0.35 * (Math.sin(cp*sc*5.3 + t*0.8) + 0.5*Math.sin(cp*sc*8.7 - t*1.1));
+        var v1 = sin01((fp + warp) * sc * 7.0 - t * 3.5);
+
+        // Secondary cross-current: turbulent eddies
+        var v2 = sin01(cp*sc*4.7 + fp*sc*2.1 + t*1.9) * sin01(cp*sc*6.3 - fp*sc*1.6 - t*2.7);
+        // v2 peaks at both sin = high simultaneously → blob-like eddies
+
+        // Blend layers: low turbulence = laminar flow, high = churning eddies
+        var v = v1*(1-turb*0.5) + v2*turb*0.5;
+
+        // Caustic highlights: product of two high-freq waves → narrow bright streaks
+        var caustic = 0.0;
+        if (camt > 0){
+          var c1 = sin01(fp*sc*19.3 + cp*sc*11.7 - t*5.9);
+          var c2 = sin01(cp*sc*13.9 + fp*sc* 7.3 + t*4.3);
+          caustic = c1 * c2;
+          caustic = caustic * caustic * caustic; // sharpen to bright spots
+          caustic *= camt;
+        }
+
+        // Color: map wave value to palette; caustics push toward palette peak (foam)
+        var palIdx = Math.min(1.0, v * 0.85 + caustic * 0.8);
+        var color  = samplePalette(pal, palIdx);
+
+        // Strong caustics: bloom toward white
+        if (caustic > 0.4){
+          color = lerpColor(color, 0xFFFFFF, Math.min(1, (caustic-0.4)*camt*2.5));
+        }
+
+        map[y][x] = color;
+      }
+    }
+    return map;
+  };
+
+  algo.rgbMapStepCount = function(_w,_h){ return 2; };
+
+  return algo;
+})();


### PR DESCRIPTION
## Description

**Summary of Changes:**
11 more RGB scripts, following on from #1959 (batch 1):
- confetti.js - random speckles that blink and fade (FastLED idea)
- connectdots.js - moving dot clusters connected by lines ("constellations")
- juggle.js - multiple sinelons with phase offsets (FastLED idea)
- lantern.js - organic candle/lantern flame for short LED strips
- meteor.js - falling meteors with tails (FastLED idea)
- pacifica.js - layered ocean waves (FastLED idea)
- ripple.js - expanding ripple circles from random centers
- shapes.js - circle/polygon renderer (fill modes, outline, rotation)
- stagepulse.js - concentric ring pulses radiating from a fixed point
- twinklefox.js - palette-driven twinkles with attack/decay (FastLED idea)
- waterflow.js - directional water flow with turbulence and caustic glints

**Related Issues:**
None of these touch lines.js, so they're independent of #1959/the fix in
that PR.

## Checklist

- [x] I have read and followed the [QLC+ Coding Guidelines](https://github.com/mcallegari/qlcplus/wiki/Coding-guidelines).
- [x] My code adheres to the project's coding style.
- [x] I have tested my changes on the following platforms:
  - [ ] Linux
  - [ ] Windows
  - [x] macOS
- [ ] I have added or updated documentation as necessary.

## Testing

**Test Cases:**
- All 11 scanned specifically for the ES6/QtScript-vs-Qt5 compatibility
  class of bug that broke `lines.js` in #1959 (`Array.prototype.fill()`,
  arrow functions, `let`/`const`, template literals, spread, `for...of`,
  classes) — none found in any of them.
- `node --check` syntax validation on all 11 (informational only — doesn't
  catch Qt5-specific engine gaps, which is what the targeted scan above is
  for).
- Running in production.

## Additional Notes

Written with AI assistance (disclosed via the commit's `Co-Authored-By`
trailer), reviewed and tested by me.
